### PR TITLE
Use asan in smoke tests.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -87,7 +87,7 @@ case "$MODE" in
     bazel build --keep_going $BAZEL_OPTS //...
     ;;
 
-  smoke-test)
+  smoke-test|smoke-test-clang)
     $(dirname $0)/smoke-test.sh
     ;;
 


### PR DESCRIPTION
Binaries with address sanitizer can help find subtle issues.

  * Add USE_ASAN=1 to indicate if binaries should be compiled
    with address sanitizer (making an option for now as it seems
    to be significantly slower than one would want in the CI.
    Consider running processes in parallel first maybe)
  * To make this work in our test, use the ASAN_OPTIONS environment
    variable to use an exit code that is useful for detection.

Signed-off-by: Henner Zeller <h.zeller@acm.org>