### PR TITLE
EnumMap: don't construct globally.

### DIFF
--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -43,21 +43,24 @@
 
 namespace verible {
 
-static const verible::EnumNameMap<AlignmentPolicy> kAlignmentPolicyNameMap = {
-    {"align", AlignmentPolicy::kAlign},
-    {"flush-left", AlignmentPolicy::kFlushLeft},
-    {"preserve", AlignmentPolicy::kPreserve},
-    {"infer", AlignmentPolicy::kInferUserIntent},
-    // etc.
-};
+static const verible::EnumNameMap<AlignmentPolicy>& AlignmentPolicyNameMap() {
+  static const verible::EnumNameMap<AlignmentPolicy> kAlignmentPolicyNameMap({
+      {"align", AlignmentPolicy::kAlign},
+      {"flush-left", AlignmentPolicy::kFlushLeft},
+      {"preserve", AlignmentPolicy::kPreserve},
+      {"infer", AlignmentPolicy::kInferUserIntent},
+      // etc.
+  });
+  return kAlignmentPolicyNameMap;
+}
 
 std::ostream& operator<<(std::ostream& stream, AlignmentPolicy policy) {
-  return kAlignmentPolicyNameMap.Unparse(policy, stream);
+  return AlignmentPolicyNameMap().Unparse(policy, stream);
 }
 
 bool AbslParseFlag(absl::string_view text, AlignmentPolicy* policy,
                    std::string* error) {
-  return kAlignmentPolicyNameMap.Parse(text, policy, error, "AlignmentPolicy");
+  return AlignmentPolicyNameMap().Parse(text, policy, error, "AlignmentPolicy");
 }
 
 std::string AbslUnparseFlag(const AlignmentPolicy& policy) {

--- a/common/formatting/basic_format_style.cc
+++ b/common/formatting/basic_format_style.cc
@@ -24,20 +24,22 @@
 namespace verible {
 
 // This mapping defines how this enum is displayed and parsed.
-static const verible::EnumNameMap<IndentationStyle> kIndentationStyleStringMap =
-    {
-        {"indent", IndentationStyle::kIndent},
-        {"wrap", IndentationStyle::kWrap},
-};
+static const verible::EnumNameMap<IndentationStyle>& IndentationStyleStrings() {
+  static const verible::EnumNameMap<IndentationStyle>
+      kIndentationStyleStringMap({
+          {"indent", IndentationStyle::kIndent},
+          {"wrap", IndentationStyle::kWrap},
+      });
+  return kIndentationStyleStringMap;
+}
 
 std::ostream& operator<<(std::ostream& stream, IndentationStyle p) {
-  return kIndentationStyleStringMap.Unparse(p, stream);
+  return IndentationStyleStrings().Unparse(p, stream);
 }
 
 bool AbslParseFlag(absl::string_view text, IndentationStyle* mode,
                    std::string* error) {
-  return kIndentationStyleStringMap.Parse(text, mode, error,
-                                          "IndentationStyle");
+  return IndentationStyleStrings().Parse(text, mode, error, "IndentationStyle");
 }
 
 std::string AbslUnparseFlag(const IndentationStyle& mode) {

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -66,31 +66,34 @@ static absl::string_view StripOuterQuotes(absl::string_view text) {
   return absl::StripSuffix(absl::StripPrefix(text, "\""), "\"");
 }
 
-static const verible::EnumNameMap<SymbolMetaType> kSymbolMetaTypeNames({
-    // short-hand annotation for identifier reference type
-    {"<root>", SymbolMetaType::kRoot},
-    {"class", SymbolMetaType::kClass},
-    {"module", SymbolMetaType::kModule},
-    {"package", SymbolMetaType::kPackage},
-    {"parameter", SymbolMetaType::kParameter},
-    {"typedef", SymbolMetaType::kTypeAlias},
-    {"data/net/var/instance", SymbolMetaType::kDataNetVariableInstance},
-    {"function", SymbolMetaType::kFunction},
-    {"task", SymbolMetaType::kTask},
-    {"struct", SymbolMetaType::kStruct},
-    {"enum", SymbolMetaType::kEnumType},
-    {"<enum constant>", SymbolMetaType::kEnumConstant},
-    {"interface", SymbolMetaType::kInterface},
-    {"<unspecified>", SymbolMetaType::kUnspecified},
-    {"<callable>", SymbolMetaType::kCallable},
-});
+static const verible::EnumNameMap<SymbolMetaType>& SymbolMetaTypeNames() {
+  static const verible::EnumNameMap<SymbolMetaType> kSymbolMetaTypeNames({
+      // short-hand annotation for identifier reference type
+      {"<root>", SymbolMetaType::kRoot},
+      {"class", SymbolMetaType::kClass},
+      {"module", SymbolMetaType::kModule},
+      {"package", SymbolMetaType::kPackage},
+      {"parameter", SymbolMetaType::kParameter},
+      {"typedef", SymbolMetaType::kTypeAlias},
+      {"data/net/var/instance", SymbolMetaType::kDataNetVariableInstance},
+      {"function", SymbolMetaType::kFunction},
+      {"task", SymbolMetaType::kTask},
+      {"struct", SymbolMetaType::kStruct},
+      {"enum", SymbolMetaType::kEnumType},
+      {"<enum constant>", SymbolMetaType::kEnumConstant},
+      {"interface", SymbolMetaType::kInterface},
+      {"<unspecified>", SymbolMetaType::kUnspecified},
+      {"<callable>", SymbolMetaType::kCallable},
+  });
+  return kSymbolMetaTypeNames;
+}
 
 std::ostream& operator<<(std::ostream& stream, SymbolMetaType symbol_type) {
-  return kSymbolMetaTypeNames.Unparse(symbol_type, stream);
+  return SymbolMetaTypeNames().Unparse(symbol_type, stream);
 }
 
 static absl::string_view SymbolMetaTypeAsString(SymbolMetaType type) {
-  return kSymbolMetaTypeNames.EnumName(type);
+  return SymbolMetaTypeNames().EnumName(type);
 }
 
 // Root SymbolTableNode has no key, but we identify it as "$root"

--- a/verilog/analysis/verilog_equivalence.cc
+++ b/verilog/analysis/verilog_equivalence.cc
@@ -42,15 +42,18 @@ using verible::TokenSequence;
 // TODO(fangism): majority of this code is not Verilog-specific and could
 // be factored into a common/analysis library.
 
-static const verible::EnumNameMap<DiffStatus> kDiffStatusStringMap = {
-    {"equivalent", DiffStatus::kEquivalent},
-    {"different", DiffStatus::kDifferent},
-    {"left-error", DiffStatus::kLeftError},
-    {"right-error", DiffStatus::kRightError},
-};
+static const verible::EnumNameMap<DiffStatus>& DiffStatusStringMap() {
+  static const verible::EnumNameMap<DiffStatus> kDiffStatusStringMap({
+      {"equivalent", DiffStatus::kEquivalent},
+      {"different", DiffStatus::kDifferent},
+      {"left-error", DiffStatus::kLeftError},
+      {"right-error", DiffStatus::kRightError},
+  });
+  return kDiffStatusStringMap;
+}
 
 std::ostream& operator<<(std::ostream& stream, DiffStatus status) {
-  return kDiffStatusStringMap.Unparse(status, stream);
+  return DiffStatusStringMap().Unparse(status, stream);
 }
 
 // Lex a token into smaller substrings/subtokens.

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -192,7 +192,7 @@ class ViolationFixer : public ViolationHandler {
   using AnswerChooser =
       std::function<Answer(const verible::LintViolation&, absl::string_view)>;
 
-  // Violation fixer with user-choosen answer chooser.
+  // Violation fixer with user-chosen answer chooser.
   ViolationFixer(std::ostream* message_stream, std::ostream* patch_stream,
                  AnswerChooser answer_chooser)
       : ViolationFixer(message_stream, patch_stream, answer_chooser, false) {}

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -359,14 +359,17 @@ std::ostream& operator<<(std::ostream& stream,
                 << " }";
 }
 
-static const verible::EnumNameMap<RuleSet> kRuleSetEnumStringMap = {
-    {"all", RuleSet::kAll},
-    {"none", RuleSet::kNone},
-    {"default", RuleSet::kDefault},
-};
+static const verible::EnumNameMap<RuleSet>& RuleSetEnumStringMap() {
+  static const verible::EnumNameMap<RuleSet> kRuleSetEnumStringMap({
+      {"all", RuleSet::kAll},
+      {"none", RuleSet::kNone},
+      {"default", RuleSet::kDefault},
+  });
+  return kRuleSetEnumStringMap;
+}
 
 std::ostream& operator<<(std::ostream& stream, RuleSet rules) {
-  return kRuleSetEnumStringMap.Unparse(rules, stream);
+  return RuleSetEnumStringMap().Unparse(rules, stream);
 }
 
 //
@@ -379,7 +382,7 @@ std::string AbslUnparseFlag(const RuleSet& rules) {
 }
 
 bool AbslParseFlag(absl::string_view text, RuleSet* rules, std::string* error) {
-  return kRuleSetEnumStringMap.Parse(text, rules, error, "--ruleset value");
+  return RuleSetEnumStringMap().Parse(text, rules, error, "--ruleset value");
 }
 
 std::string AbslUnparseFlag(const RuleBundle& bundle) {

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -144,18 +144,22 @@ enum TokenScannerState {
   kEndNoNewline,
 };
 
-static const verible::EnumNameMap<TokenScannerState>
-    kTokenScannerStateStringMap = {
-        {"kStart", TokenScannerState::kStart},
-        {"kHaveNewline", TokenScannerState::kHaveNewline},
-        {"kNewPartition", TokenScannerState::kNewPartition},
-        {"kEndWithNewline", TokenScannerState::kEndWithNewline},
-        {"kEndNoNewline", TokenScannerState::kEndNoNewline},
-};
+static const verible::EnumNameMap<TokenScannerState>&
+TokenScannerStateStrings() {
+  static const verible::EnumNameMap<TokenScannerState>
+      kTokenScannerStateStringMap({
+          {"kStart", TokenScannerState::kStart},
+          {"kHaveNewline", TokenScannerState::kHaveNewline},
+          {"kNewPartition", TokenScannerState::kNewPartition},
+          {"kEndWithNewline", TokenScannerState::kEndWithNewline},
+          {"kEndNoNewline", TokenScannerState::kEndNoNewline},
+      });
+  return kTokenScannerStateStringMap;
+}
 
 // Conventional stream printer (declared in header providing enum).
 std::ostream& operator<<(std::ostream& stream, TokenScannerState p) {
-  return kTokenScannerStateStringMap.Unparse(p, stream);
+  return TokenScannerStateStrings().Unparse(p, stream);
 }
 
 // This finite state machine class is used to determine the placement of

--- a/verilog/tools/diff/verilog_diff.cc
+++ b/verilog/tools/diff/verilog_diff.cc
@@ -43,17 +43,20 @@ enum class DiffMode {
   kObfuscate,
 };
 
-static const verible::EnumNameMap<DiffMode> kDiffModeStringMap = {
-    {"format", DiffMode::kFormat},
-    {"obfuscate", DiffMode::kObfuscate},
-};
+static const verible::EnumNameMap<DiffMode>& DiffModeStringMap() {
+  static const verible::EnumNameMap<DiffMode> kDiffModeStringMap({
+      {"format", DiffMode::kFormat},
+      {"obfuscate", DiffMode::kObfuscate},
+  });
+  return kDiffModeStringMap;
+}
 
 std::ostream& operator<<(std::ostream& stream, DiffMode p) {
-  return kDiffModeStringMap.Unparse(p, stream);
+  return DiffModeStringMap().Unparse(p, stream);
 }
 
 bool AbslParseFlag(absl::string_view text, DiffMode* mode, std::string* error) {
-  return kDiffModeStringMap.Parse(text, mode, error, "--mode value");
+  return DiffModeStringMap().Parse(text, mode, error, "--mode value");
 }
 
 std::string AbslUnparseFlag(const DiffMode& mode) {

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -39,20 +39,23 @@ enum class PrintMode {
   kProto,
 };
 
-static const verible::EnumNameMap<PrintMode> kPrintModeStringMap{{
-    {"json", PrintMode::kJSON},
-    {"json_debug", PrintMode::kJSONDebug},
-    {"proto", PrintMode::kProto},
-}};
+static const verible::EnumNameMap<PrintMode>& PrintModeStringMap() {
+  static const verible::EnumNameMap<PrintMode> kPrintModeStringMap({
+      {"json", PrintMode::kJSON},
+      {"json_debug", PrintMode::kJSONDebug},
+      {"proto", PrintMode::kProto},
+  });
+  return kPrintModeStringMap;
+}
 
 static std::ostream& operator<<(std::ostream& stream, PrintMode mode) {
-  return kPrintModeStringMap.Unparse(mode, stream);
+  return PrintModeStringMap().Unparse(mode, stream);
 }
 
 static bool AbslParseFlag(absl::string_view text, PrintMode* mode,
                           std::string* error) {
-  return kPrintModeStringMap.Parse(text, mode, error,
-                                   "--print_kythe_facts value");
+  return PrintModeStringMap().Parse(text, mode, error,
+                                    "--print_kythe_facts value");
 }
 
 static std::string AbslUnparseFlag(const PrintMode& mode) {

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -45,27 +45,30 @@ enum class AutofixMode {
   kInplace,             // Automatically apply patch in-place.
 };
 
-static const verible::EnumNameMap<AutofixMode> kAutofixModeEnumStringMap = {
-    {"no", AutofixMode::kNo},
-    {"patch-interactive", AutofixMode::kPatchInteractive},
-    {"patch", AutofixMode::kPatch},
-    {"inplace-interactive", AutofixMode::kInplaceInteractive},
-    {"inplace", AutofixMode::kInplace},
-};
+static const verible::EnumNameMap<AutofixMode>& AutofixModeEnumStringMap() {
+  static const verible::EnumNameMap<AutofixMode> kAutofixModeEnumStringMap({
+      {"no", AutofixMode::kNo},
+      {"patch-interactive", AutofixMode::kPatchInteractive},
+      {"patch", AutofixMode::kPatch},
+      {"inplace-interactive", AutofixMode::kInplaceInteractive},
+      {"inplace", AutofixMode::kInplace},
+  });
+  return kAutofixModeEnumStringMap;
+}
 
 std::ostream& operator<<(std::ostream& stream, AutofixMode mode) {
-  return kAutofixModeEnumStringMap.Unparse(mode, stream);
+  return AutofixModeEnumStringMap().Unparse(mode, stream);
 }
 
 std::string AbslUnparseFlag(const AutofixMode& mode) {
   std::ostringstream stream;
-  kAutofixModeEnumStringMap.Unparse(mode, stream);
+  AutofixModeEnumStringMap().Unparse(mode, stream);
   return stream.str();
 }
 
 bool AbslParseFlag(absl::string_view text, AutofixMode* mode,
                    std::string* error) {
-  return kAutofixModeEnumStringMap.Parse(text, mode, error, "--autofix value");
+  return AutofixModeEnumStringMap().Parse(text, mode, error, "--autofix value");
 }
 
 // LINT.IfChange

--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -63,19 +63,22 @@ enum class LanguageMode {
   kVerilogLibraryMap,
 };
 
-static const verible::EnumNameMap<LanguageMode> kLanguageModeStringMap{{
-    {"auto", LanguageMode::kAutoDetect},
-    {"sv", LanguageMode::kSystemVerilog},
-    {"lib", LanguageMode::kVerilogLibraryMap},
-}};
+static const verible::EnumNameMap<LanguageMode>& LanguageModeStringMap() {
+  static const verible::EnumNameMap<LanguageMode> kLanguageModeStringMap({
+      {"auto", LanguageMode::kAutoDetect},
+      {"sv", LanguageMode::kSystemVerilog},
+      {"lib", LanguageMode::kVerilogLibraryMap},
+  });
+  return kLanguageModeStringMap;
+}
 
 static std::ostream& operator<<(std::ostream& stream, LanguageMode mode) {
-  return kLanguageModeStringMap.Unparse(mode, stream);
+  return LanguageModeStringMap().Unparse(mode, stream);
 }
 
 static bool AbslParseFlag(absl::string_view text, LanguageMode* mode,
                           std::string* error) {
-  return kLanguageModeStringMap.Parse(text, mode, error, "--flag value");
+  return LanguageModeStringMap().Parse(text, mode, error, "--flag value");
 }
 
 static std::string AbslUnparseFlag(const LanguageMode& mode) {


### PR DESCRIPTION
Objects with non-trivial construction should not be
initialized at global scope.

Signed-off-by: Henner Zeller <hzeller@google.com>