### PR TITLE
Run tests with clang.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -66,6 +66,8 @@ if [ "$COMPILER" == "gcc" ] ; then
   export CXX="g++"
 fi
 
+bazel clean --expunge
+
 case "$MODE" in
 test)
     bazel test --keep_going --test_output=errors $BAZEL_OPTS //...

--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -16,6 +16,8 @@
 set -x
 set -e
 
+COMPILER=clang
+
 source ./.github/settings.sh
 
 # Make sure we don't have cc_library rules that use exceptions but do not
@@ -26,6 +28,10 @@ BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-fno-exceptions"
 # Turn warnings to 11. And fail compliation if we encounter one.
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Werror"  # Always want bail on warning
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wall --cxxopt=-Wextra"
+
+# Warning options are different between compilers. Don't complain about the
+# others' compiler warnings.
+BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-unknown-warning-option"
 
 # -- now disable some of the warnings that happen, so that the compile finishes.
 
@@ -49,13 +55,24 @@ BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-implicit-fallthrough"     # gflags
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-cast-function-type"       # gflags
 BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-deprecated-declarations"  # jsconcpp
 
+# Layering check (only works with clang) provides a simple check that
+# cc targets depend on everything the header inclusion implies.
+# Currently disabled, it seems to get hang up on gtest/ gmock/ includes.
+# BAZEL_OPTS="${BAZEL_OPTS} --features=layering_check"
+
+export CC="${COMPILER}"
+export CXX="${COMPILER}++"
+if [ "$COMPILER" == "gcc" ] ; then
+  export CXX="g++"
+fi
+
 case "$MODE" in
 test)
-    bazel test --test_output=errors $BAZEL_OPTS //...
+    bazel test --keep_going --test_output=errors $BAZEL_OPTS //...
     ;;
 
 compile|clean)
-    bazel build $BAZEL_OPTS //...
+    bazel build --keep_going $BAZEL_OPTS //...
     ;;
 
 *)

--- a/.github/bin/set-compiler.sh
+++ b/.github/bin/set-compiler.sh
@@ -15,8 +15,8 @@
 
 VERSION=$1
 
-sudo dpkg --list | grep gcc
-sudo dpkg --list | grep libstdc++
+dpkg --list | grep "gcc\|clang"
+dpkg --list | grep libstdc++
 sudo ln -sf /usr/bin/gcc-$VERSION /usr/bin/gcc
 sudo ln -sf /usr/bin/g++-$VERSION /usr/bin/g++
 gcc --version || true

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -79,7 +79,7 @@ jobs:
       run: |
         set -x
         source ./.github/settings.sh
-        ./.github/bin/set-compiler.sh 9
+        sudo apt install clang-9 libstdc++-9-dev
         ./.github/bin/install-bazel.sh
         ./.github/bin/install-python.sh
 

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -205,7 +205,7 @@ absl::StatusOr<Directory> ListDir(absl::string_view dir) {
     return absl::InvalidArgumentError(absl::StrCat(dir, ": not a directory"));
   }
 
-  for (const fs::directory_entry entry : fs::directory_iterator(d.path)) {
+  for (const fs::directory_entry& entry : fs::directory_iterator(d.path)) {
     const std::string entry_name = entry.path().string();
     if (entry.is_directory()) {
       d.directories.push_back(entry_name);

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -205,7 +205,7 @@ absl::StatusOr<Directory> ListDir(absl::string_view dir) {
     return absl::InvalidArgumentError(absl::StrCat(dir, ": not a directory"));
   }
 
-  for (const fs::directory_entry& entry : fs::directory_iterator(d.path)) {
+  for (const fs::directory_entry &entry : fs::directory_iterator(d.path)) {
     const std::string entry_name = entry.path().string();
     if (entry.is_directory()) {
       d.directories.push_back(entry_name);

--- a/verilog/CST/dimensions_test.cc
+++ b/verilog/CST/dimensions_test.cc
@@ -14,9 +14,8 @@
 
 #include "verilog/CST/dimensions.h"
 
-#include <stddef.h>
-
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <vector>
 

--- a/verilog/analysis/checkers/no_tabs_rule.h
+++ b/verilog/analysis/checkers/no_tabs_rule.h
@@ -15,8 +15,7 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TABS_RULE_H_
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TABS_RULE_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <set>
 #include <string>
 

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.cc
@@ -14,10 +14,9 @@
 
 #include "verilog/analysis/checkers/no_trailing_spaces_rule.h"
 
-#include <stddef.h>
-
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <iterator>
 #include <set>
 #include <string>

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.h
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.h
@@ -15,8 +15,7 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TRAILING_SPACES_RULE_H_
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TRAILING_SPACES_RULE_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <set>
 #include <string>
 

--- a/verilog/analysis/lint_rule_registry_test.cc
+++ b/verilog/analysis/lint_rule_registry_test.cc
@@ -14,8 +14,7 @@
 
 #include "verilog/analysis/lint_rule_registry.h"
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Clang offers more opportunities for warnings and layering check.

Signed-off-by: Henner Zeller <h.zeller@acm.org>