### PR TITLE
Install failure signal handler

### DIFF
--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -55,6 +55,7 @@ std::vector<char*> InitCommandLine(
   absl::SetFlagsUsageConfig(usage_config);
   absl::SetProgramUsageMessage(usage);  // copies usage string
   google::InitGoogleLogging(**argv);
+  google::InstallFailureSignalHandler();
   return absl::ParseCommandLine(*argc, *argv);
 }
 


### PR DESCRIPTION
Print backtrace to stderr after getting fatal signal like sigsegv.

I find it really useful during development. It should also help in bug report analysis.