### PR TITLE
Remove obsolete parameter in VerilogLintTextStructure().

### DIFF
--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -355,7 +355,7 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
   // Analyze the parsed structure for lint violations.
   const auto& text_structure = analyzer->Data();
   const auto linter_result =
-      VerilogLintTextStructure(filename, config, text_structure, show_context);
+      VerilogLintTextStructure(filename, config, text_structure);
   if (!linter_result.ok()) {
     // Something went wrong with running the lint analysis itself.
     LOG(ERROR) << "Fatal error: " << linter_result.status().message();
@@ -531,7 +531,7 @@ absl::StatusOr<LinterConfiguration> LinterConfigurationFromFlags(
 
 absl::StatusOr<std::vector<LintRuleStatus>> VerilogLintTextStructure(
     absl::string_view filename, const LinterConfiguration& config,
-    const TextStructureView& text_structure, bool show_context) {
+    const TextStructureView& text_structure) {
   // Create the linter, add rules, and run it.
   VerilogLinter linter;
   const absl::Status configuration_status = linter.Configure(config, filename);

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -254,8 +254,7 @@ class ViolationFixer : public ViolationHandler {
 //   Vector of LintRuleStatuses on success, otherwise error code.
 absl::StatusOr<std::vector<verible::LintRuleStatus>> VerilogLintTextStructure(
     absl::string_view filename, const LinterConfiguration& config,
-    const verible::TextStructureView& text_structure,
-    bool show_context = false);
+    const verible::TextStructureView& text_structure);
 
 // Prints the rule, description and default_enabled.
 absl::Status PrintRuleInfo(std::ostream*,

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -221,7 +221,7 @@ class VerilogLinterTest : public DefaultLinterConfigTestFixture,
     // lint success, so as long as we have a syntax tree (even if there
     // are errors), run the lint checks.
     const absl::StatusOr<std::vector<verible::LintRuleStatus>> lint_result =
-        VerilogLintTextStructure(filename, config_, text_structure, false);
+        VerilogLintTextStructure(filename, config_, text_structure);
     verilog::ViolationPrinter violation_printer(&diagnostics);
     const std::set<LintViolationWithStatus> violations =
         GetSortedViolations(lint_result.value());


### PR DESCRIPTION
The context printing parameter is not needed inside that
function anymore as it doesn't do the printing of the message.

Signed-off-by: Henner Zeller <h.zeller@acm.org>