### PR TITLE
Make json-rpc-expect match substrings not exact strings.

### DIFF
--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -119,6 +119,7 @@ cc_binary(
     deps = [
       ":message-stream-splitter",
       "@com_google_absl//absl/status",
+      "@com_google_absl//absl/strings",
       "@jsonhpp//:jsonhpp",
     ]
 )

--- a/verilog/tools/ls/verible-verilog-ls_test.sh
+++ b/verilog/tools/ls/verible-verilog-ls_test.sh
@@ -73,7 +73,7 @@ cat > "${JSON_EXPECTED}" <<EOF
        "method":"textDocument/publishDiagnostics",
        "params": {
           "uri": "file://mini.sv",
-          "diagnostics":[{"message":"File must end with a newline. [Style: posix-file-endings][posix-eof] (fix available)"}]
+          "diagnostics":[{"message":"File must end with a newline."}]
        }
     }
   },


### PR DESCRIPTION
Whenever a scalar string value is to be compared, apply the
same 'fuzzy in spirit' approach as comparing structs: make
sure the mentioned part is found in the string without having
to specify the exact string. This makes tests less brittle.

Signed-off-by: Henner Zeller <h.zeller@acm.org>