### PR TITLE
Apply some clang-tidy performance findings.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 # Disabled some clang-analyzer static checks, need some more investigation.
 # TODO(hzeller) fix and re-enable clang-analyzer checks.
-# TODO(hzeller) Enable performance-* once somewhat silent output.
 # TODO(hzeller) Looking over magic numbers might be good, but probably
 #               not worthwhile hard-failing
 # TODO(hzeller) Fix qualified auto readability suggestions and enable.
@@ -29,6 +28,7 @@ Checks: >
   google-*,
   -google-readability-braces-around-statements,
   -google-readability-todo,
+  performance-*,
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -71,7 +71,7 @@ class AutoFix {
     CHECK_EQ(edits_.size(), edits.size()) << "Edits must not overlap.";
   }
 
-  AutoFix(absl::string_view description, ReplacementEdit edit)
+  AutoFix(absl::string_view description, const ReplacementEdit& edit)
       : AutoFix(description, {edit}) {}
 
   // Applies the fix on a `base` and returns modified text.

--- a/common/analysis/syntax_tree_search.cc
+++ b/common/analysis/syntax_tree_search.cc
@@ -38,7 +38,7 @@ class SyntaxTreeSearcher : public TreeContextVisitor {
  public:
   SyntaxTreeSearcher(
       const matcher::Matcher& m,
-      std::function<bool(const SyntaxTreeContext&)> context_predicate)
+      const std::function<bool(const SyntaxTreeContext&)>& context_predicate)
       : matcher_(m), context_predicate_(context_predicate) {}
 
   void Search(const Symbol& root) { root.Accept(this); }
@@ -86,7 +86,7 @@ void SyntaxTreeSearcher::Visit(const SyntaxTreeNode& node) {
 
 std::vector<TreeSearchMatch> SearchSyntaxTree(
     const Symbol& root, const verible::matcher::Matcher& matcher,
-    std::function<bool(const SyntaxTreeContext&)> context_predicate) {
+    const std::function<bool(const SyntaxTreeContext&)>& context_predicate) {
   SyntaxTreeSearcher searcher(matcher, context_predicate);
   searcher.Search(root);
   return searcher.Matches();

--- a/common/analysis/syntax_tree_search.h
+++ b/common/analysis/syntax_tree_search.h
@@ -45,7 +45,7 @@ struct TreeSearchMatch {
 // of related nodes together, rather than as each one is encountered.
 std::vector<TreeSearchMatch> SearchSyntaxTree(
     const Symbol& root, const verible::matcher::Matcher& matcher,
-    std::function<bool(const SyntaxTreeContext&)> context_predicate);
+    const std::function<bool(const SyntaxTreeContext&)>& context_predicate);
 
 // This overload treats the missing context_predicate as always returning true.
 std::vector<TreeSearchMatch> SearchSyntaxTree(

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -374,7 +374,7 @@ template <class ScannerType>
 ColumnPositionTree ScanPartitionForAlignmentCells_WithNonTreeTokens(
     const TokenPartitionTree& row,
     const std::function<ScannerType(void)>& scanner_factory,
-    const std::function<void(TokenRange, ColumnPositionTree*)>
+    const std::function<void(TokenRange, ColumnPositionTree*)>&
         non_tree_column_scanner) {
   // re-use existing scanner
   ColumnPositionTree column_entries =

--- a/common/formatting/tree_unwrapper.cc
+++ b/common/formatting/tree_unwrapper.cc
@@ -252,7 +252,7 @@ bool TreeUnwrapper::NextUnfilteredTokenIsRetained() const {
 }
 
 void TreeUnwrapper::SkipUnfilteredTokens(
-    std::function<bool(const verible::TokenInfo&)> predicate) {
+    const std::function<bool(const verible::TokenInfo&)>& predicate) {
   while (predicate(*next_unfiltered_token_)) {
     ++next_unfiltered_token_;
   }

--- a/common/formatting/tree_unwrapper.h
+++ b/common/formatting/tree_unwrapper.h
@@ -137,7 +137,7 @@ class TreeUnwrapper : public TreeContextVisitor {
   // Skip over uninteresting tokens, those for which the predicate is true.
   // For example, this could be used to skip over spaces, but not newlines.
   void SkipUnfilteredTokens(
-      std::function<bool(const verible::TokenInfo&)> predicate);
+      const std::function<bool(const verible::TokenInfo&)>& predicate);
 
   // Returns true of next_unfiltered_tokens_ points to a token that was kept
   // in preformatted_tokens_.

--- a/common/lexer/token_stream_adapter.cc
+++ b/common/lexer/token_stream_adapter.cc
@@ -27,7 +27,7 @@ TokenGenerator MakeTokenGenerator(Lexer* l) {
 
 absl::Status MakeTokenSequence(
     Lexer* lexer, absl::string_view text, TokenSequence* tokens,
-    std::function<void(const TokenInfo&)> error_token_handler) {
+    const std::function<void(const TokenInfo&)>& error_token_handler) {
   // TODO(fangism): provide a Lexer interface to grab all tokens en masse,
   // which would save virtual function dispatch overhead.
   lexer->Restart(text);

--- a/common/lexer/token_stream_adapter.h
+++ b/common/lexer/token_stream_adapter.h
@@ -36,7 +36,7 @@ TokenGenerator MakeTokenGenerator(Lexer* l);
 // Populates a TokenSequence with lexed tokens.
 absl::Status MakeTokenSequence(
     Lexer* lexer, absl::string_view text, TokenSequence* tokens,
-    std::function<void(const TokenInfo&)> error_token_handler);
+    const std::function<void(const TokenInfo&)>& error_token_handler);
 
 // Generic container-to-iterator-generator adapter.
 // Once the end is reached, keep returning the end iterator.

--- a/common/strings/obfuscator.h
+++ b/common/strings/obfuscator.h
@@ -46,7 +46,7 @@ class Obfuscator {
                        StringViewCompare>
       translator_type;
 
-  explicit Obfuscator(generator_type g) : generator_(g) {}
+  explicit Obfuscator(const generator_type& g) : generator_(g) {}
 
   // Declares a mapping from key-string to value-string that will be
   // used in obfuscation.  This is useful for applying previously used

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -133,13 +133,11 @@ absl::Status HunkHeader::Parse(absl::string_view text) {
           "new-file range should start with '+', but got: ", new_range_str,
           "\"."));
     }
-    {
-      const auto status = old_range.Parse(old_range_str);
-      if (!status.ok()) return status;
+    if (auto status = old_range.Parse(old_range_str); !status.ok()) {
+      return status;
     }
-    {
-      const auto status = new_range.Parse(new_range_str);
-      if (!status.ok()) return status;
+    if (auto status = new_range.Parse(new_range_str); !status.ok()) {
+      return status;
     }
   }
 
@@ -291,9 +289,8 @@ std::vector<Hunk> Hunk::Split() const {
 }
 
 absl::Status Hunk::Parse(const LineRange& hunk_lines) {
-  {
-    const auto status = header_.Parse(hunk_lines.front());
-    if (!status.ok()) return status;
+  if (auto status = header_.Parse(hunk_lines.front()); !status.ok()) {
+    return status;
   }
 
   LineRange body(hunk_lines);
@@ -301,8 +298,9 @@ absl::Status Hunk::Parse(const LineRange& hunk_lines) {
   lines_.resize(body.size());
   auto line_iter = lines_.begin();
   for (const auto& line : body) {
-    const auto status = line_iter->Parse(line);
-    if (!status.ok()) return status;
+    if (auto status = line_iter->Parse(line); !status.ok()) {
+      return status;
+    }
     ++line_iter;
   }
   return IsValid();
@@ -388,8 +386,10 @@ static char PromptHunkAction(std::istream& ins, std::ostream& outs) {
 absl::Status FilePatch::VerifyAgainstOriginalLines(
     const std::vector<absl::string_view>& original_lines) const {
   for (const Hunk& hunk : hunks_) {
-    const auto status = hunk.VerifyAgainstOriginalLines(original_lines);
-    if (!status.ok()) return status;
+    if (auto status = hunk.VerifyAgainstOriginalLines(original_lines);
+        !status.ok()) {
+      return status;
+    }
   }
   return absl::OkStatus();
 }
@@ -411,9 +411,8 @@ absl::Status FilePatch::PickApply(std::istream& ins, std::ostream& outs,
   // original diff structure/stream to provide original contents.
   // Below, we VerifyAgainstOriginalLines for all hunks in this FilePatch.
   std::string original_file;
-  {
-    const auto status = file_reader(old_file_.path, &original_file);
-    if (!status.ok()) return status;
+  if (auto status = file_reader(old_file_.path, &original_file); !status.ok()) {
+    return status;
   }
 
   if (!hunks_.empty()) {
@@ -423,9 +422,8 @@ absl::Status FilePatch::PickApply(std::istream& ins, std::ostream& outs,
   }
 
   const std::vector<absl::string_view> orig_lines(SplitLines(original_file));
-  {
-    const auto status = VerifyAgainstOriginalLines(orig_lines);
-    if (!status.ok()) return status;
+  if (auto status = VerifyAgainstOriginalLines(orig_lines); !status.ok()) {
+    return status;
   }
 
   // Accumulate lines to write here.
@@ -539,19 +537,19 @@ absl::Status FilePatch::Parse(const LineRange& lines) {
     metadata_.emplace_back(line);
   }
 
-  {
-    const auto status =
-        ParseSourceInfoWithMarker(&old_file_, *line_iter, "---");
-    if (!status.ok()) return status;
+  if (auto status = ParseSourceInfoWithMarker(&old_file_, *line_iter, "---");
+      !status.ok()) {
+    return status;
   }
   ++line_iter;
   if (line_iter == lines.end()) {
     return absl::InvalidArgumentError(
         "Expected a file marker starting with \"+++\", but did not find one.");
   } else {
-    const auto status =
-        ParseSourceInfoWithMarker(&new_file_, *line_iter, "+++");
-    if (!status.ok()) return status;
+    if (auto status = ParseSourceInfoWithMarker(&new_file_, *line_iter, "+++");
+        !status.ok()) {
+      return status;
+    }
   }
   ++line_iter;
 
@@ -573,8 +571,9 @@ absl::Status FilePatch::Parse(const LineRange& lines) {
   hunks_.resize(hunk_ranges.size());
   auto hunk_iter = hunks_.begin();
   for (const auto& hunk_range : hunk_ranges) {
-    const auto status = hunk_iter->Parse(hunk_range);
-    if (!status.ok()) return status;
+    if (auto status = hunk_iter->Parse(hunk_range); !status.ok()) {
+      return status;
+    }
     ++hunk_iter;
   }
   return absl::OkStatus();
@@ -649,8 +648,9 @@ absl::Status PatchSet::Parse(absl::string_view patch_contents) {
   file_patches_.resize(file_patch_ranges.size());
   auto iter = file_patches_.begin();
   for (const auto& range : file_patch_ranges) {
-    const auto status = iter->Parse(range);
-    if (!status.ok()) return status;
+    if (auto status = iter->Parse(range); !status.ok()) {
+      return status;
+    }
     ++iter;
   }
 
@@ -693,9 +693,10 @@ absl::Status PatchSet::PickApply(
     const internal::FileReaderFunction& file_reader,
     const internal::FileWriterFunction& file_writer) const {
   for (const internal::FilePatch& file_patch : file_patches_) {
-    const auto status =
-        file_patch.PickApply(ins, outs, file_reader, file_writer);
-    if (!status.ok()) return status;
+    if (auto status = file_patch.PickApply(ins, outs, file_reader, file_writer);
+        !status.ok()) {
+      return status;
+    }
   }
   return absl::OkStatus();
 }

--- a/common/text/token_info.h
+++ b/common/text/token_info.h
@@ -68,7 +68,7 @@ class TokenInfo {
     explicit Context(absl::string_view b);
 
     Context(absl::string_view b,
-            std::function<void(std::ostream&, int)> translator)
+            const std::function<void(std::ostream&, int)>& translator)
         : base(b), token_enum_translator(translator) {}
 
     Context(const Context&) = default;

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -38,14 +38,13 @@ static absl::Status ChangedLines(const SubcommandArgsRange& args,
   }
   const auto patchfile = args[0];
   std::string patch_contents;
-  {
-    const auto status = verible::file::GetContents(patchfile, &patch_contents);
-    if (!status.ok()) return status;
+  if (auto status = verible::file::GetContents(patchfile, &patch_contents);
+      !status.ok()) {
+    return status;
   }
   verible::PatchSet patch_set;
-  {
-    const auto status = patch_set.Parse(patch_contents);
-    if (!status.ok()) return status;
+  if (auto status = patch_set.Parse(patch_contents); !status.ok()) {
+    return status;
   }
   const verible::FileLineNumbersMap changed_lines(
       patch_set.AddedLinesMap(false));
@@ -67,14 +66,13 @@ static absl::Status ApplyPick(const SubcommandArgsRange& args,
   }
   const auto patchfile = args[0];
   std::string patch_contents;
-  {
-    const auto status = verible::file::GetContents(patchfile, &patch_contents);
-    if (!status.ok()) return status;
+  if (auto status = verible::file::GetContents(patchfile, &patch_contents);
+      !status.ok()) {
+    return status;
   }
   verible::PatchSet patch_set;
-  {
-    const auto status = patch_set.Parse(patch_contents);
-    if (!status.ok()) return status;
+  if (auto status = patch_set.Parse(patch_contents); !status.ok()) {
+    return status;
   }
   return patch_set.PickApplyInPlace(ins, outs);
 }
@@ -111,8 +109,10 @@ static absl::Status CatTest(const SubcommandArgsRange& args, std::istream& ins,
   size_t file_count = 0;
   for (const auto& arg : args) {
     std::string contents;
-    const auto status = verible::file::GetContents(arg, &contents);
-    if (!status.ok()) return status;
+    if (auto status = verible::file::GetContents(arg, &contents);
+        !status.ok()) {
+      return status;
+    }
     outs << "<<<< contents of file[" << file_count << "] (" << arg << ") <<<<"
          << std::endl;
     outs << contents;

--- a/common/util/interval_set.h
+++ b/common/util/interval_set.h
@@ -161,11 +161,11 @@ class IntervalSet : private _IntervalSetImpl {
   }
 
   IntervalSet(const IntervalSet<T>&) = default;
-  IntervalSet(IntervalSet<T>&&) = default;
+  IntervalSet(IntervalSet<T>&&) noexcept = default;
   ~IntervalSet() { CheckIntegrity(); }
 
   IntervalSet<T>& operator=(const IntervalSet<T>&) = default;
-  IntervalSet<T>& operator=(IntervalSet<T>&&) = default;
+  IntervalSet<T>& operator=(IntervalSet<T>&&) noexcept = default;
 
  public:
   const_iterator begin(void) const { return intervals_.begin(); }
@@ -585,9 +585,9 @@ class DisjointIntervalSet : private _IntervalSetImpl {
   DisjointIntervalSet() = default;
 
   DisjointIntervalSet(const DisjointIntervalSet&) = default;
-  DisjointIntervalSet(DisjointIntervalSet&&) = default;
+  DisjointIntervalSet(DisjointIntervalSet&&) noexcept = default;
   DisjointIntervalSet& operator=(const DisjointIntervalSet&) = default;
-  DisjointIntervalSet& operator=(DisjointIntervalSet&&) = default;
+  DisjointIntervalSet& operator=(DisjointIntervalSet&&) noexcept = default;
 
   bool empty() const { return intervals_.empty(); }
   const_iterator begin() const { return intervals_.begin(); }

--- a/common/util/iterator_range.h
+++ b/common/util/iterator_range.h
@@ -39,9 +39,9 @@ class iterator_range {
       : begin_(std::move(b)), end_(std::move(e)) {}
 
   iterator_range(const iterator_range&) = default;
-  iterator_range(iterator_range&&) = default;
+  iterator_range(iterator_range&&) noexcept = default;
   iterator_range& operator=(const iterator_range&) = default;
-  iterator_range& operator=(iterator_range&&) = default;
+  iterator_range& operator=(iterator_range&&) noexcept = default;
 
   const iterator& begin() const { return begin_; }
   const iterator& end() const { return end_; }

--- a/common/util/map_tree.h
+++ b/common/util/map_tree.h
@@ -100,7 +100,7 @@ class MapTree {
   }
 
   // move (with relink)
-  MapTree(MapTree&& other)
+  MapTree(MapTree&& other) noexcept
       : node_value_(std::move(other.node_value_)),
         subtrees_(std::move(other.subtrees_)),
         // Retain existing parent.

--- a/common/util/status_macros.h
+++ b/common/util/status_macros.h
@@ -28,7 +28,7 @@ namespace util {
 #define RETURN_IF_ERROR(expr)                                                \
   do {                                                                       \
     /* Using _status below to avoid capture problems if expr is "status". */ \
-    const absl::Status _status = (expr);                                     \
+    absl::Status _status = (expr);                                           \
     if (ABSL_PREDICT_FALSE(!_status.ok())) return _status;                   \
   } while (0)
 

--- a/common/util/subcommand.h
+++ b/common/util/subcommand.h
@@ -45,7 +45,7 @@ using SubcommandFunction =
 struct SubcommandEntry {
   SubcommandEntry(SubcommandFunction fun, absl::string_view usage,
                   bool show_in_help = true)
-      : main(fun), usage(usage), show_in_help(show_in_help) {}
+      : main(std::move(fun)), usage(usage), show_in_help(show_in_help) {}
 
   // sub-main function
   const SubcommandFunction main;

--- a/common/util/vector_tree.h
+++ b/common/util/vector_tree.h
@@ -251,7 +251,7 @@ class VectorTree : private _VectorTreeImpl {
     Relink();
   }
 
-  VectorTree(this_type&& other)
+  VectorTree(this_type&& other) noexcept
       : node_value_(std::move(other.node_value_)),
         children_(std::move(other.children_)),
         parent_(other.parent_) {
@@ -303,7 +303,7 @@ class VectorTree : private _VectorTreeImpl {
 
   // Explicit move-assignability needed for vector::erase()
   // No need to change parent links when children keep same parent.
-  VectorTree& operator=(this_type&& source) {
+  VectorTree& operator=(this_type&& source) noexcept {
     // Keep this->parent_.  Ignore source.parent_.
 
     node_value_ = std::move(source.node_value_);

--- a/verilog/analysis/checkers/always_comb_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.cc
@@ -72,7 +72,7 @@ void AlwaysCombBlockingRule::HandleSymbol(const verible::Symbol& symbol,
 
       if (node == nullptr) continue;
 
-      auto leaf = verible::GetSubtreeAsLeaf(
+      const auto& leaf = verible::GetSubtreeAsLeaf(
           *node, NodeEnum::kNonblockingAssignmentStatement, 1);
 
       if (leaf.get().token_enum() == TK_LE)

--- a/verilog/analysis/extractors.cc
+++ b/verilog/analysis/extractors.cc
@@ -30,11 +30,12 @@ absl::Status CollectInterfaceNames(absl::string_view content,
 
   const auto analyzer =
       verilog::VerilogAnalyzer::AnalyzeAutomaticMode(content, "<file>");
-  const auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();
-  const auto parse_status = analyzer->ParseStatus();
+  auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();
+  auto parse_status = analyzer->ParseStatus();
 
   if (!lex_status.ok()) return lex_status;
   if (!parse_status.ok()) return parse_status;
+
   // TODO: Having a syntax error may still result in a partial syntax tree
   // to work with.  Currently, this utility has zero tolerance on syntax error.
 
@@ -47,7 +48,7 @@ absl::Status CollectInterfaceNames(absl::string_view content,
   for (const auto& mod_header : mod_headers) {
     const auto if_leafs = FindAllSymbolIdentifierLeafs(*mod_header.match);
     for (const auto& if_leaf_match : if_leafs) {
-      const auto if_leaf = SymbolCastToLeaf(*if_leaf_match.match);
+      const auto& if_leaf = SymbolCastToLeaf(*if_leaf_match.match);
       absl::string_view if_name = if_leaf.get().text();
       if_names->insert(std::string(if_name));  // TODO: use absl::string_view
     }

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -1374,14 +1374,14 @@ absl::Status ReferenceComponent::MatchesMetatype(
 absl::Status ReferenceComponent::ResolveSymbol(
     const SymbolTableNode& resolved) {
   // Verify metatype match.
-  const auto metatype_match_status = MatchesMetatype(resolved.Value().metatype);
-  if (metatype_match_status.ok()) {
-    VLOG(2) << "  resolved: " << ContextFullPath(resolved);
-    resolved_symbol = &resolved;
-  } else {
+  if (auto metatype_match_status = MatchesMetatype(resolved.Value().metatype);
+      !metatype_match_status.ok()) {
     VLOG(2) << metatype_match_status.message();
     return metatype_match_status;
   }
+
+  VLOG(2) << "  resolved: " << ContextFullPath(resolved);
+  resolved_symbol = &resolved;
   return absl::OkStatus();
 }
 

--- a/verilog/analysis/verilog_equivalence.cc
+++ b/verilog/analysis/verilog_equivalence.cc
@@ -91,9 +91,9 @@ static bool ShouldRecursivelyAnalyzeToken(const TokenInfo& token) {
 
 DiffStatus VerilogLexicallyEquivalent(
     absl::string_view left, absl::string_view right,
-    std::function<bool(const verible::TokenInfo&)> remove_predicate,
-    std::function<bool(const verible::TokenInfo&, const verible::TokenInfo&)>
-        equal_comparator,
+    const std::function<bool(const verible::TokenInfo&)>& remove_predicate,
+    const std::function<bool(const verible::TokenInfo&,
+                             const verible::TokenInfo&)>& equal_comparator,
     std::ostream* errstream) {
   // Bind some Verilog-specific parameters.
   return LexicallyEquivalent(
@@ -110,12 +110,13 @@ DiffStatus VerilogLexicallyEquivalent(
 
 DiffStatus LexicallyEquivalent(
     absl::string_view left_text, absl::string_view right_text,
-    std::function<bool(absl::string_view, TokenSequence*)> lexer,
-    std::function<bool(const verible::TokenInfo&)> recursion_predicate,
-    std::function<bool(const verible::TokenInfo&)> remove_predicate,
-    std::function<bool(const verible::TokenInfo&, const verible::TokenInfo&)>
-        equal_comparator,
-    std::function<void(const verible::TokenInfo&, std::ostream&)> token_printer,
+    const std::function<bool(absl::string_view, TokenSequence*)>& lexer,
+    const std::function<bool(const verible::TokenInfo&)>& recursion_predicate,
+    const std::function<bool(const verible::TokenInfo&)>& remove_predicate,
+    const std::function<bool(const verible::TokenInfo&,
+                             const verible::TokenInfo&)>& equal_comparator,
+    const std::function<void(const verible::TokenInfo&, std::ostream&)>&
+        token_printer,
     std::ostream* errstream) {
   VLOG(2) << __FUNCTION__;
   // Lex texts into token sequences.

--- a/verilog/analysis/verilog_equivalence.h
+++ b/verilog/analysis/verilog_equivalence.h
@@ -46,12 +46,14 @@ std::ostream& operator<<(std::ostream&, DiffStatus);
 // TODO(fangism): move this to language-agnostic common/analysis library.
 DiffStatus LexicallyEquivalent(
     absl::string_view left, absl::string_view right,
-    std::function<bool(absl::string_view, verible::TokenSequence*)> lexer,
-    std::function<bool(const verible::TokenInfo&)> recursion_predicate,
-    std::function<bool(const verible::TokenInfo&)> remove_predicate,
-    std::function<bool(const verible::TokenInfo&, const verible::TokenInfo&)>
-        equal_comparator,
-    std::function<void(const verible::TokenInfo&, std::ostream&)> token_printer,
+    const std::function<bool(absl::string_view, verible::TokenSequence*)>&
+        lexer,
+    const std::function<bool(const verible::TokenInfo&)>& recursion_predicate,
+    const std::function<bool(const verible::TokenInfo&)>& remove_predicate,
+    const std::function<bool(const verible::TokenInfo&,
+                             const verible::TokenInfo&)>& equal_comparator,
+    const std::function<void(const verible::TokenInfo&, std::ostream&)>&
+        token_printer,
     std::ostream* errstream = nullptr);
 
 // Returns a DiffStatus that captures 'equivalence' ignoring tokens filtered
@@ -59,9 +61,9 @@ DiffStatus LexicallyEquivalent(
 // If errstream is provided, print detailed error message to that stream.
 DiffStatus VerilogLexicallyEquivalent(
     absl::string_view left, absl::string_view right,
-    std::function<bool(const verible::TokenInfo&)> remove_predicate,
-    std::function<bool(const verible::TokenInfo&, const verible::TokenInfo&)>
-        equal_comparator,
+    const std::function<bool(const verible::TokenInfo&)>& remove_predicate,
+    const std::function<bool(const verible::TokenInfo&,
+                             const verible::TokenInfo&)>& equal_comparator,
     std::ostream* errstream = nullptr);
 
 // Returns true if both token sequences are equivalent, ignoring whitespace.

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -362,8 +362,7 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
     return 2;
   }
 
-  const std::vector<LintRuleStatus> linter_statuses =
-      std::move(linter_result.value());
+  const std::vector<LintRuleStatus>& linter_statuses = linter_result.value();
 
   size_t total_violations = 0;
   for (const auto& rule_status : linter_statuses) {

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -194,7 +194,7 @@ class ViolationFixer : public ViolationHandler {
 
   // Violation fixer with user-chosen answer chooser.
   ViolationFixer(std::ostream* message_stream, std::ostream* patch_stream,
-                 AnswerChooser answer_chooser)
+                 const AnswerChooser& answer_chooser)
       : ViolationFixer(message_stream, patch_stream, answer_chooser, false) {}
 
   // Violation fixer with interactive answer choice.
@@ -207,7 +207,7 @@ class ViolationFixer : public ViolationHandler {
 
  private:
   ViolationFixer(std::ostream* message_stream, std::ostream* patch_stream,
-                 AnswerChooser answer_chooser, bool is_interactive)
+                 const AnswerChooser& answer_chooser, bool is_interactive)
       : message_stream_(message_stream),
         patch_stream_(patch_stream),
         answer_chooser_(answer_chooser),

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -288,7 +288,7 @@ absl::Status LinterConfiguration::AppendFromFile(
   // Read local configuration file
   std::string content;
 
-  const absl::Status config_read_status =
+  absl::Status config_read_status =
       verible::file::GetContents(config_filename, &content);
   if (config_read_status.ok()) {
     RuleBundle local_rules_bundle;

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -31,7 +31,7 @@
 namespace verilog {
 
 VerilogSourceFile::VerilogSourceFile(absl::string_view referenced_path,
-                                     absl::Status status)
+                                     const absl::Status& status)
     : referenced_path_(referenced_path), status_(status) {}
 
 absl::Status VerilogSourceFile::Open() {

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -42,7 +42,8 @@ class VerilogSourceFile {
 
   // When a file is not found among a set of paths, remember it with an
   // error status.
-  VerilogSourceFile(absl::string_view referenced_path, absl::Status status);
+  VerilogSourceFile(absl::string_view referenced_path,
+                    const absl::Status& status);
 
   VerilogSourceFile(const VerilogSourceFile&) = delete;
   VerilogSourceFile& operator=(const VerilogSourceFile&) = delete;

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -220,7 +220,7 @@ Status FormatVerilog(absl::string_view text, absl::string_view filename,
   fmt.SelectLines(lines);
 
   // Format code.
-  const Status format_status = fmt.Format(control);
+  Status format_status = fmt.Format(control);
   if (!format_status.ok()) {
     if (format_status.code() != StatusCode::kResourceExhausted) {
       // Some more fatal error, halt immediately.
@@ -246,9 +246,9 @@ Status FormatVerilog(absl::string_view text, absl::string_view filename,
   return format_status;
 
   // For now, unconditionally verify.
-  const Status verify_status =
-      VerifyFormatting(text_structure, formatted_text, filename);
-  if (!verify_status.ok()) {
+  if (Status verify_status =
+          VerifyFormatting(text_structure, formatted_text, filename);
+      !verify_status.ok()) {
     return verify_status;
   }
 
@@ -257,9 +257,10 @@ Status FormatVerilog(absl::string_view text, absl::string_view filename,
   //   format(format(text)) == format(text)
   if (control.verify_convergence) {
     std::ostringstream reformat_stream;
-    const auto reformat_status = ReformatVerilog(
-        text, formatted_text, filename, style, reformat_stream, lines, control);
-    if (!reformat_status.ok()) {
+    if (auto reformat_status =
+            ReformatVerilog(text, formatted_text, filename, style,
+                            reformat_stream, lines, control);
+        !reformat_status.ok()) {
       return reformat_status;
     }
     const std::string& reformatted_text(reformat_stream.str());

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -37,10 +37,9 @@ static absl::Status StripComments(const SubcommandArgsRange& args,
   }
   const auto source_file = args[0];
   std::string source_contents;
-  {
-    const auto status =
-        verible::file::GetContents(source_file, &source_contents);
-    if (!status.ok()) return status;
+  if (auto status = verible::file::GetContents(source_file, &source_contents);
+      !status.ok()) {
+    return status;
   }
 
   // TODO(fangism): parse a subcommand-specific flag for replacement option

--- a/verilog/tools/project/project_tool.cc
+++ b/verilog/tools/project/project_tool.cc
@@ -80,7 +80,7 @@ struct VerilogProjectConfig {
     file_list_root = absl::GetFlag(FLAGS_file_list_root);
 
     // Load file list.
-    const auto files_names_or_status(
+    auto files_names_or_status(
         verilog::ParseSourceFileListFromFile(file_list_path));
     if (!files_names_or_status.ok()) return files_names_or_status.status();
     files_names = std::move(*files_names_or_status);
@@ -160,16 +160,14 @@ static absl::Status BuildAndShowSymbolTable(const SubcommandArgsRange& args,
   VLOG(1) << __FUNCTION__;
   // Load configuration.
   VerilogProjectConfig config;
-  {
-    const auto status = config.LoadFromGlobalFlags();
-    if (!status.ok()) return status;
+  if (auto status = config.LoadFromGlobalFlags(); !status.ok()) {
+    return status;
   }
 
   // Load project and files.
   ProjectSymbols project_symbols(config);
-  {
-    const auto status = project_symbols.Load();
-    if (!status.ok()) return status;
+  if (auto status = project_symbols.Load(); !status.ok()) {
+    return status;
   }
 
   // Build symbol table.
@@ -194,16 +192,14 @@ static absl::Status ResolveAndShowSymbolReferences(
   VLOG(1) << __FUNCTION__;
   // Load configuration.
   VerilogProjectConfig config;
-  {
-    const auto status = config.LoadFromGlobalFlags();
-    if (!status.ok()) return status;
+  if (auto status = config.LoadFromGlobalFlags(); !status.ok()) {
+    return status;
   }
 
   // Load project and files.
   ProjectSymbols project_symbols(config);
-  {
-    const auto status = project_symbols.Load();
-    if (!status.ok()) return status;
+  if (auto status = project_symbols.Load(); !status.ok()) {
+    return status;
   }
 
   // Build symbol table.
@@ -231,16 +227,14 @@ static absl::Status ShowFileDependencies(const SubcommandArgsRange& args,
   VLOG(1) << __FUNCTION__;
   // Load configuration.
   VerilogProjectConfig config;
-  {
-    const auto status = config.LoadFromGlobalFlags();
-    if (!status.ok()) return status;
+  if (auto status = config.LoadFromGlobalFlags(); !status.ok()) {
+    return status;
   }
 
   // Load project and files.
   ProjectSymbols project_symbols(config);
-  {
-    const auto status = project_symbols.Load();
-    if (!status.ok()) return status;
+  if (auto status = project_symbols.Load(); !status.ok()) {
+    return status;
   }
 
   // Build symbol table.

--- a/verilog/transform/obfuscate.cc
+++ b/verilog/transform/obfuscate.cc
@@ -104,8 +104,9 @@ static absl::Status VerifyDecoding(absl::string_view original,
 
   // Copy over mappings.  Verify map reconstruction.
   const auto saved_map = subst.save();
-  const auto status = reverse_subst.load(saved_map);
-  if (!status.ok()) return status;
+  if (auto status = reverse_subst.load(saved_map); !status.ok()) {
+    return status;
+  }
 
   // Decode and compare.
   std::ostringstream decoded_output;
@@ -149,12 +150,15 @@ absl::Status ObfuscateVerilogCode(absl::string_view content,
   ObfuscateVerilogCodeInternal(content, &buffer, subst);
 
   // Always verify equivalence.
-  const auto eq_status = VerifyEquivalence(content, buffer.str());
-  if (!eq_status.ok()) return eq_status;
+  if (auto status = VerifyEquivalence(content, buffer.str()); !status.ok()) {
+    return status;
+  }
 
   // Always verify decoding.
-  const auto verify_status = VerifyDecoding(content, buffer.str(), *subst);
-  if (!verify_status.ok()) return verify_status;
+  if (auto status = VerifyDecoding(content, buffer.str(), *subst);
+      !status.ok()) {
+    return status;
+  }
 
   *output << buffer.str();
   return absl::OkStatus();


### PR DESCRIPTION
Most notably it complained that return values that are
'const' can't be returned by an automatic move, so
would have to be copied. Typically, that happens
with absl::Status in our code base.

Changed common pattern

```
const absl::Status status = foo();
if (status.ok()) return status;
```

To something that does not const-qualify, but limit
the scope

```
if (absl::Status status = foo(); !status.ok()) {
  return status;
}
```

Signed-off-by: Henner Zeller <h.zeller@acm.org>