### PR TITLE
Prefer 'final' to 'override' if method is last in hierachy.

### DIFF
--- a/common/analysis/command_file_lexer_test.cc
+++ b/common/analysis/command_file_lexer_test.cc
@@ -40,7 +40,7 @@ class FilteredCommandFileLexer : public CommandFileLexer {
     }
   }
 
-  const verible::TokenInfo& DoNextToken() override {
+  const verible::TokenInfo& DoNextToken() final {
     do {
       CommandFileLexer::DoNextToken();
     } while (!KeepSyntaxTreeTokens(GetLastToken()));

--- a/common/analysis/file_analyzer_test.cc
+++ b/common/analysis/file_analyzer_test.cc
@@ -46,7 +46,7 @@ class FakeFileAnalyzer : public FileAnalyzer {
   FakeFileAnalyzer(const std::string& text, const std::string& filename)
       : FileAnalyzer(text, filename) {}
 
-  absl::Status Tokenize() override {
+  absl::Status Tokenize() final {
     // TODO(fangism): Tokenize(lexer) interface is not directly tested, but
     // covered elsewhere.
     return absl::OkStatus();

--- a/common/analysis/line_linter_test.cc
+++ b/common/analysis/line_linter_test.cc
@@ -37,14 +37,14 @@ class BlankLineRule : public LineLintRule {
  public:
   BlankLineRule() {}
 
-  void HandleLine(absl::string_view line) override {
+  void HandleLine(absl::string_view line) final {
     if (line.empty()) {
       const TokenInfo token(0, line);
       violations_.insert(LintViolation(token, "some reason"));
     }
   }
 
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
  private:
   std::set<LintViolation> violations_;
@@ -92,16 +92,16 @@ class EmptyFileRule : public LineLintRule {
  public:
   EmptyFileRule() {}
 
-  void HandleLine(absl::string_view line) override { ++lines_; }
+  void HandleLine(absl::string_view line) final { ++lines_; }
 
-  void Finalize() override {
+  void Finalize() final {
     if (lines_ == 0) {
       violations_.insert(
           LintViolation(TokenInfo::EOFToken(), "insufficient bytes"));
     }
   }
 
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
   size_t lines_ = 0;
 

--- a/common/analysis/matcher/matcher_test_utils.cc
+++ b/common/analysis/matcher/matcher_test_utils.cc
@@ -65,8 +65,8 @@ class MatchCounter : public TreeVisitorRecursive {
     return num_matches_;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override { TestSymbol(leaf); }
-  void Visit(const SyntaxTreeNode& node) override { TestSymbol(node); }
+  void Visit(const SyntaxTreeLeaf& leaf) final { TestSymbol(leaf); }
+  void Visit(const SyntaxTreeNode& node) final { TestSymbol(node); }
 
  private:
   Matcher matcher_;

--- a/common/analysis/syntax_tree_linter.h
+++ b/common/analysis/syntax_tree_linter.h
@@ -51,8 +51,8 @@ class SyntaxTreeLinter : public TreeContextVisitor {
  public:
   SyntaxTreeLinter() : rules_() {}
 
-  void Visit(const SyntaxTreeLeaf& leaf) override;
-  void Visit(const SyntaxTreeNode& node) override;
+  void Visit(const SyntaxTreeLeaf& leaf) final;
+  void Visit(const SyntaxTreeNode& node) final;
 
   // Transfers ownership of rule into Linter
   void AddRule(std::unique_ptr<SyntaxTreeLintRule> rule) {

--- a/common/analysis/syntax_tree_linter_test.cc
+++ b/common/analysis/syntax_tree_linter_test.cc
@@ -40,7 +40,7 @@ class AllLeavesMustBeN : public SyntaxTreeLintRule {
   // When handling leaf, check that it has target tag and report a violation
   // is not
   void HandleLeaf(const SyntaxTreeLeaf& leaf,
-                  const SyntaxTreeContext& context) override {
+                  const SyntaxTreeContext& context) final {
     if (leaf.get().token_enum() != target_) {
       violations_.insert(LintViolation(leaf.get(), "", context));
     }
@@ -48,8 +48,8 @@ class AllLeavesMustBeN : public SyntaxTreeLintRule {
 
   // Do not operate on nodes
   void HandleNode(const SyntaxTreeNode& node,
-                  const SyntaxTreeContext& context) override {}
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+                  const SyntaxTreeContext& context) final {}
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
  private:
   std::set<LintViolation> violations_;
@@ -114,12 +114,12 @@ class ChildrenLeavesAscending : public SyntaxTreeLintRule {
  public:
   // Do not process leaves
   void HandleLeaf(const SyntaxTreeLeaf& leaf,
-                  const SyntaxTreeContext& context) override {}
+                  const SyntaxTreeContext& context) final {}
 
   // When handling nodes, iterate through all children and check that tags
   // are ascending. Report leafs nodes that have leaves that are out of order.
   void HandleNode(const SyntaxTreeNode& node,
-                  const SyntaxTreeContext& context) override {
+                  const SyntaxTreeContext& context) final {
     int last_tag = 0;
     for (const auto& child : node.children()) {
       if (child->Kind() == SymbolKind::kLeaf) {
@@ -136,7 +136,7 @@ class ChildrenLeavesAscending : public SyntaxTreeLintRule {
     }
   }
 
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
  private:
   std::set<LintViolation> violations_;
@@ -222,16 +222,16 @@ class TagMatchesContextDepth : public SyntaxTreeLintRule {
  public:
   // When handling a leaf, check leaf's tag vs the size of its context
   void HandleLeaf(const SyntaxTreeLeaf& leaf,
-                  const SyntaxTreeContext& context) override {
+                  const SyntaxTreeContext& context) final {
     if (static_cast<size_t>(leaf.get().token_enum()) != context.size()) {
       violations_.insert(LintViolation(leaf.get(), "", context));
     }
   }
   // Do not process nodes
   void HandleNode(const SyntaxTreeNode& node,
-                  const SyntaxTreeContext& context) override {}
+                  const SyntaxTreeContext& context) final {}
 
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
  private:
   std::set<LintViolation> violations_;

--- a/common/analysis/syntax_tree_search.cc
+++ b/common/analysis/syntax_tree_search.cc
@@ -47,8 +47,8 @@ class SyntaxTreeSearcher : public TreeContextVisitor {
 
  private:
   void CheckSymbol(const Symbol&);
-  void Visit(const SyntaxTreeLeaf& leaf) override;
-  void Visit(const SyntaxTreeNode& node) override;
+  void Visit(const SyntaxTreeLeaf& leaf) final;
+  void Visit(const SyntaxTreeNode& node) final;
 
   // Main matcher that finds a particular type of tree node.
   const verible::matcher::Matcher matcher_;

--- a/common/analysis/text_structure_linter_test.cc
+++ b/common/analysis/text_structure_linter_test.cc
@@ -38,7 +38,7 @@ class RequireHelloRule : public TextStructureLintRule {
   RequireHelloRule() {}
 
   void Lint(const TextStructureView& text_structure,
-            absl::string_view filename) override {
+            absl::string_view filename) final {
     const auto& lines = text_structure.Lines();
     const absl::string_view contents = text_structure.Contents();
     if (!lines.empty() && !absl::StartsWith(contents, "Hello")) {
@@ -47,7 +47,7 @@ class RequireHelloRule : public TextStructureLintRule {
     }
   }
 
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
  private:
   std::set<LintViolation> violations_;

--- a/common/analysis/token_stream_linter_test.cc
+++ b/common/analysis/token_stream_linter_test.cc
@@ -36,13 +36,13 @@ class ForbidTokenRule : public TokenStreamLintRule {
  public:
   explicit ForbidTokenRule(int n) : target_(n) {}
 
-  void HandleToken(const TokenInfo& token) override {
+  void HandleToken(const TokenInfo& token) final {
     if (token.token_enum() == target_) {
       violations_.insert(LintViolation(token, "some reason"));
     }
   }
 
-  LintRuleStatus Report() const override { return LintRuleStatus(violations_); }
+  LintRuleStatus Report() const final { return LintRuleStatus(violations_); }
 
  private:
   std::set<LintViolation> violations_;

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -77,10 +77,10 @@ class TokenColumnizer : public ColumnSchemaScanner {
  public:
   TokenColumnizer() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     ColumnSchemaScanner::Visit(node);
   }
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     // Let each token occupy its own column.
     ReserveNewColumn(leaf, FlushLeft);
   }
@@ -90,10 +90,10 @@ class TokenColumnizerRightFlushed : public ColumnSchemaScanner {
  public:
   TokenColumnizerRightFlushed() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     ColumnSchemaScanner::Visit(node);
   }
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     // Let each token occupy its own column.
     ReserveNewColumn(leaf, FlushRight);
   }
@@ -983,7 +983,7 @@ class SyntaxTreeColumnizer : public ColumnSchemaScanner {
  public:
   SyntaxTreeColumnizer() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     ColumnPositionTree* column;
     if (!current_column_)
       column = ReserveNewColumn(node, props);
@@ -994,7 +994,7 @@ class SyntaxTreeColumnizer : public ColumnSchemaScanner {
                                                          column);
     ColumnSchemaScanner::Visit(node);
   }
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     AlignmentColumnProperties local_props = props;
     if (leaf.get().text() == ",") local_props.contains_delimiter = true;
 

--- a/common/formatting/tree_annotator.cc
+++ b/common/formatting/tree_annotator.cc
@@ -45,7 +45,7 @@ class TreeAnnotator : public TreeContextVisitor {
 
  private:                           // methods
   using TreeContextVisitor::Visit;  // for SyntaxTreeNode
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     CatchUpToCurrentLeaf(leaf.get());
   }
 

--- a/common/formatting/tree_unwrapper_test.cc
+++ b/common/formatting/tree_unwrapper_test.cc
@@ -66,23 +66,23 @@ class FakeTreeUnwrapper : public TreeUnwrapperData, public TreeUnwrapper {
         TreeUnwrapper(view, TreeUnwrapperData::preformatted_tokens_) {}
 
   // There are no filtered-out tokens in this fake.
-  void CollectLeadingFilteredTokens() override {}
-  void CollectTrailingFilteredTokens() override {}
+  void CollectLeadingFilteredTokens() final {}
+  void CollectTrailingFilteredTokens() final {}
 
   // Leaf visit that adds a PreFormatToken from the leaf's TokenInfo
   // to the current_unwrapped_line_
-  void Visit(const verible::SyntaxTreeLeaf& leaf) override {
+  void Visit(const verible::SyntaxTreeLeaf& leaf) final {
     CatchUpFilteredTokens();
     AddTokenToCurrentUnwrappedLine();
   }
 
   // Node visit that always starts a new unwrapped line
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     StartNewUnwrappedLine(PartitionPolicyEnum::kAlwaysExpand, &node);
     TraverseChildren(node);
   }
 
-  void InterChildNodeHook(const SyntaxTreeNode& node) override {}
+  void InterChildNodeHook(const SyntaxTreeNode& node) final {}
 
   using TreeUnwrapper::StartNewUnwrappedLine;
 

--- a/common/formatting/unwrapped_line_test.cc
+++ b/common/formatting/unwrapped_line_test.cc
@@ -45,9 +45,9 @@ TEST(PartitionPolicyTest, Printing) {
 class UnwrappedLineTest : public UnwrappedLineMemoryHandler,
                           public testing::Test {
  protected:
-  void SetUp() override {}
+  void SetUp() final {}
 
-  void TearDown() override {}
+  void TearDown() final {}
 };
 
 // Testing IsEmpty() and initialization of UnwrappedLine with no FormatTokens

--- a/common/lexer/flex_lexer_adapter.h
+++ b/common/lexer/flex_lexer_adapter.h
@@ -74,7 +74,7 @@ class FlexLexerAdapter : private CodeStreamHolder, protected L, public Lexer {
   }
 
   // Returns the token associated with the last UpdateLocation() call.
-  const TokenInfo& GetLastToken() const override { return last_token_; }
+  const TokenInfo& GetLastToken() const final { return last_token_; }
 
   // Returns next token and updates its location.
   const TokenInfo& DoNextToken() override {
@@ -129,7 +129,7 @@ class FlexLexerAdapter : private CodeStreamHolder, protected L, public Lexer {
   }
 
   // Overrides yyFlexLexer's implementation to handle unrecognized chars.
-  void LexerOutput(const char* buf, int size) override {
+  void LexerOutput(const char* buf, int size) final {
     VLOG(1) << "LexerOutput: rejected text: \"" << std::string(buf, size)
             << '\"';
 
@@ -143,7 +143,7 @@ class FlexLexerAdapter : private CodeStreamHolder, protected L, public Lexer {
   }
 
   // Overrides yyFlexLexer's implementation to do proper error handling.
-  void LexerError(const char* msg) override {
+  void LexerError(const char* msg) final {
     std::cerr << "Fatal LexerError: " << msg;
     abort();
   }

--- a/common/lexer/token_stream_adapter_test.cc
+++ b/common/lexer/token_stream_adapter_test.cc
@@ -28,11 +28,11 @@ class FakeTokenSequenceLexer : public Lexer, public FakeLexer {
  public:
   using FakeLexer::SetTokensData;
 
-  const TokenInfo& GetLastToken() const override { return *tokens_iter_; }
+  const TokenInfo& GetLastToken() const final { return *tokens_iter_; }
 
-  const TokenInfo& DoNextToken() override { return FakeLexer::DoNextToken(); }
+  const TokenInfo& DoNextToken() final { return FakeLexer::DoNextToken(); }
 
-  void Restart(absl::string_view) override {}
+  void Restart(absl::string_view) final {}
 
   bool TokenIsError(const TokenInfo&) const override { return false; }
 };
@@ -69,7 +69,7 @@ TEST(MakeTokenSequenceTest, Sequencer) {
 }
 
 class TheNumberTwoIsErrorLexer : public FakeTokenSequenceLexer {
-  bool TokenIsError(const TokenInfo& token) const override {
+  bool TokenIsError(const TokenInfo& token) const final {
     return token.token_enum() == 2;
   }
 };

--- a/common/parser/bison_parser_adapter.h
+++ b/common/parser/bison_parser_adapter.h
@@ -43,7 +43,7 @@ class BisonParserAdapter : public Parser {
   explicit BisonParserAdapter(TokenGenerator* token_generator)
       : Parser(), param_(token_generator) {}
 
-  absl::Status Parse() override {
+  absl::Status Parse() final {
     int result = ParseFunc(&param_);
     // Results of parsing are stored in param_.
     VLOG(3) << "max_used_stack_size : " << MaxUsedStackSize();
@@ -57,17 +57,17 @@ class BisonParserAdapter : public Parser {
     }
   }
 
-  const TokenInfo& GetLastToken() const override {
+  const TokenInfo& GetLastToken() const final {
     return param_.GetLastToken();
   }
 
-  const std::vector<TokenInfo>& RejectedTokens() const override {
+  const std::vector<TokenInfo>& RejectedTokens() const final {
     return param_.RecoveredSyntaxErrors();
   }
 
-  const ConcreteSyntaxTree& Root() const override { return param_.Root(); }
+  const ConcreteSyntaxTree& Root() const final { return param_.Root(); }
 
-  ConcreteSyntaxTree TakeRoot() override { return param_.TakeRoot(); }
+  ConcreteSyntaxTree TakeRoot() final { return param_.TakeRoot(); }
 
   size_t MaxUsedStackSize() const { return param_.MaxUsedStackSize(); }
 

--- a/common/parser/bison_parser_common_test.cc
+++ b/common/parser/bison_parser_common_test.cc
@@ -36,13 +36,13 @@ class MockLexer : public Lexer {
  public:
   MockLexer() : token_(13, "foo") {}
 
-  const TokenInfo& GetLastToken() const override { return token_; }
+  const TokenInfo& GetLastToken() const final { return token_; }
 
-  const TokenInfo& DoNextToken() override { return token_; }
+  const TokenInfo& DoNextToken() final { return token_; }
 
-  void Restart(absl::string_view) override {}
+  void Restart(absl::string_view) final {}
 
-  bool TokenIsError(const TokenInfo&) const override { return false; }
+  bool TokenIsError(const TokenInfo&) const final { return false; }
 
  private:
   TokenInfo token_;

--- a/common/text/concrete_syntax_leaf.h
+++ b/common/text/concrete_syntax_leaf.h
@@ -45,7 +45,7 @@ class SyntaxTreeLeaf : public Symbol {
 
   // Compares this to an arbitrary symbol using compare_tokens
   bool equals(const Symbol* symbol,
-              const TokenComparator& compare_tokens) const override;
+              const TokenComparator& compare_tokens) const final;
 
   // Compares this to another leaf using compare_tokens
   bool equals(const SyntaxTreeLeaf* leaf,
@@ -53,14 +53,14 @@ class SyntaxTreeLeaf : public Symbol {
 
   // The Accept() methods have the visitor visit this leaf and perform no
   // other actions.
-  void Accept(TreeVisitorRecursive* visitor) const override;
-  void Accept(SymbolVisitor* visitor) const override;
+  void Accept(TreeVisitorRecursive* visitor) const final;
+  void Accept(SymbolVisitor* visitor) const final;
   void Accept(MutableTreeVisitorRecursive* visitor,
-              SymbolPtr* this_owned) override;
+              SymbolPtr* this_owned) final;
 
   // Method override that returns the Kind of SyntaxTreeLeaf
-  SymbolKind Kind() const override { return SymbolKind::kLeaf; }
-  SymbolTag Tag() const override { return LeafTag(get().token_enum()); }
+  SymbolKind Kind() const final { return SymbolKind::kLeaf; }
+  SymbolTag Tag() const final { return LeafTag(get().token_enum()); }
 
  private:
   TokenInfo token_;

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -122,7 +122,7 @@ class SyntaxTreeNode : public Symbol {
   // Compares this node to an arbitrary symbol using the compare_tokens
   // function.
   bool equals(const Symbol* symbol,
-              const TokenComparator& compare_tokens) const override;
+              const TokenComparator& compare_tokens) const final;
 
   // Compares this node to another node.
   // Checks for recursive equality among all children of both nodes.
@@ -131,16 +131,16 @@ class SyntaxTreeNode : public Symbol {
 
   // Uses passed TreeVisitorRecursive to visit all children recursively,
   // then visit itself.
-  void Accept(TreeVisitorRecursive* visitor) const override;
+  void Accept(TreeVisitorRecursive* visitor) const final;
   void Accept(MutableTreeVisitorRecursive* visitor,
-              SymbolPtr* this_owned) override;
+              SymbolPtr* this_owned) final;
 
   // Accepting a symbol visitor does not recursively visit children.
-  void Accept(SymbolVisitor* visitor) const override;
+  void Accept(SymbolVisitor* visitor) const final;
 
   // Method override that returns the Kind of Symbol
-  SymbolKind Kind() const override { return SymbolKind::kNode; }
-  SymbolTag Tag() const override { return NodeTag(tag_); }
+  SymbolKind Kind() const final { return SymbolKind::kNode; }
+  SymbolTag Tag() const final { return NodeTag(tag_); }
 
   // MatchesTag returns true if the tag value matches the argument.
   // This is designed to work with any enumeration type.

--- a/common/text/parser_verifier.h
+++ b/common/text/parser_verifier.h
@@ -61,8 +61,8 @@ class ParserVerifier : public TreeVisitorRecursive {
   // Do call these methods directly. Use Verify instead
   // TODO(jeremycs): changed these to protected and make SyntaxTreeLeaf
   //                 and SyntaxTreeNode friend classes
-  void Visit(const SyntaxTreeLeaf& leaf) override;
-  void Visit(const SyntaxTreeNode& node) override{};
+  void Visit(const SyntaxTreeLeaf& leaf) final;
+  void Visit(const SyntaxTreeNode& node) final{};
 
  private:
   const Symbol& root_;

--- a/common/text/tree_context_visitor_test.cc
+++ b/common/text/tree_context_visitor_test.cc
@@ -37,11 +37,11 @@ static std::vector<int> ContextToTags(const SyntaxTreeContext& context) {
 template <class BaseVisitor>
 class ContextRecorder : public BaseVisitor {
  public:
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     context_history_.push_back(BaseVisitor::Context());
   }
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     context_history_.push_back(BaseVisitor::Context());
     BaseVisitor::Visit(node);
   }
@@ -140,11 +140,11 @@ TEST(TreeContextVisitorTest, FullTree) {
 // Test class demonstrating visitation and path tracking
 class PathRecorder : public TreeContextPathVisitor {
  public:
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     path_history_.push_back(Path());
   }
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     path_history_.push_back(Path());
     TreeContextPathVisitor::Visit(node);
   }

--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -137,7 +137,7 @@ class FirstSubtreeFinderMutable : public MutableTreeVisitorRecursive {
   explicit FirstSubtreeFinderMutable(const TreePredicate& predicate)
       : predicate_(predicate) {}
 
-  void Visit(const SyntaxTreeNode& node, SymbolPtr* symbol_ptr) override {
+  void Visit(const SyntaxTreeNode& node, SymbolPtr* symbol_ptr) final {
     CHECK_EQ(symbol_ptr->get(), &node);  // symbol_ptr owns node.
     if (result_ == nullptr) {
       // If this node matches, return it, and skip evaluating children.
@@ -158,7 +158,7 @@ class FirstSubtreeFinderMutable : public MutableTreeVisitorRecursive {
     }
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr* symbol_ptr) override {
+  void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr* symbol_ptr) final {
     CHECK_EQ(symbol_ptr->get(), &leaf);  // symbol_ptr owns leaf.
     // If already have a result, stop checking and return right away.
     if (result_ == nullptr) {
@@ -186,7 +186,7 @@ class FirstSubtreeFinder : public TreeVisitorRecursive {
   explicit FirstSubtreeFinder(const TreePredicate& predicate)
       : predicate_(predicate) {}
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     if (result_ == nullptr) {
       // If this node matches, return it, and skip evaluating children.
       if (predicate_(node)) {
@@ -203,7 +203,7 @@ class FirstSubtreeFinder : public TreeVisitorRecursive {
     }
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     // If already have a result, stop checking and return right away.
     if (result_ == nullptr) {
       if (predicate_(leaf)) {
@@ -356,10 +356,10 @@ class LeafMutatorVisitor : public MutableTreeVisitorRecursive {
   explicit LeafMutatorVisitor(const LeafMutator* mutator)
       : leaf_mutator_(*mutator) {}
 
-  void Visit(const SyntaxTreeNode&, SymbolPtr*) override {}
+  void Visit(const SyntaxTreeNode&, SymbolPtr*) final {}
 
   // Transforms a single leaf.
-  void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr* leaf_owner) override {
+  void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr* leaf_owner) final {
     CHECK_EQ(leaf_owner->get(), &leaf);
     auto* const mutable_leaf = down_cast<SyntaxTreeLeaf*>(leaf_owner->get());
     leaf_mutator_(ABSL_DIE_IF_NULL(mutable_leaf)->get_mutable());

--- a/verilog/CST/verilog_tree_json.cc
+++ b/verilog/CST/verilog_tree_json.cc
@@ -33,8 +33,8 @@ class VerilogTreeToJsonConverter : public verible::SymbolVisitor {
  public:
   explicit VerilogTreeToJsonConverter(absl::string_view base);
 
-  void Visit(const verible::SyntaxTreeLeaf&) override;
-  void Visit(const verible::SyntaxTreeNode&) override;
+  void Visit(const verible::SyntaxTreeLeaf&) final;
+  void Visit(const verible::SyntaxTreeNode&) final;
 
   json TakeJsonValue() { return std::move(json_); }
 

--- a/verilog/CST/verilog_tree_print.h
+++ b/verilog/CST/verilog_tree_print.h
@@ -31,10 +31,10 @@ class VerilogPrettyPrinter : public verible::PrettyPrinter {
   explicit VerilogPrettyPrinter(std::ostream* output_stream,
                                 absl::string_view base);
 
-  void Visit(const verible::SyntaxTreeLeaf&) override;
-  void Visit(const verible::SyntaxTreeNode&) override;
+  void Visit(const verible::SyntaxTreeLeaf&) final;
+  void Visit(const verible::SyntaxTreeNode&) final;
 
-  // void Visit(verible::SyntaxTreeNode*) override;
+  // void Visit(verible::SyntaxTreeNode*) final;
 };
 
 // Prints tree contained at root to stream

--- a/verilog/analysis/checkers/always_comb_blocking_rule.h
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.h
@@ -34,9 +34,9 @@ class AlwaysCombBlockingRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/always_comb_rule.h
+++ b/verilog/analysis/checkers/always_comb_rule.h
@@ -37,9 +37,9 @@ class AlwaysCombRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.h
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.h
@@ -34,11 +34,11 @@ class AlwaysFFNonBlockingRule : public verible::SyntaxTreeLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  absl::Status Configure(const absl::string_view configuration) override;
+  absl::Status Configure(const absl::string_view configuration) final;
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Detects entering and leaving relevant code inside always_ff

--- a/verilog/analysis/checkers/banned_declared_name_patterns_rule.h
+++ b/verilog/analysis/checkers/banned_declared_name_patterns_rule.h
@@ -38,9 +38,9 @@ class BannedDeclaredNamePatternsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleNode(const verible::SyntaxTreeNode& node,
-                  const verible::SyntaxTreeContext& context) override;
+                  const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/case_missing_default_rule.h
+++ b/verilog/analysis/checkers/case_missing_default_rule.h
@@ -36,9 +36,9 @@ class CaseMissingDefaultRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/constraint_name_style_rule.h
+++ b/verilog/analysis/checkers/constraint_name_style_rule.h
@@ -37,9 +37,9 @@ class ConstraintNameStyleRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/create_object_name_match_rule.h
+++ b/verilog/analysis/checkers/create_object_name_match_rule.h
@@ -47,9 +47,9 @@ class CreateObjectNameMatchRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Record of found violations.

--- a/verilog/analysis/checkers/disable_statement_rule.h
+++ b/verilog/analysis/checkers/disable_statement_rule.h
@@ -35,9 +35,9 @@ class DisableStatementNoLabelsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/endif_comment_rule.h
+++ b/verilog/analysis/checkers/endif_comment_rule.h
@@ -52,9 +52,9 @@ class EndifCommentRule : public verible::TokenStreamLintRule {
 
   EndifCommentRule() : state_(State::kNormal) {}
 
-  void HandleToken(const verible::TokenInfo& token) override;
+  void HandleToken(const verible::TokenInfo& token) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // States of the internal token-based analysis.

--- a/verilog/analysis/checkers/enum_name_style_rule.h
+++ b/verilog/analysis/checkers/enum_name_style_rule.h
@@ -36,9 +36,9 @@ class EnumNameStyleRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/explicit_function_lifetime_rule.h
+++ b/verilog/analysis/checkers/explicit_function_lifetime_rule.h
@@ -36,9 +36,9 @@ class ExplicitFunctionLifetimeRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.h
+++ b/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.h
@@ -37,9 +37,9 @@ class ExplicitFunctionTaskParameterTypeRule
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.h
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.h
@@ -36,11 +36,11 @@ class ExplicitParameterStorageTypeRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
-  absl::Status Configure(absl::string_view configuration) override;
+  absl::Status Configure(absl::string_view configuration) final;
 
  private:
   // TODO(hzeller): would other exempt types be interesting?

--- a/verilog/analysis/checkers/explicit_task_lifetime_rule.h
+++ b/verilog/analysis/checkers/explicit_task_lifetime_rule.h
@@ -39,9 +39,9 @@ class ExplicitTaskLifetimeRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.h
+++ b/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.h
@@ -41,9 +41,9 @@ class ForbidConsecutiveNullStatementsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleLeaf(const verible::SyntaxTreeLeaf& leaf,
-                  const verible::SyntaxTreeContext& context) override;
+                  const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // States of the internal leaf-based analysis.

--- a/verilog/analysis/checkers/forbid_defparam_rule.h
+++ b/verilog/analysis/checkers/forbid_defparam_rule.h
@@ -36,9 +36,9 @@ class ForbidDefparamRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/forbidden_anonymous_enums_rule.h
+++ b/verilog/analysis/checkers/forbidden_anonymous_enums_rule.h
@@ -49,9 +49,9 @@ class ForbiddenAnonymousEnumsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Collection of found violations.

--- a/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h
+++ b/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.h
@@ -57,12 +57,12 @@ class ForbiddenAnonymousStructsUnionsRule : public verible::SyntaxTreeLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  absl::Status Configure(absl::string_view configuration) override;
+  absl::Status Configure(absl::string_view configuration) final;
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Tests if the rule is met, taking waiving condition into account.

--- a/verilog/analysis/checkers/forbidden_macro_rule.h
+++ b/verilog/analysis/checkers/forbidden_macro_rule.h
@@ -45,9 +45,9 @@ class ForbiddenMacroRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::string FormatReason(const verible::SyntaxTreeLeaf& leaf) const;

--- a/verilog/analysis/checkers/forbidden_symbol_rule.h
+++ b/verilog/analysis/checkers/forbidden_symbol_rule.h
@@ -45,9 +45,9 @@ class ForbiddenSystemTaskFunctionRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::string FormatReason(const verible::SyntaxTreeLeaf& leaf) const;

--- a/verilog/analysis/checkers/generate_label_prefix_rule.h
+++ b/verilog/analysis/checkers/generate_label_prefix_rule.h
@@ -37,9 +37,9 @@ class GenerateLabelPrefixRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/generate_label_rule.h
+++ b/verilog/analysis/checkers/generate_label_rule.h
@@ -47,9 +47,9 @@ class GenerateLabelRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/interface_name_style_rule.h
+++ b/verilog/analysis/checkers/interface_name_style_rule.h
@@ -36,9 +36,9 @@ class InterfaceNameStyleRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/legacy_generate_region_rule.h
+++ b/verilog/analysis/checkers/legacy_generate_region_rule.h
@@ -35,9 +35,9 @@ class LegacyGenerateRegionRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleNode(const verible::SyntaxTreeNode& node,
-                  const verible::SyntaxTreeContext& context) override;
+                  const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/legacy_genvar_declaration_rule.h
+++ b/verilog/analysis/checkers/legacy_genvar_declaration_rule.h
@@ -36,9 +36,9 @@ class LegacyGenvarDeclarationRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleNode(const verible::SyntaxTreeNode& node,
-                  const verible::SyntaxTreeContext& context) override;
+                  const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/line_length_rule.h
+++ b/verilog/analysis/checkers/line_length_rule.h
@@ -47,11 +47,11 @@ class LineLengthRule : public verible::TextStructureLintRule {
 
   LineLengthRule() {}
 
-  absl::Status Configure(absl::string_view configuration) override;
+  absl::Status Configure(absl::string_view configuration) final;
 
-  void Lint(const verible::TextStructureView&, absl::string_view) override;
+  void Lint(const verible::TextStructureView&, absl::string_view) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   int line_length_limit_ = kDefaultLineLength;

--- a/verilog/analysis/checkers/macro_name_style_rule.h
+++ b/verilog/analysis/checkers/macro_name_style_rule.h
@@ -36,9 +36,9 @@ class MacroNameStyleRule : public verible::TokenStreamLintRule {
 
   MacroNameStyleRule() : state_(State::kNormal) {}
 
-  void HandleToken(const verible::TokenInfo& token) override;
+  void HandleToken(const verible::TokenInfo& token) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // States of the internal token-based analysis.

--- a/verilog/analysis/checkers/macro_string_concatenation_rule.h
+++ b/verilog/analysis/checkers/macro_string_concatenation_rule.h
@@ -35,9 +35,9 @@ class MacroStringConcatenationRule : public verible::TokenStreamLintRule {
 
   MacroStringConcatenationRule() : state_(State::kNormal) {}
 
-  void HandleToken(const verible::TokenInfo& token) override;
+  void HandleToken(const verible::TokenInfo& token) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // States of the internal token-based analysis.

--- a/verilog/analysis/checkers/mismatched_labels_rule.h
+++ b/verilog/analysis/checkers/mismatched_labels_rule.h
@@ -37,9 +37,9 @@ class MismatchedLabelsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/module_begin_block_rule.h
+++ b/verilog/analysis/checkers/module_begin_block_rule.h
@@ -43,9 +43,9 @@ class ModuleBeginBlockRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/module_filename_rule.h
+++ b/verilog/analysis/checkers/module_filename_rule.h
@@ -36,10 +36,10 @@ class ModuleFilenameRule : public verible::TextStructureLintRule {
 
   ModuleFilenameRule() {}
 
-  absl::Status Configure(absl::string_view configuration) override;
-  void Lint(const verible::TextStructureView&, absl::string_view) override;
+  absl::Status Configure(absl::string_view configuration) final;
+  void Lint(const verible::TextStructureView&, absl::string_view) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Ok to treat dashes as underscores.

--- a/verilog/analysis/checkers/module_instantiation_rules.h
+++ b/verilog/analysis/checkers/module_instantiation_rules.h
@@ -36,8 +36,8 @@ class ModuleParameterRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
-  verible::LintRuleStatus Report() const override;
+                    const verible::SyntaxTreeContext& context) final;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;
@@ -51,8 +51,8 @@ class ModulePortRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
-  verible::LintRuleStatus Report() const override;
+                    const verible::SyntaxTreeContext& context) final;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Returns false if a port list node is in violation of this rule and

--- a/verilog/analysis/checkers/no_tabs_rule.h
+++ b/verilog/analysis/checkers/no_tabs_rule.h
@@ -37,9 +37,9 @@ class NoTabsRule : public verible::LineLintRule {
 
   NoTabsRule() {}
 
-  void HandleLine(absl::string_view line) override;
+  void HandleLine(absl::string_view line) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Collection of found violations.

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.h
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.h
@@ -37,9 +37,9 @@ class NoTrailingSpacesRule : public verible::LineLintRule {
 
   NoTrailingSpacesRule() {}
 
-  void HandleLine(absl::string_view line) override;
+  void HandleLine(absl::string_view line) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Collection of found violations.

--- a/verilog/analysis/checkers/numeric_format_string_style_rule.h
+++ b/verilog/analysis/checkers/numeric_format_string_style_rule.h
@@ -36,9 +36,9 @@ class NumericFormatStringStyleRule : public verible::TokenStreamLintRule {
 
   NumericFormatStringStyleRule() {}
 
-  void HandleToken(const verible::TokenInfo& token) override;
+  void HandleToken(const verible::TokenInfo& token) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   void CheckAndReportViolation(const verible::TokenInfo& token, size_t position,

--- a/verilog/analysis/checkers/one_module_per_file_rule.h
+++ b/verilog/analysis/checkers/one_module_per_file_rule.h
@@ -36,9 +36,9 @@ class OneModulePerFileRule : public verible::TextStructureLintRule {
 
   OneModulePerFileRule() {}
 
-  void Lint(const verible::TextStructureView&, absl::string_view) override;
+  void Lint(const verible::TextStructureView&, absl::string_view) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Collection of found violations.

--- a/verilog/analysis/checkers/package_filename_rule.h
+++ b/verilog/analysis/checkers/package_filename_rule.h
@@ -37,10 +37,10 @@ class PackageFilenameRule : public verible::TextStructureLintRule {
 
   PackageFilenameRule() {}
 
-  absl::Status Configure(absl::string_view configuration) override;
-  void Lint(const verible::TextStructureView&, absl::string_view) override;
+  absl::Status Configure(absl::string_view configuration) final;
+  void Lint(const verible::TextStructureView&, absl::string_view) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Ok to treat dashes as underscores.

--- a/verilog/analysis/checkers/packed_dimensions_rule.h
+++ b/verilog/analysis/checkers/packed_dimensions_rule.h
@@ -36,8 +36,8 @@ class PackedDimensionsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
-  verible::LintRuleStatus Report() const override;
+                    const verible::SyntaxTreeContext& context) final;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/parameter_name_style_rule.h
+++ b/verilog/analysis/checkers/parameter_name_style_rule.h
@@ -38,12 +38,12 @@ class ParameterNameStyleRule : public verible::SyntaxTreeLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  absl::Status Configure(absl::string_view configuration) override;
+  absl::Status Configure(absl::string_view configuration) final;
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Format diagnostic message.

--- a/verilog/analysis/checkers/parameter_type_name_style_rule.h
+++ b/verilog/analysis/checkers/parameter_type_name_style_rule.h
@@ -36,9 +36,9 @@ class ParameterTypeNameStyleRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/plusarg_assignment_rule.h
+++ b/verilog/analysis/checkers/plusarg_assignment_rule.h
@@ -44,9 +44,9 @@ class PlusargAssignmentRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::string FormatReason() const;

--- a/verilog/analysis/checkers/port_name_suffix_rule.h
+++ b/verilog/analysis/checkers/port_name_suffix_rule.h
@@ -38,9 +38,9 @@ class PortNameSuffixRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Helper functions

--- a/verilog/analysis/checkers/positive_meaning_parameter_name_rule.h
+++ b/verilog/analysis/checkers/positive_meaning_parameter_name_rule.h
@@ -36,9 +36,9 @@ class PositiveMeaningParameterNameRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/posix_eof_rule.h
+++ b/verilog/analysis/checkers/posix_eof_rule.h
@@ -43,9 +43,9 @@ class PosixEOFRule : public verible::TextStructureLintRule {
 
   PosixEOFRule() {}
 
-  void Lint(const verible::TextStructureView&, absl::string_view) override;
+  void Lint(const verible::TextStructureView&, absl::string_view) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Collection of found violations.

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule.h
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule.h
@@ -37,9 +37,9 @@ class ProperParameterDeclarationRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/signal_name_style_rule.h
+++ b/verilog/analysis/checkers/signal_name_style_rule.h
@@ -37,9 +37,9 @@ class SignalNameStyleRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/struct_union_name_style_rule.h
+++ b/verilog/analysis/checkers/struct_union_name_style_rule.h
@@ -37,11 +37,11 @@ class StructUnionNameStyleRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  absl::Status Configure(absl::string_view configuration) override;
+  absl::Status Configure(absl::string_view configuration) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<std::string> exceptions_;

--- a/verilog/analysis/checkers/suggest_parentheses_rule.h
+++ b/verilog/analysis/checkers/suggest_parentheses_rule.h
@@ -33,9 +33,9 @@ class SuggestParenthesesRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleNode(const verible::SyntaxTreeNode& node,
-                  const verible::SyntaxTreeContext& context) override;
+                  const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/token_stream_lint_rule.h
+++ b/verilog/analysis/checkers/token_stream_lint_rule.h
@@ -35,9 +35,9 @@ class TokenStreamLintRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/unpacked_dimensions_rule.h
+++ b/verilog/analysis/checkers/unpacked_dimensions_rule.h
@@ -37,8 +37,8 @@ class UnpackedDimensionsRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
-  verible::LintRuleStatus Report() const override;
+                    const verible::SyntaxTreeContext& context) final;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule.h
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule.h
@@ -49,9 +49,9 @@ class UvmMacroSemicolonRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleLeaf(const verible::SyntaxTreeLeaf& leaf,
-                  const verible::SyntaxTreeContext& context) override;
+                  const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // States of the internal leaf-based analysis.

--- a/verilog/analysis/checkers/v2001_generate_begin_rule.h
+++ b/verilog/analysis/checkers/v2001_generate_begin_rule.h
@@ -46,9 +46,9 @@ class V2001GenerateBeginRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/void_cast_rule.h
+++ b/verilog/analysis/checkers/void_cast_rule.h
@@ -37,9 +37,9 @@ class VoidCastRule : public verible::SyntaxTreeLintRule {
   static const LintRuleDescriptor& GetDescriptor();
 
   void HandleSymbol(const verible::Symbol& symbol,
-                    const verible::SyntaxTreeContext& context) override;
+                    const verible::SyntaxTreeContext& context) final;
 
-  verible::LintRuleStatus Report() const override;
+  verible::LintRuleStatus Report() const final;
 
  private:
   // Generate diagnostic message of why lint error occurred.

--- a/verilog/analysis/lint_rule_registry_test.cc
+++ b/verilog/analysis/lint_rule_registry_test.cc
@@ -50,10 +50,10 @@ class TreeRuleBase : public SyntaxTreeLintRule {
  public:
   using rule_type = SyntaxTreeLintRule;
   void HandleLeaf(const verible::SyntaxTreeLeaf& leaf,
-                  const verible::SyntaxTreeContext& context) override {}
+                  const verible::SyntaxTreeContext& context) final {}
   void HandleNode(const verible::SyntaxTreeNode& node,
-                  const verible::SyntaxTreeContext& context) override {}
-  verible::LintRuleStatus Report() const override {
+                  const verible::SyntaxTreeContext& context) final {}
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };
@@ -121,8 +121,8 @@ TEST(GetAllRuleDescriptions, SyntaxRuleValid) {
 class TokenRuleBase : public TokenStreamLintRule {
  public:
   using rule_type = TokenStreamLintRule;
-  void HandleToken(const verible::TokenInfo&) override {}
-  verible::LintRuleStatus Report() const override {
+  void HandleToken(const verible::TokenInfo&) final {}
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };
@@ -180,8 +180,8 @@ class LineRule1 : public LineLintRule {
     return d;
   }
 
-  void HandleLine(absl::string_view) override {}
-  verible::LintRuleStatus Report() const override {
+  void HandleLine(absl::string_view) final {}
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };
@@ -227,8 +227,8 @@ class TextRule1 : public TextStructureLintRule {
     return d;
   }
 
-  void Lint(const verible::TextStructureView&, absl::string_view) override {}
-  verible::LintRuleStatus Report() const override {
+  void Lint(const verible::TextStructureView&, absl::string_view) final {}
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -272,9 +272,9 @@ class MacroCallArgExpander : public MutableTreeVisitorRecursive {
  public:
   explicit MacroCallArgExpander(absl::string_view text) : full_text_(text) {}
 
-  void Visit(const SyntaxTreeNode&, SymbolPtr*) override {}
+  void Visit(const SyntaxTreeNode&, SymbolPtr*) final {}
 
-  void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr* leaf_owner) override {
+  void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr* leaf_owner) final {
     const TokenInfo& token(leaf.get());
     if (token.token_enum() == MacroArg) {
       VLOG(3) << "MacroCallArgExpander: examining token: " << token;

--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -35,7 +35,7 @@ class VerilogAnalyzer : public verible::FileAnalyzer {
       : verible::FileAnalyzer(text, name), max_used_stack_size_(0) {}
 
   // Lex-es the input text into tokens.
-  absl::Status Tokenize() override;
+  absl::Status Tokenize() final;
 
   // Create token stream view without comments and whitespace.
   // The retained tokens will become leaves of a concrete syntax tree.

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -58,10 +58,10 @@ using testing::SizeIs;
 class TestRuleBase : public SyntaxTreeLintRule {
  public:
   void HandleLeaf(const verible::SyntaxTreeLeaf& leaf,
-                  const verible::SyntaxTreeContext& context) override {}
+                  const verible::SyntaxTreeContext& context) final {}
   void HandleNode(const verible::SyntaxTreeNode& node,
-                  const verible::SyntaxTreeContext& context) override {}
-  verible::LintRuleStatus Report() const override {
+                  const verible::SyntaxTreeContext& context) final {}
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };
@@ -101,9 +101,9 @@ class TestRule3 : public TokenStreamLintRule {
     return d;
   }
 
-  void HandleToken(const verible::TokenInfo&) override {}
+  void HandleToken(const verible::TokenInfo&) final {}
 
-  verible::LintRuleStatus Report() const override {
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };
@@ -119,9 +119,9 @@ class TestRule4 : public LineLintRule {
     return d;
   }
 
-  void HandleLine(absl::string_view) override {}
+  void HandleLine(absl::string_view) final {}
 
-  verible::LintRuleStatus Report() const override {
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };
@@ -137,9 +137,9 @@ class TestRule5 : public TextStructureLintRule {
     return d;
   }
 
-  void Lint(const TextStructureView&, absl::string_view) override {}
+  void Lint(const TextStructureView&, absl::string_view) final {}
 
-  verible::LintRuleStatus Report() const override {
+  verible::LintRuleStatus Report() const final {
     return verible::LintRuleStatus();
   }
 };

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -160,7 +160,7 @@ class InMemoryVerilogSourceFile final : public VerilogSourceFile {
         contents_for_open_(contents) {}
 
   // Load text into analyzer structure without actually opening a file.
-  absl::Status Open() override;
+  absl::Status Open() final;
 
  private:
   const absl::string_view contents_for_open_;
@@ -182,13 +182,13 @@ class ParsedVerilogSourceFile final : public VerilogSourceFile {
         text_structure_(text_structure) {}
 
   // Do nothing (file contents already loaded)
-  absl::Status Open() override;
+  absl::Status Open() final;
 
   // Do nothing (contents already parsed)
-  absl::Status Parse() override;
+  absl::Status Parse() final;
 
   // Return TextStructureView provided previously in constructor
-  const verible::TextStructureView* GetTextStructure() const override;
+  const verible::TextStructureView* GetTextStructure() const final;
 
  private:
   const verible::TextStructureView* text_structure_;

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -218,7 +218,7 @@ class ActualNamedParameterColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   ActualNamedParameterColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -248,7 +248,7 @@ class ActualNamedPortColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   ActualNamedPortColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -278,7 +278,7 @@ class PortDeclarationColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   PortDeclarationColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -335,7 +335,7 @@ class PortDeclarationColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
     if (new_column_after_open_bracket_) {
@@ -415,7 +415,7 @@ class StructUnionMemberColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   StructUnionMemberColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -441,7 +441,7 @@ class StructUnionMemberColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
     const int tag = leaf.get().token_enum();
@@ -606,7 +606,7 @@ class DataDeclarationColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   DataDeclarationColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -676,7 +676,7 @@ class DataDeclarationColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << "end of " << __FUNCTION__ << ", node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
     if (new_column_after_open_bracket_) {
@@ -734,7 +734,7 @@ class ClassPropertyColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   ClassPropertyColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -777,7 +777,7 @@ class ClassPropertyColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << "end of " << __FUNCTION__ << ", node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
     const int tag = leaf.get().token_enum();
@@ -799,7 +799,7 @@ class ParameterDeclarationColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   ParameterDeclarationColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -838,7 +838,7 @@ class ParameterDeclarationColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
 
@@ -938,7 +938,7 @@ class CaseItemColumnSchemaScanner : public ColumnSchemaScanner {
          NodeEnum::kGenerateCaseItem, NodeEnum::kDefaultItem});
   }
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -968,7 +968,7 @@ class CaseItemColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
     const int tag = leaf.get().token_enum();
@@ -998,7 +998,7 @@ class AssignmentColumnSchemaScanner : public ColumnSchemaScanner {
  public:
   AssignmentColumnSchemaScanner() = default;
 
-  void Visit(const SyntaxTreeNode& node) override {
+  void Visit(const SyntaxTreeNode& node) final {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -1021,7 +1021,7 @@ class AssignmentColumnSchemaScanner : public ColumnSchemaScanner {
     VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override {
+  void Visit(const SyntaxTreeLeaf& leaf) final {
     VLOG(2) << __FUNCTION__ << ", leaf: " << leaf.get() << " at "
             << TreePathFormatter(Path());
     const int tag = leaf.get().token_enum();

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -81,16 +81,16 @@ class TreeUnwrapper : public verible::TreeUnwrapper {
 
   void LookAheadBeyondCurrentLeaf();
   void LookAheadBeyondCurrentNode();
-  void InterChildNodeHook(const verible::SyntaxTreeNode&) override;
+  void InterChildNodeHook(const verible::SyntaxTreeNode&) final;
 
-  void CollectLeadingFilteredTokens() override;
+  void CollectLeadingFilteredTokens() final;
 
   // Collects filtered tokens into the UnwrappedLines from
   // next_unfiltered_token_ until EOF.
-  void CollectTrailingFilteredTokens() override;
+  void CollectTrailingFilteredTokens() final;
 
-  void Visit(const verible::SyntaxTreeLeaf& leaf) override;
-  void Visit(const verible::SyntaxTreeNode& node) override;
+  void Visit(const verible::SyntaxTreeLeaf& leaf) final;
+  void Visit(const verible::SyntaxTreeNode& node) final;
 
   void SetIndentationsAndCreatePartitions(const verible::SyntaxTreeNode& node);
 

--- a/verilog/parser/verilog_lexer_unittest.cc
+++ b/verilog/parser/verilog_lexer_unittest.cc
@@ -36,7 +36,7 @@ class FilteredVerilogLexer : public VerilogLexer {
  public:
   explicit FilteredVerilogLexer(absl::string_view code) : VerilogLexer(code) {}
 
-  const TokenInfo& DoNextToken() override {
+  const TokenInfo& DoNextToken() final {
     do {
       VerilogLexer::DoNextToken();
     } while (!VerilogLexer::KeepSyntaxTreeTokens(GetLastToken()));

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -86,8 +86,8 @@ class IndexingFactsTreeExtractor : public verible::TreeContextVisitor {
         Anchor(base));
   }
 
-  void Visit(const SyntaxTreeLeaf& leaf) override;
-  void Visit(const SyntaxTreeNode& node) override;
+  void Visit(const SyntaxTreeLeaf& leaf) final;
+  void Visit(const SyntaxTreeNode& node) final;
 
   const IndexingFactNode& Root() const { return root_; }
   IndexingFactNode TakeRoot() { return std::move(root_); }


### PR DESCRIPTION
This not only documents the hierachy better for humans (and
it is a deliberate action to extend something), but also can
improve speed if the compiler happens to know the instance
it calls as it can do de-virtualization.

Signed-off-by: Henner Zeller <h.zeller@acm.org>