### PR TITLE
Add protocol base support for the language server protocol.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -34,9 +34,12 @@ cat bazel-bin/compile_commands.json \
 # for now.
 # Also, exclude kythe for now, as it is somehwat noisy and should be
 # addressed separately.
+# common/lsp excluded as the compilation database generation gets confused
+# with pure libraries not yet wired up to a binary (it is otherwise tidy-clean)
 find . -name "*.cc" -and -not -name "*test*.cc" \
      -or -name "*.h" -and -not -name "*test*.h" \
   | grep -v "verilog/tools/kythe" \
+  | grep -v "common/lsp/" \
   | xargs -P$(nproc) -n 5 -- \
           ${CLANG_TIDY} --quiet 2>/dev/null \
   | sed "s|$EXEC_ROOT/||g" > ${TIDY_OUT}

--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -1,0 +1,56 @@
+# This package contains the basic language server protocol [1] implementation
+# needed in language specific parts to provide LSP services.
+# LSP is using JSON-PRC [2] for the RPC protocol.
+# [1]: https://microsoft.github.io/language-server-protocol/specification
+# [2]: https://www.jsonrpc.org/specification
+
+licenses(["notice"])
+
+package(
+    default_visibility = [
+        "//:__subpackages__",
+    ],
+)
+
+cc_library(
+    name = "message-stream-splitter",
+    hdrs = ["message-stream-splitter.h"],
+    srcs = ["message-stream-splitter.cc"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+
+cc_test(
+    name = "message-stream-splitter_test",
+    srcs = ["message-stream-splitter_test.cc"],
+    deps = [
+        ":message-stream-splitter",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "json-rpc-dispatcher",
+    hdrs = ["json-rpc-dispatcher.h"],
+    srcs = ["json-rpc-dispatcher.cc"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/status",
+        "@jsonhpp//:jsonhpp",
+    ],
+)
+
+
+cc_test(
+    name = "json-rpc-dispatcher_test",
+    srcs = ["json-rpc-dispatcher_test.cc"],
+    deps = [
+        ":json-rpc-dispatcher",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/common/lsp/json-rpc-dispatcher.cc
+++ b/common/lsp/json-rpc-dispatcher.cc
@@ -1,0 +1,122 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/lsp/json-rpc-dispatcher.h"
+
+static constexpr int kParseError = -32700;
+static constexpr int kMethodNotFound = -32601;
+static constexpr int kInternalError = -32603;
+
+namespace verible {
+// Dispatch incoming message, a string view with json data.
+// Call this with the content of exactly one message.
+// If this is an RPC call, it send the response via the WriteFun.
+void JsonRpcDispatcher::DispatchMessage(absl::string_view data) {
+  nlohmann::json request;
+  try {
+    request = nlohmann::json::parse(data);
+  } catch (const std::exception &e) {
+    statistic_counters_[e.what()]++;
+    ++exception_count_;
+    SendReply(CreateError(request, kParseError, e.what()));
+    return;
+  }
+
+  if (request.find("method") == request.end()) {
+    SendReply(
+        CreateError(request, kMethodNotFound, "Method required in request"));
+    statistic_counters_["Request without method"]++;
+    return;
+  }
+  const std::string &method = request["method"];
+
+  // Direct dispatch, later maybe send to thread-pool ?
+  const bool is_notification = (request.find("id") == request.end());
+  bool handled = false;
+  if (is_notification) {
+    handled = CallNotification(request, method);
+  } else {
+    handled = CallRequestHandler(request, method);
+  }
+  statistic_counters_[method + (handled ? "" : " (unhandled)") +
+                      (is_notification ? "  ev" : " RPC")]++;
+}
+
+bool JsonRpcDispatcher::CallNotification(const nlohmann::json &req,
+                                         const std::string &method) {
+  const auto &found = notifications_.find(method);
+  if (found == notifications_.end()) return false;
+  try {
+    found->second(req["params"]);
+    return true;
+  } catch (const std::exception &e) {
+    ++exception_count_;
+    statistic_counters_[method + " : " + e.what()]++;
+  }
+  return false;
+}
+
+bool JsonRpcDispatcher::CallRequestHandler(const nlohmann::json &req,
+                                           const std::string &method) {
+  const auto &found = handlers_.find(method);
+  if (found == handlers_.end()) {
+    SendReply(CreateError(req, kMethodNotFound,
+                          "method '" + method + "' not found."));
+    return false;
+  }
+
+  try {
+    SendReply(MakeResponse(req, found->second(req["params"])));
+    return true;
+  } catch (const std::exception &e) {
+    ++exception_count_;
+    statistic_counters_[method + " : " + e.what()]++;
+    SendReply(CreateError(req, kInternalError, e.what()));
+  }
+  return false;
+}
+
+/*static*/ nlohmann::json JsonRpcDispatcher::CreateError(
+    const nlohmann::json &request, int code, absl::string_view message) {
+  nlohmann::json result = {
+      {"jsonrpc", "2.0"},
+  };
+  result["error"] = {{"code", code}};
+  if (!message.empty()) {
+    result["error"]["message"] = message;
+  }
+
+  if (request.find("id") != request.end()) {
+    result["id"] = request["id"];
+  }
+
+  return result;
+}
+
+/*static*/ nlohmann::json JsonRpcDispatcher::MakeResponse(
+    const nlohmann::json &request, const nlohmann::json &call_result) {
+  nlohmann::json result = {
+      {"jsonrpc", "2.0"},
+  };
+  result["id"] = request["id"];
+  result["result"] = call_result;
+  return result;
+}
+
+void JsonRpcDispatcher::SendReply(const nlohmann::json &response) {
+  std::stringstream out_bytes;
+  out_bytes << response << "\n";
+  write_fun_(out_bytes.str());
+}
+}  // namespace verible

--- a/common/lsp/json-rpc-dispatcher.h
+++ b/common/lsp/json-rpc-dispatcher.h
@@ -1,0 +1,121 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_COMMON_LSP_JSON_RPC_DISPATCHER_H
+#define VERIBLE_COMMON_LSP_JSON_RPC_DISPATCHER_H
+
+#include <functional>
+#include <map>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+//
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "nlohmann/json.hpp"
+
+namespace verible {
+// A Dispatcher that is fed JSON as string, parses them to json objects and
+// dispatches the contained method call to pre-registered handlers.
+// Results of RPCCallHandlers are wrapped in a json rpc response object
+// and written out to the provided write function.
+//
+// This implements the JSON RPC specification [1].
+//
+// All receiving (call to DispatchMessage()) and writing of response (WriteFun)
+// is abstracted out to make the dispatcher agnostic of the transport layer.
+//
+// The RPCHandlers take and return json objects, but since nlohmann::json
+// provides ways to auto-convert objects to json, it is possible to
+// register properly typed handlers. To create the boilerplate for custom
+// types and their conversion, simplest is to use a code generator such
+// as jcxxgen [2].
+//
+// With that, you then can register fully typed handlers with seamless
+// conversion
+// dispatcer.AddRequestHandler("MyMethod",
+//                             [](const MyParamType &p) -> MyResponseType {
+//                               return doSomething(p);
+//                             });
+//
+// [1]: https://www.jsonrpc.org/specification
+// [2]: https://github.com/hzeller/jcxxgen
+class JsonRpcDispatcher {
+ public:
+  // A notification receives a request, but does not return anything
+  using RPCNotification = std::function<void(const nlohmann::json &r)>;
+
+  // A RPC call receives a request and returns a response.
+  // If we ever have a meaningful set of error conditions to convey, maybe
+  // change this to absl::StatusOr<nlohmann::json> as return value.
+  using RPCCallHandler = std::function<nlohmann::json(const nlohmann::json &)>;
+
+  // A function of type WriteFun is called by the dispatcher to send the
+  // string-formatted json response. The user of the JsonRpcDispatcher then
+  // can wire that to the underlying transport.
+  using WriteFun = std::function<void(absl::string_view response)>;
+
+  // Some statistical counters of method calls or exceptions encountered.
+  using StatsMap = std::map<std::string, int>;
+
+  // Responses are written using the "out" write function.
+  explicit JsonRpcDispatcher(const WriteFun &out) : write_fun_(out) {}
+  JsonRpcDispatcher(const JsonRpcDispatcher &) = delete;
+
+  // Add a request handler for RPC calls that receive data and send a response.
+  void AddRequestHandler(const std::string &method_name,
+                         const RPCCallHandler &fun) {
+    handlers_.insert({method_name, fun});
+  }
+
+  // Add a request handler for RPC Notifications, that are receive-only events.
+  void AddNotificationHandler(const std::string &method_name,
+                              const RPCNotification &fun) {
+    notifications_.insert({method_name, fun});
+  }
+
+  // Dispatch incoming message, a string view with json data.
+  // Call this with the content of exactly one message.
+  // If this is an RPC call, response will call WriteFun.
+  void DispatchMessage(absl::string_view data);
+
+  // Get some statistical counters of methods called and exceptions encountered.
+  const StatsMap &GetStatCounters() const { return statistic_counters_; }
+
+  // Number of exceptions that have been dealt with and turned into error
+  // messages or ignored depending on the context.
+  // The counters returnded by GetStatsCounters() will report counts by
+  // exception message.
+  int exception_count() const { return exception_count_; }
+
+ private:
+  bool CallNotification(const nlohmann::json &req, const std::string &method);
+  bool CallRequestHandler(const nlohmann::json &req, const std::string &method);
+  void SendReply(const nlohmann::json &response);
+
+  static nlohmann::json CreateError(const nlohmann::json &request, int code,
+                                    absl::string_view message);
+  static nlohmann::json MakeResponse(const nlohmann::json &request,
+                                     const nlohmann::json &call_result);
+
+  const WriteFun write_fun_;
+
+  std::unordered_map<std::string, RPCCallHandler> handlers_;
+  std::unordered_map<std::string, RPCNotification> notifications_;
+  int exception_count_ = 0;
+  StatsMap statistic_counters_;
+};
+}  // namespace verible
+#endif  // VERIBLE_COMMON_LSP_JSON_RPC_DISPATCHER_H

--- a/common/lsp/json-rpc-dispatcher_test.cc
+++ b/common/lsp/json-rpc-dispatcher_test.cc
@@ -1,0 +1,195 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/lsp/json-rpc-dispatcher.h"
+
+#include <algorithm>
+#include <exception>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using nlohmann::json;
+
+static constexpr int kJsonRpcParseError = -32700;
+static constexpr int kJsonRpcMethodNotFound = -32601;
+static constexpr int kJsonRpcInternalError = -32603;
+
+namespace verible {
+TEST(JsonRpcDispatcherTest, Call_GarbledInputRequest) {
+  int write_fun_called = 0;
+
+  // If the input can't even be parsed, it is reported back to the client
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {
+    const json j = json::parse(s);
+    EXPECT_TRUE(j.find("error") != j.end());
+    EXPECT_EQ(j["error"]["code"], kJsonRpcParseError) << s;
+    ++write_fun_called;
+  });
+
+  dispatcher.DispatchMessage("This is not even close to Json");
+
+  EXPECT_EQ(write_fun_called, 1);  // Complain unparseable input.
+  EXPECT_EQ(dispatcher.exception_count(), 1);
+}
+
+TEST(JsonRpcDispatcherTest, Call_MissingMethodInRequest) {
+  // If the request does not contain a method name, it is malformed.
+  int write_fun_called = 0;
+  int notification_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {
+    const json j = json::parse(s);
+    EXPECT_TRUE(j.find("error") != j.end());
+    EXPECT_EQ(j["error"]["code"], kJsonRpcMethodNotFound) << s;
+    ++write_fun_called;
+  });
+  dispatcher.AddNotificationHandler("foo", [&](const json &j) {  //
+    ++notification_fun_called;
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","params":{"hello": "world"}})");
+
+  EXPECT_EQ(notification_fun_called, 0);
+  EXPECT_EQ(write_fun_called, 1);  // Complain about missing method.
+  EXPECT_EQ(dispatcher.exception_count(), 0);
+}
+
+TEST(JsonRpcDispatcherTest, CallNotification) {
+  int write_fun_called = 0;
+  int notification_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {
+    std::cerr << s;
+    ++write_fun_called;
+  });
+  dispatcher.AddNotificationHandler("foo", [&](const json &j) {
+    EXPECT_EQ(j, json::parse(R"({ "hello": "world"})"));
+    ++notification_fun_called;
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","method":"foo","params":{"hello": "world"}})");
+
+  EXPECT_EQ(notification_fun_called, 1);
+  EXPECT_EQ(write_fun_called, 0);  // Notifications don't have responses.
+  EXPECT_EQ(dispatcher.exception_count(), 0);
+}
+
+TEST(JsonRpcDispatcherTest, CallNotification_NotReportInternalError) {
+  int write_fun_called = 0;
+  int notification_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher(
+      [&](absl::string_view s) { ++write_fun_called; });
+
+  // This method does not complete but throws an exception.
+  dispatcher.AddNotificationHandler("foo", [&](const json &j) -> json {
+    ++notification_fun_called;
+    throw std::runtime_error("Okay, Houston, we've had a problem here");
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","method":"foo","params":{"hello":"world"}})");
+
+  EXPECT_EQ(notification_fun_called, 1);
+  EXPECT_EQ(write_fun_called, 0);  // Notification issues never sent back.
+  EXPECT_EQ(dispatcher.exception_count(), 1);
+}
+
+TEST(JsonRpcDispatcherTest, CallNotification_MissingMethodImplemented) {
+  // A notification whose method is not registered must be silently ignored.
+  // No response with error.
+  int write_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {  //
+    ++write_fun_called;
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","method":"foo","params":{"hello": "world"}})");
+
+  EXPECT_EQ(write_fun_called, 0);
+  EXPECT_EQ(dispatcher.exception_count(), 0);
+}
+
+TEST(JsonRpcDispatcherTest, CallRpcHandler) {
+  int write_fun_called = 0;
+  int rpc_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {
+    const json j = json::parse(s);
+    EXPECT_EQ(std::string(j["result"]["some"]), "response");
+    EXPECT_TRUE(j.find("error") == j.end());
+    ++write_fun_called;
+  });
+  dispatcher.AddRequestHandler("foo", [&](const json &j) -> json {
+    EXPECT_EQ(j, json::parse(R"({ "hello":"world"})"));
+    ++rpc_fun_called;
+    return json::parse(R"({ "some": "response"})");
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","id":1,"method":"foo","params":{"hello":"world"}})");
+
+  EXPECT_EQ(rpc_fun_called, 1);
+  EXPECT_EQ(write_fun_called, 1);
+  EXPECT_EQ(dispatcher.exception_count(), 0);
+}
+
+TEST(JsonRpcDispatcherTest, CallRpcHandler_ReportInternalError) {
+  int write_fun_called = 0;
+  int rpc_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {
+    const json j = json::parse(s);
+    EXPECT_TRUE(j.find("error") != j.end());
+    EXPECT_EQ(j["error"]["code"], kJsonRpcInternalError) << s;
+    ++write_fun_called;
+  });
+
+  // This method does not complete but throws an exception.
+  dispatcher.AddRequestHandler("foo", [&](const json &j) -> json {
+    ++rpc_fun_called;
+    throw std::runtime_error("Okay, Houston, we've had a problem here");
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","id":1,"method":"foo","params":{"hello":"world"}})");
+
+  EXPECT_EQ(rpc_fun_called, 1);
+  EXPECT_EQ(write_fun_called, 1);
+  EXPECT_EQ(dispatcher.exception_count(), 1);
+}
+
+TEST(JsonRpcDispatcherTest, CallRpcHandler_MissingMethodImplemented) {
+  int write_fun_called = 0;
+
+  JsonRpcDispatcher dispatcher([&](absl::string_view s) {
+    const json j = json::parse(s);
+    EXPECT_TRUE(j.find("error") != j.end());
+    EXPECT_EQ(j["error"]["code"], kJsonRpcMethodNotFound) << s;
+    ++write_fun_called;
+  });
+
+  dispatcher.DispatchMessage(
+      R"({"jsonrpc":"2.0","id":1,"method":"foo","params":{"hello":"world"}})");
+
+  EXPECT_EQ(write_fun_called, 1);  // Reported error.
+  EXPECT_EQ(dispatcher.exception_count(), 0);
+}
+}  // namespace verible

--- a/common/lsp/message-stream-splitter.cc
+++ b/common/lsp/message-stream-splitter.cc
@@ -1,0 +1,126 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/lsp/message-stream-splitter.h"
+
+namespace verible {
+static constexpr absl::string_view kEndHeaderMarker = "\r\n\r\n";
+static constexpr absl::string_view kContentLengthHeader = "Content-Length: ";
+
+absl::Status MessageStreamSplitter::PullFrom(const ReadFun &read_fun) {
+  if (!message_processor_) {
+    return absl::FailedPreconditionError(
+        "MessageStreamSplitter: Message "
+        "processor not yet set, needed "
+        "before ProcessInput() called");
+  }
+  return ReadInput(read_fun);
+}
+
+// Return -1 if header is incomplete (not enough data yet).
+// Return -2 if header complete, but does not contain a valid
+//    Content-Length header (i.e. an actual problem)
+// On success, returns the offset to the body and its size in "body_size"
+int MessageStreamSplitter::ParseHeaderGetBodyOffset(absl::string_view data,
+                                                    int *body_size) {
+  auto end_of_header = data.find(kEndHeaderMarker);
+  if (end_of_header == absl::string_view::npos) return -1;  // incomplete
+
+  // Very dirty search for header - we don't check if starts with line.
+  const absl::string_view header_content(data.data(), end_of_header);
+  auto found_ContentLength_header = header_content.find(kContentLengthHeader);
+  if (found_ContentLength_header == absl::string_view::npos) return -2;
+
+  size_t end_key = found_ContentLength_header + kContentLengthHeader.size();
+  absl::string_view body_size_start_of_value = {
+      header_content.data() + end_key, header_content.size() - end_key};
+  if (!absl::SimpleAtoi(body_size_start_of_value, body_size)) {
+    return -2;
+  }
+
+  return end_of_header + kEndHeaderMarker.size();
+}
+
+// Read from data and process all fully available messages found in data.
+// Updates "data" to return the remaining unprocessed data.
+// Returns ok() status unless header is corrupted or one of the
+// message processor call fails.
+absl::Status MessageStreamSplitter::ProcessContainedMessages(
+    absl::string_view *data) {
+  while (!data->empty()) {
+    int body_size = 0;
+    const int body_offset = ParseHeaderGetBodyOffset(*data, &body_size);
+    if (body_offset == -2) {
+      absl::string_view limited_view(data->data(),
+                                     std::min(data->size(),
+                                              static_cast<size_t>(256)));
+      return absl::InvalidArgumentError(
+          absl::StrCat("No `Content-Length:` header. '", limited_view, "...'"));
+    }
+
+    const int message_size = body_offset + body_size;
+    if (body_offset < 0 || message_size > static_cast<int>(data->size()))
+      return absl::OkStatus();  // Only insufficient partial buffer available.
+
+    absl::string_view header(data->data(), body_offset);
+    absl::string_view body(data->data() + body_offset, body_size);
+    message_processor_(header, body);
+
+    stats_largest_body_ = std::max(stats_largest_body_, body.size());
+
+    *data = {data->data() + message_size, data->size() - message_size};
+  }
+  return absl::OkStatus();
+}
+
+// Read from "read_fun", fill internal buffer and call all available
+// complete messages in it.
+absl::Status MessageStreamSplitter::ReadInput(const ReadFun &read_fun) {
+  char *begin_of_read = read_buffer_.get();
+  int available_read_space = read_buffer_size_;
+
+  // Get all we had left from last time to the beginning of the buffer.
+  // This is in the same buffer, so we need to memmove()
+  if (!pending_data_.empty()) {
+    memmove(begin_of_read, pending_data_.data(), pending_data_.size());
+    begin_of_read += pending_data_.size();
+    available_read_space -= pending_data_.size();
+  }
+
+  int bytes_read = read_fun(begin_of_read, available_read_space);
+  if (bytes_read <= 0) {
+    // Got EOF.
+    // If we still have data pending, regard this as data loss situation, as
+    // we were never able to fully read the last message and send to process.
+    // Otherwise, report 'Unavailable' to indicate EOF (meh, this should
+    // be a better message).
+    if (!pending_data_.empty()) {
+      return absl::DataLossError(
+          absl::StrCat("Got EOF, but still have incomplete message with ",
+                       pending_data_.size(), "bytes read so far."));
+    }
+    return absl::UnavailableError(absl::StrCat("read() returned ", bytes_read));
+  }
+  stats_total_bytes_read_ += bytes_read;
+
+  absl::string_view data(read_buffer_.get(), pending_data_.size() + bytes_read);
+  if (auto status = ProcessContainedMessages(&data); !status.ok()) {
+    return status;
+  }
+
+  pending_data_ = data;  // Remember for next round.
+
+  return absl::OkStatus();
+}
+}  // namespace verible

--- a/common/lsp/message-stream-splitter.h
+++ b/common/lsp/message-stream-splitter.h
@@ -1,0 +1,107 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_COMMON_LSP_MESSAGE_STREAM_SPLITTER_H
+#define VERIBLE_COMMON_LSP_MESSAGE_STREAM_SPLITTER_H
+
+#include <functional>
+#include <memory>
+#include <string>
+
+//
+#include "absl/status/status.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+
+namespace verible {
+// Splits messages that are formatted as header + body coming from some
+// abstracted input stream and calls a handler for each complete message it
+// receives.
+//
+// The MessageStreamSplitter does not read data directly from a source but
+// gets handed a read function to get the data from. This allows to use this
+// in different environments from testing to using it with a filedescriptor
+// event dispatcher (select()).
+// The simplest implementation of the "ReadFun" just wraps a system read() call.
+//
+// The header data MUST contain a Content-Length header.
+class MessageStreamSplitter {
+ public:
+  // A function that reads from some source and writes up to "size" bytes
+  // into the buffer. Returns the number of bytes read.
+  // Blocks until there is content or returns '0' on end-of-file. Values
+  // below zero indicate errors.
+  // Only the amount of bytes available at the time of the call are filled
+  // into the buffer, so the return value can be less than size.
+  // So essentially: this behaves like the standard read() system call.
+  using ReadFun = std::function<int(char *buf, int size)>;
+
+  // Function called with each complete message that has been extracted from
+  // the stream.
+  using MessageProcessFun =
+      std::function<void(absl::string_view header, absl::string_view body)>;
+
+  // Read using an internal buffer of "read_buffer_size", which must be larger
+  // than the largest expected message.
+  explicit MessageStreamSplitter(size_t read_buffer_size)
+      : read_buffer_size_(read_buffer_size),
+        read_buffer_(new char[read_buffer_size]) {}
+  MessageStreamSplitter(const MessageStreamSplitter &) = delete;
+
+  // Set the function that will receive extracted message bodies.
+  void SetMessageProcessor(const MessageProcessFun &message_processor) {
+    message_processor_ = message_processor;
+  }
+
+  // The passed "read_fun()" is called exactly _once_ to get
+  // the next amount of data and calls the message processor for each complete
+  // message found. Partial data received is retained to be re-considered on
+  // the next call to PullFrom().
+  //
+  // Within the context of this method, the message processor might be
+  // called zero to multiple times depending on how much data arrives from
+  // the read.
+  //
+  // Note: The once-call behaviour allows to hook this into some file-descriptor
+  // event dispatcher (e.g using select()).
+  //
+  // Returns with an ok status until EOF or some error occurs.
+  // Code
+  //  - kUnavailable     : regular EOF, no data pending. A 'good' non-ok status.
+  //  - kDataloss        : got EOF, but still incomplete data pending.
+  //  - kInvalidargument : stream corrupted, couldn't read header.
+  absl::Status PullFrom(const ReadFun &read_fun);
+
+  // -- Statistical data
+
+  uint64_t StatLargestBodySeen() const { return stats_largest_body_; }
+  uint64_t StatTotalBytesRead() const { return stats_total_bytes_read_; }
+
+ private:
+  static int ParseHeaderGetBodyOffset(absl::string_view data, int *body_size);
+  absl::Status ProcessContainedMessages(absl::string_view *data);
+  absl::Status ReadInput(const ReadFun &read_fun);
+
+  const size_t read_buffer_size_;
+  std::unique_ptr<char[]> read_buffer_;
+
+  MessageProcessFun message_processor_;
+
+  size_t stats_largest_body_ = 0;
+  uint64_t stats_total_bytes_read_ = 0;
+  absl::string_view pending_data_;
+};
+}  // namespace verible
+#endif  // VERIBLE_COMMON_LSP_MESSAGE_STREAM_SPLITTER_H

--- a/common/lsp/message-stream-splitter_test.cc
+++ b/common/lsp/message-stream-splitter_test.cc
@@ -1,0 +1,192 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/lsp/message-stream-splitter.h"
+
+#include <algorithm>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::HasSubstr;
+
+namespace verible {
+TEST(MessageStreamSplitterTest, NotRegisteredMessageProcessor) {
+  MessageStreamSplitter s(4096);
+  auto status = s.PullFrom([](char *, int) { return 0; });
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+}
+
+// A stream simulator that is pre-filled with data and allows to
+// simulate partial reads.
+class DataStreamSimulator {
+ public:
+  DataStreamSimulator(absl::string_view content, int max_chunk = -1)
+      : content_(content), max_chunk_(max_chunk) {}
+
+  int read(char *buf, int size) {
+    if (max_chunk_ > 0 && size > max_chunk_) size = max_chunk_;
+    size = std::min(size, (int)content_.length() - read_pos_);
+    memcpy(buf, content_.data() + read_pos_, size);
+    read_pos_ += size;
+    return size;
+  }
+
+ private:
+  const std::string content_;
+  const int max_chunk_;
+  int read_pos_ = 0;
+};
+
+TEST(MessageStreamSplitterTest, CompleteReadValidMessage) {
+  static constexpr absl::string_view kHeader = "Content-Length: 3\r\n\r\n";
+  static constexpr absl::string_view kBody = "foo";
+
+  DataStreamSimulator stream(absl::StrCat(kHeader, kBody));
+  MessageStreamSplitter s(4096);
+  int processor_call_count = 0;
+  s.SetMessageProcessor([&](absl::string_view header, absl::string_view body) {
+    ++processor_call_count;
+    EXPECT_EQ(std::string(header), kHeader);
+    EXPECT_EQ(std::string(body), kBody);
+  });
+
+  auto status =
+      s.PullFrom([&](char *buf, int size) { return stream.read(buf, size); });
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(processor_call_count, 1);
+
+  // Calling more read will report EOF as we have finished our data.
+  // This is reported as kUnavailable, the expected status code in this case.
+  status = s.PullFrom([&](char *buf, int size) {  //
+    return stream.read(buf, size);
+  });
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kUnavailable);
+
+  EXPECT_EQ(processor_call_count, 1);  // No additional calls recorded here.
+}
+
+TEST(MessageStreamSplitterTest, StreamDoesNotContainCompleteData) {
+  static constexpr absl::string_view kHeader = "Content-Length: 3\r\n\r\n";
+  static constexpr absl::string_view kBody = "fo";  // <- too short
+
+  DataStreamSimulator stream(absl::StrCat(kHeader, kBody));
+  MessageStreamSplitter s(4096);
+  int processor_call_count = 0;
+  s.SetMessageProcessor(
+      [&](absl::string_view, absl::string_view) { ++processor_call_count; });
+
+  absl::Status status = absl::OkStatus();
+  while (status.ok()) {
+    status =
+        s.PullFrom([&](char *buf, int size) { return stream.read(buf, size); });
+  }
+
+  // We reached EOF, but we still have data pending. Reported as data loss.
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kDataLoss);
+
+  EXPECT_EQ(processor_call_count, 0);
+}
+
+TEST(MessageStreamSplitterTest, CompleteReadMultipleMessages) {
+  static constexpr absl::string_view kHeader = "Content-Length: 3\r\n\r\n";
+  static constexpr absl::string_view kBody[2] = {"foo", "bar"};
+
+  DataStreamSimulator stream(
+      absl::StrCat(kHeader, kBody[0], kHeader, kBody[1]));
+  MessageStreamSplitter s(4096);
+  int processor_call_count = 0;
+  // We expect one call per complete header/body pair.
+  s.SetMessageProcessor([&](absl::string_view header, absl::string_view body) {
+    EXPECT_EQ(std::string(header), kHeader);
+    EXPECT_EQ(std::string(body), kBody[processor_call_count]);
+    ++processor_call_count;
+  });
+  auto status = s.PullFrom([&](char *buf, int size) {
+    return stream.read(buf, size);  // The complete chunk is read in one go.
+  });
+  EXPECT_EQ(processor_call_count, 2);
+}
+
+// Simulate short reads. Each read call only trickles out a few bytes.
+TEST(MessageStreamSplitterTest, CompleteReadMultipleMessagesShortRead) {
+  static constexpr absl::string_view kHeader = "Content-Length: 3\r\n\r\n";
+  static constexpr absl::string_view kBody[2] = {"foo", "bar"};
+  static constexpr int kTrickleReadSize = 2;
+
+  DataStreamSimulator stream(absl::StrCat(kHeader, kBody[0], kHeader, kBody[1]),
+                             kTrickleReadSize);
+  MessageStreamSplitter s(4096);
+  int processor_call_count = 0;
+  s.SetMessageProcessor([&](absl::string_view header, absl::string_view body) {
+    EXPECT_EQ(std::string(header), kHeader);
+    EXPECT_EQ(std::string(body), kBody[processor_call_count]);
+    ++processor_call_count;
+  });
+
+  int read_call_count = 0;
+  absl::Status status = absl::OkStatus();
+  while (status.ok()) {
+    ++read_call_count;
+    status =
+        s.PullFrom([&](char *buf, int size) { return stream.read(buf, size); });
+  }
+
+  // Read until we reached EOF, indicated as kUnavailable
+  EXPECT_EQ(status.code(), absl::StatusCode::kUnavailable);  // EOF
+  EXPECT_GT(read_call_count, 10);  // this requires a few read calls.
+  EXPECT_EQ(processor_call_count, 2);
+}
+
+TEST(MessageStreamSplitterTest, NotAvailableContentHeaderReadError) {
+  static constexpr absl::string_view kHeader = "not-content-length: 3\r\n\r\n";
+  static constexpr absl::string_view kBody = "foo";
+
+  DataStreamSimulator stream(absl::StrCat(kHeader, kBody));
+  MessageStreamSplitter s(4096);
+  int processor_call_count = 0;
+  s.SetMessageProcessor([&](absl::string_view header, absl::string_view body) {
+    ++processor_call_count;
+  });
+  auto status =
+      s.PullFrom([&](char *buf, int size) { return stream.read(buf, size); });
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(status.message(), HasSubstr("header"));
+  EXPECT_EQ(processor_call_count, 0);
+}
+
+TEST(MessageStreamSplitterTest, GarbledSizeInContentHeader) {
+  static constexpr absl::string_view kHeader = "Content-Length: xyz\r\n\r\n";
+  static constexpr absl::string_view kBody = "foo";
+
+  DataStreamSimulator stream(absl::StrCat(kHeader, kBody));
+  MessageStreamSplitter s(4096);
+  int processor_call_count = 0;
+  s.SetMessageProcessor([&](absl::string_view header, absl::string_view body) {
+    ++processor_call_count;
+  });
+  auto status =
+      s.PullFrom([&](char *buf, int size) { return stream.read(buf, size); });
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(status.message(), HasSubstr("header"));
+  EXPECT_EQ(processor_call_count, 0);
+}
+}  // namespace verible


### PR DESCRIPTION
  * JsonRpcDispatcher is implementing the needed functionality
     for JSON-RPC [1] calling notifications and RPC-calls.
   * MessageStreamSplitter is needed in the LSP [2] specifically
     as the transport layer separates each message with a
     header (containing a Content-Length: header) and a body
     (very similar to HTTP).
    
[1] https://www.jsonrpc.org/specification
[2] https://microsoft.github.io/language-server-protocol/specification
