### PR TITLE
Add autofix-hints to all autofixes.

### DIFF
--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -37,7 +37,7 @@ namespace verible {
 std::string AutoFix::Apply(absl::string_view base) const {
   std::string result;
   auto prev_start = base.cbegin();
-  for (const auto& edit : edits) {
+  for (const auto& edit : edits_) {
     CHECK_LE(base.cbegin(), edit.fragment.cbegin());
     CHECK_GE(base.cend(), edit.fragment.cend());
 
@@ -55,11 +55,11 @@ std::string AutoFix::Apply(absl::string_view base) const {
 bool AutoFix::AddEdits(const std::set<ReplacementEdit>& new_edits) {
   // Check for conflicts
   for (const auto& edit : new_edits) {
-    if (edits.find(edit) != edits.end()) {
+    if (edits_.find(edit) != edits_.end()) {
       return false;
     }
   }
-  edits.insert(new_edits.cbegin(), new_edits.cend());
+  edits_.insert(new_edits.cbegin(), new_edits.cend());
   return true;
 }
 

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -62,37 +62,29 @@ struct ReplacementEdit {
 class AutoFix {
  public:
   AutoFix() {}
-  AutoFix(const AutoFix& other)
-      : description(other.description), edits(other.edits) {}
-  AutoFix(const AutoFix&& other)
-      : description(std::move(other.description)),
-        edits(std::move(other.edits)) {}
+  AutoFix(const AutoFix& other) = default;
+  AutoFix(AutoFix&& other) = default;
 
-  AutoFix(const std::string& description,
+  AutoFix(absl::string_view description,
           std::initializer_list<ReplacementEdit> edits)
-      : description(description), edits(edits) {
-    CHECK_EQ(this->edits.size(), edits.size()) << "Edits must not overlap.";
+      : description_(description), edits_(edits) {
+    CHECK_EQ(edits_.size(), edits.size()) << "Edits must not overlap.";
   }
 
-  AutoFix(std::initializer_list<ReplacementEdit> edits)
-      : AutoFix("Fix", edits) {}
-
-  AutoFix(const std::string& description, ReplacementEdit edit)
+  AutoFix(absl::string_view description, ReplacementEdit edit)
       : AutoFix(description, {edit}) {}
-
-  explicit AutoFix(ReplacementEdit edit) : AutoFix({edit}) {}
 
   // Applies the fix on a `base` and returns modified text.
   std::string Apply(absl::string_view base) const;
 
   bool AddEdits(const std::set<ReplacementEdit>& new_edits);
 
-  const std::set<ReplacementEdit>& Edits() const { return edits; }
-  const std::string& Description() const { return description; }
+  const std::set<ReplacementEdit>& Edits() const { return edits_; }
+  const std::string& Description() const { return description_; }
 
  private:
-  std::string description;
-  std::set<ReplacementEdit> edits;
+  std::string description_;
+  std::set<ReplacementEdit> edits_;
 };
 
 // LintViolation is a class that represents a single rule violation.

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -243,10 +243,10 @@ TEST(AutoFixTest, ValidUseCases) {
   static constexpr absl::string_view text("This is an image");
 
   // AutoFix(ReplacementEdit)
-  const AutoFix singleEdit({text.substr(5, 2), "isn't"});
+  const AutoFix singleEdit("e", {text.substr(5, 2), "isn't"});
   EXPECT_EQ(singleEdit.Apply(text), "This isn't an image");
 
-  const AutoFix singleInsert({text.substr(16, 0), "."});
+  const AutoFix singleInsert("i", {text.substr(16, 0), "."});
   EXPECT_EQ(singleInsert.Apply(text), "This is an image.");
 
   // AutoFix()
@@ -262,15 +262,15 @@ TEST(AutoFixTest, ValidUseCases) {
 
   // AutoFix(ReplacementEdit),
   // ReplacementEdit(const TokenInfo&, const std::string&)
-  AutoFix otherCollection({image_token, "🖼"});
+  AutoFix otherCollection("image", {image_token, "🖼"});
   EXPECT_TRUE(otherCollection.AddEdits(fixesCollection.Edits()));
   EXPECT_EQ(otherCollection.Apply(text), "Hello. This isn't an 🖼.");
 
   // AutoFix(std::initializer_list<ReplacementEdit>)
-  const AutoFix multipleEdits({
-      {text.substr(11, 5), "text"},
-      {text.substr(8, 2), "a"},
-  });
+  const AutoFix multipleEdits("Multi-edit", {
+                                                {text.substr(11, 5), "text"},
+                                                {text.substr(8, 2), "a"},
+                                            });
   EXPECT_EQ(multipleEdits.Apply(text), "This is a text");
 
   // AutoFix(const AutoFix& other)
@@ -310,16 +310,16 @@ TEST(AutoFixTest, ConflictingEdits) {
   EXPECT_FALSE(fixesCollection.AddEdits({{text.substr(15, 1), "ination"}}));
   EXPECT_EQ(fixesCollection.Apply(text), "This is a text");
 
-  EXPECT_DEATH(AutoFix({{text.substr(8, 8), "a text"},  //
-                        {text.substr(11, 5), "IMAGE"}}),
+  EXPECT_DEATH(AutoFix("overlap", {{text.substr(8, 8), "a text"},  //
+                                   {text.substr(11, 5), "IMAGE"}}),
                "Edits must not overlap");
 
-  EXPECT_DEATH(AutoFix({{text.substr(8, 8), "a text"},  //
-                        {text.substr(8, 1), "A"}}),
+  EXPECT_DEATH(AutoFix("overlap", {{text.substr(8, 8), "a text"},  //
+                                   {text.substr(8, 1), "A"}}),
                "Edits must not overlap");
 
-  EXPECT_DEATH(AutoFix({{text.substr(8, 8), "a text"},  //
-                        {text.substr(15, 1), "ination"}}),
+  EXPECT_DEATH(AutoFix("overlap", {{text.substr(8, 8), "a text"},  //
+                                   {text.substr(15, 1), "ination"}}),
                "Edits must not overlap");
 }
 

--- a/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.cc
+++ b/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.cc
@@ -67,8 +67,9 @@ void ForbidConsecutiveNullStatementsRule::HandleLeaf(
 
       case State::kExpectNonSemicolon: {
         if (leaf.Tag().tag == ';') {
-          violations_.insert(LintViolation(leaf, kMessage, context,
-                                           {AutoFix({leaf.get(), ""})}));
+          violations_.insert(LintViolation(
+              leaf, kMessage, context,
+              {AutoFix("Remove superfluous semicolon", {leaf.get(), ""})}));
         } else {
           state_ = State::kNormal;
         }

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.cc
@@ -69,8 +69,8 @@ void NoTrailingSpacesRule::HandleLine(absl::string_view line) {
       const int column = line.length() - trailing;
       const TokenInfo token(TK_SPACE, line.substr(column));
 
-      violations_.insert(
-          LintViolation(token, kMessage, {AutoFix({token, ""})}));
+      violations_.insert(LintViolation(
+          token, kMessage, {AutoFix("Remove trailing space", {token, ""})}));
     }
   }
 }

--- a/verilog/analysis/checkers/posix_eof_rule.cc
+++ b/verilog/analysis/checkers/posix_eof_rule.cc
@@ -56,8 +56,9 @@ void PosixEOFRule::Lint(const TextStructureView& text_structure,
     if (!last_line.empty()) {
       // Point to the end of the line (also EOF).
       const TokenInfo token(TK_OTHER, last_line.substr(last_line.length(), 0));
-      violations_.insert(
-          LintViolation(token, kMessage, {AutoFix({token, "\n"})}));
+      violations_.insert(LintViolation(
+          token, kMessage,
+          {AutoFix("Add newline at end of file", {token, "\n"})}));
     }
   }
 }

--- a/verilog/analysis/checkers/suggest_parentheses_rule.cc
+++ b/verilog/analysis/checkers/suggest_parentheses_rule.cc
@@ -64,7 +64,8 @@ void SuggestParenthesesRule::HandleNode(
 
         violations_.insert(LintViolation(
             token, kMessage, context,
-            {AutoFix({{token.text().substr(0, 0), "("},
+            {AutoFix("Add parenthesis for readability",
+                     {{token.text().substr(0, 0), "("},
                       {token.text().substr(token.text().length(), 0), ")"}})}));
       }
       break;

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.cc
@@ -132,22 +132,25 @@ void UndersizedBinaryLiteralRule::HandleSymbol(
     // Special number zero (if lint_zero defined): suggest a '0 in this case
     if (number.literal == "0" && !number.signedness) {
       autofixes.push_back(
-          AutoFix({{width_text, ""}, {base_text.substr(0, 2), "'"}}));
+          AutoFix("Replace with unsized `0",
+                  {{width_text, ""}, {base_text.substr(0, 2), "'"}}));
     }
 
     // Regular fix: prefix with leading zeroes.
     const int leading_0 = (missing_bits + bits_per_digit - 1) / bits_per_digit;
     autofixes.push_back(
-        AutoFix({{digits_text.substr(0, 0), std::string(leading_0, '0')}}));
+        AutoFix("Left-expand leading zeroes",
+                {{digits_text.substr(0, 0), std::string(leading_0, '0')}}));
 
     // For literals with small values that can be represented in one decimal
     // digit, this often might also be useful as decimal. Make this the final
     // suggestion.
     if (number.literal.size() == 1 && std::isdigit(number.literal[0])) {
+      static const std::string desc = "Replace with decimal";
       if (number.signedness) {
-        autofixes.push_back(AutoFix({{base_text.substr(0, 3), "'sd"}}));
+        autofixes.push_back(AutoFix(desc, {{base_text.substr(0, 3), "'sd"}}));
       } else {
-        autofixes.push_back(AutoFix({{base_text.substr(0, 2), "'d"}}));
+        autofixes.push_back(AutoFix(desc, {{base_text.substr(0, 2), "'d"}}));
       }
     }
 

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule.cc
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule.cc
@@ -81,9 +81,10 @@ void UvmMacroSemicolonRule::HandleLeaf(
 
       case State::kCheckMacro: {
         if (leaf.Tag().tag == ';') {
-          violations_.insert(LintViolation(leaf, FormatReason(macro_id_),
-                                           context,
-                                           {AutoFix({leaf.get(), ""})}));
+          violations_.insert(
+              LintViolation(leaf, FormatReason(macro_id_), context,
+                            {AutoFix("Remove semicolon at end of macro call",
+                                     {leaf.get(), ""})}));
           state_ = State::kNormal;
         } else if (leaf.Tag().tag ==
                    verilog_tokentype::MacroCallCloseToEndLine) {

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -121,6 +121,9 @@ static void PrintFixAlternatives(std::ostream& stream, absl::string_view text,
     if (print_alternative_number) {
       stream << verible::term::inverse(absl::StrCat(
           "[ ", (i + 1), ". Alternative ", fixes[i].Description(), " ]\n"));
+    } else {
+      stream << verible::term::inverse(
+          absl::StrCat("[ ", fixes[i].Description(), " ]\n"));
     }
     PrintFix(stream, text, fixes[i]);
   }

--- a/verilog/tools/lint/README.md
+++ b/verilog/tools/lint/README.md
@@ -1,7 +1,7 @@
 # SystemVerilog Style Linter
 
 <!--*
-freshness: { owner: 'hzeller' reviewed: '2020-10-07' }
+freshness: { owner: 'hzeller' reviewed: '2021-09-23' }
 *-->
 
 The `verible-verilog-lint` SV style linter analyzes code for patterns and
@@ -124,15 +124,28 @@ The `--rules` flag allows to enable/disable rules as well as pass configuration
 to rules that accept them. It accepts a comma-separated list
 [rule names][lint-rule-list]. If prefixed with a `-` (minus), the rule is
 disabled. No prefix or a '+' (plus) prefix enables the rule. An optional
-configuration can be passed after an `=` assignment.
+configuration can be passed after an `=` assignment. Each name/value is
+
+So rule configurations with parameters looks like this
+```
+  --rules=[+-]rule-name="<param>:<paramvalue>;<param2>:<value>",[+-]next-rule...
+```
 
 The following example enables the
 [`enum-name-style`][lint-rule-list_enum-name-style] rule, enables and configures
 the [`line-length`][lint-rule-list_line-length] rule (80 characters length) and
 disables the [`no-tabs`][lint-rule-list_no-tabs] rule.
 
-```
+```bash
 verible-verilog-lint --rules=enum-name-style,+line-length=length:80,-no-tabs ...
+```
+
+Some lint rules have multiple parameters, these are separated with semicolon.
+Since common shells treat semicolon as special character, you have to put
+the parameters in quotes.
+
+```bash
+verible-verilog-lint --rules="undersized-binary-literal=hex:true;lint_zero:true" ...
 ```
 
 Additionally, the `--rules_config` flag can be used to read configuration stored
@@ -238,29 +251,40 @@ The interactive modes `--autofix=patch-interactive` and
 
 Example interactive session (`--autofix=inplace-interactive`):
 
-```
-autofixtest.sv:3:1: Remove trailing spaces. [Style: trailing-spaces] [no-trailing-spaces]
-Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] a
-(fixed)
-autofixtest.sv:6:31: Parenthesize condition expressions that appear in the true-clause of another condition expression. [Style: parentheses] [suggest-parentheses]
-Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] p
-@@ -5,3 +5,3 @@
+<pre>
+$ verible-verilog-lint --rules="undersized-binary-literal=hex:true" --autofix=inplace-interactive autofixtest.sv
 
--    assign foo = condition_a? condition_b ? condition_c ? a : b : c : d;
-+    assign foo = condition_a? (condition_b ? condition_c ? a : b : c) : d;
-
-Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] y
-(fixed)
-autofixtest.sv:6:45: Parenthesize condition expressions that appear in the true-clause of another condition expression. [Style: parentheses] [suggest-parentheses]
-Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] p
-@@ -5,3 +5,3 @@
-
--    assign foo = condition_a? condition_b ? condition_c ? a : b : c : d;
-+    assign foo = condition_a? condition_b ? (condition_c ? a : b) : c : d;
-
-Autofix is available. Apply? [y,n,a,d,A,D,p,P,?] y
-(fixed)
-```
+autofixtest.sv:2:30: Parenthesize condition expressions that appear in the true-clause of another condition expression. [Style: parentheses] [suggest-parentheses]
+<b>[ Add parenthesis for readability ]</b>
+@@ -1,3 +1,3 @@
+ module foo();
+-   assign foo = condition_a? condition_b ? condition_c ? a : b : c : d;
++   assign foo = condition_a? (condition_b ? condition_c ? a : b : c) : d;
+    assign c = 32'h1;
+<b>Autofix is available. Apply? [y,n,a,d,A,D,p,P,?]</b> y
+autofixtest.sv:2:44: Parenthesize condition expressions that appear in the true-clause of another condition expression. [Style: parentheses] [suggest-parentheses]
+<b>[ Add parenthesis for readability ]</b>
+@@ -1,3 +1,3 @@
+ module foo();
+-   assign foo = condition_a? condition_b ? condition_c ? a : b : c : d;
++   assign foo = condition_a? condition_b ? (condition_c ? a : b) : c : d;
+    assign c = 32'h1;
+<b>Autofix is available. Apply? [y,n,a,d,A,D,p,P,?]</b> y
+autofixtest.sv:3:19: Hex literal 32'h1 has less digits than expected for 32 bits. [Style: number-literals] [undersized-binary-literal]
+<b>[ 1. Alternative Left-expand leading zeroes ]</b>
+@@ -2,3 +2,3 @@
+    assign foo = condition_a? condition_b ? condition_c ? a : b : c : d;
+-   assign c = 32'h1;
++   assign c = 32'h00000001;
+ endmodule
+<b>[ 2. Alternative Replace with decimal ]</b>
+@@ -2,3 +2,3 @@
+    assign foo = condition_a? condition_b ? condition_c ? a : b : c : d;
+-   assign c = 32'h1;
++   assign c = 32'd1;
+ endmodule
+<b>Autofix is available. Apply? [1,2,y,n,a,d,A,D,p,P,?]</b> 1
+</pre>
 
 <!-- reference links -->
 


### PR DESCRIPTION
Since we have a chance to show a description of a lint autofix
in the potential UI or github pull, add descriptions to all of
them.

Remove the AutoFix constructors that allow to skip adding a
description, thus AutoFix implementors are always required
to add a description.

Signed-off-by: Henner Zeller <hzeller@google.com>