### PR TITLE
Use isblank instead of isspace for trailing spaces detection

### DIFF
--- a/verilog/analysis/checkers/no_trailing_spaces_rule.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.cc
@@ -24,6 +24,7 @@
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
 #include "common/analysis/lint_rule_status.h"
 #include "common/text/token_info.h"
 #include "verilog/analysis/descriptions.h"
@@ -53,11 +54,14 @@ const LintRuleDescriptor& NoTrailingSpacesRule::GetDescriptor() {
 }
 
 void NoTrailingSpacesRule::HandleLine(absl::string_view line) {
+  // Lines may end with \n or \r\n. '\n' is already excluded.
+  // Exclude '\r'
+  absl::ConsumeSuffix(&line, "\r");
+  // Now any line endings (either \n or \r\n) are excluded.
   // Searches each line in reverse for spaces.
   const auto rbegin = line.crbegin();
   const auto rend = line.crend();
   if (rbegin != rend) {
-    // Lines already exclude \n, so we can check using std::isspace.
     const auto reverse_iter =
         std::find_if(rbegin, rend, [](char c) { return !std::isspace(c); });
     const int trailing = std::distance(rbegin, reverse_iter);

--- a/verilog/analysis/checkers/no_trailing_spaces_rule_test.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule_test.cc
@@ -35,6 +35,7 @@ using verible::RunLintTestCases;
 TEST(NoTrailingSpacesRuleTest, AcceptsText) {
   const std::initializer_list<LintTestCase> kTestCases = {
       {""},
+      {"\r\n"},
       {"\n"},
       {"\n\n\n"},
       {"\naaa"},
@@ -42,6 +43,8 @@ TEST(NoTrailingSpacesRuleTest, AcceptsText) {
       {"  xxx\n\n"},
       {"\txxx\n\n"},
       {"  xxx\n  yyy\n"},
+      {"  xxx\n  yyy\r\n"},
+      {"  xxx\n  yyy\r\n\r\n"},
       {"module foo;\nendmodule\n"},
   };
   RunLintTestCases<VerilogAnalyzer, NoTrailingSpacesRule>(kTestCases);
@@ -62,6 +65,8 @@ TEST(NoTrailingSpacesRuleTest, RejectsTrailingSpaces) {
       {"a  b", {kToken, "   "}, "\n\n1  2", {kToken, "  "}, "\n"},
       {"module foo;", {kToken, " "}, "\nendmodule\n"},
       {"module foo;\nendmodule", {kToken, " "}, "\n"},
+      {"module foo;\nendmodule", {kToken, "  "}, "\r\n"},
+      {"module foo;\nendmodule", {kToken, "  "}, "\r\n\r\n"},
       {"`define\tIGNORANCE\t\"strength\"", {kToken, " "}, "\n"},
   };
   RunLintTestCases<VerilogAnalyzer, NoTrailingSpacesRule>(kTestCases);


### PR DESCRIPTION
`no-trailing-spaces` rule reports issues in every line of files which use `\r\n` line endings.
Example file: https://github.com/chipsalliance/UHDM-integration-tests/blob/master/tests/AssignmentPattern/top.sv

~~The solution uses `std::isblank` which means only spaces and tabs in the end of lines will cause errors.~~

~~A useful comparison of `isblank` and `isspace` can be seen in the table in the bottom of this page:
https://en.cppreference.com/w/cpp/string/byte/isspace~~

EDIT:
The suggested test case has shown that the idea of solving the problem with `isblank` won't work.
Right now the code drops one `\r` character from the end of the line if it exists.