### PR TITLE
Provide a simple smoke-test.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -69,6 +69,10 @@ case "$MODE" in
     bazel build $BAZEL_OPTS //...
     ;;
 
+  smoke-test)
+    $(dirname $0)/smoke-test.sh
+    ;;
+
   *)
     echo "$0: Unknown value in MODE environment variable: $MODE"
     exit 1

--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Simple smoke test by running the formatter over some code-base
+# making sure it dos not crash
+
+bazel build verilog/tools/formatter:verible-verilog-format
+
+IBEX_DIR=/tmp/test/ibex
+git clone https://github.com/lowrisc/ibex ${IBEX_DIR}
+
+bazel-bin/verilog/tools/formatter/verible-verilog-format --inplace $(find ${IBEX_DIR} -name "*.sv")
+
+# A regular error exit code we accept as normal operation of the tool if it
+# encountered a syntax error. Here, we are only interested in not receiving
+# a signal such as an abort or segmentation fault.
+# So we check for 126, 127 (command not found or executable) and >= 128 (signal)
+# https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+EXIT_CODE=$?
+if [ $EXIT_CODE -ge 126 ]; then
+  echo "Got exit code $EXIT_CODE"
+  exit 1
+fi

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -49,6 +49,7 @@ jobs:
       matrix:
         mode:
         - test
+        - smoke-test
         - asan
         - compile
         - coverage


### PR DESCRIPTION
To make sure verible doesn't crash on a real-world input,
have a little smoke test: run verible on ibex and make sure
we don't exit with a crash.

Signed-off-by: Henner Zeller <hzeller@google.com>