### PR TITLE
Formatter: Align multiline string initializer

### DIFF
--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -547,12 +547,12 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
     first_line.SpanUpToToken(trailer->Value().TokensRange().end());
   }
 
-  bool wrapped_first_subpartition;
   int longest_line_len = 0;
 
-  verible::FitResult fit_result;
-  if (!wrap_first_subpartition &&
-      (fit_result = FitsOnLine(first_line, style)).fits == true) {
+  verible::FitResult fit_result = FitsOnLine(first_line, style);
+  const bool wrapped_first_subpartition =
+      wrap_first_subpartition || !fit_result.fits;
+  if (!wrapped_first_subpartition) {
     // Compute new indentation level based on first partition
     const UnwrappedLine& uwline = group->Value().Value();
     indent = FitsOnLine(uwline, style).final_column;
@@ -563,8 +563,6 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
     // keep group indentation
 
     longest_line_len = fit_result.final_column;
-    // Appended first argument
-    wrapped_first_subpartition = false;
   } else {
     // Measure header
     fit_result = FitsOnLine(group->Value().Value(), style);
@@ -580,9 +578,6 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
     // Measure first wrapped line
     fit_result = FitsOnLine(group->Value().Value(), style);
     longest_line_len = std::max(longest_line_len, fit_result.final_column);
-
-    // Wrapped first argument
-    wrapped_first_subpartition = true;
   }
 
   const auto remaining_args =

--- a/common/formatting/token_partition_tree_test.cc
+++ b/common/formatting/token_partition_tree_test.cc
@@ -1425,6 +1425,9 @@ TEST_F(ReshapeFittingSubpartitionsTest, NoneOneFits) {
   UnwrappedLine all(0, header.TokensRange().begin());
   all.SpanUpToToken(arg5.TokensRange().end());
 
+  verible::BasicFormatStyle style;  // default
+  style.column_limit = 2;
+
   using tree_type = TokenPartitionTree;
   tree_type tree{
       all,
@@ -1439,6 +1442,11 @@ TEST_F(ReshapeFittingSubpartitionsTest, NoneOneFits) {
       },
   };
 
+  tree.Children()[1].ApplyPreOrder([&style](TokenPartitionTree& node) {
+    auto& uwline = node.Value();
+    uwline.SetIndentationSpaces(style.wrap_spaces);
+  });
+
   const tree_type tree_expected{
       all,
       tree_type{header, tree_type{header}},
@@ -1449,8 +1457,6 @@ TEST_F(ReshapeFittingSubpartitionsTest, NoneOneFits) {
       tree_type{arg5, tree_type{arg5}},
   };
 
-  verible::BasicFormatStyle style;  // default
-  style.column_limit = 2;
   ReshapeFittingSubpartitions(&tree, style);
 
   const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
@@ -1707,6 +1713,14 @@ TEST_F(ReshapeFittingSubpartitionsFunctionTest,
       },
   };
 
+  verible::BasicFormatStyle style;
+  style.column_limit = 20;
+
+  tree.Children()[1].ApplyPreOrder([&style](TokenPartitionTree& node) {
+    auto& uwline = node.Value();
+    uwline.SetIndentationSpaces(style.wrap_spaces);
+  });
+
   // Expect each subpartition in its own partition...
   const tree_type tree_expected{
       all,
@@ -1719,8 +1733,6 @@ TEST_F(ReshapeFittingSubpartitionsFunctionTest,
       tree_type{arg6, tree_type{arg6}},
   };
 
-  verible::BasicFormatStyle style;
-  style.column_limit = 20;
   ReshapeFittingSubpartitions(&tree, style);
 
   const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
@@ -1781,6 +1793,14 @@ TEST_F(ReshapeFittingSubpartitionsFunctionTest,
       },
   };
 
+  verible::BasicFormatStyle style;
+  style.column_limit = 40;
+
+  tree.Children()[1].ApplyPreOrder([&style](TokenPartitionTree& node) {
+    auto& uwline = node.Value();
+    uwline.SetIndentationSpaces(style.wrap_spaces);
+  });
+
   UnwrappedLine group1(0, begin);
   group1.SpanUpToToken(header.TokensRange().end());
   UnwrappedLine group2(0, arg1.TokensRange().begin());
@@ -1811,8 +1831,6 @@ TEST_F(ReshapeFittingSubpartitionsFunctionTest,
                                     tree_type{arg6},
                                 }};
 
-  verible::BasicFormatStyle style;
-  style.column_limit = 40;
   ReshapeFittingSubpartitions(&tree, style);
 
   const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);

--- a/common/formatting/token_partition_tree_test.cc
+++ b/common/formatting/token_partition_tree_test.cc
@@ -1175,6 +1175,52 @@ TEST_F(ReshapeFittingSubpartitionsTest, OneArgumentInSubpartition) {
   EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
 }
 
+TEST_F(ReshapeFittingSubpartitionsTest, OneArgumentInSubpartitionAndTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+  UnwrappedLine arg1(0, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine trailer(0, arg1.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          arg1,
+          tree_type{arg1},
+      },
+      tree_type{trailer},
+  };
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          all,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{trailer},
+      },
+  };
+
+  verible::BasicFormatStyle style;  // default
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+}
+
 TEST_F(ReshapeFittingSubpartitionsTest, OneArgumentFlat) {
   const auto& preformat_tokens = pre_format_tokens_;
   const auto begin = preformat_tokens.begin();
@@ -1198,6 +1244,49 @@ TEST_F(ReshapeFittingSubpartitionsTest, OneArgumentFlat) {
           all,
           tree_type{header},
           tree_type{arg1},
+      },
+  };
+
+  verible::BasicFormatStyle style;  // default
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+}
+
+TEST_F(ReshapeFittingSubpartitionsTest, OneArgumentFlatAndTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+  UnwrappedLine arg1(0, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine trailer(0, arg1.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{arg1},  // flat, not in subpartition
+      tree_type{trailer},
+  };
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          all,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{trailer},
       },
   };
 
@@ -1262,6 +1351,61 @@ TEST_F(ReshapeFittingSubpartitionsTest, TwoArguments) {
   EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
 }
 
+TEST_F(ReshapeFittingSubpartitionsTest, TwoArgumentsAndTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(0, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(0, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+
+  UnwrappedLine args(0, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg2.TokensRange().end());
+
+  UnwrappedLine trailer(0, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+      },
+      tree_type{trailer},
+  };
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          all,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{trailer},
+      },
+  };
+
+  verible::BasicFormatStyle style;  // default
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+}
+
 // All fits in one partition
 TEST_F(ReshapeFittingSubpartitionsTest, OnePartition) {
   const auto& preformat_tokens = pre_format_tokens_;
@@ -1311,6 +1455,70 @@ TEST_F(ReshapeFittingSubpartitionsTest, OnePartition) {
           tree_type{arg3},
           tree_type{arg4},
           tree_type{arg5},
+      },
+  };
+
+  verible::BasicFormatStyle style;  // default
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+}
+
+// All fits in one partition
+TEST_F(ReshapeFittingSubpartitionsTest, OnePartitionWithTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(0, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(0, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(0, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(0, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(0, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(0, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          all,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+          tree_type{trailer},
       },
   };
 
@@ -1400,6 +1608,82 @@ TEST_F(ReshapeFittingSubpartitionsTest, TwoPartitions) {
       header.TokensRange()[0].Length());  // indenation equal first token length
 }
 
+// Wrap into two partitions
+TEST_F(ReshapeFittingSubpartitionsTest, TwoPartitionsWithTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(0, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(0, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(0, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(0, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(0, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(0, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  UnwrappedLine group1(0, header.TokensRange().begin());
+  group1.SpanUpToToken(arg2.TokensRange().end());
+  UnwrappedLine group2(0, arg3.TokensRange().begin());
+  group2.SpanUpToToken(trailer.TokensRange().end());
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          group1,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{arg2},
+      },
+      tree_type{
+          group2,
+          tree_type{arg3},
+          tree_type{arg4},
+          tree_type{trailer},
+      },
+  };
+
+  verible::BasicFormatStyle style;  // default
+  style.column_limit = 14;
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+  EXPECT_EQ(
+      tree.Children()[1].Value().IndentationSpaces(),
+      header.TokensRange()[0].Length());  // indenation equal first token length
+}
+
 // None fits
 TEST_F(ReshapeFittingSubpartitionsTest, NoneOneFits) {
   const auto& preformat_tokens = pre_format_tokens_;
@@ -1470,6 +1754,73 @@ TEST_F(ReshapeFittingSubpartitionsTest, NoneOneFits) {
   EXPECT_EQ(tree.Children()[4].Value().IndentationSpaces(), style.wrap_spaces);
 }
 
+// None fits
+TEST_F(ReshapeFittingSubpartitionsTest, NoneOneFitsWithTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  verible::BasicFormatStyle style;  // default
+  style.column_limit = 2;
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(style.wrap_spaces, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(style.wrap_spaces, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(style.wrap_spaces, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(style.wrap_spaces, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(style.wrap_spaces, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(0, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  const tree_type tree_expected{
+      all,
+      tree_type{header, tree_type{header}},
+      tree_type{arg1, tree_type{arg1}},
+      tree_type{arg2, tree_type{arg2}},
+      tree_type{arg3, tree_type{arg3}},
+      tree_type{arg4, tree_type{arg4}},
+      tree_type{trailer, tree_type{trailer}},
+  };
+
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+  EXPECT_EQ(tree.Children()[1].Value().IndentationSpaces(), style.wrap_spaces);
+  EXPECT_EQ(tree.Children()[2].Value().IndentationSpaces(), style.wrap_spaces);
+  EXPECT_EQ(tree.Children()[3].Value().IndentationSpaces(), style.wrap_spaces);
+  EXPECT_EQ(tree.Children()[4].Value().IndentationSpaces(), style.wrap_spaces);
+  EXPECT_EQ(tree.Children()[5].Value().IndentationSpaces(), 0);
+}
+
 // All fits in one partition
 TEST_F(ReshapeFittingSubpartitionsTest, IndentationOnePartition) {
   const auto& preformat_tokens = pre_format_tokens_;
@@ -1529,6 +1880,73 @@ TEST_F(ReshapeFittingSubpartitionsTest, IndentationOnePartition) {
           tree_type{arg3},
           tree_type{arg4},
           tree_type{arg5},
+      },
+  };
+
+  auto saved_tree(tree);
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // keep orig indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(),
+            saved_tree.Value().IndentationSpaces());
+}
+
+// All fits in one partition
+TEST_F(ReshapeFittingSubpartitionsTest, IndentationOnePartitionWithTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  verible::BasicFormatStyle style;  // default
+
+  UnwrappedLine header(3, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(3 + style.indentation_spaces, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(3 + style.indentation_spaces, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(3 + style.indentation_spaces, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(3 + style.indentation_spaces, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(3 + style.indentation_spaces, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(3, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(3, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          all,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+          tree_type{trailer},
       },
   };
 
@@ -1638,6 +2056,369 @@ TEST_F(ReshapeFittingSubpartitionsTest, IndentationTwoPartitions) {
             header.TokensRange()[0].Length() + 7);  // appended
   EXPECT_EQ(tree.Children()[1].Children()[2].Value().IndentationSpaces(),
             header.TokensRange()[0].Length() + 7);  // appended
+}
+
+// Wrap into two partitions
+TEST_F(ReshapeFittingSubpartitionsTest, IndentationTwoPartitionsWithTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  verible::BasicFormatStyle style;  // default
+  style.column_limit = 14 + 7;
+
+  UnwrappedLine header(7, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(7 + style.indentation_spaces, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(7 + style.indentation_spaces, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(7 + style.indentation_spaces, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(7 + style.indentation_spaces, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(7 + style.indentation_spaces, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(7, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(7, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  UnwrappedLine group1(0, header.TokensRange().begin());
+  group1.SpanUpToToken(arg2.TokensRange().end());
+  UnwrappedLine group2(0, arg3.TokensRange().begin());
+  group2.SpanUpToToken(trailer.TokensRange().end());
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          group1,
+          tree_type{header},
+          tree_type{arg1},
+          tree_type{arg2},
+      },
+      tree_type{
+          group2,
+          tree_type{arg3},
+          tree_type{arg4},
+          tree_type{trailer},
+      },
+  };
+
+  auto saved_tree(tree);
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check group nodes indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 7);
+  EXPECT_EQ(tree.Children()[1].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7);  // appended
+
+  EXPECT_EQ(saved_tree.Children()[0].Value().IndentationSpaces(),
+            tree.Children()[0].Children()[0].Value().IndentationSpaces());
+  EXPECT_EQ(tree.Children()[0].Children()[1].Value().IndentationSpaces(), 7);
+  EXPECT_EQ(tree.Children()[0].Children()[2].Value().IndentationSpaces(), 7);
+
+  EXPECT_EQ(tree.Children()[1].Children()[0].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7);  // appended
+  EXPECT_EQ(tree.Children()[1].Children()[1].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7);  // appended
+  EXPECT_EQ(tree.Children()[1].Children()[2].Value().IndentationSpaces(),
+            header.TokensRange()[0].Length() + 7);  // appended
+}
+
+// One subpartition per line
+TEST_F(ReshapeFittingSubpartitionsTest, OnePerLine) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  verible::BasicFormatStyle style;  // default
+
+  const int kIndent = style.indentation_spaces;
+
+  UnwrappedLine header(1 * kIndent, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(2 * kIndent, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(2 * kIndent, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(2 * kIndent, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(2 * kIndent, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(2 * kIndent, arg1.TokensRange().begin(),
+                     PartitionPolicyEnum::kAlwaysExpand);
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine all(1 * kIndent, header.TokensRange().begin());
+  all.SpanUpToToken(args.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+  };
+
+  UnwrappedLine first_line(1 * kIndent, header.TokensRange().begin());
+  first_line.SpanUpToToken(arg1.TokensRange().end());
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          first_line,
+          tree_type{header},
+          tree_type{arg1},
+      },
+      tree_type{arg2, tree_type{arg2}},
+      tree_type{arg3, tree_type{arg3}},
+      tree_type{arg4, tree_type{arg4}},
+  };
+
+  auto saved_tree(tree);
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check group nodes indentation
+  const int header_width = header.TokensRange()[0].Length();
+
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 1 * kIndent);
+  EXPECT_EQ(tree.Children()[0].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent);
+  EXPECT_EQ(tree.Children()[0].Children()[1].Value().IndentationSpaces(),
+            1 * kIndent);
+
+  EXPECT_EQ(tree.Children()[1].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[1].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+
+  EXPECT_EQ(tree.Children()[2].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[2].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+
+  EXPECT_EQ(tree.Children()[3].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[3].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+}
+
+// One subpartition per line
+TEST_F(ReshapeFittingSubpartitionsTest, OnePerLineWithTrailer) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  verible::BasicFormatStyle style;  // default
+
+  const int kIndent = style.indentation_spaces;
+
+  UnwrappedLine header(1 * kIndent, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(2 * kIndent, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(2 * kIndent, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(2 * kIndent, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(2 * kIndent, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(2 * kIndent, arg1.TokensRange().begin(),
+                     PartitionPolicyEnum::kAlwaysExpand);
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(1 * kIndent, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(1 * kIndent, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  UnwrappedLine first_line(1 * kIndent, header.TokensRange().begin());
+  first_line.SpanUpToToken(arg1.TokensRange().end());
+  UnwrappedLine last_line(1 * kIndent, arg4.TokensRange().begin());
+  last_line.SpanUpToToken(trailer.TokensRange().end());
+
+  const tree_type tree_expected{
+      all,
+      tree_type{
+          first_line,
+          tree_type{header},
+          tree_type{arg1},
+      },
+      tree_type{arg2, tree_type{arg2}},
+      tree_type{arg3, tree_type{arg3}},
+      tree_type{
+          last_line,
+          tree_type{arg4},
+          tree_type{trailer},
+      },
+  };
+
+  auto saved_tree(tree);
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check group nodes indentation
+  const int header_width = header.TokensRange()[0].Length();
+
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 1 * kIndent);
+  EXPECT_EQ(tree.Children()[0].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent);
+  EXPECT_EQ(tree.Children()[0].Children()[1].Value().IndentationSpaces(),
+            1 * kIndent);
+
+  EXPECT_EQ(tree.Children()[1].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[1].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+
+  EXPECT_EQ(tree.Children()[2].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[2].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+
+  EXPECT_EQ(tree.Children()[3].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[3].Children()[0].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+  EXPECT_EQ(tree.Children()[3].Children()[1].Value().IndentationSpaces(),
+            1 * kIndent + header_width);
+}
+
+TEST_F(ReshapeFittingSubpartitionsTest, AvoidExceedingColumnLimit) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  verible::BasicFormatStyle style;  // default
+  style.column_limit = 9;
+
+  UnwrappedLine header(0, begin);
+  header.SpanNextToken();
+
+  UnwrappedLine arg1(1, header.TokensRange().end());
+  arg1.SpanNextToken();
+  UnwrappedLine arg2(1, arg1.TokensRange().end());
+  arg2.SpanNextToken();
+  UnwrappedLine arg3(1, arg2.TokensRange().end());
+  arg3.SpanNextToken();
+  UnwrappedLine arg4(1, arg3.TokensRange().end());
+  arg4.SpanNextToken();
+
+  UnwrappedLine args(1, arg1.TokensRange().begin());
+  args.SpanUpToToken(arg4.TokensRange().end());
+
+  UnwrappedLine trailer(0, args.TokensRange().end());
+  trailer.SpanNextToken();
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(trailer.TokensRange().end());
+
+  using tree_type = TokenPartitionTree;
+  tree_type tree{
+      all,
+      tree_type{header},
+      tree_type{
+          args,
+          tree_type{arg1},
+          tree_type{arg2},
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer},
+  };
+
+  UnwrappedLine second_line(1, arg1.TokensRange().begin());
+  second_line.SpanUpToToken(arg2.TokensRange().end());
+  UnwrappedLine third_line(1, arg3.TokensRange().begin());
+  third_line.SpanUpToToken(arg4.TokensRange().end());
+
+  const tree_type tree_expected{
+      all,
+      tree_type{header, tree_type{header}},
+      tree_type{
+          second_line,
+          tree_type{arg1},
+          tree_type{arg2},
+      },
+      tree_type{
+          third_line,
+          tree_type{arg3},
+          tree_type{arg4},
+      },
+      tree_type{trailer, tree_type{trailer}},
+  };
+
+  auto saved_tree(tree);
+  ReshapeFittingSubpartitions(&tree, style);
+
+  const auto diff = DeepEqual(tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:" << tree << "\n";
+
+  // Check group nodes indentation
+  EXPECT_EQ(tree.Children()[0].Value().IndentationSpaces(), 0);
+  EXPECT_EQ(tree.Children()[0].Children()[0].Value().IndentationSpaces(), 0);
+
+  EXPECT_EQ(tree.Children()[1].Value().IndentationSpaces(), 1);
+  EXPECT_EQ(tree.Children()[1].Children()[0].Value().IndentationSpaces(), 1);
+  EXPECT_EQ(tree.Children()[1].Children()[1].Value().IndentationSpaces(), 1);
+
+  EXPECT_EQ(tree.Children()[2].Value().IndentationSpaces(), 1);
+  EXPECT_EQ(tree.Children()[2].Children()[0].Value().IndentationSpaces(), 1);
+  EXPECT_EQ(tree.Children()[2].Children()[1].Value().IndentationSpaces(), 1);
+
+  EXPECT_EQ(tree.Children()[3].Value().IndentationSpaces(), 0);
+  EXPECT_EQ(tree.Children()[3].Children()[0].Value().IndentationSpaces(), 0);
 }
 
 // Tests with real-world example

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -7257,6 +7257,85 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "function int f;\n"
      "  return $x;\n"
      "endfunction\n"},
+    // String initializers
+    {"string a[] = {\n\"a\"\n};\n", "string a[] = {\"a\"};\n"},
+    {"string abc[] = {\n\"a\",\n\"b\",\n\"c\"\n};\n",
+     "string abc[] = {\"a\", \"b\", \"c\"};\n"},
+    {"string abc[] = {\n"
+     "\"a\",//\n"
+     "\"b\", \"c\"\n"
+     "};\n",
+     "string abc[] = {\"a\",  //\n"
+     "                \"b\",\n"
+     "                \"c\"};\n"},
+    {"string abc[] = {//\n"
+     "\"a\", \"b\", \"c\""
+     "};\n",
+     "string abc[] = {  //\n"
+     "  \"a\",\n"
+     "  \"b\",\n"
+     "  \"c\"\n"
+     "};\n"},
+    {"string abc[] = {\n"
+     "\"a\", \"b\", \"c\"//\n"
+     "};\n",
+     "string abc[] = {\"a\",\n"
+     "                \"b\",\n"
+     "                \"c\"  //\n"
+     "                };\n"},
+    {"string abc[] = {//\n"
+     "\"a\",//\n"
+     "\"b\", \"c\"//\n"
+     "};\n",
+     "string abc[] = {  //\n"
+     "  \"a\",  //\n"
+     "  \"b\",\n"
+     "  \"c\"  //\n"
+     "};\n"},
+    {"string abc[] = {\n"
+     "\"a\",\n"
+     "// comment\n"
+     "// comment\n"
+     "\"b\",\n"
+     "\"c\"\n"
+     "};\n",
+     "string abc[] = {\"a\",\n"
+     "                // comment\n"
+     "                // comment\n"
+     "                \"b\",\n"
+     "                \"c\"};\n"},
+    {"string numbers[] = {\"one\", \"two\", \"three\", \"four\"};\n",
+     "string numbers[] = {\"one\",\n"
+     "                    \"two\",\n"
+     "                    \"three\",\n"
+     "                    \"four\"};\n"},
+    {"string numbers[] = {\"one\", \"two\", THREE, \"four\"};\n",
+     "string numbers[] = {\n"
+     "  \"one\", \"two\", THREE, \"four\"\n"
+     "};\n"},
+    {"string numbers[] = {\"one\", {\"two\", \"three\"}, \"four\"};\n",
+     "string numbers[] = {\n"
+     "  \"one\", {\"two\", \"three\"}, \"four\"\n"
+     "};\n"},
+    {"string numbers[] = {\"one\", {\"two\", //\n"
+     "\"three\"}, \"four\"};\n",
+     "string numbers[] = {\n"
+     "  \"one\",\n"
+     "  {\n"
+     "    \"two\",  //\n"
+     "    \"three\"\n"
+     "  },\n"
+     "  \"four\"\n"
+     "};\n"},
+    {"string years[] = {\"two_thousand_nineteen\", \"two_thousand_twenty\",\n"
+     "\"two_thousand_twenty_one\"};\n",
+     // line with 3rd string would exceed column limit in unwrapped style
+     "string years[] = {\n"
+     "  \"two_thousand_nineteen\",\n"
+     "  \"two_thousand_twenty\",\n"
+     "  \"two_thousand_twenty_one\"\n"
+     "};\n"},
+
     //{   // parameterized class with 'parameter_declaration' and MACRO
     //    "class foo #(parameter int a = 2,\n"
     //    "parameter int aaa = `MACRO);\n"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1430,6 +1430,19 @@ static void IndentBetweenUVMBeginEndMacros(TokenPartitionTree* partition_ptr,
   }
 }
 
+static const SyntaxTreeNode* GetAssignedExpressionFromDataDeclaration(
+    const verible::Symbol& data_declaration) {
+  const auto* trailing_assign_symbol = verible::FindFirstSubtree(
+      &data_declaration, [](const verible::Symbol& sym) {
+        return sym.Tag() == verible::NodeTag(NodeEnum::kTrailingAssign);
+      });
+
+  if (trailing_assign_symbol == nullptr) return nullptr;
+  return &verible::GetSubtreeAsNode(*trailing_assign_symbol,
+                                    NodeEnum::kTrailingAssign, 1,
+                                    NodeEnum::kExpression);
+}
+
 // This phase is strictly concerned with reshaping token partitions,
 // and occurs on the return path of partition tree construction.
 void TreeUnwrapper::ReshapeTokenPartitions(
@@ -1517,6 +1530,48 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       } else {
         VLOG(4) << "None of the special cases apply.";
       }
+
+      // Handle variable declaration with string concatenation assignment
+
+      const auto* assigned_expr =
+          GetAssignedExpressionFromDataDeclaration(node);
+      if (!assigned_expr || assigned_expr->children().empty()) break;
+
+      const auto* concat_expr_symbol = assigned_expr->children().front().get();
+      if (concat_expr_symbol->Tag() !=
+          verible::NodeTag(NodeEnum::kConcatenationExpression))
+        break;
+
+      const auto* open_range_list_symbol =
+          verible::SymbolCastToNode(*concat_expr_symbol).children()[1].get();
+      if (open_range_list_symbol->Tag() !=
+          verible::NodeTag(NodeEnum::kOpenRangeList))
+        break;
+
+      const auto& open_range_list =
+          verible::SymbolCastToNode(*open_range_list_symbol);
+
+      if (std::all_of(
+              open_range_list.children().cbegin(),
+              open_range_list.children().cend(),
+              [](const verible::SymbolPtr& sym) {
+                if (sym->Tag() == verible::NodeTag(NodeEnum::kExpression)) {
+                  const auto& expr = verible::SymbolCastToNode(*sym.get());
+                  return !expr.children().empty() &&
+                         expr.children().front()->Tag() ==
+                             verible::LeafTag(
+                                 verilog_tokentype::TK_StringLiteral);
+                }
+                return (sym->Kind() == verible::SymbolKind::kLeaf);
+              })) {
+        auto& assigned_value_partition =
+            data_declaration_partition.Children()[1];
+        partition.Value().SetPartitionPolicy(
+            PartitionPolicyEnum::kAppendFittingSubPartitions);
+        assigned_value_partition.Value().SetPartitionPolicy(
+            PartitionPolicyEnum::kAlwaysExpand);
+      }
+
       break;
     }
 

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -4679,11 +4679,10 @@ expr_primary_braces
   | range_list_in_braces
     /* Reshape to use kConcatenationExpression instead of kBraceGroup */
     { auto& node = SymbolCastToNode(*$1);
-      $$ = MakeTaggedNode(N::kExpression,
-                          MakeTaggedNode(N::kConcatenationExpression,
+      $$ = MakeTaggedNode(N::kConcatenationExpression,
                                          node[0],
                                          node[1],
-                                         node[2])); }
+                                         node[2]); }
   | streaming_concatenation
     { $$ = MakeTaggedNode(N::kExpression, $1); }
 


### PR DESCRIPTION
Demo:

```systemverilog
string seq_names[] = {"uart_sanity_vseq",
                      "uart_tx_rx_vseq",
                      "uart_fifo_full_vseq",
                      "uart_fifo_overflow_vseq",
                      "uart_fifo_reset_vseq",
                      "uart_common_vseq",  // for intr_test
                      "uart_intr_vseq",
                      "uart_noise_filter_vseq",
                      "uart_rx_start_bit_filter_vseq",
                      "uart_rx_parity_err_vseq",
                      "uart_tx_ovrd_vseq",
                      "uart_perf_vseq",
                      "uart_loopback_vseq"};
```

```systemverilog
string abc[] = {"a",
                "b",  //
                "c"};
```

```systemverilog
string abc[] = {"a",
                "b",  //
                "c"  //
                };
```

```systemverilog
string abc[] = {  //
  "a",
  "b",
  "c"
};
```

```systemverilog
string seq_names_without_comments[] = {"uart_sanity_vseq",
                                       "uart_tx_rx_vseq",
                                       "uart_fifo_full_vseq",
                                       "uart_fifo_overflow_vseq",
                                       "uart_fifo_reset_vseq",
                                       "uart_common_vseq",
                                       "uart_intr_vseq",
                                       "uart_noise_filter_vseq",
                                       "uart_rx_start_bit_filter_vseq",
                                       "uart_rx_parity_err_vseq",
                                       "uart_tx_ovrd_vseq",
                                       "uart_perf_vseq",
                                       "uart_loopback_vseq"};
```

```systemverilog
string abc_without_comments[] = {"a", "b", "c"};
```

```systemverilog
string seq_names_width_doubled_strings_and_a_variable_name_that_is_too_long[] = {
  "uart_sanity_vseq uart_sanity_vseq",
  "uart_tx_rx_vseq uart_tx_rx_vseq",
  "uart_fifo_full_vseq uart_fifo_full_vseq",
  "uart_fifo_overflow_vseq uart_fifo_overflow_vseq",
  "uart_fifo_reset_vseq uart_fifo_reset_vseq",
  "uart_common_vseq uart_common_vseq",  // for intr_test
  "uart_intr_vseq uart_intr_vseq",
  "uart_noise_filter_vseq uart_noise_filter_vseq",
  "uart_rx_start_bit_filter_vseq uart_rx_start_bit_filter_vseq",
  "uart_rx_parity_err_vseq uart_rx_parity_err_vseq",
  "uart_tx_ovrd_vseq uart_tx_ovrd_vseq",
  "uart_perf_vseq uart_perf_vseq",
  "uart_loopback_vseq uart_loopback_vseq"
};
```

```systemverilog
string aaaabbbbcccc[] = {"aaaaaaaaaaaaaaaaaaaaaaaa",
                         "bbbbbbbbbbbbbbbbbbbbbbbb",  //
                         "cccccccccccccccccccccccc"};
```

```systemverilog
string aaaabbbbcccc[] = {"aaaaaaaaaaaaaaaaaaaaaaaa",
                         "bbbbbbbbbbbbbbbbbbbbbbbb",
                         "cccccccccccccccccccccccc"};
```

```systemverilog
string seq_names_with_non_string_item[] = {
  "uart_sanity_vseq",
  UART_TX_RX_VSEQ,
  "uart_fifo_full_vseq",
  "uart_fifo_overflow_vseq",
  "uart_fifo_reset_vseq",
  "uart_common_vseq",  // for intr_test
  "uart_intr_vseq",
  "uart_noise_filter_vseq",
  "uart_rx_start_bit_filter_vseq",
  "uart_rx_parity_err_vseq",
  "uart_tx_ovrd_vseq",
  "uart_perf_vseq",
  "uart_loopback_vseq"
};
```

```systemverilog
string abc[] = {
  "a",
  B,  // non-string-literal
  "c"
};
```

```systemverilog
string abc[] = {"a", B, "c"};
```

```systemverilog
string nesting[] = {
  "uart_sanity_vseq",
  "uart_tx_rx_vseq",
  {
    "uart_fifo_full_vseq",
    "uart_fifo_overflow_vseq",
    "uart_fifo_reset_vseq",
    "uart_common_vseq",  // for intr_test
    "uart_intr_vseq",
    "uart_noise_filter_vseq",
    "uart_rx_start_bit_filter_vseq",
    "uart_rx_parity_err_vseq",
    "uart_tx_ovrd_vseq"
  },
  "uart_perf_vseq",
  "uart_loopback_vseq"
};
```

```systemverilog
string abcd[] = {
  "a",
  {
    "b",  //
    "c"
  },
  "d"
};
```

```systemverilog
string abcd[] = {"a", {"b", "c"}, "d"};
```

```systemverilog
string seq_names_with_long_non_first_item[] = {
  "uart_sanity_vseq",
  "uart_tx_rx_vseq",
  "uart_fifo_full_vseq",
  "uart_fifo_overflow_vseq",
  "uart_fifo_reset_vseq",
  "uart_common_vseq",
  "uart_intr_vseq",
  "uart_noise_filter_vseq",
  "uart_rx_start_bit_filter_vseq aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "uart_rx_parity_err_vseq",
  "uart_tx_ovrd_vseq",
  "uart_perf_vseq",
  "uart_loopback_vseq"
};
```

Closes #41
