### PR TITLE
Remove unneded dependency.

### DIFF
--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -84,7 +84,6 @@ cc_library(
         ":json-rpc-dispatcher",
         ":lsp-protocol",
         "@com_google_absl//absl/strings",
-        "@jsonhpp//:jsonhpp",
     ]
 )
 


### PR DESCRIPTION
the lsp-protocol provides the necessary dependency for its
use of json.

Signed-off-by: Henner Zeller <hzeller@google.com>