### PR TITLE
Add jdk to nix-shell.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ pkgs.mkShell {
       bazel
       gcc
       glibc
+      jdk
       python3
     ];
 


### PR DESCRIPTION
This allows building with `nix-shell --pure`.

Without the jdk package builds will fail when using `--pure`:
```text
Error in fail: Auto-Configuration Error: Cannot find Java binary bin/java in /home/alex/.cache/bazel/_bazel_alex/install/a1b2cf98f1aadcf49735c7833d8c2677/embedded_tools/tools/jdk/nosystemjdk; either correct your JAVA_HOME, PATH or specify embedded Java (e.g. --javabase=@bazel_tools//tools/jdk:remote_jdk11)
```