### PR TITLE
GetAssignedExpressionFromDataDeclaration: check symbol tag

### DIFF
--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1465,8 +1465,13 @@ static const SyntaxTreeNode* GetAssignedExpressionFromDataDeclaration(
   }
   if (!trailing_assign) return nullptr;
 
-  return &verible::GetSubtreeAsNode(*trailing_assign, NodeEnum::kTrailingAssign,
-                                    1, NodeEnum::kExpression);
+  const verible::Symbol* expression = verible::GetSubtreeAsSymbol(
+      *trailing_assign, NodeEnum::kTrailingAssign, 1);
+  if (!expression ||
+      expression->Tag() != verible::NodeTag(NodeEnum::kExpression))
+    return nullptr;
+
+  return &verible::SymbolCastToNode(*expression);
 }
 
 // This phase is strictly concerned with reshaping token partitions,


### PR DESCRIPTION
Fixes bug described in the comment: https://github.com/chipsalliance/verible/pull/834

Problematic use case:
```systemverilog
class class_name;
  var_type var_name = new("the_string");
endclass
```

I'll add a test case tomorrow.