### PR TITLE
For undersized literals with value one: also suggest decimal.

### DIFF
--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -74,7 +74,7 @@ static TokenInfo SymbolToToken(const Symbol& root) {
 
 LintViolation::LintViolation(const Symbol& root, const std::string& reason,
                              const SyntaxTreeContext& context,
-                             std::initializer_list<AutoFix> autofixes)
+                             const std::vector<AutoFix>& autofixes)
     : root(&root),
       token(SymbolToToken(root)),
       reason(reason),

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -99,7 +99,7 @@ class AutoFix {
 struct LintViolation {
   // This construct records a token stream lint violation.
   LintViolation(const TokenInfo& token, const std::string& reason,
-                std::initializer_list<AutoFix> autofixes = {})
+                const std::vector<AutoFix>& autofixes = {})
       : root(nullptr),
         token(token),
         reason(reason),
@@ -110,7 +110,7 @@ struct LintViolation {
   // Use this variation when the violation can be localized to a single token.
   LintViolation(const TokenInfo& token, const std::string& reason,
                 const SyntaxTreeContext& context,
-                std::initializer_list<AutoFix> autofixes = {})
+                const std::vector<AutoFix>& autofixes = {})
       : root(nullptr),
         token(token),
         reason(reason),
@@ -123,7 +123,7 @@ struct LintViolation {
   // the left-most leaf of the subtree.
   LintViolation(const Symbol& root, const std::string& reason,
                 const SyntaxTreeContext& context,
-                std::initializer_list<AutoFix> autofixes = {});
+                const std::vector<AutoFix>& autofixes = {});
 
   // root is a reference into original ConcreteSyntaxTree that
   // linter was run against. LintViolations should not outlive this tree.

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.h
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.h
@@ -54,6 +54,8 @@ class UndersizedBinaryLiteralRule : public verible::SyntaxTreeLintRule {
   bool check_bin_numbers_ = true;
   bool check_hex_numbers_ = false;
   bool check_oct_numbers_ = false;
+  bool autofix = true;
+  bool autofix_suggest_decimal_for_one = true;
 
   std::set<verible::LintViolation> violations_;
 };

--- a/verilog/analysis/checkers/undersized_binary_literal_rule_test.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule_test.cc
@@ -180,7 +180,36 @@ TEST(UndersizedBinaryLiteralTest, ApplyAutoFix) {
       {"localparam x = 8'o7;", "localparam x = 8'o007;"},
   };
   RunApplyFixCases<VerilogAnalyzer, UndersizedBinaryLiteralRule>(
-      kTestCases, "bin:true;hex:true;oct:true");
+      kTestCases, "bin:true;hex:true;oct:true;autofix:true");
+}
+
+TEST(UndersizedBinaryLiteralRule, ApplyAutoFixDigitOne) {
+  // Alternatives the auto fix offers
+  constexpr int kFirstFix = 0;
+  constexpr int kSecondFix = 1;
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"localparam x = 32'h1;", "localparam x = 32'd1;", kFirstFix},
+      {"localparam x = 32'sh1;", "localparam x = 32'sd1;", kFirstFix},
+      {"localparam x = 32'h1;", "localparam x = 32'h00000001;", kSecondFix},
+      {"localparam x = 32'sh1;", "localparam x = 32'sh00000001;", kSecondFix},
+  };
+  RunApplyFixCases<VerilogAnalyzer, UndersizedBinaryLiteralRule>(
+      kTestCases,
+      "bin:true;hex:true;oct:true;"
+      "autofix:true;autofix_suggest_decimal_for_one:true");
+}
+
+TEST(UndersizedBinaryLiteralRule, ApplyAutoDoNotFixDigitOne) {
+  // Alternatives the auto fix offers
+  constexpr int kFirstFix = 0;
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"localparam x = 32'h1;", "localparam x = 32'h00000001;", kFirstFix},
+      {"localparam x = 32'sh1;", "localparam x = 32'sh00000001;", kFirstFix},
+  };
+  RunApplyFixCases<VerilogAnalyzer, UndersizedBinaryLiteralRule>(
+      kTestCases,
+      "bin:true;hex:true;oct:true;"
+      "autofix:true;autofix_suggest_decimal_for_one:false");
 }
 
 }  // namespace


### PR DESCRIPTION
e.g. 32'h1 now provides two suggestions
  * 32'd1
  * 32'h00000001

Signed-off-by: Henner Zeller <h.zeller@acm.org>