### PR TITLE
Make ABSL_DIE_IF_NULL() more useful.

### DIFF
--- a/common/util/logging.h
+++ b/common/util/logging.h
@@ -36,7 +36,7 @@ namespace verible {
 template <typename T>
 ABSL_MUST_USE_RESULT T DieIfNull(const char* file, int line,
                                  const char* exprtext, T&& t) {
-  CHECK(t != nullptr) << exprtext;
+  CHECK((t != nullptr)) << file << ":" << line << ": " << exprtext;
   return std::forward<T>(t);
 }
 }  // namespace verible


### PR DESCRIPTION
... acutally use the `__FILE__` and `__LINE__` when printing
the crash.

Issues: #917

Signed-off-by: Henner Zeller <hzeller@google.com>