### PR TITLE
Fail CI if clang-tidy reports an issue.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -40,6 +40,8 @@ find . -name "*.cc" -and -not -name "*test*.cc" \
 
 cat ${TIDY_OUT}
 
-# For now, we always exit succesfully, but once we're tidy clean, consider
-# exiting with failure if there is something in the file.
+if [ -s ${TIDY_OUT} ]; then
+   echo "There were clang-tidy warnings. Please fix"
+   exit 1
+fi
 exit 0

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -62,7 +62,7 @@ jobs:
         sudo apt-get install clang-tidy
         clang-tidy --version
 
-    - name: Run clang tidy (Check output)
+    - name: Run clang tidy
       run: ./.github/bin/run-clang-tidy.sh
 
 


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>