### PR TITLE
Augment unit-tests of AutoFix rules to test for fixes.

### DIFF
--- a/verilog/analysis/checkers/endif_comment_rule.cc
+++ b/verilog/analysis/checkers/endif_comment_rule.cc
@@ -120,14 +120,35 @@ void EndifCommentRule::HandleToken(const TokenInfo& token) {
           auto endif_end =
               last_endif_.text().substr(last_endif_.text().size(), 0);
 
+          // The whitespace before the comment is something that should come
+          // from the formatter configuration so that we don't emit code that
+          // then would be complained about by the formatter.
+          // Or, make this a configuration option in the lint rule (probably
+          // best, as we don't intermingle formatter/linter).
+          // TODO(hzeller) Until that is happening just comment here.
+          constexpr int kSpacesBeforeComment = 2;
+          std::string ws(kSpacesBeforeComment, ' ');
+
+          // TOOD(hzeller): rethink the 'alternative fixes' thing. Problem is,
+          // that it makes it impossible to run this unattended as that choice
+          // would've to be made at apply time (and the chooser doesn't provide
+          // that yet, and it would probably complicate the UI a lot when it
+          // will be added).
+          //
+          // Maybe better: only have _one_ alternative and pre-configure the
+          // rule to do that.
+          // So with the above our rule needs two configurations.
+          //   autofix_whitespace
+          //   autofix_block_comment
+
           // includes TK_NEWLINE and TK_EOF.
           violations_.insert(LintViolation(
               last_endif_, absl::StrCat(kMessage, " (", expect, ")"),
               {
                   AutoFix("Insert // comment",
-                          {endif_end, absl::StrCat(" // ", expect)}),
+                          {endif_end, absl::StrCat(ws, "// ", expect)}),
                   AutoFix("Insert /* comment */",
-                          {endif_end, absl::StrCat(" /* ", expect, " */")}),
+                          {endif_end, absl::StrCat(ws, "/* ", expect, " */")}),
               }));
           conditional_scopes_.pop();
           state_ = State::kNormal;

--- a/verilog/analysis/checkers/endif_comment_rule_test.cc
+++ b/verilog/analysis/checkers/endif_comment_rule_test.cc
@@ -28,6 +28,7 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
 // Tests that space-only text passes.
@@ -104,6 +105,19 @@ TEST(EndifCommentRuleTest, RejectsEndifWithoutComment) {
        " // BAR\n"},
   };
   RunLintTestCases<VerilogAnalyzer, EndifCommentRule>(kTestCases);
+}
+
+TEST(EndifCommentRuleTest, ApplyAutoFix) {
+  // Alternatives the auto fix offers
+  constexpr int kEOLComment = 0;
+  constexpr int kBlkComment = 1;
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"`ifdef FOO\n`endif\n", "`ifdef FOO\n`endif  // FOO\n", kEOLComment},
+      {"`ifdef FOO  /*xyz*/\n`endif\n", "`ifdef FOO  /*xyz*/\n`endif  // FOO\n",
+       kEOLComment},
+      {"`ifdef FOO\n`endif\n", "`ifdef FOO\n`endif  /* FOO */\n", kBlkComment},
+  };
+  RunApplyFixCases<VerilogAnalyzer, EndifCommentRule>(kTestCases, "");
 }
 
 }  // namespace

--- a/verilog/analysis/checkers/forbid_consecutive_null_statements_rule_test.cc
+++ b/verilog/analysis/checkers/forbid_consecutive_null_statements_rule_test.cc
@@ -29,9 +29,10 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
-TEST(ForbidConsecutiveNullStatementsRule, FunctionFailures) {
+TEST(ForbidConsecutiveNullStatementsRuleTest, FunctionFailures) {
   auto kToken = ';';
   const std::initializer_list<LintTestCase> kTestCases = {
       {""},
@@ -224,6 +225,24 @@ TEST(ForbidConsecutiveNullStatementsRule, FunctionFailures) {
 
   RunLintTestCases<VerilogAnalyzer, ForbidConsecutiveNullStatementsRule>(
       kTestCases);
+}
+
+TEST(ForbidConsecutiveNullStatementsRuleTest, ApplyAutoFix) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+    {"module m;\ninitial begin ;; end\nendmodule",
+     "module m;\ninitial begin ; end\nendmodule"},
+    {"module m;\ninitial begin ;  ; end\nendmodule",
+     "module m;\ninitial begin ;   end\nendmodule"},
+    {"module m;\ninitial begin ;  /*  */; end\nendmodule",
+     "module m;\ninitial begin ;  /*  */ end\nendmodule"},
+#if 0
+      // TODO: apply multi-violation fixes in linter_test_utils.
+      { "module m;\ninitial begin; ; ; ; end\nendmodule",
+        "module m;\ninitial begin ; end\nendmodule" }
+#endif
+  };
+  RunApplyFixCases<VerilogAnalyzer, ForbidConsecutiveNullStatementsRule>(
+      kTestCases, "");
 }
 
 }  // namespace

--- a/verilog/analysis/checkers/no_trailing_spaces_rule_test.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule_test.cc
@@ -28,6 +28,7 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
 // Tests that compliant text passes trailing-spaces check.
@@ -64,6 +65,14 @@ TEST(NoTrailingSpacesRuleTest, RejectsTrailingSpaces) {
       {"`define\tIGNORANCE\t\"strength\"", {kToken, " "}, "\n"},
   };
   RunLintTestCases<VerilogAnalyzer, NoTrailingSpacesRule>(kTestCases);
+}
+
+TEST(NoTrailingSpacesRuleTest, ApplyAutoFix) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module m;   \nendmodule\n", "module m;\nendmodule\n"},
+      {"module m;\t \t\nendmodule\n", "module m;\nendmodule\n"},
+  };
+  RunApplyFixCases<VerilogAnalyzer, NoTrailingSpacesRule>(kTestCases, "");
 }
 
 }  // namespace

--- a/verilog/analysis/checkers/posix_eof_rule_test.cc
+++ b/verilog/analysis/checkers/posix_eof_rule_test.cc
@@ -28,6 +28,7 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
 // Tests that compliant files are accepted.
@@ -48,6 +49,13 @@ TEST(PosixEOFRuleTest, RejectsText) {
       {"foo\nbar", {TK_OTHER, ""}},
   };
   RunLintTestCases<VerilogAnalyzer, PosixEOFRule>(kTestCases);
+}
+
+TEST(PosixEOFRuleTest, ApplyAutoFix) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module m;\nendmodule", "module m;\nendmodule\n"},
+  };
+  RunApplyFixCases<VerilogAnalyzer, PosixEOFRule>(kTestCases, "");
 }
 
 }  // namespace

--- a/verilog/analysis/checkers/suggest_parentheses_rule_test.cc
+++ b/verilog/analysis/checkers/suggest_parentheses_rule_test.cc
@@ -22,9 +22,10 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
-TEST(SuggestParenthesesTest, Various) {
+TEST(SuggestParenthesesRuleTest, Various) {
   constexpr int kTag = 293;  // don't care
 
   const std::initializer_list<LintTestCase> kSuggestParenthesesTestCases = {
@@ -95,6 +96,18 @@ TEST(SuggestParenthesesTest, Various) {
 
   RunLintTestCases<VerilogAnalyzer, SuggestParenthesesRule>(
       kSuggestParenthesesTestCases);
+}
+
+TEST(SuggestParenthesesRuleTest, ApplyAutoFix) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module m;\n"
+       "assign a = condition_a? condition_b ? b : c : d;"
+       "endmodule",
+       "module m;\n"
+       "assign a = condition_a? (condition_b ? b : c) : d;"
+       "endmodule"},
+  };
+  RunApplyFixCases<VerilogAnalyzer, SuggestParenthesesRule>(kTestCases, "");
 }
 
 }  // namespace

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
@@ -28,9 +28,10 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
-TEST(UvmMacroSemicolonRule, BaseTests) {
+TEST(UvmMacroSemicolonRuleTest, BaseTests) {
   const std::initializer_list<LintTestCase> kTestCases = {
       {""},
       {"function void f();\nendfunction\n"},
@@ -42,7 +43,7 @@ TEST(UvmMacroSemicolonRule, BaseTests) {
   RunLintTestCases<VerilogAnalyzer, UvmMacroSemicolonRule>(kTestCases);
 }
 
-TEST(UvmMacroSemicolonRule, AcceptedUvmMacroCallTests) {
+TEST(UvmMacroSemicolonRuleTest, AcceptedUvmMacroCallTests) {
   const std::initializer_list<LintTestCase> kTestCases = {
       // Function/Task scope
       {"function void f();"
@@ -314,6 +315,13 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        "end\n"
        "endtask\n"}};
   RunLintTestCases<VerilogAnalyzer, UvmMacroSemicolonRule>(kTestCases);
+}
+
+TEST(UvmMacroSemicolonRuleTest, ApplyAutoFix) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"`uvm_foo(abc);\n", "`uvm_foo(abc)\n"},
+  };
+  RunApplyFixCases<VerilogAnalyzer, UvmMacroSemicolonRule>(kTestCases, "");
 }
 
 }  // namespace


### PR DESCRIPTION
Add the boilderplate and test for typical fixes.

Signed-off-by: Henner Zeller <hzeller@google.com>