### PR TITLE
Enable more clang tidy warnings; fix fallout.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,13 @@ Checks: >
   -google-readability-braces-around-statements,
   -google-readability-todo,
   performance-*,
+  bugprone-*,
+  -bugprone-narrowing-conversions,
+  -bugprone-branch-clone,
+  -bugprone-reserved-identifier,
+  -bugprone-move-forwarding-reference,
+  -bugprone-exception-escape,
+  modernize-use-override,
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/common/analysis/file_analyzer.h
+++ b/common/analysis/file_analyzer.h
@@ -77,7 +77,7 @@ class FileAnalyzer : public TextStructure {
   explicit FileAnalyzer(absl::string_view contents, absl::string_view filename)
       : TextStructure(contents), filename_(filename) {}
 
-  virtual ~FileAnalyzer() {}
+  ~FileAnalyzer() override {}
 
   virtual absl::Status Tokenize() = 0;
 

--- a/common/util/vector_tree.h
+++ b/common/util/vector_tree.h
@@ -295,6 +295,7 @@ class VectorTree : private _VectorTreeImpl {
 
   // Copy value and children, but relink new children to this node.
   VectorTree& operator=(const this_type& source) {
+    if (this == &source) return *this;
     node_value_ = source.node_value_;
     children_ = source.Children();
     Relink();

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -56,7 +56,7 @@ class TreeUnwrapper : public verible::TreeUnwrapper {
                          const FormatStyle& style,
                          const preformatted_tokens_type&);
 
-  ~TreeUnwrapper();
+  ~TreeUnwrapper() override;
 
   // Deleted standard interfaces:
   TreeUnwrapper() = delete;


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>