### PR TITLE
Allow for lenient header parsing with simple newline.

### DIFF
--- a/common/lsp/message-stream-splitter.cc
+++ b/common/lsp/message-stream-splitter.cc
@@ -34,9 +34,15 @@ static constexpr int kGarbledHeader = -2;
 int MessageStreamSplitter::ParseHeaderGetBodyOffset(absl::string_view data,
                                                     int *body_size) {
   static constexpr absl::string_view kEndHeaderMarker = "\r\n\r\n";
+  static constexpr absl::string_view kLenientEndHeaderMarker = "\n\n";
   static constexpr absl::string_view kContentLengthHeader = "Content-Length: ";
 
+  int header_marker_len = kEndHeaderMarker.length();
   auto end_of_header = data.find(kEndHeaderMarker);
+  if (end_of_header == absl::string_view::npos && lenient_lf_separation_) {
+    end_of_header = data.find(kLenientEndHeaderMarker);
+    header_marker_len = kLenientEndHeaderMarker.length();
+  }
   if (end_of_header == absl::string_view::npos) return kIncompleteHeader;
 
   // Very dirty search for header - we don't check if starts with line.
@@ -51,7 +57,7 @@ int MessageStreamSplitter::ParseHeaderGetBodyOffset(absl::string_view data,
     return kGarbledHeader;
   }
 
-  return end_of_header + kEndHeaderMarker.size();
+  return end_of_header + header_marker_len;
 }
 
 // Read from data and process all fully available messages found in data.


### PR DESCRIPTION
The header requires to have CRLF line endings, so for
end of headers that would be two of these: \r\n\r\n.

For 'manual' speaking of the protocol on the shell it would
be desirable to have a 'lenient' mode that accepts
simple newlines. Add this as a possible mode with
a new default parameter to the constructor
"strict_crlf_header_separation" (default true).

Signed-off-by: Henner Zeller <h.zeller@acm.org>