### PR TITLE
Add a lint rule that detects truncated number literals.

### DIFF
--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -63,6 +63,7 @@ cc_library(
         ":struct_union_name_style_rule",
         ":suggest_parentheses_rule",
         ":token_stream_lint_rule",
+        ":truncated_numeric_literal_rule",
         ":undersized_binary_literal_rule",
         ":unpacked_dimensions_rule",
         ":uvm_macro_semicolon_rule",
@@ -984,6 +985,46 @@ cc_test(
     srcs = ["undersized_binary_literal_rule_test.cc"],
     deps = [
         ":undersized_binary_literal_rule",
+        "//common/analysis:linter_test_utils",
+        "//common/analysis:syntax_tree_linter_test_utils",
+        "//common/text:symbol",
+        "//verilog/CST:verilog_nonterminals",
+        "//verilog/analysis:verilog_analyzer",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "truncated_numeric_literal_rule",
+    srcs = ["truncated_numeric_literal_rule.cc"],
+    hdrs = ["truncated_numeric_literal_rule.h"],
+    deps = [
+        "//common/analysis:citation",
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:syntax_tree_lint_rule",
+        "//common/analysis/matcher",
+        "//common/analysis/matcher:bound_symbol_manager",
+        "//common/text:concrete_syntax_leaf",
+        "//common/text:config_utils",
+        "//common/text:symbol",
+        "//common/text:syntax_tree_context",
+        "//common/text:token_info",
+        "//common/util:logging",
+        "//verilog/CST:numbers",
+        "//verilog/CST:verilog_matchers",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
+)
+
+cc_test(
+    name = "truncated_numeric_literal_rule_test",
+    srcs = ["truncated_numeric_literal_rule_test.cc"],
+    deps = [
+        ":truncated_numeric_literal_rule",
         "//common/analysis:linter_test_utils",
         "//common/analysis:syntax_tree_linter_test_utils",
         "//common/text:symbol",

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
@@ -1,0 +1,197 @@
+// Copyright 2017-2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/truncated_numeric_literal_rule.h"
+
+#include <cmath>
+#include <cstddef>
+#include <set>
+#include <string>
+
+#include "absl/numeric/int128.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "common/analysis/citation.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/matcher/bound_symbol_manager.h"
+#include "common/analysis/matcher/matcher.h"
+#include "common/text/concrete_syntax_leaf.h"
+#include "common/text/config_utils.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "common/text/token_info.h"
+#include "common/util/logging.h"
+#include "verilog/CST/numbers.h"
+#include "verilog/CST/verilog_matchers.h"
+#include "verilog/analysis/descriptions.h"
+#include "verilog/analysis/lint_rule_registry.h"
+
+namespace verilog {
+namespace analysis {
+
+using verible::down_cast;
+using verible::GetStyleGuideCitation;
+using verible::LintRuleStatus;
+using verible::LintViolation;
+using verible::SyntaxTreeContext;
+using verible::SyntaxTreeLeaf;
+using verible::SyntaxTreeNode;
+using verible::matcher::Matcher;
+
+VERILOG_REGISTER_LINT_RULE(TruncatedNumericLiteralRule);
+
+absl::string_view TruncatedNumericLiteralRule::Name() {
+  return "truncated-numeric-literal";
+}
+const char TruncatedNumericLiteralRule::kTopic[] = "number-literals";
+
+std::string TruncatedNumericLiteralRule::GetDescription(
+    DescriptionType description_type) {
+  static const std::string basic_desc = absl::StrCat(
+      "Checks that numeric literals are not longer than their stated "
+      "bit-width to avoid undesired accidental truncation. See ",
+      GetStyleGuideCitation(kTopic), ".\n");
+  return basic_desc;
+}
+
+static const Matcher& NumberMatcher() {
+  static const Matcher matcher(
+      NodekNumber(NumberHasConstantWidth().Bind("width"),
+                  NumberHasBasedLiteral().Bind("literal")));
+  return matcher;
+}
+
+// Given a binary/oct/hex digit, return how many bits it occupies
+static int digitBits(char digit, bool* is_lower_bound) {
+  if (digit == 'z' || digit == 'x' || digit == '?') {
+    *is_lower_bound = true;
+    return 1;  // Minimum number of bits assumed
+  }
+  *is_lower_bound = false;
+  if (digit > '7')
+    return 4;
+  else if (digit > '3')
+    return 3;
+  else if (digit > '1')
+    return 2;
+  return 1;
+}
+
+static absl::string_view StripLeadingZeroes(absl::string_view str) {
+  auto it =
+      std::find_if_not(str.begin(), str.end(), [](char c) { return c == '0'; });
+  return str.substr(it - str.begin());
+}
+
+// Return count of bits the given number occupies. Sometims we can only make
+// a lower bound estimate, return that in "is_lower_bound".
+static size_t GetBitWidthOfNumber(const BasedNumber& n, bool* is_lower_bound) {
+  const absl::string_view literal = StripLeadingZeroes(n.literal);
+
+  *is_lower_bound = true;           // Can only estimate for the following two
+  if (literal.empty()) return 1;    // all zeroes
+  if (literal[0] == '`') return 1;  // Not dealing with macros.
+
+  *is_lower_bound = false;  // Now, we strive for exact bits
+  switch (n.base) {
+    case 'h':
+      return digitBits(literal[0], is_lower_bound) + 4 * (literal.length() - 1);
+    case 'o':
+      return digitBits(literal[0], is_lower_bound) + 3 * (literal.length() - 1);
+    case 'b':
+      return literal.length();
+    case 'd': {
+      if (!isdigit(literal[0])) {
+        *is_lower_bound = true;
+        return 1;  // Not dealing with ? or z
+      }
+
+      // Let's first try if we can parse it with regular means. Luckily,
+      // absl provides system-independent abstraction of 128 bit numbers,
+      // so we can parse most commonly used values accurately.
+      absl::uint128 number;
+      if (absl::SimpleAtoi(literal, &number)) {
+        int bits;
+        for (bits = 0; bits < 128 && number; ++bits) {
+          number >>= 1;
+        }
+        return bits;
+      }
+
+      *is_lower_bound = true;  // Heuristic below only gives us a lower bound
+
+      // More than 128 bits. Best effort to establish at least a lower bound.
+
+      // We parse the number as double, so that parsing can keep track of
+      // pretty long numbers and we get log2 for 15-ish significant dec digits.
+
+      // This will create false negatives, i.e. undercounting required bits,
+
+      // TODO(hzeller): is there a cheap way to accurately determine bits used
+      // without fully parsing the decimal number ?
+      double v;
+      if (absl::SimpleAtod(literal, &v) && !std::isinf(v)) {
+        return std::max(129, (int)ceil(log(v) / log(2)));
+      }
+
+      // Uh, more than 300-ish decimal digits ? ... rough estimation it is.
+      return ceil((literal.length() - 1) * log(10) / log(2));
+    } break;
+  }
+  return 0;  // not reached.
+}
+
+void TruncatedNumericLiteralRule::HandleSymbol(
+    const verible::Symbol& symbol, const SyntaxTreeContext& context) {
+  verible::matcher::BoundSymbolManager manager;
+  if (!NumberMatcher().Matches(symbol, &manager)) return;
+  const auto width_leaf = manager.GetAs<SyntaxTreeLeaf>("width");
+  const auto literal_node = manager.GetAs<SyntaxTreeNode>("literal");
+  if (!width_leaf || !literal_node) return;
+
+  const auto width_text = width_leaf->get().text();
+  size_t width;
+  if (!absl::SimpleAtoi(width_text, &width)) return;
+
+  const auto& base_digit_part = literal_node->children();
+  auto base_leaf = down_cast<const SyntaxTreeLeaf*>(base_digit_part[0].get());
+  auto digits_leaf = down_cast<const SyntaxTreeLeaf*>(base_digit_part[1].get());
+
+  const auto base_text = base_leaf->get().text();
+  const auto digits_text = digits_leaf->get().text();
+
+  const BasedNumber number(base_text, digits_text);
+
+  bool is_lower_bound = false;
+  const size_t actual_width = GetBitWidthOfNumber(number, &is_lower_bound);
+
+  if (actual_width > width) {
+    violations_.insert(LintViolation(
+        digits_leaf->get(),
+        absl::StrCat("Number ", width_text, base_text, digits_text,
+                     " occupies ", is_lower_bound ? "at least " : "",
+                     actual_width, " bits, truncated to ", width, " bits."),
+        context));
+    // No autofix yet. In particular signed numbers might be hairy, and
+    // numbers for which we only have a lower bound.
+  }
+}
+
+LintRuleStatus TruncatedNumericLiteralRule::Report() const {
+  return LintRuleStatus(violations_, Name(), GetStyleGuideCitation(kTopic));
+}
+
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.h
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.h
@@ -1,0 +1,55 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_TRUNCATED_NUMERIC_LITERAL_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_TRUNCATED_NUMERIC_LITERAL_RULE_H_
+
+#include <set>
+#include <string>
+
+#include "absl/strings/string_view.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/syntax_tree_lint_rule.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "verilog/analysis/descriptions.h"
+
+namespace verilog {
+namespace analysis {
+
+// TruncatedNumericLiteralRule checks that numeric literals don't occupy
+// more bits than their width state.
+class TruncatedNumericLiteralRule : public verible::SyntaxTreeLintRule {
+ public:
+  using rule_type = verible::SyntaxTreeLintRule;
+  static absl::string_view Name();
+
+  static std::string GetDescription(DescriptionType);
+
+  void HandleSymbol(const verible::Symbol& symbol,
+                    const verible::SyntaxTreeContext& context) final;
+
+  verible::LintRuleStatus Report() const final;
+
+ private:
+  // Link to style guide rule.
+  static const char kTopic[];
+
+  std::set<verible::LintViolation> violations_;
+};
+
+}  // namespace analysis
+}  // namespace verilog
+
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_TRUNCATED_NUMERIC_LITERAL_RULE_H_

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule_test.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule_test.cc
@@ -1,0 +1,239 @@
+// Copyright 2017-2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/truncated_numeric_literal_rule.h"
+
+#include <initializer_list>
+
+#include "common/analysis/linter_test_utils.h"
+#include "common/analysis/syntax_tree_linter_test_utils.h"
+#include "common/text/symbol.h"
+#include "gtest/gtest.h"
+#include "verilog/CST/verilog_nonterminals.h"
+#include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+namespace {
+
+using verible::LintTestCase;
+using verible::RunConfiguredLintTestCases;
+
+TEST(TruncatedNumericLiteralRuleTest, TruncatedBinaryNumbers) {
+  constexpr int kToken = TK_BinDigits;
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {""},
+      {"localparam x = 0;"},
+      {"localparam x = 1;"},
+      {"localparam x = 1'b?;"},
+      {"localparam x = 1'bz;"},
+      {"localparam x = 1'bx;"},
+      {"localparam x = 1'b", {kToken, "zz"}, ";"},
+      {"localparam x = 1'b", {kToken, "xx"}, ";"},
+      {"localparam x = 1'b", {kToken, "??"}, ";"},
+
+      // Not doing macro expansion yet, but we know that it uses at least 1 bit
+      {"localparam x = 1'b`SOME_MACRO;"},
+      {"localparam x = 0'b", {MacroIdentifier, "`SOME_MACRO"}, ";"},
+
+      {"localparam x = 0'b", {kToken, "0"}, ";"},  // Even a zero uses one bit
+      {"localparam x = 0'b", {kToken, "1"}, ";"},
+      {"localparam x = 3'b111;"},
+      {"localparam x = 3'b00000111;"},
+      {"localparam x = 3'b11_1;"},
+      {"localparam x = 3'b", {kToken, "1111"}, ";"},
+      {"localparam x = 3'b", {kToken, "00001111"}, ";"},
+  };
+
+  RunConfiguredLintTestCases<VerilogAnalyzer, TruncatedNumericLiteralRule>(
+      kTestCases, "");
+}
+
+TEST(TruncatedNumericLiteralRuleTest, TooShortHexNumbers) {
+  constexpr int kToken = TK_HexDigits;
+  const std::string superlong(1001, 'F');
+  const std::string exp = absl::StrCat("localparam x = 4004'h", superlong, ";");
+  const absl::string_view good_long_expression = exp;
+
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {"localparam x = 1'h1;"},
+      {"localparam x = 0'h", {kToken, "0"}, ";"},
+      {"localparam x = 0'h", {kToken, "1"}, ";"},
+      {"localparam x = 4'h?;"},
+      {"localparam x = 3'h?;"},
+      {"localparam x = 1'h?;"},  // ? can mean anything 1..4 bits, all ok.
+      {"localparam x = 4'h", {kToken, "??"}, ";"},  // Two digits exceed 4 bit
+      {"localparam x = 5'h??;"},  // Minimum that two digits use is 5 bits
+
+      // Same spiel with z and x
+      {"localparam x = 3'hz;"},
+      {"localparam x = 4'h", {kToken, "zz"}, ";"},
+      {"localparam x = 5'hzz;"},
+
+      {"localparam x = 3'hx;"},
+      {"localparam x = 4'h", {kToken, "xx"}, ";"},
+      {"localparam x = 5'hxx;"},
+
+      {"localparam x = 4'h", {kToken, "xz"}, ";"},  // or a mix of these
+
+      // Not doing macro expansion yet, but we know that it uses at least 1 bit
+      {"localparam x = 1'h`SOME_MACRO;"},
+      {"localparam x = 0'h", {MacroIdentifier, "`SOME_MACRO"}, ";"},
+
+      {"localparam x = 4'hf;"},
+      {"localparam x = 6'h2f;"},
+      {"localparam x = 6'h2_f;"},
+      {"localparam x = 6'h0000000002f;"},  // MSB fits ? good.
+      {"localparam x = 5'h", {kToken, "2f"}, ";"},
+      {"localparam x = 5'h", {kToken, "00000002f"}, ";"},
+      {"localparam x = 5'h1f;"},
+      {"localparam x = 16'habcd;"},
+      {"localparam x = 15'h", {kToken, "abcd"}, ";"},
+      {"localparam x = 16'hab_cd;"},
+
+      {good_long_expression},
+      {"localparam x = 4003'h", {kToken, superlong}, ";"},
+
+      {"localparam x = -16'hffff;"},  // TODO: should we complain about -(-1)?
+  };
+
+  RunConfiguredLintTestCases<VerilogAnalyzer, TruncatedNumericLiteralRule>(
+      kTestCases, "");
+}
+
+TEST(TruncatedNumericLiteralRuleTest, TruncatedOctalNumbers) {
+  constexpr int kToken = TK_OctDigits;
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {"localparam x = 1'o1;"},
+      {"localparam x = 3'o7;"},
+      {"localparam x = 2'o3;"},
+      {"localparam x = 2'o", {kToken, "4"}, ";"},
+      {"localparam x = 2'o", {kToken, "7"}, ";"},
+      {"localparam x = 8'o377;"},
+      {"localparam x = 8'o000000377;"},
+      {"localparam x = 8'o", {kToken, "477"}, ";"},
+  };
+
+  RunConfiguredLintTestCases<VerilogAnalyzer, TruncatedNumericLiteralRule>(
+      kTestCases, "");
+}
+
+TEST(TruncatedNumericLiteralRuleTest, TruncatedDecimalNumbers) {
+  constexpr int kToken = TK_DecDigits;
+  // A number longer than can be parsed as double to force fallback of fallback.
+  const std::string superlong(500, '9');
+  const std::string exp = absl::StrCat("localparam x = 1661'd", superlong, ";");
+  const absl::string_view good_long_expression = exp;
+
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {"localparam x = 1'd1;"},
+      {"localparam x = 0'd", {kToken, "0"}, ";"},
+      {"localparam x = 0'd", {kToken, "1"}, ";"},
+
+      {"localparam x = 1'dz;"},  // Not dealing with special digits
+      {"localparam x = 1'dx;"},
+      {"localparam x = 1'd?;"},
+
+      // Negative numbers: we really only look that the literal bits fit
+      {"localparam x = -4'd15;"},
+      {"localparam x = -4'd", {kToken, "16"}, ";"},
+
+      // 16 bit boundary
+      {"localparam x = 16'd65535;"},
+      {"localparam x = 16'd", {kToken, "65536"}, ";"},
+      {"localparam x = 17'd65536;"},
+
+      // TODO: should we warn about implicit negative numbers ?
+      {"localparam x = -16'd65535;"},
+
+      // 32 Bit.
+      {"localparam x = 32'd4294967295;"},                    // 2^32-1
+      {"localparam x = 32'd", {kToken, "4294967296"}, ";"},  // too long
+      {"localparam x = 33'd4294967296;"},  // needs one more bit
+
+      // 64 bit
+      {"localparam x = 64'd18446744073709551615;"},  // 2^64-1
+      {"localparam x = 64'd", {kToken, "18446744073709551616"}, ";"},
+      {"localparam x = 65'd18446744073709551616;"},
+
+      // 2^100-1.
+      {"localparam x = 100'd1267650600228229401496703205375;"},
+      {"localparam x = 100'd",  // Value +1 doesn't fit in 100 bits.
+       {kToken, "1267650600228229401496703205376"},
+       ";"},
+
+      // 2^128-1
+      {"localparam x = 128'd340282366920938463463374607431768211455;"},
+      {"localparam x = 127'd",  // ... but doesn't fit in 127 bits.
+       {kToken, "340282366920938463463374607431768211455"},
+       ";"},
+
+      /*
+       * For larger than 128 bit numbers, we only do best effort, but making
+       * sure to not give false positives, only false negatives.
+       *
+       * In practice, super long decimals are probably not something someone
+       * would use in code anyway, so best effort is probably good enough.
+       */
+
+      // This number (2^128, so 1<<129) is dealt with by the heuristic,
+      // and accurately detected as not fitting into 128 bits.
+      // The heuristic would estimate 128 bits, but we also know that
+      // we need to be at least 129 bits if we entered the heuristic realm :)
+      {"localparam x = 128'd",
+       {kToken, "340282366920938463463374607431768211456"},
+       ";"},
+      {"localparam x = 129'd340282366920938463463374607431768211456;"},
+
+      /* larger numbers will only be somewhat accurate and we underestimate
+       * the number of bits, so there will be some non-reported issues,
+       * false negatives.
+       */
+
+      // This number, 2^145-1 is accepted with 145 bit precision.
+      {"localparam x = 145'd44601490397061246283071436545296723011960831;"},
+
+      // We correctly recognize that this can't be represented in 144 bits.
+      {"localparam x = 144'd",
+       {kToken, "44601490397061246283071436545296723011960831"},
+       ";"},
+
+      // However, due to our heuristic, we don't actually recognize that this
+      // one-more-bit number 2^145 will need 146 bits...
+      {"localparam x = 145'd44601490397061246283071436545296723011960832;"},
+
+      // In fact, we don't really notice any change beyond the first 15 or 16
+      // first digits or so (as we internally parse it as double) and still
+      // accept this as 145 bits even though it really needs 146 bits by now.
+      // Erring on the side of not complaining.
+      // And who describes huge numbers in decimal anyway...
+      {"localparam x = 145'd",
+       {kToken, "44601490397061700000000000000000000000000000"},
+       //----------------------^ this needed to change from 2 to >= 6
+       ";"},
+
+      // This one should be ceil(log(10^500-1)/log(2)) = 1661 bits
+      // long, but we only start to complain below 1658 bits.
+      {good_long_expression},
+      {"localparam x = 1657'd", {kToken, superlong}, ";"},
+  };
+
+  RunConfiguredLintTestCases<VerilogAnalyzer, TruncatedNumericLiteralRule>(
+      kTestCases, "");
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/default_rules.h
+++ b/verilog/analysis/default_rules.h
@@ -65,6 +65,7 @@ constexpr const char* kDefaultRuleSet[] = {
     "positive-meaning-parameter-name",
     "constraint-name-style",
     "suggest-parentheses",
+    // TODO(hzeller) enable after #907 "truncated-numeric-literal",
     // TODO(fangism): enable in production:
     // TODO(b/155128436): "uvm-macro-semicolon"
     // TODO(b/117131903): "proper-parameter-declaration",


### PR DESCRIPTION
Detects number literals that have a shorter bit-width than the
digits provided, e.g. 16'h1FFFF.

Decimal numbers are only dealt with correctly up to 128 bits,
beyond that, only some lower-bound estimates are applied so
it might miss complain opportunity there. Given that super-long
constants are very likely not given as decimal, this
tradeoff is accepted.

Signed-off-by: Henner Zeller <hzeller@google.com>