### PR TITLE
Undo compilation database with fileset.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -18,11 +18,11 @@ TIDY_OUT=${TMPDIR:-/tmp}/clang-tidy.out
 # First, build the compilation database.
 bazel build :compdb > /dev/null 2>&1
 
-OUTPUT_BASE=$(bazel info output_base)
+EXEC_ROOT=$(bazel info execution_root)
 
-# Fix up the __OUTPUT_BASE__ to the path used by bazel.
+# Fix up the __EXEC_ROOT__ to the path used by bazel.
 cat bazel-bin/compile_commands.json \
-  | sed "s|__OUTPUT_BASE__|$OUTPUT_BASE|g" \
+  | sed "s|__EXEC_ROOT__|$EXEC_ROOT|" \
   | sed 's/-fno-canonical-system-headers//g' \
         > compile_commands.json
 

--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,7 @@
 #  bazel test ...
 
 load("@com_github_google_rules_install//installer:def.bzl", "installer")
-load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
+load("@com_grail_bazel_compdb//:aspects.bzl", "compilation_database")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -72,7 +72,21 @@ action_listener(
 
 compilation_database(
     name = "compdb",
-    targets = [ ":install-binaries" ],
+    # targets = [ ":install-binaries" ],
+    # Unfortunately, compilation_database does not support filesets yet,
+    # so expand them here manually.
+    # https://github.com/grailbio/bazel-compilation-database/issues/84
+   targets = [
+        "//common/tools:verible-patch-tool",
+        "//verilog/tools/diff:verible-verilog-diff",
+        "//verilog/tools/formatter:verible-verilog-format",
+        "//verilog/tools/kythe:verible-verilog-kythe-extractor",
+        "//verilog/tools/lint:verible-verilog-lint",
+        "//verilog/tools/obfuscator:verible-verilog-obfuscate",
+        "//verilog/tools/preprocessor:verible-verilog-preprocessor",
+        "//verilog/tools/project:verible-verilog-project",
+        "//verilog/tools/syntax:verible-verilog-syntax",
+    ],
     # TODO: is there a way to essentially specify //... so that all tests
     # are included as well ?
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -198,7 +198,7 @@ http_archive(
 
 http_archive(
     name = "com_grail_bazel_compdb",
-    sha256 = "39b6632e7d3a6b6d076d9a0a0d936e6ddb6b1ebe2b1ff0200adac52761c94286",
-    strip_prefix = "bazel-compilation-database-08d706d3cf7daf3d529a26ca76d75da1a3eae6c0",
-    urls = ["https://github.com/grailbio/bazel-compilation-database/archive/08d706d3cf7daf3d529a26ca76d75da1a3eae6c0.tar.gz"],
+    sha256 = "f798690ddb6bba453ed489665c408bb0ce630bd7f0992c160c9414f933481a91",
+    strip_prefix = "bazel-compilation-database-ace73b04e76111afa09934f8771a2798847e724e",
+    urls = ["https://github.com/grailbio/bazel-compilation-database/archive/ace73b04e76111afa09934f8771a2798847e724e.tar.gz"],
 )


### PR DESCRIPTION
This breaks building on centos 7/8, possibly due
to bazel version incompatibility; needs to be figured
out.

Signed-off-by: Henner Zeller <h.zeller@acm.org>