### PR TITLE
Pin clang-tidy version used to stay consistent.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -34,7 +34,7 @@ find . -name "*.cc" -and -not -name "*test*.cc" \
      -or -name "*.h" -and -not -name "*test*.h" \
   | grep -v "verilog/tools/kythe" \
   | xargs -P$(nproc) -n 5 -- \
-          clang-tidy --quiet 2>/dev/null \
+          clang-tidy-10 --quiet 2>/dev/null \
   | sed "s|$EXEC_ROOT/||g" > ${TIDY_OUT}
 
 
@@ -44,4 +44,6 @@ if [ -s ${TIDY_OUT} ]; then
    echo "There were clang-tidy warnings. Please fix"
    exit 1
 fi
+
+echo "No clang-tidy complaints."
 exit 0

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -59,8 +59,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt -qq -y install clang-tidy
-        clang-tidy --version
+        sudo apt -qq -y install clang-tidy-10
 
     - name: Run clang tidy
       run: ./.github/bin/run-clang-tidy.sh


### PR DESCRIPTION
Current version used by default in actions CI is clang-tidy-10; make
sure we're explicit in requesting exactly that as later versions might
have additional warnings which we should enable deliberately.

Signed-off-by: Henner Zeller <hzeller@google.com>