### PR TITLE
Add version/feature check to verible_verilog_syntax.py

### DIFF
--- a/verilog/tools/syntax/export_json_examples/verible_verilog_syntax.py
+++ b/verilog/tools/syntax/export_json_examples/verible_verilog_syntax.py
@@ -387,8 +387,8 @@ class VeribleVerilogSyntax:
     if isinstance(executable, str):
       executable = [executable]
 
-    proc = subprocess.run([*executable, "--version"], capture_output=True,
-        encoding="utf-8")
+    proc = subprocess.run([*executable, "--version"], stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, encoding="utf-8")
 
     ver_match = self._VERSION_RE.match(proc.stdout)
     if ver_match:
@@ -413,10 +413,10 @@ class VeribleVerilogSyntax:
 
     else:
       # Version not available; check help message for `--export_json` flag
-      proc = subprocess.run([*executable, "--helpfull"], capture_output=True,
-          encoding="utf-8")
+      proc = subprocess.run([*executable, "--helpfull"], stdout=subprocess.PIPE,
+          stderr=subprocess.STDOUT, encoding="utf-8")
 
-      if not self._EXPORT_JSON_RE.search(proc.stdout + proc.stderr):
+      if not self._EXPORT_JSON_RE.search(proc.stdout):
         raise Exception("Unsupported verible-verilog-syntax version."
             f"Minimum required version: {self._MIN_VERSION}.")
 

--- a/verilog/tools/syntax/export_json_examples/verible_verilog_syntax.py
+++ b/verilog/tools/syntax/export_json_examples/verible_verilog_syntax.py
@@ -17,7 +17,7 @@ import collections
 import json
 import re
 import subprocess
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
 
 import anytree
 import dataclasses
@@ -374,7 +374,10 @@ class VeribleVerilogSyntax:
     executable: path to ``verible-verilog-syntax`` binary.
   """
 
-  def __init__(self, executable: str = "verible-verilog-syntax"):
+  def __init__(self, executable: Union[str, List[str]] = "verible-verilog-syntax"):
+    if isinstance(executable, str):
+      executable = [executable]
+
     self.executable = executable
 
   @staticmethod
@@ -436,7 +439,7 @@ class VeribleVerilogSyntax:
     if options["gen_rawtokens"]:
       args.append("-printrawtokens")
 
-    proc = subprocess.run([self.executable, *args , *paths],
+    proc = subprocess.run([*self.executable, *args , *paths],
         stdout=subprocess.PIPE,
         input=input_,
         encoding="utf-8",


### PR DESCRIPTION
Makes `VeribleVerilogSyntax` constructor raise an exception when `verible-verilog-syntax` executable version is too old. It checks the version printed by `--version` switch. It fallbacks to checking `--helpfull` output for `--export_json` string when version string is not available.

The executable's version is additionally stored in the `version` attribute.

Depends on https://github.com/google/verible/pull/832 to pass Windows build in CI.