### PR TITLE
Provide an additional alternative for autofixing zero literals.

### DIFF
--- a/verilog/analysis/checkers/undersized_binary_literal_rule.h
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.h
@@ -54,8 +54,8 @@ class UndersizedBinaryLiteralRule : public verible::SyntaxTreeLintRule {
   bool check_bin_numbers_ = true;
   bool check_hex_numbers_ = false;
   bool check_oct_numbers_ = false;
-  bool autofix = true;
-  bool autofix_suggest_decimal_for_one = true;
+  bool lint_zero_ = false;
+  bool autofix_ = true;
 
   std::set<verible::LintViolation> violations_;
 };

--- a/verilog/tools/lint/README.md
+++ b/verilog/tools/lint/README.md
@@ -237,6 +237,7 @@ The interactive modes `--autofix=patch-interactive` and
 * `?` - print this help and prompt again
 
 Example interactive session (`--autofix=inplace-interactive`):
+
 ```
 autofixtest.sv:3:1: Remove trailing spaces. [Style: trailing-spaces] [no-trailing-spaces]
 Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] a


### PR DESCRIPTION
Autofixes for undersized zero literals, e.g. 32'h0 provide
as one alternative to fix it to a simple '0. Thus the alternatives
for a zero constant `32'h0` are now

  1. `'0`
  2. `32'h00000000`
  3. `32'd0`

Signed-off-by: Henner Zeller <hzeller@google.com>