### PR TITLE
Add clang-tidy script, to be run from the CI.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,18 @@
+---
+# Disabled some clang-analyzer static checks, need some more investigation.
+# TODO(hzeller) fix and re-enable clang-analyzer checks.
+# TODO(hzeller) Enable performance-* once somewhat silent output.
+Checks: >
+  clang-diagnostic-*,clang-analyzer-*,
+  -clang-analyzer-core.NonNullParamChecker,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -clang-diagnostic-unused-const-variable,
+  abseil-*,-abseil-no-namespace,
+  google-*,
+  -google-readability-braces-around-statements,
+  -google-readability-todo,
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+...

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright 2021 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TIDY_OUT=${TMPDIR:-/tmp}/clang-tidy.out
+
+# First, build the compilation database.
+bazel build :compdb > /dev/null 2>&1
+
+EXEC_ROOT=$(bazel info execution_root)
+
+# Fix up the __EXEC_ROOT__ to the path used by bazel.
+cat bazel-bin/compile_commands.json \
+  | sed "s|__EXEC_ROOT__|$EXEC_ROOT|" \
+  | sed 's/-fno-canonical-system-headers//g' \
+        > compile_commands.json
+
+# The compdb doesn't include tests currently, so we exclude all test files
+# for now.
+# Also, exclude kythe for now, as it is somehwat noisy and should be
+# addressed separately.
+find . -name "*.cc" -and -not -name "*test*.cc" \
+     -or -name "*.h" -and -not -name "*test*.h" \
+  | grep -v "verilog/tools/kythe" \
+  | xargs -P$(nproc) -n 5 -- \
+          clang-tidy --quiet 2>/dev/null \
+  | sed "s|$EXEC_ROOT/||g" > ${TIDY_OUT}
+
+
+cat ${TIDY_OUT}
+
+# For now, we always exit succesfully, but once we're tidy clean, consider
+# exiting with failure if there is something in the file.
+exit 0

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -42,6 +42,29 @@ jobs:
     - name: Run formatting style check
       run: ./.github/bin/run-clang-format.sh
 
+  ClangTidy:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install clang-tidy
+        clang-tidy --version
+
+    - name: Run clang tidy (Check output)
+      run: ./.github/bin/run-clang-tidy.sh
+
 
   Check:
     runs-on: ubuntu-16.04

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bazel-*
 tags
 releasing/out
+compile_commands.json
+

--- a/BUILD
+++ b/BUILD
@@ -5,6 +5,7 @@
 #  bazel test ...
 
 load("@com_github_google_rules_install//installer:def.bzl", "installer")
+load("@com_grail_bazel_compdb//:aspects.bzl", "compilation_database")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -12,15 +13,12 @@ exports_files([
     "LICENSE",
 ])
 
-installer(
-    name = "install",
-    data = [
+filegroup(
+   name = "install-binaries",
+   srcs = [
         "//common/tools:verible-patch-tool",
-        "//common/tools:verible-transform-interactive",
         "//verilog/tools/diff:verible-verilog-diff",
-        "//verilog/tools/formatter:git-verilog-format",
         "//verilog/tools/formatter:verible-verilog-format",
-        "//verilog/tools/formatter:verible-verilog-format-changed-lines-interactive",
         "//verilog/tools/kythe:verible-verilog-kythe-extractor",
         "//verilog/tools/lint:verible-verilog-lint",
         "//verilog/tools/obfuscator:verible-verilog-obfuscate",
@@ -28,6 +26,23 @@ installer(
         "//verilog/tools/project:verible-verilog-project",
         "//verilog/tools/syntax:verible-verilog-syntax",
     ],
+)
+
+filegroup(
+   name = "install-scripts",
+   srcs = [
+        "//common/tools:verible-transform-interactive",
+        "//verilog/tools/formatter:verible-verilog-format-changed-lines-interactive",
+        "//verilog/tools/formatter:git-verilog-format",
+   ]
+)
+
+installer(
+    name = "install",
+    data = [
+        ":install-binaries",
+        ":install-scripts",
+   ]
 )
 
 genrule(
@@ -53,4 +68,25 @@ action_listener(
     extra_actions = [":extractor"],
     mnemonics = ["CppCompile"],
     visibility = ["//visibility:public"],
+)
+
+compilation_database(
+    name = "compdb",
+    # targets = [ ":install-binaries" ],
+    # Unfortunately, compilation_database does not support filesets yet,
+    # so expand them here manually.
+    # https://github.com/grailbio/bazel-compilation-database/issues/84
+   targets = [
+        "//common/tools:verible-patch-tool",
+        "//verilog/tools/diff:verible-verilog-diff",
+        "//verilog/tools/formatter:verible-verilog-format",
+        "//verilog/tools/kythe:verible-verilog-kythe-extractor",
+        "//verilog/tools/lint:verible-verilog-lint",
+        "//verilog/tools/obfuscator:verible-verilog-obfuscate",
+        "//verilog/tools/preprocessor:verible-verilog-preprocessor",
+        "//verilog/tools/project:verible-verilog-project",
+        "//verilog/tools/syntax:verible-verilog-syntax",
+    ],
+    # TODO: is there a way to essentially specify //... so that all tests
+    # are included as well ?
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -195,3 +195,10 @@ http_archive(
         "https://github.com/c0fec0de/anytree/archive/2.8.0.tar.gz",
     ],
 )
+
+http_archive(
+    name = "com_grail_bazel_compdb",
+    sha256 = "f798690ddb6bba453ed489665c408bb0ce630bd7f0992c160c9414f933481a91",
+    strip_prefix = "bazel-compilation-database-ace73b04e76111afa09934f8771a2798847e724e",
+    urls = ["https://github.com/grailbio/bazel-compilation-database/archive/ace73b04e76111afa09934f8771a2798847e724e.tar.gz"],
+)


### PR DESCRIPTION
  * Use bazel rule to generate compilation database.
  * Run clang-tidy with some initial useful warnings enabled.
    The output file is currently just displayed in the CI log,
    but once that is clean, we can fail-on-warning

Fixes: #653

Signed-off-by: Henner Zeller <h.zeller@acm.org>