### PR TITLE
Make CI names fit into length limited titles.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -1,4 +1,4 @@
-name: verible-ci
+name: ci
 
 on:
   push:
@@ -57,7 +57,7 @@ jobs:
         - clean
     env:
       MODE: ${{ matrix.mode }}
-    name: Check · ${{ matrix.mode }}
+    name: ${{ matrix.mode }}
 
     steps:
 


### PR DESCRIPTION
E.g. on the toplevel project page, clicking on the check-marker
pops up a smallish window with the results of the various tests.
But since the prefix is so long, they are all abbreviated to
'verible-ci / Che…', which is not very helpful.

Signed-off-by: Henner Zeller <hzeller@google.com>