### PR TITLE
Provide UI choice if there are multiple autofix alternatives.

### DIFF
--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -470,7 +470,7 @@ class ViolationFixerTest : public testing::Test {
   }
 
   void DoFixerTest(
-      std::initializer_list<ViolationFixer::AnswerChoice> choices,
+      std::initializer_list<ViolationFixer::Answer> choices,
       std::initializer_list<absl::string_view> expected_fixed_sources) const {
     static constexpr std::array<const absl::string_view, 3> input_sources{
         // Input source 0:
@@ -503,7 +503,7 @@ class ViolationFixerTest : public testing::Test {
     };
     EXPECT_EQ(expected_fixed_sources.size(), input_sources.size());
 
-    std::initializer_list<ViolationFixer::AnswerChoice>::iterator choice_it;
+    std::initializer_list<ViolationFixer::Answer>::iterator choice_it;
     const ViolationFixer::AnswerChooser answer_chooser =
         [&choice_it, &choices](const verible::LintViolation&,
                                absl::string_view) {
@@ -586,7 +586,7 @@ class ViolationFixerTest : public testing::Test {
 TEST_F(ViolationFixerTest, ApplyAll) {
   DoFixerTest(
       {
-          ViolationFixer::AnswerChoice::kApplyAll,
+          {ViolationFixer::AnswerChoice::kApplyAll, 0},
       },
       {
           "module Autofix;\n"
@@ -608,7 +608,7 @@ TEST_F(ViolationFixerTest, ApplyAll) {
 TEST_F(ViolationFixerTest, RejectAll) {
   DoFixerTest(
       {
-          ViolationFixer::AnswerChoice::kRejectAll,
+          {ViolationFixer::AnswerChoice::kRejectAll, 0},
       },
       {
           "module Autofix;    \n"
@@ -630,8 +630,8 @@ TEST_F(ViolationFixerTest, RejectAll) {
 TEST_F(ViolationFixerTest, Reject) {
   DoFixerTest(
       {
-          ViolationFixer::AnswerChoice::kReject,
-          ViolationFixer::AnswerChoice::kApplyAll,
+          {ViolationFixer::AnswerChoice::kReject, 0},
+          {ViolationFixer::AnswerChoice::kApplyAll, 0},
       },
       {
           "module Autofix;    \n"
@@ -653,8 +653,8 @@ TEST_F(ViolationFixerTest, Reject) {
 TEST_F(ViolationFixerTest, Apply) {
   DoFixerTest(
       {
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kRejectAll,
+          {ViolationFixer::AnswerChoice::kApply, 0},
+          {ViolationFixer::AnswerChoice::kRejectAll, 0},
       },
       {
           "module Autofix;\n"
@@ -678,24 +678,24 @@ TEST_F(ViolationFixerTest, ApplyAllForRule) {
       {
           // Input source 0:
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApplyAllForRule,
+          {ViolationFixer::AnswerChoice::kApplyAllForRule},
           // :3:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :4:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :4:11: no-trailing-spaces
           // AUTOMATICALLY APPLIED due to kApplyAllForRule
           // :5:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :6:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :7:10: no-trailing-spaces
           // AUTOMATICALLY APPLIED due to kApplyAllForRule
           // :7:14: posix-eof
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // Input source 2:
           // :1:21: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :2:10: no-trailing-spaces
           // AUTOMATICALLY APPLIED due to kApplyAllForRule
       },
@@ -721,24 +721,24 @@ TEST_F(ViolationFixerTest, RejectAllForRule) {
       {
           // Input source 0:
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kRejectAllForRule,
+          {ViolationFixer::AnswerChoice::kRejectAllForRule},
           // :3:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :4:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :4:11: no-trailing-spaces
           // AUTOMATICALLY REJECTED due to kApplyAllForRule
           // :5:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :6:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :7:10: no-trailing-spaces
           // AUTOMATICALLY REJECTED due to kApplyAllForRule
           // :7:14: posix-eof
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // Input source 2:
           // :1:21: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :2:10: no-trailing-spaces
           // AUTOMATICALLY REJECTED due to kApplyAllForRule
       },
@@ -764,9 +764,9 @@ TEST_F(ViolationFixerTest, RejectAllForRuleApplyAllForRule) {
       {
           // Input source 0:
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kRejectAllForRule,
+          {ViolationFixer::AnswerChoice::kRejectAllForRule},
           // :3:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApplyAllForRule,
+          {ViolationFixer::AnswerChoice::kApplyAllForRule},
           // :4:10: forbid-consecutive-null-statements
           // AUTOMATICALLY APPLIED due to kApplyAllForRule
           // :4:11: no-trailing-spaces
@@ -778,7 +778,7 @@ TEST_F(ViolationFixerTest, RejectAllForRuleApplyAllForRule) {
           // :7:10: no-trailing-spaces
           // AUTOMATICALLY REJECTED due to kApplyAllForRule
           // :7:14: posix-eof
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // Input source 2:
           // :1:21: forbid-consecutive-null-statements
           // AUTOMATICALLY APPLIED due to kApplyAllForRule
@@ -808,34 +808,34 @@ TEST_F(ViolationFixerTest, PrintFix) {
       {
           // Input source 0:
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintFix,
-          ViolationFixer::AnswerChoice::kPrintFix,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintFix},
+          {ViolationFixer::AnswerChoice::kPrintFix},
           // :3:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :4:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
-          ViolationFixer::AnswerChoice::kPrintFix,
+          {ViolationFixer::AnswerChoice::kReject},
+          {ViolationFixer::AnswerChoice::kPrintFix},
           // :4:11: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintFix,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintFix},
           // :5:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :6:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintFix,
-          ViolationFixer::AnswerChoice::kPrintFix,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintFix},
+          {ViolationFixer::AnswerChoice::kPrintFix},
           // :7:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :7:14: posix-eof
-          ViolationFixer::AnswerChoice::kReject,
-          ViolationFixer::AnswerChoice::kPrintFix,
+          {ViolationFixer::AnswerChoice::kReject},
+          {ViolationFixer::AnswerChoice::kPrintFix},
           // Input source 2:
           // :1:21: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintFix,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintFix},
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
       },
       {
           "module Autofix;\n"
@@ -860,34 +860,34 @@ TEST_F(ViolationFixerTest, PrintAppliedFixes) {
       {
           // Input source 0:
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
           // :3:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
           // :4:10: forbid-consecutive-null-staments
-          ViolationFixer::AnswerChoice::kReject,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
+          {ViolationFixer::AnswerChoice::kReject},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
           // :4:11: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
           // :5:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :6:10: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
           // :7:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kApply,
+          {ViolationFixer::AnswerChoice::kApply},
           // :7:14: posix-eof
-          ViolationFixer::AnswerChoice::kReject,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
+          {ViolationFixer::AnswerChoice::kReject},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
           // Input source 2:
           // :1:21: forbid-consecutive-null-statements
-          ViolationFixer::AnswerChoice::kApply,
-          ViolationFixer::AnswerChoice::kPrintAppliedFixes,
+          {ViolationFixer::AnswerChoice::kApply},
+          {ViolationFixer::AnswerChoice::kPrintAppliedFixes},
           // :2:10: no-trailing-spaces
-          ViolationFixer::AnswerChoice::kReject,
+          {ViolationFixer::AnswerChoice::kReject},
       },
       {
           "module Autofix;\n"

--- a/verilog/tools/lint/lint_tool_test.sh
+++ b/verilog/tools/lint/lint_tool_test.sh
@@ -893,22 +893,25 @@ echo "=== Test --autofix=inplace-interactive: Choose alternative fix"
 
 # Files with alternatives in autofixes
 ORIGINAL_ALT_AUTO_FIX="${TEST_TMPDIR}/orig-autofix-alternative.sv"
->"${ORIGINAL_ALT_AUTO_FIX}"
-echo -en "module AlternativeAutoFix;\n" >>"${ORIGINAL_ALT_AUTO_FIX}"
-echo -en "  assign a = 32'h1;\n"        >>"${ORIGINAL_ALT_AUTO_FIX}"
-echo -en "endmodule\n"                  >>"${ORIGINAL_ALT_AUTO_FIX}"
+cat >"${ORIGINAL_ALT_AUTO_FIX}" <<EOF
+module AlternativeAutoFix;
+  assign a = 32'h1;
+endmodule
+EOF
 
 REFERENCE_ALT_AUTO_FIX_1="${TEST_TMPDIR}/alt-autofix-alternative-1.sv"
->"${REFERENCE_ALT_AUTO_FIX_1}"
-echo -en "module AlternativeAutoFix;\n" >>"${REFERENCE_ALT_AUTO_FIX_1}"
-echo -en "  assign a = 32'h00000001;\n" >>"${REFERENCE_ALT_AUTO_FIX_1}"
-echo -en "endmodule\n"                  >>"${REFERENCE_ALT_AUTO_FIX_1}"
+cat >"${REFERENCE_ALT_AUTO_FIX_1}" <<EOF
+module AlternativeAutoFix;
+  assign a = 32'h00000001;
+endmodule
+EOF
 
 REFERENCE_ALT_AUTO_FIX_2="${TEST_TMPDIR}/alt-autofix-alternative-2.sv"
->"${REFERENCE_ALT_AUTO_FIX_2}"
-echo -en "module AlternativeAutoFix;\n" >>"${REFERENCE_ALT_AUTO_FIX_2}"
-echo -en "  assign a = 32'd1;\n"        >>"${REFERENCE_ALT_AUTO_FIX_2}"
-echo -en "endmodule\n"                  >>"${REFERENCE_ALT_AUTO_FIX_2}"
+cat >"${REFERENCE_ALT_AUTO_FIX_2}" <<EOF
+module AlternativeAutoFix;
+  assign a = 32'd1;
+endmodule
+EOF
 
 failure=0
 cp ${ORIGINAL_ALT_AUTO_FIX} ${TEST_FILE}
@@ -918,7 +921,18 @@ cp ${ORIGINAL_ALT_AUTO_FIX} ${TEST_FILE}
              <<< "1"
 
 check_diff "${REFERENCE_ALT_AUTO_FIX_1}" "${TEST_FILE}" "${DIFF_FILE}" \
-    "First alternative not coosen."
+    "First alternative not chosen."
+(( failure|="$?" ))
+
+# Choosing first non-existing alternative, then an existing one.
+cp ${ORIGINAL_ALT_AUTO_FIX} ${TEST_FILE}
+"$lint_tool" --ruleset=none --rules="undersized-binary-literal=hex:true" \
+             --autofix=inplace-interactive \
+             "${TEST_FILE}" > /dev/null 2>&1 \
+             <<< "41"
+
+check_diff "${REFERENCE_ALT_AUTO_FIX_1}" "${TEST_FILE}" "${DIFF_FILE}" \
+    "First alternative not chosen."
 (( failure|="$?" ))
 
 cp ${ORIGINAL_ALT_AUTO_FIX} ${TEST_FILE}
@@ -927,7 +941,7 @@ cp ${ORIGINAL_ALT_AUTO_FIX} ${TEST_FILE}
              "${TEST_FILE}" > /dev/null 2>&1 \
              <<< "2"
 check_diff "${REFERENCE_ALT_AUTO_FIX_2}" "${TEST_FILE}" "${DIFF_FILE}" \
-    "Second alternative not coosen."
+    "Second alternative not chosen."
 (( failure|="$?" ))
 
 (( $failure )) && exit 1

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -155,9 +155,10 @@ int main(int argc, char** argv) {
   }
 
   const verilog::ViolationFixer::AnswerChooser applyAllFixes =
-      [](const verible::LintViolation&, absl::string_view) {
-        return verilog::ViolationFixer::AnswerChoice::kApplyAll;
-      };
+      [](const verible::LintViolation&,
+         absl::string_view) -> verilog::ViolationFixer::Answer {
+    return {verilog::ViolationFixer::AnswerChoice::kApplyAll, 0};
+  };
 
   std::unique_ptr<verilog::ViolationHandler> violation_handler;
   switch (autofix_mode) {


### PR DESCRIPTION
Most lint rules with autofix have exactly one choice of fixes,
but there are some that have 2 or even three alternatives.

Provide a way to choose if there are multiple options.
The short choices are then including the digits
'1', '2', etc. The default 'y' is equivalent to choosing
choice 1.

If there are multiple options, print all of these and
mark as "1. alternative", "2. alternative", etc.

Also while at it: improve interactive sessions by always
printing the available patch first (or patches, if there are
alternatives), as the user typically will not
choose blindly, so make the initial 'print' automatic.

Signed-off-by: Henner Zeller <hzeller@google.com>