### PR TITLE
Interactive lint autofix application: use terminal highlight.

### DIFF
--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <string>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 #ifndef _WIN32
@@ -57,4 +58,20 @@ char ReadCharFromUser(std::istream& input, std::ostream& output,
   }
 }
 
+namespace term {
+// TODO(hzeller): assumption here that basic ANSI codes work on all
+// platforms, but if not, change this with ifdef.
+static constexpr absl::string_view kBoldEscape("\e[1m");
+static constexpr absl::string_view kInverseEscape("\e[7m");
+static constexpr absl::string_view kNormalEscape("\e[0m");
+
+std::string bold(absl::string_view s) {
+  if (!IsInteractiveTerminalSession()) return std::string(s);
+  return absl::StrCat(kBoldEscape, s, kNormalEscape);
+}
+std::string inverse(absl::string_view s) {
+  if (!IsInteractiveTerminalSession()) return std::string(s);
+  return absl::StrCat(kInverseEscape, s, kNormalEscape);
+}
+}  // namespace term
 }  // namespace verible

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -61,9 +61,9 @@ char ReadCharFromUser(std::istream& input, std::ostream& output,
 namespace term {
 // TODO(hzeller): assumption here that basic ANSI codes work on all
 // platforms, but if not, change this with ifdef.
-static constexpr absl::string_view kBoldEscape("\e[1m");
-static constexpr absl::string_view kInverseEscape("\e[7m");
-static constexpr absl::string_view kNormalEscape("\e[0m");
+static constexpr absl::string_view kBoldEscape("\033[1m");
+static constexpr absl::string_view kInverseEscape("\033[7m");
+static constexpr absl::string_view kNormalEscape("\033[0m");
 
 std::string bold(absl::string_view s) {
   if (!IsInteractiveTerminalSession()) return std::string(s);

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -20,6 +20,12 @@
 #include "absl/strings/string_view.h"
 
 namespace verible {
+namespace term {
+// Convenience functions that wrap a string to output colored on screen, iff
+// this is an interactive session.
+std::string bold(absl::string_view s);
+std::string inverse(absl::string_view s);
+}  // namespace term
 
 // Returns if this is likely a terminal session (tests if stdin filedescriptor
 // is a terminal).

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -119,8 +119,8 @@ static void PrintFixAlternatives(std::ostream& stream, absl::string_view text,
   const bool print_alternative_number = fixes.size() > 1;
   for (size_t i = 0; i < fixes.size(); ++i) {
     if (print_alternative_number) {
-      stream << "=== " << (i + 1)
-             << ". alternative =================================\n";
+      stream << verible::term::inverse(
+          absl::StrCat("[ ", (i + 1), ". Alternative ]\n"));
     }
     PrintFix(stream, text, fixes[i]);
   }
@@ -262,8 +262,8 @@ ViolationFixer::Answer ViolationFixer::InteractiveAnswerChooser(
   for (;;) {
     const char c = verible::ReadCharFromUser(
         std::cin, std::cerr, verible::IsInteractiveTerminalSession(),
-        "Autofix is available. Apply? [" + alternative_list +
-            "y,n,a,d,A,D,p,P,?] ");
+        verible::term::bold("Autofix is available. Apply? [" +
+                            alternative_list + "y,n,a,d,A,D,p,P,?] "));
 
     // Single character digit chooses the available alternative.
     if (c >= '1' && c <= '9' &&

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -119,8 +119,8 @@ static void PrintFixAlternatives(std::ostream& stream, absl::string_view text,
   const bool print_alternative_number = fixes.size() > 1;
   for (size_t i = 0; i < fixes.size(); ++i) {
     if (print_alternative_number) {
-      stream << verible::term::inverse(
-          absl::StrCat("[ ", (i + 1), ". Alternative ]\n"));
+      stream << verible::term::inverse(absl::StrCat(
+          "[ ", (i + 1), ". Alternative ", fixes[i].Description(), " ]\n"));
     }
     PrintFix(stream, text, fixes[i]);
   }


### PR DESCRIPTION
Use bold and inverse to improve readability of lint autofix
sessions.

![interactive-lint-apply](https://user-images.githubusercontent.com/140937/134468145-f6c03ddb-b109-4b58-afa5-df6d7de04132.png)
