### PR TITLE
fix parsing of 'with' inside streaming operator #693

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -775,6 +775,10 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "   parameter  int  b={ << 4  {{ << 2 { a }  }} } ;",
         "parameter int b = {<<4{{<<2{a}}}};\n",
     },
+    {
+      "   parameter  int  b={ << {foo with [ 1 +: 4 ] } } ;",
+      "parameter int b = {<<{foo with [1+:4]}};\n",
+    },
 
     // basic module test cases
     {"module foo;endmodule:foo\n",

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -208,6 +208,9 @@ static WithReason<int> SpacesRequiredBetween(
   if (right_context.IsInsideFirst({NodeEnum::kStreamingConcatenation}, {})) {
     if (left.TokenEnum() == TK_LS || left.TokenEnum() == TK_RS) {
       return {0, "No space around streaming operators"};
+    } else if (left.TokenEnum() == TK_with__followed_by_bracket ||
+               right.TokenEnum() == TK_with__followed_by_bracket) {
+      return {1, "Space around 'with' keyword in streaming concatenation."};
     } else if (left.format_token_enum == FormatTokenType::numeric_literal ||
                left.format_token_enum == FormatTokenType::identifier ||
                left.format_token_enum == FormatTokenType::keyword) {

--- a/verilog/formatting/verilog_token.cc
+++ b/verilog/formatting/verilog_token.cc
@@ -298,6 +298,7 @@ static const auto* FormatTokenTypeMap =
         {verilog_tokentype::TK_wait_order, FTT::keyword},
         {verilog_tokentype::TK_wildcard, FTT::keyword},
         {verilog_tokentype::TK_with, FTT::keyword},
+        {verilog_tokentype::TK_with__followed_by_bracket, FTT::keyword},
         {verilog_tokentype::TK_with__covergroup, FTT::keyword},
         {verilog_tokentype::TK_within, FTT::keyword},
         {verilog_tokentype::TK_timeprecision_check, FTT::keyword},

--- a/verilog/parser/verilog.lex
+++ b/verilog/parser/verilog.lex
@@ -672,9 +672,8 @@ wait_order { UpdateLocation(); return TK_wait_order; }
 wildcard { UpdateLocation(); return TK_wildcard; }
 <COVERGROUP>with { UpdateLocation(); return TK_with__covergroup; }
 with { UpdateLocation(); return TK_with; }
-"with"[ \t]*"[" {
-  /* TODO: formulate the ws sequence as any whitespace+comment sequence*/
-  yyless(4);
+"with"({TraditionalCommentOrSpace}|{EndOfLineComment})*"[" {
+  yyless(4);    // only consume 'with', push rest back to input
   UpdateLocation();
   return TK_with__followed_by_bracket;
 }

--- a/verilog/parser/verilog.lex
+++ b/verilog/parser/verilog.lex
@@ -672,6 +672,12 @@ wait_order { UpdateLocation(); return TK_wait_order; }
 wildcard { UpdateLocation(); return TK_wildcard; }
 <COVERGROUP>with { UpdateLocation(); return TK_with__covergroup; }
 with { UpdateLocation(); return TK_with; }
+"with"[ \t]*"[" {
+  /* TODO: formulate the ws sequence as any whitespace+comment sequence*/
+  yyless(4);
+  UpdateLocation();
+  return TK_with__followed_by_bracket;
+}
 within { UpdateLocation(); return TK_within; }
 timeprecision_check { UpdateLocation(); return TK_timeprecision_check; }
 timeunit_check { UpdateLocation(); return TK_timeunit_check; }

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -480,6 +480,7 @@ is not locally defined, so the grammar here uses only generic identifiers.
 %token TK_wait_order "wait_order"
 %token TK_wildcard "wildcard"
 %token TK_with "with"
+%token TK_with__followed_by_bracket "with ["
 %token TK_with__covergroup "with(covergroup)"
 %token TK_within "within"
 /* Fake tokens that are passed once we have an initial token. */
@@ -3217,12 +3218,12 @@ block_item_or_statement_or_null_list_opt
   | /* empty */
     { $$ = MakeTaggedNode(N::kBlockItemStatementList); }
   ;
+
 stream_expression
   : expression
     { $$ = move($1); }
-  /* TODO(fangism):
-  | expression TK_with select_variable_dimension
-   */
+  | expression TK_with__followed_by_bracket select_variable_dimension
+    { $$ = ExtendNode($1, $2, $3); }
   ;
 stream_expression_list
   : stream_expression_list ',' stream_expression

--- a/verilog/parser/verilog_lexer_unittest.cc
+++ b/verilog/parser/verilog_lexer_unittest.cc
@@ -1470,6 +1470,9 @@ static std::initializer_list<LexerTestData> kSequenceTests = {
 
 static std::initializer_list<LexerTestData> kContextKeywordTests = {
     {{SymbolIdentifier, "option"}},
+    {{TK_with__followed_by_bracket, "with"},
+     " // hello\n"
+     " /* this bracket is the context we're looking for -> */["},
     {{TK_covergroup, "covergroup"},
      " ",
      {SymbolIdentifier, "blah1"},

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -627,7 +627,8 @@ static const ParserTestCaseArray kFunctionTests = {
     "{>>8 {foo, bar with \t [ a +: b]}} = nums;\n"
     "endfunction",
     "function void unpack_id_with(int nums);\n"
-    "{>>8 {foo, bar with /* some comment */ [ a +: b]}} = nums;\n"
+    "{>>8 {foo, bar with /* some comment */ /* another one */ // more\n"
+    "[ a +: b]}} = nums;\n"
     "endfunction",
     "function void unpack_id_with(int nums);\n"
     "{>>8 {foo, bar with // eol comment\n"

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -624,7 +624,14 @@ static const ParserTestCaseArray kFunctionTests = {
     "{<< byte {this.reserved, this.id}} = bytes;\n"
     "endfunction",
     "function void unpack_id_with(int nums);\n"
-    "{>>8 {foo, bar with [ a +: b]}} = nums;\n"
+    "{>>8 {foo, bar with \t [ a +: b]}} = nums;\n"
+    "endfunction",
+    "function void unpack_id_with(int nums);\n"
+    "{>>8 {foo, bar with /* some comment */ [ a +: b]}} = nums;\n"
+    "endfunction",
+    "function void unpack_id_with(int nums);\n"
+    "{>>8 {foo, bar with // eol comment\n"
+    "      [ a +: b]}} = nums;\n"
     "endfunction",
     // concatenation lvalue
     "module foo;\n"

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -623,6 +623,9 @@ static const ParserTestCaseArray kFunctionTests = {
     "function void unpack_id(utils_pkg::bytestream_t bytes);\n"
     "{<< byte {this.reserved, this.id}} = bytes;\n"
     "endfunction",
+    "function void unpack_id_with(int nums);\n"
+    "{>>8 {foo, bar with [ a +: b]}} = nums;\n"
+    "endfunction",
     // concatenation lvalue
     "module foo;\n"
     "  initial begin\n"


### PR DESCRIPTION
The stream expression has an expression followed by
an optional 'with' '[' array_range_expression ']'
(LRM 11.4.14)

There are a few other cases where an expression can
be trailed with 'with',
 * with_constraint_block: there we expect an
   identifier list in parenthesis after 'with'
 * similar with array methods with predicate
   with '(' ...)

Since the parser with one look-ahead can't see beyond
the 'with', it runs into a shift/reduce conflict
as it does not know if '(' or '[' is to follow.

Disambiguate that in the lexer by creating a
separate token TK_with__followed_by_bracket which is
a TK_with, where the lexer already looked ahead and
knows that it will be followed by '['.

After seeing the '[', everything but the "with" is put
back into the stream to be processed separately.

Changed lexer and parser as well as associated unit tests including formatter.

Fixing #693 

Signed-off-by: Henner Zeller <h.zeller@acm.org>