### PR TITLE
Fix clang-tidy warnings, resulting in empty clang tidy output.

### DIFF
--- a/.github/bin/install-python.sh
+++ b/.github/bin/install-python.sh
@@ -15,16 +15,15 @@
 
 # Latest Python version in Xenial is 3.5. `verible_verilog_syntax.py` test
 # requires at least 3.6.
-echo 'deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main' | sudo tee /etc/apt/sources.list.d/deadsnakes.list
+echo 'deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/deadsnakes.list
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
 
 sudo apt update
 sudo apt install -y \
     curl \
-    python3.9 \
+    python3.9 libpython3.9-stdlib \
     python3.9-distutils
 
 sudo ln -sf /usr/bin/python3.9 /usr/bin/python3
 
 python3 --version
-

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -67,7 +67,9 @@ jobs:
 
 
   Check:
-    runs-on: ubuntu-16.04
+    # Running the checks on slightly older ubuntu will find if there
+    # are issues with older versions. Oldest supported: 18.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -80,7 +80,7 @@ class AutoFix {
   AutoFix(const std::string& description, ReplacementEdit edit)
       : AutoFix(description, {edit}) {}
 
-  AutoFix(ReplacementEdit edit) : AutoFix({edit}) {}
+  explicit AutoFix(ReplacementEdit edit) : AutoFix({edit}) {}
 
   // Applies the fix on a `base` and returns modified text.
   std::string Apply(const absl::string_view base) const;

--- a/common/analysis/matcher/matcher_builders.h
+++ b/common/analysis/matcher/matcher_builders.h
@@ -165,7 +165,7 @@ class TagMatchBuilder {
 class DynamicTagMatchBuilder {
  public:
   // tag is a combination of {node,leaf} and enumeration.
-  DynamicTagMatchBuilder(SymbolTag tag) : tag_(tag) {}
+  explicit DynamicTagMatchBuilder(SymbolTag tag) : tag_(tag) {}
 
   template <typename... Args>
   BindableMatcher operator()(Args... args) const {

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -472,10 +472,10 @@ static FormatTokenRange EpilogRange(const TokenPartitionTree& partition,
 // Mark format tokens as must-append to remove future decision-making.
 static void CommitAlignmentDecisionToRow(
     const AlignmentRow& row, MutableFormatTokenRange::iterator ftoken_base,
-    TokenPartitionTree& partition) {  // NOLINT
+    TokenPartitionTree* partition) {
   if (!row.empty()) {
     const auto ftoken_range = ConvertToMutableFormatTokenRange(
-        partition.Value().TokensRange(), ftoken_base);
+        partition->Value().TokensRange(), ftoken_base);
     for (auto& ftoken : ftoken_range) {
       SpacingOptions& decision = ftoken.before.break_decision;
       if (decision == SpacingOptions::Undecided) {
@@ -483,7 +483,7 @@ static void CommitAlignmentDecisionToRow(
       }
     }
     // Tag every subtree as having already been committed to alignment.
-    partition.ApplyPostOrder([](TokenPartitionTree& node) {
+    partition->ApplyPostOrder([](TokenPartitionTree& node) {
       node.Value().SetPartitionPolicy(
           PartitionPolicyEnum::kSuccessfullyAligned);
     });
@@ -678,7 +678,7 @@ void AlignablePartitionGroup::ApplyAlignment(
     auto partition_iter = alignable_rows_.begin();
     for (auto& row : align_data.matrix) {
       // Commits to appending all tokens in this row (mutates format tokens)
-      CommitAlignmentDecisionToRow(row, ftoken_base, **partition_iter);
+      CommitAlignmentDecisionToRow(row, ftoken_base, &**partition_iter);
       ++partition_iter;
     }
   }

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -471,8 +471,8 @@ static FormatTokenRange EpilogRange(const TokenPartitionTree& partition,
 
 // Mark format tokens as must-append to remove future decision-making.
 static void CommitAlignmentDecisionToRow(
-    TokenPartitionTree& partition, const AlignmentRow& row,
-    MutableFormatTokenRange::iterator ftoken_base) {
+    const AlignmentRow& row, MutableFormatTokenRange::iterator ftoken_base,
+    TokenPartitionTree& partition) {  // NOLINT
   if (!row.empty()) {
     const auto ftoken_range = ConvertToMutableFormatTokenRange(
         partition.Value().TokensRange(), ftoken_base);
@@ -678,7 +678,7 @@ void AlignablePartitionGroup::ApplyAlignment(
     auto partition_iter = alignable_rows_.begin();
     for (auto& row : align_data.matrix) {
       // Commits to appending all tokens in this row (mutates format tokens)
-      CommitAlignmentDecisionToRow(**partition_iter, row, ftoken_base);
+      CommitAlignmentDecisionToRow(row, ftoken_base, **partition_iter);
       ++partition_iter;
     }
   }

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -423,10 +423,11 @@ TokenPartitionTree* MergeLeafIntoNextLeaf(TokenPartitionTree* leaf) {
 //
 class TokenPartitionTreeWrapper {
  public:
-  TokenPartitionTreeWrapper(const TokenPartitionTree& node) : node_(&node) {}
+  TokenPartitionTreeWrapper(const TokenPartitionTree& node)  // NOLINT
+      : node_(&node) {}
 
   // Grouping node with no corresponding TokenPartitionTree node
-  TokenPartitionTreeWrapper(const UnwrappedLine& unwrapped_line)
+  TokenPartitionTreeWrapper(const UnwrappedLine& unwrapped_line)  // NOLINT
       : node_(nullptr) {
     unwrapped_line_ =
         std::unique_ptr<UnwrappedLine>(new UnwrappedLine(unwrapped_line));
@@ -535,7 +536,7 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
   // Create first partition group
   // and populate it with function name (e.g. { [function foo (] })
   auto* group = fitted_partitions->NewChild(header.Value());
-  auto* child = group->NewChild(header);
+  group->NewChild(header);
 
   int indent;
 
@@ -558,7 +559,7 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
     indent = FitsOnLine(uwline, style).final_column;
 
     // Append first argument to current group
-    child = group->NewChild(subpartitions.front());
+    auto* child = group->NewChild(subpartitions.front());
     group->Value().Update(child);
     // keep group indentation
 
@@ -572,7 +573,7 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
     indent = first_arg.Value().IndentationSpaces();
     // wrap line
     group = group->NewSibling(first_arg.Value());  // start new group
-    child = group->NewChild(first_arg);  // append not fitting 1st argument
+    group->NewChild(first_arg);  // append not fitting 1st argument
     group->Value().SetIndentationSpaces(indent);
 
     // Measure first wrapped line
@@ -597,7 +598,7 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
       fit_result = FitsOnLine(uwline, style);
       if (fit_result.fits) {
         // Fits, appending child
-        child = group->NewChild(arg);
+        auto* child = group->NewChild(arg);
         group->Value().Update(child);
         longest_line_len = std::max(longest_line_len, fit_result.final_column);
         continue;
@@ -606,7 +607,7 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
 
     // Forced one per line or does not fit, start new group with current child
     group = group->NewSibling(arg.Value());
-    child = group->NewChild(arg);
+    group->NewChild(arg);
     // no need to update because group was created
     // with current child value
 
@@ -619,10 +620,10 @@ static AppendFittingSubpartitionsResult AppendFittingSubpartitions(
   if (trailer) {
     if (wrapped_first_subpartition) {
       group = group->NewSibling(trailer->Value());
-      child = group->NewChild(*trailer);
+      group->NewChild(*trailer);
       group->Value().SetIndentationSpaces(first_line.IndentationSpaces());
     } else {
-      child = group->NewChild(*trailer);
+      auto* child = group->NewChild(*trailer);
       group->Value().Update(child);
     }
     fit_result = FitsOnLine(group->Value().Value(), style);

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -420,14 +420,18 @@ TokenPartitionTree* MergeLeafIntoNextLeaf(TokenPartitionTree* leaf) {
 //
 // TokenPartitionTree class wrapper used by AppendFittingSubpartitions and
 // ReshapeFittingSubpartitions for partition reshaping purposes.
+// These wrappers take single-argument constructors to implicitly convert
+// to this wrapper.
 //
 class TokenPartitionTreeWrapper {
  public:
-  TokenPartitionTreeWrapper(const TokenPartitionTree& node)  // NOLINT
+  /* implicit */ TokenPartitionTreeWrapper(  // NOLINT
+      const TokenPartitionTree& node)
       : node_(&node) {}
 
   // Grouping node with no corresponding TokenPartitionTree node
-  TokenPartitionTreeWrapper(const UnwrappedLine& unwrapped_line)  // NOLINT
+  /* implicit */ TokenPartitionTreeWrapper(  // NOLINT
+      const UnwrappedLine& unwrapped_line)
       : node_(nullptr) {
     unwrapped_line_ =
         std::unique_ptr<UnwrappedLine>(new UnwrappedLine(unwrapped_line));

--- a/common/parser/parser_param.h
+++ b/common/parser/parser_param.h
@@ -73,9 +73,7 @@ class ParserParam {
   // Returns the maximum allocated size of parser stacks or 0
   // if ResizeStacks() was never called.
   // This is useful to determine a reasonable default parser stack size.
-  long MaxUsedStackSize() const {  // NOLINT
-    return max_used_stack_size_;
-  }
+  size_t MaxUsedStackSize() const { return max_used_stack_size_; }
 
   const ConcreteSyntaxTree& Root() const { return root_; }
 
@@ -101,7 +99,7 @@ class ParserParam {
   // Overflow storage for parser's internal symbol and value stack.
   StateStack state_stack_;
   ValueStack value_stack_;
-  int64_t max_used_stack_size_;
+  size_t max_used_stack_size_;
 
   ParserParam(const ParserParam&) = delete;
   ParserParam& operator=(const ParserParam&) = delete;

--- a/common/parser/parser_param.h
+++ b/common/parser/parser_param.h
@@ -73,7 +73,7 @@ class ParserParam {
   // Returns the maximum allocated size of parser stacks or 0
   // if ResizeStacks() was never called.
   // This is useful to determine a reasonable default parser stack size.
-  long MaxUsedStackSize() const {  // NOLINT(runtime/int)
+  long MaxUsedStackSize() const {  // NOLINT
     return max_used_stack_size_;
   }
 

--- a/common/strings/split.h
+++ b/common/strings/split.h
@@ -54,7 +54,9 @@ class StringSpliterator {
   StringSpliterator& operator=(StringSpliterator&&) = default;
 
   // Returns true if there is at least one result to come.
-  operator bool() const { return !end_; }  // NOLINT
+  operator bool() const {  // NOLINT(google-explicit-constructor)
+    return !end_;
+  }
 
   // Returns the substring up to the next occurrence of the delimiter,
   // and advances internal state to point to text after the delimiter.

--- a/common/strings/split.h
+++ b/common/strings/split.h
@@ -54,7 +54,7 @@ class StringSpliterator {
   StringSpliterator& operator=(StringSpliterator&&) = default;
 
   // Returns true if there is at least one result to come.
-  operator bool() const { return !end_; }
+  operator bool() const { return !end_; }  // NOLINT
 
   // Returns the substring up to the next occurrence of the delimiter,
   // and advances internal state to point to text after the delimiter.

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -63,7 +63,8 @@ using ConcreteSyntaxTree = SymbolPtr;
 // This takes over ownership of the symbol pointer.
 //    $$ = MakeNode($1, $2, ForwardChildren($3), $4);
 struct ForwardChildren {
-  explicit ForwardChildren(SymbolPtr& symbol) : node(std::move(symbol)) {}
+  explicit ForwardChildren(SymbolPtr& symbol)  // NOLINT
+      : node(std::move(symbol)) {}
   SymbolPtr node;
 };
 

--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -46,8 +46,8 @@ struct DefaultTokenInfo : public TokenInfo {
 
 // Macro formal parameter specification: name with optional default.
 struct MacroParameterInfo {
-  MacroParameterInfo(const TokenInfo& n = TokenInfo::EOFToken(),
-                     const TokenInfo& d = TokenInfo::EOFToken())
+  explicit MacroParameterInfo(const TokenInfo& n = TokenInfo::EOFToken(),
+                              const TokenInfo& d = TokenInfo::EOFToken())
       : name(n), default_value(d) {}
 
   // Name of macro parameter.

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -49,14 +49,16 @@ absl::string_view StringSpanOfSymbol(const Symbol& lsym, const Symbol& rsym);
 // Returns a SyntaxTreeNode down_casted from a Symbol.
 const SyntaxTreeNode& SymbolCastToNode(const Symbol&);
 // Mutable variant.
-SyntaxTreeNode& SymbolCastToNode(Symbol&);
+SyntaxTreeNode& SymbolCastToNode(Symbol&);  // NOLINT
 
 // The following no-op overloads allow SymbolCastToNode() to work with zero
 // overhead when the argument type is statically known to be the same.
 inline const SyntaxTreeNode& SymbolCastToNode(const SyntaxTreeNode& node) {
   return node;
 }
-inline SyntaxTreeNode& SymbolCastToNode(SyntaxTreeNode& node) { return node; }
+inline SyntaxTreeNode& SymbolCastToNode(SyntaxTreeNode& node) {  // NOLINT
+  return node;
+}
 
 // Returns a SyntaxTreeLeaf down_casted from a Symbol.
 const SyntaxTreeLeaf& SymbolCastToLeaf(const Symbol&);
@@ -77,7 +79,8 @@ const SyntaxTreeNode& CheckNodeEnum(const SyntaxTreeNode& node,
 }
 // Mutable variant.
 template <typename E>
-SyntaxTreeNode& CheckNodeEnum(SyntaxTreeNode& node, E expected_node_enum) {
+SyntaxTreeNode& CheckNodeEnum(SyntaxTreeNode& node,
+                              E expected_node_enum) {  // NOLINT
   // Uses operator<<(std::ostream&, E) for diagnostics.
   CHECK_EQ(E(node.Tag().tag), expected_node_enum);
   return node;

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -79,8 +79,8 @@ const SyntaxTreeNode& CheckNodeEnum(const SyntaxTreeNode& node,
 }
 // Mutable variant.
 template <typename E>
-SyntaxTreeNode& CheckNodeEnum(SyntaxTreeNode& node,
-                              E expected_node_enum) {  // NOLINT
+SyntaxTreeNode& CheckNodeEnum(SyntaxTreeNode& node,  // NOLINT
+                              E expected_node_enum) {
   // Uses operator<<(std::ostream&, E) for diagnostics.
   CHECK_EQ(E(node.Tag().tag), expected_node_enum);
   return node;

--- a/verilog/CST/type.cc
+++ b/verilog/CST/type.cc
@@ -33,7 +33,7 @@ using verible::Symbol;
 using verible::SymbolPtr;
 using verible::SyntaxTreeNode;
 
-static SymbolPtr ReinterpretReferenceAsType(Symbol& reference) {
+static SymbolPtr ReinterpretReferenceAsType(Symbol& reference) {  // NOLINT
   SyntaxTreeNode& local_root(verible::GetSubtreeAsNode(
       reference, NodeEnum::kReference, 0, NodeEnum::kLocalRoot));
   auto& children(local_root.mutable_children());

--- a/verilog/CST/type.h
+++ b/verilog/CST/type.h
@@ -94,7 +94,7 @@ const verible::Symbol* GetBaseTypeFromDataType(
 // grammar conflicts.
 // The original reference_call_base pointer is consumed in the process.
 verible::SymbolPtr ReinterpretReferenceCallBaseAsDataTypePackedDimensions(
-    verible::SymbolPtr& reference_call_base);
+    verible::SymbolPtr& reference_call_base);  // NOLINT
 
 // Finds all node kDataType declarations. Used for testing the functions below.
 std::vector<verible::TreeSearchMatch> FindAllDataTypeDeclarations(

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
@@ -138,7 +138,7 @@ static size_t GetBitWidthOfNumber(const BasedNumber& n, bool* is_lower_bound) {
       // without fully parsing the decimal number ?
       double v;
       if (absl::SimpleAtod(literal, &v) && !std::isinf(v)) {
-        return std::max(129, (int)ceil(log(v) / log(2)));
+        return std::max(129, static_cast<int>(ceil(log(v) / log(2))));
       }
 
       // Uh, more than 300-ish decimal digits ? ... rough estimation it is.

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -138,7 +138,7 @@ absl::Status AppendLinterConfigurationFromFile(
 // messages.
 class ViolationPrinter : public ViolationHandler {
  public:
-  ViolationPrinter(std::ostream* stream)
+  explicit ViolationPrinter(std::ostream* stream)
       : stream_(stream), formatter_(nullptr) {}
 
   void HandleViolations(const std::set<LintViolationWithStatus>& violations,
@@ -185,9 +185,9 @@ class ViolationFixer : public ViolationHandler {
   using AnswerChooser = std::function<AnswerChoice(
       const verible::LintViolation&, absl::string_view)>;
 
-  ViolationFixer(std::ostream* message_stream,
-                 std::ostream* patch_stream = nullptr,
-                 AnswerChooser answer_chooser = InteractiveAnswerChooser)
+  explicit ViolationFixer(
+      std::ostream* message_stream, std::ostream* patch_stream = nullptr,
+      AnswerChooser answer_chooser = InteractiveAnswerChooser)
       : message_stream_(message_stream),
         patch_stream_(patch_stream),
         ultimate_answer_(AnswerChoice::kUnknown),

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -363,7 +363,8 @@ static void DeterminePartitionExpansion(
       break;
     }
     case PartitionPolicyEnum::kTabularAlignment: {
-      if (uwline.Origin()->Tag().tag == (int)NodeEnum::kArgumentList) {
+      if (uwline.Origin()->Tag().tag ==
+          static_cast<int>(NodeEnum::kArgumentList)) {
         // Check whether the whole function call fits on one line. If possible,
         // unexpand and fit into one line. Otherwise expand argument list with
         // tabular alignment.
@@ -402,11 +403,11 @@ static void DeterminePartitionExpansion(
     case PartitionPolicyEnum::kFitOnLineElseExpand: {
       if (uwline.Origin() &&
           (uwline.Origin()->Tag().tag ==
-               (int)NodeEnum::kNetVariableAssignment ||
+               static_cast<int>(NodeEnum::kNetVariableAssignment) ||
            uwline.Origin()->Tag().tag ==
-               (int)NodeEnum::kBlockItemStatementList ||
+               static_cast<int>(NodeEnum::kBlockItemStatementList) ||
            uwline.Origin()->Tag().tag ==
-               (int)NodeEnum::kBlockingAssignmentStatement)) {
+               static_cast<int>(NodeEnum::kBlockingAssignmentStatement))) {
         // Align unnamed parameters in function call. Example:
         // always_comb begin
         //   value = function_name(8'hA, signal,

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -642,7 +642,8 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
           Context().IsInside(NodeEnum::kNetVariableAssignment)) {
         if (any_of(node.children().begin(), node.children().end(),
                    [](const verible::SymbolPtr& p) {
-                     return p->Tag().tag == (int)NodeEnum::kParamByName;
+                     return p->Tag().tag ==
+                            static_cast<int>(NodeEnum::kParamByName);
                    })) {
           // Indentation of named arguments of functions
           VisitIndentedSection(node, style_.indentation_spaces,

--- a/verilog/tools/kythe/indexing_facts_tree.h
+++ b/verilog/tools/kythe/indexing_facts_tree.h
@@ -40,9 +40,9 @@ class Anchor {
   // conversion from std::string (and others).
   template <class T>
   struct DisableConversion {
-    /* implicit */ DisableConversion(T v) : value(v) {}
+    /* implicit */ DisableConversion(T v) : value(v) {}  // NOLINT
 
-    operator T() const { return value; }
+    operator T() const { return value; }  // NOLINT
 
     T value;
   };


### PR DESCRIPTION
These are outside verilog/tools/kythe, which requires a bit
more work.

Signed-off-by: Henner Zeller <h.zeller@acm.org>