### PR TITLE
Add the language server to the set of binaries to install.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,7 @@ filegroup(
         "//verilog/tools/preprocessor:verible-verilog-preprocessor",
         "//verilog/tools/project:verible-verilog-project",
         "//verilog/tools/syntax:verible-verilog-syntax",
+        "//verilog/tools/ls:verible-verilog-ls",
     ],
 )
 


### PR DESCRIPTION
Probably not much use yet, as it is in alpha stage, but
having it already in the distribution helps for people to try.

Signed-off-by: Henner Zeller <h.zeller@acm.org>