### PR TITLE
Only install failure signal handler if not compiled with --config=asan

### DIFF
--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -55,7 +55,13 @@ std::vector<char*> InitCommandLine(
   absl::SetFlagsUsageConfig(usage_config);
   absl::SetProgramUsageMessage(usage);  // copies usage string
   google::InitGoogleLogging(**argv);
+
+  // Print stacktrace on issue, but not if --config=asan
+  // which comes with its own stacktrace handling.
+#if !defined(__SANITIZE_ADDRESS__)
   google::InstallFailureSignalHandler();
+#endif
+
   return absl::ParseCommandLine(*argc, *argv);
 }
 


### PR DESCRIPTION
The address sanitizer comes with its own stacktrace printer, so
we should not install our own in that case.

Signed-off-by: Henner Zeller <h.zeller@acm.org>