### PR TITLE
Reallocate message stream buffer if needed.

### DIFF
--- a/common/lsp/dummy-ls.cc
+++ b/common/lsp/dummy-ls.cc
@@ -73,11 +73,7 @@ int main(int argc, char *argv[]) {
     std::cout << reply << std::flush;
   };
 
-  // We want the buffer size to be the largest message we could
-  // receive. It typically would be in the order of largest file to
-  // be opened (as it is sent verbatim in didOpen).
-  // Should be chosen accordingly.
-  MessageStreamSplitter stream_splitter(1 << 20);
+  MessageStreamSplitter stream_splitter;
   JsonRpcDispatcher dispatcher(write_fun);
 
   // All bodies the stream splitter extracts are pushed to the json dispatcher


### PR DESCRIPTION
Test in practice show that there can be very large messages
as file content is sent to the server as-is.
Instead of requiring a fixed, pre-determined size, just
realloc if needed.

Switch to std::vector<char> as a convenient data structure
that provides its own resize.

Signed-off-by: Henner Zeller <h.zeller@acm.org>