### PR TITLE
Remove superfluous assert()

### DIFF
--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -225,7 +225,6 @@ static void ColumnsTreeFormatter(
       auto extra_width = node.Value().width - children_width;
       for (auto& child : node.Children()) {
         CHECK_GT(children_width, 0);
-        assert(children_width > 0);
         const auto added_child_width =
             extra_width * child.Value().width / children_width;
         extra_width -= added_child_width;


### PR DESCRIPTION
Same thing tested with CHECK_GT() right above. Also, prefer
CHECK() to assert()

Signed-off-by: Henner Zeller <h.zeller@acm.org>