### PR TITLE
Provide more detailed choices for linter autofix.

### DIFF
--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -156,7 +156,7 @@ void ViolationFixer::HandleViolation(
   std::stringstream violation_message;
   formatter.FormatViolation(&violation_message, violation, base, path, url,
                             rule_name);
-  (*stream_) << violation_message.str() << std::endl;
+  (*message_stream_) << violation_message.str() << std::endl;
 
   if (violation.autofixes.empty()) {
     return;
@@ -186,7 +186,7 @@ void ViolationFixer::HandleViolation(
           VLOG(2) << "The fix conflicts with previously applied fixes, "
                      "rejecting.";
         } else {
-          (*stream_) << "(fixed)" << std::endl;
+          (*message_stream_) << "(fixed)" << std::endl;
         }
         break;
 
@@ -201,10 +201,10 @@ void ViolationFixer::HandleViolation(
 
       case AnswerChoice::kPrintFix:
         // Print first available fix
-        PrintFix(*stream_, base, violation.autofixes[0]);
+        PrintFix(*message_stream_, base, violation.autofixes[0]);
         continue;
       case AnswerChoice::kPrintAppliedFixes:
-        PrintFix(*stream_, base, *fix);
+        PrintFix(*message_stream_, base, *fix);
         continue;
 
       default:

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -185,9 +185,10 @@ class ViolationFixer : public ViolationHandler {
   using AnswerChooser = std::function<AnswerChoice(
       const verible::LintViolation&, absl::string_view)>;
 
-  ViolationFixer(std::ostream* stream, std::ostream* patch_stream = nullptr,
+  ViolationFixer(std::ostream* message_stream,
+                 std::ostream* patch_stream = nullptr,
                  AnswerChooser answer_chooser = InteractiveAnswerChooser)
-      : stream_(stream),
+      : message_stream_(message_stream),
         patch_stream_(patch_stream),
         ultimate_answer_(AnswerChoice::kUnknown),
         rule_answers_(),
@@ -210,7 +211,7 @@ class ViolationFixer : public ViolationHandler {
                    absl::string_view source_path,
                    const verible::AutoFix& fix) const;
 
-  std::ostream* const stream_;
+  std::ostream* const message_stream_;
   std::ostream* const patch_stream_;
   AnswerChoice ultimate_answer_;
   std::map<absl::string_view, AnswerChoice> rule_answers_;

--- a/verilog/tools/lint/README.md
+++ b/verilog/tools/lint/README.md
@@ -65,10 +65,10 @@ usage: verible-verilog-lint [options] <file> [<file>...]
     --verilog_trace_parser (Trace verilog parser); default: false;
 
   Flags from verilog/tools/lint/verilog_lint.cc:
-    --autofix ([yes|no|interactive], autofix mode.); default: no;
-    --autofix_output_file (File to write a patch with autofixes to. If not set
-      autofixes are applied directly to the analyzed file. Relevant only when
-      --autofix option is enabled.); default: "";
+    --autofix (autofix mode; one of
+      [no|patch-interactive|patch|inplace-interactive|inplace]); default: no;
+    --autofix_output_file (File to write a patch with autofixes to if
+      --autofix=patch or --autofix=patch-interactive); default: "";
     --check_syntax (If true, check for lexical and syntax errors, otherwise
       ignore.); default: true;
     --generate_markdown (If true, print the description of every rule formatted
@@ -210,12 +210,21 @@ parse-as-module-body`.
 ## Automatically fixing trivial violations
 
 Some trivial violations (e.g. trailing spaces or repeated semicolons) can be
-fixed automatically.
+fixed automatically. The `--autofix` flag controls the mode in which fixes
+are presented or applied.
 
-When `--autofix=yes` option is specified, the linter applies all possible fixes.
-To get more control on what to do with each fixable violation,
-`--autofix=interactive` option can be used. Interactive mode offers following
-actions for each fix:
+|--autofix value       | Description
+:----------------------|:---------------------------------------------------
+| no                   | No fix is is shown or applied.
+| patch-interactive    | Interactive choice of fixes that are written as unified diff to `--autofix_output_file`.  |
+| inplace-interactive  | Interacive choice of fixes that are applied to the original file in place. **(modifies input)**
+| patch                | _All_ available fixes are written as unified diff.
+| inplace              | _All_ available fixes are applied to the original file in place. **(modifies input)**
+
+If `--autofix_output_file` is not given, patch output is written to stdout.
+
+The interactive modes `--autofix=patch-interactive` and
+`--autofix=inplace-interactive` offer the following actions for each fix:
 
 * `y` - apply fix
 * `n` - reject fix
@@ -227,12 +236,7 @@ actions for each fix:
 * `P` - show fixes applied so far
 * `?` - print this help and prompt again
 
-By default, accepted fixes are applied directly to linted source files. To
-generate a patch file instead, specify its name using `--autofix_output_file=`
-option.
-
-Example interactive session:
-
+Example interactive session (`--autofix=inplace-interactive`):
 ```
 autofixtest.sv:3:1: Remove trailing spaces. [Style: trailing-spaces] [no-trailing-spaces]
 Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] a

--- a/verilog/tools/lint/verilog_style_lint.bzl
+++ b/verilog/tools/lint/verilog_style_lint.bzl
@@ -152,7 +152,7 @@ def _verilog_style_lint_report(name, srcs, flags = None):
             srcs = srcs,
         )
 
-        lint_cmd = "$(location {tool}) {flags} $(SRCS) > $@".format(
+        lint_cmd = "$(location {tool}) {flags} $(SRCS) > $@ 2>&1".format(
             tool = _linter_tool,
             flags = " ".join(use_flags),
         )


### PR DESCRIPTION
The autofix choices were easy to set in a way that
it would accidentally overwrite the input file (setting
--autofix=yes and forgetting output file). This patch
makes the choice explicit and in particular requires
to choose 'inplace' option to modify output.

  * no
  * patch-interactive
  * patch
  * inplace-interactive
  * inplace

The `yes` option does not exist anymore, as it is replaced
by the more detailed choices. Hopefully that will not break
too many users at this point. The github action though
is probably affected.

While at it, make the default output stdout for the patch
choices (and move error messages to stderr). That way, the
tool is behaving like other command line tools.

Signed-off-by: Henner Zeller <hzeller@google.com>