### PR TITLE
Add options for right-aligning dimensions in port declarations

### DIFF
--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -393,6 +393,11 @@ class ColumnSchemaAggregator {
                   [](const auto& a, const auto& b) {
                     return a.Value().path < b.Value().path;
                   });
+        // Propagate left_border_override property to the left subcolumn
+        auto& left_child_data = node.Children().front().Value();
+        left_child_data.properties.left_border_override =
+            std::max(left_child_data.properties.left_border_override,
+                     node.Value().properties.left_border_override);
       }
     }
   }
@@ -645,6 +650,11 @@ static AlignedFormattingColumnSchema ComputeColumnWidths(
         column_iter->Value().left_border = 0;
       } else {
         column_iter->Value().UpdateFromCell(node.Value());
+        if (column_prop_iter->Value().left_border_override !=
+            verible::AlignmentColumnProperties::kNoBorderOverride) {
+          column_iter->Value().left_border =
+              column_prop_iter->Value().left_border_override;
+        }
       }
       ++column_iter;
       ++column_prop_iter;

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -33,14 +33,25 @@ namespace verible {
 
 // Attributes of columns of text alignment (controlled by developer).
 struct AlignmentColumnProperties {
+  static constexpr int kNoBorderOverride = -1;
+
   // If true format cell with padding to the right: |text   |
   // else format cell with padding to the left:     |   text|
   bool flush_left = true;
+  // When set, ignores tokens' left_border and uses this value instead.
+  // This is propagated to a leftmost subcolumn if the subcolumn's
+  // left_border_override is lower.
+  int left_border_override = kNoBorderOverride;
+
   bool contains_delimiter = false;
 
   AlignmentColumnProperties() = default;
+
   explicit AlignmentColumnProperties(bool flush_left)
       : flush_left(flush_left) {}
+
+  explicit AlignmentColumnProperties(bool flush_left, int left_border_override)
+      : flush_left(flush_left), left_border_override(left_border_override) {}
 };
 
 // This object represents a bid for a new column as a row of tokens is scanned.

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -365,13 +365,13 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
 
         const verible::AlignmentColumnProperties no_border(false, 0);
         auto* column = ABSL_DIE_IF_NULL(ReserveNewColumn(
-            *current_dimensions_group_, node,
+            current_dimensions_group_, node,
             right_align ? no_border : FlushLeft, dimension_path));
 
-        ReserveNewColumn(*column, *node[0],
+        ReserveNewColumn(column, *node[0],
                          right_align ? no_border : FlushLeft);  // '['
-        ReserveNewColumn(*column, *node[1], FlushRight);        // value
-        ReserveNewColumn(*column, *node[4], FlushLeft);         // ']'
+        ReserveNewColumn(column, *node[1], FlushRight);         // value
+        ReserveNewColumn(column, *node[4], FlushLeft);          // ']'
         return;
       }
       case NodeEnum::kDimensionScalar:
@@ -392,16 +392,16 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
         const verible::AlignmentColumnProperties no_border(false, 0);
 
         auto* column = ABSL_DIE_IF_NULL(ReserveNewColumn(
-            *current_dimensions_group_, node,
+            current_dimensions_group_, node,
             right_align ? no_border : FlushLeft, dimension_path));
 
         const auto& column_path = column->Value().path;
         // Value can be empty - set paths explicitly
-        ReserveNewColumn(*column, *node[0], right_align ? no_border : FlushLeft,
+        ReserveNewColumn(column, *node[0], right_align ? no_border : FlushLeft,
                          GetSubpath(column_path, {0}));  // '['
-        ReserveNewColumn(*column, *node[1], FlushRight,
+        ReserveNewColumn(column, *node[1], FlushRight,
                          GetSubpath(column_path, {1}));  // value
-        ReserveNewColumn(*column, *node[2], FlushLeft,
+        ReserveNewColumn(column, *node[2], FlushLeft,
                          GetSubpath(column_path, {2}));  // ']'
         return;
       }

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -68,6 +68,11 @@ using verible::ValueSaver;
 static const AlignmentColumnProperties FlushLeft(true);
 static const AlignmentColumnProperties FlushRight(false);
 
+// Special SyntaxTreePath index used for non-tree tokens
+static const size_t kNonTreeTokenPathIndex = std::numeric_limits<size_t>::max();
+// Maximum SyntaxTreePath index available for tree tokens
+static const size_t kMaxPathIndex = std::numeric_limits<size_t>::max() - 1;
+
 template <class T>
 static bool TokensAreAllCommentsOrAttributes(const T& tokens) {
   return std::all_of(
@@ -1217,22 +1222,22 @@ using AlignmentHandlerMapType =
 static void non_tree_column_scanner(
     verible::TokenRange token_range,
     verible::ColumnPositionTree* column_entries) {
-  static const size_t kLargestPathIndex = std::numeric_limits<size_t>::max();
+  static const SyntaxTreePath kCommaPath = {kNonTreeTokenPathIndex, 0};
+  static const SyntaxTreePath kCommentPath = {kNonTreeTokenPathIndex, 1};
 
   for (auto token : token_range) {
     switch (token.token_enum()) {
       case ',': {
-        SyntaxTreePath path{kLargestPathIndex - 1};
         AlignmentColumnProperties prop;
         prop.contains_delimiter = true;
-        const verible::ColumnPositionTree column({path, token, prop});
+        const verible::ColumnPositionTree column({kCommaPath, token, prop});
         column_entries->NewChild(column);
         break;
       }
       case TK_COMMENT_BLOCK:
       case TK_EOL_COMMENT: {
-        SyntaxTreePath path{kLargestPathIndex};
-        const verible::ColumnPositionTree column({path, token, FlushLeft});
+        const verible::ColumnPositionTree column(
+            {kCommentPath, token, FlushLeft});
         column_entries->NewChild(column);
         break;
       }

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -215,7 +215,8 @@ static bool IgnoreMultilineCaseStatements(const TokenPartitionTree& partition) {
 
 class VerilogColumnSchemaScanner : public ColumnSchemaScanner {
  public:
-  VerilogColumnSchemaScanner(const FormatStyle& style) : style_(style) {}
+  explicit VerilogColumnSchemaScanner(const FormatStyle& style)
+      : style_(style) {}
 
  protected:
   const FormatStyle& style_;
@@ -246,7 +247,7 @@ UnstyledAlignmentCellScannerGenerator(
 class ActualNamedParameterColumnSchemaScanner
     : public VerilogColumnSchemaScanner {
  public:
-  ActualNamedParameterColumnSchemaScanner(const FormatStyle& style)
+  explicit ActualNamedParameterColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -277,7 +278,7 @@ class ActualNamedParameterColumnSchemaScanner
 // e.g. ".port_name(net_name)"
 class ActualNamedPortColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  ActualNamedPortColumnSchemaScanner(const FormatStyle& style)
+  explicit ActualNamedPortColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -308,7 +309,7 @@ class ActualNamedPortColumnSchemaScanner : public VerilogColumnSchemaScanner {
 // e.g. "input wire clk,"
 class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  PortDeclarationColumnSchemaScanner(const FormatStyle& style)
+  explicit PortDeclarationColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -486,7 +487,7 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
 // e.g. bit [31:0] member_name;
 class StructUnionMemberColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  StructUnionMemberColumnSchemaScanner(const FormatStyle& style)
+  explicit StructUnionMemberColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -676,7 +677,7 @@ static std::vector<TaggedTokenPartitionRange> GetAlignableStatementGroups(
 // TODO(fangism): refactor out common logic
 class DataDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  DataDeclarationColumnSchemaScanner(const FormatStyle& style)
+  explicit DataDeclarationColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -805,7 +806,7 @@ class DataDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
 // re-use the same column scanner as data/variable/net declarations.
 class ClassPropertyColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  ClassPropertyColumnSchemaScanner(const FormatStyle& style)
+  explicit ClassPropertyColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -872,7 +873,7 @@ class ClassPropertyColumnSchemaScanner : public VerilogColumnSchemaScanner {
 class ParameterDeclarationColumnSchemaScanner
     : public VerilogColumnSchemaScanner {
  public:
-  ParameterDeclarationColumnSchemaScanner(const FormatStyle& style)
+  explicit ParameterDeclarationColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -1006,7 +1007,7 @@ class ParameterDeclarationColumnSchemaScanner
 // items.
 class CaseItemColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  CaseItemColumnSchemaScanner(const FormatStyle& style)
+  explicit CaseItemColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   bool ParentContextIsCaseItem() const {
@@ -1073,7 +1074,7 @@ class CaseItemColumnSchemaScanner : public VerilogColumnSchemaScanner {
 // * foo <= bar;
 class AssignmentColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  AssignmentColumnSchemaScanner(const FormatStyle& style)
+  explicit AssignmentColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) override {
@@ -1131,7 +1132,7 @@ class AssignmentColumnSchemaScanner : public VerilogColumnSchemaScanner {
 class EnumWithAssignmentsColumnSchemaScanner
     : public VerilogColumnSchemaScanner {
  public:
-  EnumWithAssignmentsColumnSchemaScanner(const FormatStyle& style)
+  explicit EnumWithAssignmentsColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) final {
@@ -1175,7 +1176,7 @@ class EnumWithAssignmentsColumnSchemaScanner
 // Distribution items should align on the :/ and := operators.
 class DistItemColumnSchemaScanner : public VerilogColumnSchemaScanner {
  public:
-  DistItemColumnSchemaScanner(const FormatStyle& style)
+  explicit DistItemColumnSchemaScanner(const FormatStyle& style)
       : VerilogColumnSchemaScanner(style) {}
 
   void Visit(const SyntaxTreeNode& node) final {

--- a/verilog/formatting/format_style.h
+++ b/verilog/formatting/format_style.h
@@ -90,6 +90,9 @@ struct FormatStyle : public verible::BasicFormatStyle {
   // Internal tests assume these are forced to kAlign.
   AlignmentPolicy distribution_items_alignment = AlignmentPolicy::kAlign;
 
+  bool port_declarations_right_align_packed_dimensions = false;
+  bool port_declarations_right_align_unpacked_dimensions = false;
+
   // At this time line wrap optimization is problematic and risks ruining
   // otherwise reasonable code.  When set to false, this switch will make the
   // formatter give-up and leave code as-is in cases where it would otherwise

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -10696,6 +10696,158 @@ TEST(FormatterEndToEndTest, OnelineFormatExpandTest) {
   }
 }
 
+struct DimensionsAlignmentTestCase {
+  absl::string_view input;
+  absl::string_view expected[4];
+};
+
+static constexpr DimensionsAlignmentTestCase
+    kPortDeclarationDimensionsAlignmentTestCases[] = {
+        {"import \"DPI-C\" context function void func(\n"
+         "input bit foo,\n"
+         "input bit [2] foobar,\n"
+         "input bit [24:16] bar,\n"
+         "input bit [2:0][31:0] baz,\n"
+         "input bit [4][24:0][16:0] foobarbaz[],\n"
+         "input bit [FOOBAZ][31:24] qux[16],\n"
+         "input bit [16] quux[8:2][16][32],\n"
+         "output bit [2:0][2:0][2:0] quuz[8][16:12]\n"
+         ");\n",
+         {
+             "import \"DPI-C\" context function void func(\n"
+             "  input  bit                       foo,\n"
+             "  input  bit [     2]              foobar,\n"
+             "  input  bit [ 24:16]              bar,\n"
+             "  input  bit [   2:0][ 31:0]       baz,\n"
+             "  input  bit [     4][ 24:0][16:0] foobarbaz[   ],\n"
+             "  input  bit [FOOBAZ][31:24]       qux      [ 16],\n"
+             "  input  bit [    16]              quux     [8:2][   16][32],\n"
+             "  output bit [   2:0][  2:0][ 2:0] quuz     [  8][16:12]\n"
+             ");\n",
+             "import \"DPI-C\" context function void func(\n"
+             "  input  bit                       foo,\n"
+             "  input  bit [     2]              foobar,\n"
+             "  input  bit [ 24:16]              bar,\n"
+             "  input  bit [   2:0][ 31:0]       baz,\n"
+             "  input  bit [     4][ 24:0][16:0] foobarbaz         [     ],\n"
+             "  input  bit [FOOBAZ][31:24]       qux               [   16],\n"
+             "  input  bit [    16]              quux     [8:2][16][   32],\n"
+             "  output bit [   2:0][  2:0][ 2:0] quuz          [ 8][16:12]\n"
+             ");\n",
+             "import \"DPI-C\" context function void func(\n"
+             "  input  bit                      foo,\n"
+             "  input  bit              [    2] foobar,\n"
+             "  input  bit              [24:16] bar,\n"
+             "  input  bit      [   2:0][ 31:0] baz,\n"
+             "  input  bit [  4][  24:0][ 16:0] foobarbaz[   ],\n"
+             "  input  bit      [FOOBAZ][31:24] qux      [ 16],\n"
+             "  input  bit              [   16] quux     [8:2][   16][32],\n"
+             "  output bit [2:0][   2:0][  2:0] quuz     [  8][16:12]\n"
+             ");\n",
+             "import \"DPI-C\" context function void func(\n"
+             "  input  bit                      foo,\n"
+             "  input  bit              [    2] foobar,\n"
+             "  input  bit              [24:16] bar,\n"
+             "  input  bit      [   2:0][ 31:0] baz,\n"
+             "  input  bit [  4][  24:0][ 16:0] foobarbaz         [     ],\n"
+             "  input  bit      [FOOBAZ][31:24] qux               [   16],\n"
+             "  input  bit              [   16] quux     [8:2][16][   32],\n"
+             "  output bit [2:0][   2:0][  2:0] quuz          [ 8][16:12]\n"
+             ");\n",
+         }},
+        {"module m(\n"
+         "output bit [2:0][2:0][2:0] quuz[8][16:12],\n"
+         "input bit [16] quux[8:2][16][32],\n"
+         "input bit [FOOBAZ][31:24] qux[16],\n"
+         "input bit [4][24:0][16:0] foobaz[],\n"
+         "input bit [2:0][31:0] baz,\n"
+         "input bit [24:16] bar,\n"
+         "input bit [2] foobar,\n"
+         "input bit foo\n"
+         "); endmodule:m\n",
+         {
+             "module m (\n"
+             "    output bit [   2:0][  2:0][ 2:0] quuz  [  8][16:12],\n"
+             "    input  bit [    16]              quux  [8:2][   16][32],\n"
+             "    input  bit [FOOBAZ][31:24]       qux   [ 16],\n"
+             "    input  bit [     4][ 24:0][16:0] foobaz[   ],\n"
+             "    input  bit [   2:0][ 31:0]       baz,\n"
+             "    input  bit [ 24:16]              bar,\n"
+             "    input  bit [     2]              foobar,\n"
+             "    input  bit                       foo\n"
+             ");\n"
+             "endmodule : m\n",
+             "module m (\n"
+             "    output bit [   2:0][  2:0][ 2:0] quuz       [ 8][16:12],\n"
+             "    input  bit [    16]              quux  [8:2][16][   32],\n"
+             "    input  bit [FOOBAZ][31:24]       qux            [   16],\n"
+             "    input  bit [     4][ 24:0][16:0] foobaz         [     ],\n"
+             "    input  bit [   2:0][ 31:0]       baz,\n"
+             "    input  bit [ 24:16]              bar,\n"
+             "    input  bit [     2]              foobar,\n"
+             "    input  bit                       foo\n"
+             ");\n"
+             "endmodule : m\n",
+             "module m (\n"
+             "    output bit [2:0][   2:0][  2:0] quuz  [  8][16:12],\n"
+             "    input  bit              [   16] quux  [8:2][   16][32],\n"
+             "    input  bit      [FOOBAZ][31:24] qux   [ 16],\n"
+             "    input  bit [  4][  24:0][ 16:0] foobaz[   ],\n"
+             "    input  bit      [   2:0][ 31:0] baz,\n"
+             "    input  bit              [24:16] bar,\n"
+             "    input  bit              [    2] foobar,\n"
+             "    input  bit                      foo\n"
+             ");\n"
+             "endmodule : m\n",
+             "module m (\n"
+             "    output bit [2:0][   2:0][  2:0] quuz       [ 8][16:12],\n"
+             "    input  bit              [   16] quux  [8:2][16][   32],\n"
+             "    input  bit      [FOOBAZ][31:24] qux            [   16],\n"
+             "    input  bit [  4][  24:0][ 16:0] foobaz         [     ],\n"
+             "    input  bit      [   2:0][ 31:0] baz,\n"
+             "    input  bit              [24:16] bar,\n"
+             "    input  bit              [    2] foobar,\n"
+             "    input  bit                      foo\n"
+             ");\n"
+             "endmodule : m\n",
+         }},
+};
+
+TEST(FormatterEndToEndTest, PortDeclarationDimensionsAlignmentTest) {
+  FormatStyle style;
+  style.column_limit = 64;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+
+  // All combinations of port_declaration_right_align_{un,}packed_dimensions
+  static const bool right_align_combinations[][2] = {
+      {false, false}, {false, true}, {true, false}, {true, true}};
+
+  for (const auto& test_case : kPortDeclarationDimensionsAlignmentTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    size_t expected_index = 0;
+    for (const auto& right_align : right_align_combinations) {
+      VLOG(1) << "style variant:\n"
+              << "port_declarations_right_align_packed_dimensions: "
+              << right_align[0] << "\n"
+              << "port_declarations_right_align_unpacked_dimensions: "
+              << right_align[1] << "\n";
+      style.port_declarations_right_align_packed_dimensions = right_align[0];
+      style.port_declarations_right_align_unpacked_dimensions = right_align[1];
+
+      std::ostringstream stream;
+
+      const auto status =
+          FormatVerilog(test_case.input, "<filename>", style, stream);
+      // Require these test cases to be valid.
+      EXPECT_OK(status) << status.message();
+      EXPECT_EQ(stream.str(), test_case.expected[expected_index++])
+          << "code:\n"
+          << test_case.input;
+    }
+  }
+}
+
 // TODO(fangism): directed tests using style variations
 
 }  // namespace

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -169,6 +169,14 @@ ABSL_FLAG(AlignmentPolicy, assignment_statement_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format various assignments: {align,flush-left,preserve,infer}");
 
+ABSL_FLAG(bool, port_declarations_right_align_packed_dimensions, false,
+          "If true, packed dimensions in contexts with enabled alignment are "
+          "aligned to the right.");
+
+ABSL_FLAG(bool, port_declarations_right_align_unpacked_dimensions, false,
+          "If true, unpacked dimensions in contexts with enabled alignment are "
+          "aligned to the right.");
+
 ABSL_FLAG(bool, expand_coverpoints, false,
           "If true, always expand coverpoints.");
 
@@ -261,6 +269,11 @@ static bool formatOneFile(absl::string_view filename,
         absl::GetFlag(FLAGS_case_items_alignment);
     format_style.assignment_statement_alignment =
         absl::GetFlag(FLAGS_assignment_statement_alignment);
+
+    format_style.port_declarations_right_align_packed_dimensions =
+        absl::GetFlag(FLAGS_port_declarations_right_align_packed_dimensions);
+    format_style.port_declarations_right_align_unpacked_dimensions =
+        absl::GetFlag(FLAGS_port_declarations_right_align_unpacked_dimensions);
   }
 
   std::ostringstream stream;


### PR DESCRIPTION
This PR depends on https://github.com/chipsalliance/verible/pull/865
The PR's unique commits are:
* `9a39375` Pass FormatStyle to Verilog's ColumnsSchemaScanners
* `47fe30a` Cleanup non_tree_column_scanner
* `bef221e` Add left_border_override column property
* `8b6db2c` Add options for right-aligning dimensions in port declarations
* `962c448` Right-aligning dimensions in port declarations: add tests

---

Two new flags are added:
* `--port_declarations_right_align_packed_dimensions`, which aligns packed dimensions in port declarations to the right:

  ```systemverilog
  import "DPI-C" context function void func(
    input  bit                      foo,
    input  bit              [    2] foobar,
    input  bit              [24:16] bar,
    input  bit      [   2:0][ 31:0] baz,
    input  bit [  4][  24:0][ 16:0] foobarbaz[   ],
    input  bit      [FOOBAZ][31:24] qux      [ 16],
    input  bit              [   16] quux     [8:2][   16][32],
    output bit [2:0][   2:0][  2:0] quuz     [  8][16:12]
  );
  ```

* `--port_declarations_right_align_unpacked_dimensions`, which aligns unpacked dimensions in port declarations to the right

  ```systemverilog
  import "DPI-C" context function void func(
    input  bit                       foo,
    input  bit [     2]              foobar,
    input  bit [ 24:16]              bar,
    input  bit [   2:0][ 31:0]       baz,
    input  bit [     4][ 24:0][16:0] foobarbaz         [     ],
    input  bit [FOOBAZ][31:24]       qux               [   16],
    input  bit [    16]              quux     [8:2][16][   32],
    output bit [   2:0][  2:0][ 2:0] quuz          [ 8][16:12]
  );
  ```

Fixes https://github.com/chipsalliance/verible/issues/838