### PR TITLE
Use better overload for single-character find()

### DIFF
--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -197,6 +197,7 @@ cc_library(
         "//common/util:file_util",
         "//common/util:logging",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -802,7 +802,7 @@ TEST(RuleBundleTest, ParseRuleBundleIgnoreExtraComma) {
     std::string error;
     bool success = bundle.ParseConfiguration(text, '\n', &error);
     ASSERT_TRUE(success) << error;
-    ASSERT_NE(error.find(","), std::string::npos) << error;  // warning report
+    ASSERT_NE(error.find(','), std::string::npos) << error;  // warning report
     ASSERT_THAT(bundle.rules, SizeIs(3));
     EXPECT_TRUE(bundle.rules["test-rule-1"].enabled);
     EXPECT_FALSE(bundle.rules["test-rule-2"].enabled);


### PR DESCRIPTION
Signed-off-by: Henner Zeller <hzeller@google.com>