### PR TITLE
Provide build-environment set-up for nix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ guide and the [development resources](./doc/development.md).
 Verible's code base is written in C++.
 
 To build, you need the [bazel] build system and a C++17 compatible compiler
-(e.g. >= g++-9).
+(e.g. >= g++-9), as well as python3.
+
+Use your package manager to install the dependencies; on a system with
+the nix package manager simply run `nix-shell` to get a build environment.
 
 ```bash
 # Build all tools and libraries

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+# This is a nix-shell for use with the nix package manager.
+# If you have nix installed, you may simply run `nix-shell`
+# in this repo, and have all dependencies ready in the new shell.
+
+{pkgs ? import (builtins.fetchTarball {
+  # Descriptive name to make the store path easier to identify
+  name = "nixos-2021-05";
+  # Commit hash
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.05.tar.gz";
+  # Hash obtained using `nix-prefetch-url --unpack <url>`
+  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+}) {}}:
+
+
+pkgs.mkShell {
+  buildInputs = with pkgs;
+    [
+      git
+      bazel
+      gcc
+      glibc
+      python3
+    ];
+
+}


### PR DESCRIPTION
Make it simple and hermetic to set-up the build environment
on systems with the nix package manager.
Inspired by https://github.com/chipsalliance/Surelog/pull/1606

Signed-off-by: Henner Zeller <h.zeller@acm.org>