### PR TITLE
Use a new absl::StrContains() functionality to clarify code.

### DIFF
--- a/verilog/CST/numbers.cc
+++ b/verilog/CST/numbers.cc
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <string>
 
+#include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "common/util/logging.h"
@@ -50,7 +51,7 @@ BasedNumber::BasedNumber(absl::string_view base_sign, absl::string_view digits)
   CHECK_EQ(base_sign.length(), 1);
   base = std::tolower(base_sign[0]);
   static const absl::string_view valid_bases("bdho");
-  if (valid_bases.find(base) == absl::string_view::npos) return;
+  if (!absl::StrContains(valid_bases, base)) return;
 
   // Filter out underscores.
   literal.reserve(digits.length());


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>