### PR TITLE
Fix formatting of ternaries

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -978,6 +978,28 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "    ((e == f) && g) ? {1'b0, f} : (h) ?\n"
         "    {1'b0, e} - 1'b1 : {1'b0, e} + 1'b1;\n",
     },
+    {
+        "assign {aaaaaaaaaa, bbbbbbbbb} = {1'b0, cccccccccccccccccc[15:0]} +\n"
+        "                                 {1'b0, ddddddddddddddddd[15:0]};\n",
+        "assign {aaaaaaaaaa, bbbbbbbbb} =\n"
+        "    {1'b0, cccccccccccccccccc[15:0]} + {\n"
+        "    1'b0, ddddddddddddddddd[15:0]};\n",
+    },
+    {
+        "covergroup a(string b);\n"
+        "foobar: cross foo, bar {"
+        "ignore_bins baz = binsof(qux) intersect {1, 2, 3, 4, 5, 6, 7};"
+        "}\n"
+        "endgroup : a\n",
+        "covergroup a(string b);\n"
+        "  foobar: cross foo, bar{\n"
+        "    ignore_bins baz =\n"
+        "        binsof (qux) intersect {\n"
+        "      1, 2, 3, 4, 5, 6, 7\n"
+        "    };\n"
+        "  }\n"
+        "endgroup : a\n",
+    },
 
     // streaming operators
     {

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -395,8 +395,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      " `AINIT(S, (D == 4 && K inside {0, 1}) ||"
      " (D == 3 && K== 4))\n",
      "`AINIT(S,\n"
-     "       (D == 4 && K inside {0, 1}) || (\n"
-     "           D == 3 && K == 4))\n"},
+     "       (D == 4 && K inside {0, 1}) ||\n"
+     "           (D == 3 && K == 4))\n"},
     {// long macro call breaking
      " `ASSERT_INIT(S, D == 4 && K inside {0, 1})\n",
      "`ASSERT_INIT(S,\n"
@@ -982,8 +982,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "assign {aaaaaaaaaa, bbbbbbbbb} = {1'b0, cccccccccccccccccc[15:0]} +\n"
         "                                 {1'b0, ddddddddddddddddd[15:0]};\n",
         "assign {aaaaaaaaaa, bbbbbbbbb} =\n"
-        "    {1'b0, cccccccccccccccccc[15:0]} + {\n"
-        "    1'b0, ddddddddddddddddd[15:0]};\n",
+        "    {1'b0, cccccccccccccccccc[15:0]} +\n"
+        "    {1'b0, ddddddddddddddddd[15:0]};\n",
     },
     {
         "covergroup a(string b);\n"
@@ -999,6 +999,11 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "    };\n"
         "  }\n"
         "endgroup : a\n",
+    },
+    {
+        "assign {aa, bb} = {1'b0, cc} + {1'b0, dd};\n",
+        "assign {aa, bb} = {1'b0, cc} +\n"
+        "    {1'b0, dd};\n",
     },
 
     // streaming operators

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -960,6 +960,24 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "      another_really_long_identifier;\n"
         "endmodule\n",
     },
+    {
+        "assign m = check                ? {10'b0, foo} :\n"
+        "           (bar && (baz == '0)) ? hello        :\n"
+        "           world                ? temp1        : temp2;\n",
+        "assign m = check ? {10'b0, foo} :\n"
+        "    (bar && (baz == '0)) ? hello :\n"
+        "    world ? temp1 : temp2;\n",
+    },
+    {
+        "assign {a, b} = !(c == d) ? {1'b0, e} :\n"
+        "                ((e == f) && g) ?\n"
+        "                {1'b0, f} : (h) ?\n"
+        "                {1'b0, e} - 1'b1 :\n"
+        "                {1'b0, e} + 1'b1;\n",
+        "assign {a, b} = !(c == d) ? {1'b0, e} :\n"
+        "    ((e == f) && g) ? {1'b0, f} : (h) ?\n"
+        "    {1'b0, e} - 1'b1 : {1'b0, e} + 1'b1;\n",
+    },
 
     // streaming operators
     {

--- a/verilog/formatting/formatter_tuning_test.cc
+++ b/verilog/formatting/formatter_tuning_test.cc
@@ -101,11 +101,11 @@ localparam int DDDDDDDDDDD = pppppppppppppppppp + LLLLLLLLLLLLLL
 + ((EEEEEEEEEEEE && FFFFFFFFFFFFFF > 0) ? hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh : 0);
 endmodule
 )sv",
-        // make sure the '+' after 'pppppppppppppppppp' is on the same line
+        // make sure the line does not break before a '+'
         R"sv(
 module m;
-  localparam int DDDDDDDDDDD = pppppppppppppppppp +
-      LLLLLLLLLLLLLL + ((EEEEEEEEEEEE && FFFFFFFFFFFFFF > 0) ? hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh : 0);
+  localparam int DDDDDDDDDDD = pppppppppppppppppp + LLLLLLLLLLLLLL +
+      ((EEEEEEEEEEEE && FFFFFFFFFFFFFF > 0) ? hhhhhhhhhhhhhhhhhhhhhhhhhhhhhh : 0);
 endmodule
 )sv"},
     {

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -607,12 +607,16 @@ static WithReason<int> BreakPenaltyBetweenTokens(
 
   // Prefer to split after an assignment operator, rather than before.
   // TODO(fangism): use context to cover all assignment-like cases
-  if (right.TokenEnum() == '=') return {5, "right is '='"};
+  if (right.TokenEnum() == '=') return {8, "right is '='"};
 
-  // Prefer to keep '(' with whatever is on the left.
-  // TODO(fangism): ... except when () is used as precedence.
-  if (right.format_token_enum == FormatTokenType::open_group)
+  if ((left.format_token_enum != FormatTokenType::binary_operator ||
+       left.TokenEnum() == '=') &&
+      right.format_token_enum == FormatTokenType::open_group) {
+    // Prefer to keep '(' with a token on the left, as long as it is not binary
+    // operator other than '='
+    // TODO(fangism): ... except when () is used as precedence.
     return {5, "right is open-group"};
+  }
   // Prefer to keep ')' with whatever is on the left.
   if (right.format_token_enum == FormatTokenType::close_group ||
       right.TokenEnum() == verilog_tokentype::MacroCallCloseToEndLine)
@@ -686,7 +690,7 @@ static WithReason<int> TokensWithContextBreakPenalty(
   }
   if (left_context.DirectParentIs(NodeEnum::kBinaryExpression) &&
       left.format_token_enum == FormatTokenType::binary_operator) {
-    return {0, "Prefer to split after binary operators (+0 on right)."};
+    return {-5, "Prefer to split after binary operators (-5 on right)."};
   }
   return {0, "No adjustment."};
 }

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1031,9 +1031,12 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
       break;
     }
     case NodeEnum::kOpenRangeList: {
-      if (Context().DirectParentIs(NodeEnum::kConcatenationExpression) &&
+      if (Context().DirectParentsAre(
+              {NodeEnum::kConcatenationExpression, NodeEnum::kExpression}) &&
           !Context().IsInside(NodeEnum::kCoverageBin) &&
-          !Context().IsInside(NodeEnum::kConditionExpression)) {
+          !Context().IsInside(NodeEnum::kConditionExpression) &&
+          (!Context().IsInside(NodeEnum::kBinaryExpression) ||
+           Context().IsInside(NodeEnum::kPropertyImplicationList))) {
         // Do not further indent preprocessor clauses.
         const int indent = suppress_indentation ? 0 : style_.indentation_spaces;
         VisitIndentedSection(node, indent,
@@ -1173,14 +1176,16 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
                                          NodeEnum::kIdentifierList})) {
         // original un-lexed macro argument was successfully expanded
         VisitNewUnwrappedLine(node);
-      } else if (Context().DirectParentIs(NodeEnum::kOpenRangeList) &&
-                 Context().IsInside(NodeEnum::kConcatenationExpression) &&
-                 !(Context().IsInside(NodeEnum::kCoverageBin) ||
-                   Context().IsInside(NodeEnum::kConditionExpression))) {
+      } else if (Context().DirectParentsAre({NodeEnum::kOpenRangeList,
+                                             NodeEnum::kConcatenationExpression,
+                                             NodeEnum::kExpression}) &&
+                 !Context().IsInside(NodeEnum::kCoverageBin) &&
+                 !Context().IsInside(NodeEnum::kConditionExpression) &&
+                 (!Context().IsInside(NodeEnum::kBinaryExpression) ||
+                  Context().IsInside(NodeEnum::kPropertyImplicationList))) {
         VisitIndentedSection(node, 0,
                              PartitionPolicyEnum::kFitOnLineElseExpand);
-      } else if (Context().IsInside(NodeEnum::kAssignmentPattern) &&
-                 !Context().IsInside(NodeEnum::kConditionExpression)) {
+      } else if (Context().IsInside(NodeEnum::kAssignmentPattern)) {
         VisitIndentedSection(node, style_.wrap_spaces,
                              PartitionPolicyEnum::kFitOnLineElseExpand);
       } else {
@@ -2098,10 +2103,13 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeLeaf& leaf) {
           (current_context_.DirectParentIsOneOf(
                {NodeEnum::kUntagged, NodeEnum::kExpressionList}) &&
            current_context_.IsInside(NodeEnum::kAssignmentPattern)) ||
-          (current_context_.DirectParentIs(NodeEnum::kOpenRangeList) &&
-           current_context_.IsInside(NodeEnum::kConcatenationExpression) &&
+          (current_context_.DirectParentsAre(
+               {NodeEnum::kOpenRangeList, NodeEnum::kConcatenationExpression,
+                NodeEnum::kExpression}) &&
            !current_context_.IsInside(NodeEnum::kCoverageBin) &&
-           !current_context_.IsInside(NodeEnum::kConditionExpression))) {
+           !current_context_.IsInside(NodeEnum::kConditionExpression) &&
+           (!current_context_.IsInside(NodeEnum::kBinaryExpression) ||
+            current_context_.IsInside(NodeEnum::kPropertyImplicationList)))) {
         MergeLastTwoPartitions();
       } else if (CurrentUnwrappedLine().Size() == 1) {
         // Partition would begin with a comma,

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1032,7 +1032,8 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     }
     case NodeEnum::kOpenRangeList: {
       if (Context().DirectParentIs(NodeEnum::kConcatenationExpression) &&
-          !Context().IsInside(NodeEnum::kCoverageBin)) {
+          !Context().IsInside(NodeEnum::kCoverageBin) &&
+          !Context().IsInside(NodeEnum::kConditionExpression)) {
         // Do not further indent preprocessor clauses.
         const int indent = suppress_indentation ? 0 : style_.indentation_spaces;
         VisitIndentedSection(node, indent,
@@ -1174,10 +1175,12 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
         VisitNewUnwrappedLine(node);
       } else if (Context().DirectParentIs(NodeEnum::kOpenRangeList) &&
                  Context().IsInside(NodeEnum::kConcatenationExpression) &&
-                 !(Context().IsInside(NodeEnum::kCoverageBin))) {
+                 !(Context().IsInside(NodeEnum::kCoverageBin) ||
+                   Context().IsInside(NodeEnum::kConditionExpression))) {
         VisitIndentedSection(node, 0,
                              PartitionPolicyEnum::kFitOnLineElseExpand);
-      } else if (Context().IsInside(NodeEnum::kAssignmentPattern)) {
+      } else if (Context().IsInside(NodeEnum::kAssignmentPattern) &&
+                 !Context().IsInside(NodeEnum::kConditionExpression)) {
         VisitIndentedSection(node, style_.wrap_spaces,
                              PartitionPolicyEnum::kFitOnLineElseExpand);
       } else {
@@ -2097,7 +2100,8 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeLeaf& leaf) {
            current_context_.IsInside(NodeEnum::kAssignmentPattern)) ||
           (current_context_.DirectParentIs(NodeEnum::kOpenRangeList) &&
            current_context_.IsInside(NodeEnum::kConcatenationExpression) &&
-           !current_context_.IsInside(NodeEnum::kCoverageBin))) {
+           !current_context_.IsInside(NodeEnum::kCoverageBin) &&
+           !current_context_.IsInside(NodeEnum::kConditionExpression))) {
         MergeLastTwoPartitions();
       } else if (CurrentUnwrappedLine().Size() == 1) {
         // Partition would begin with a comma,

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -8050,7 +8050,7 @@ const TreeUnwrapperTestData kUnwrapCovergroupTestCases[] = {
         "covergroup cg(string s);"
         "x_cross : cross s1, s2{"
         "  bins a = binsof(x) intersect {d};"
-        "  bins b = binsof(y) intersect {e};"
+        "  bins b = binsof(y) intersect {e, f};"
         "}"
         "endgroup ",
         CovergroupDeclaration(
@@ -8059,15 +8059,16 @@ const TreeUnwrapperTestData kUnwrapCovergroupTestCases[] = {
                              L(2, {"string", "s"}), L(0, {")", ";"})),
             CovergroupItemList(
                 1, L(1, {"x_cross", ":", "cross", "s1", ",", "s2", "{"}),
-                CrossItemList(2,
-                              N(2,
-                                L(2, {"bins", "a", "=", "binsof", "(", "x", ")",
-                                      "intersect", "{"}),
-                                L(3, {"d"}), L(2, {"}", ";"})),
-                              N(2,
-                                L(2, {"bins", "b", "=", "binsof", "(", "y", ")",
-                                      "intersect", "{"}),
-                                L(3, {"e"}), L(2, {"}", ";"}))),
+                CrossItemList(
+                    2,
+                    N(2,
+                      L(2, {"bins", "a", "=", "binsof", "(", "x", ")",
+                            "intersect", "{"}),
+                      L(3, {"d"}), L(2, {"}", ";"})),
+                    N(2,
+                      L(2, {"bins", "b", "=", "binsof", "(", "y", ")",
+                            "intersect", "{"}),
+                      N(3, L(3, {"e", ","}), L(3, {"f"})), L(2, {"}", ";"}))),
                 L(1, {"}"})),
             L(0, {"endgroup"})),
     },


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/verible/issues/887

Formatted test cases from the issue:

```systemverilog
module X ();
  assign myvar = check ? {10'b0, foo} : (bar && (baz == '0)) ? hello_longlonglong :
      world_longlonglong ? temp1_longlonglong : temp2_longlonglong;
endmodule : X
```

```systemverilog
module X ();
  assign {dc_wrap, dc_htbt_d} = !(htbt_ctr_q == blink_param_x_i) ?
      {1'b0, dc_htbt_q} : ((dc_htbt_q == duty_cycle_a_i) && pattern_repeat) ?
      {1'b0, duty_cycle_a_i} : (htbt_direction) ? {1'b0, dc_htbt_q} - {1'b0, blink_param_y_i} -
      1'b1 : {1'b0, dc_htbt_q} + {1'b0, blink_param_y_i} + 1'b1;
endmodule : X
```

```systemverilog
module X ();
  assign {phase_wrap, off_phase} = {1'b0, phase_delay_scaled[15:0]} +
      {1'b0, duty_cycle_scaled[15:0]};
endmodule : X
```

Todo:
* unit tests

Ideas for further work:
* It would be nice to implement tabular alignment of nested ternary operators.