### PR TITLE
Log messages that are meant to be user-visible to std::cerr

### DIFF
--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -295,8 +295,8 @@ ViolationFixer::Answer ViolationFixer::InteractiveAnswerChooser(
 
       case '\0':
         // EOF: received when too few "answers" have been piped to stdin.
-        LOG(WARNING) << "Received EOF while there are questions left. "
-                        "Rejecting all remaining fixes.";
+        std::cerr << "Received EOF while there are questions left. "
+                  << "Rejecting all remaining fixes." << std::endl;
         return {AnswerChoice::kRejectAll};
 
       case 'p':

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -302,10 +302,11 @@ absl::Status LinterConfiguration::AppendFromFile(
     std::string error;
     if (local_rules_bundle.ParseConfiguration(content, '\n', &error)) {
       if (!error.empty())
-        LOG(WARNING) << "Warnings in parse configuration: " << error;
+        std::cerr << "Warnings in parse configuration: " << error << std::endl;
       UseRuleBundle(local_rules_bundle);
     } else {
-      LOG(WARNING) << "Unable to fully parse configuration: " << error;
+      std::cerr << "Unable to fully parse configuration: " << error
+                << std::endl;
     }
     return absl::OkStatus();
   }
@@ -326,8 +327,8 @@ absl::Status LinterConfiguration::ConfigureFromOptions(
     }
 
     if (options.rules_config_search) {
-      LOG(WARNING) << "Explicit config file " << options.config_file
-                   << " disables --rules_config_search";
+      std::cerr << "Explicit config file " << options.config_file
+                << " disables --rules_config_search" << std::endl;
     }
   } else if (options.rules_config_search) {
     // Search upward if search is enabled and no configuration file is
@@ -341,9 +342,9 @@ absl::Status LinterConfiguration::ConfigureFromOptions(
           AppendFromFile(resolved_config_file);
 
       if (!config_read_status.ok()) {
-        LOG(WARNING) << resolved_config_file
-                     << ": Unable to read rules configuration file "
-                     << config_read_status << std::endl;
+        std::cerr << resolved_config_file
+                  << ": Unable to read rules configuration file "
+                  << config_read_status << std::endl;
       }
     }
   }

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -148,13 +148,13 @@ int main(int argc, char** argv) {
       }
     }
     if (!autofix_output_stream) {
-      LOG(WARNING) << "--autofix=patch needs --autofix_output_file";
+      std::cerr << "--autofix=patch needs --autofix_output_file" << std::endl;
       autofix_mode = AutofixMode::kNo;
       exit_status = kAutofixErrorExitStatus;
     }
   } else if (!autofix_output_file.empty()) {
-    LOG(WARNING) << "--autofix_output_file has no effect for --autofix="
-                 << autofix_mode;
+    std::cerr << "--autofix_output_file has no effect for --autofix="
+              << autofix_mode << std::endl;
   }
 
   const verilog::ViolationFixer::AnswerChooser applyAllFixes =


### PR DESCRIPTION
LOG(WARNING) does not show up by default unless some magic
environment variables are set, but we want genuine warnings that
should be visible as feedback to the user ... visible.

Issues #959

Signed-off-by: Henner Zeller <hzeller@google.com>