### PR TITLE
Use ccache instead of bazel cache.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -98,13 +98,6 @@ jobs:
        # Download complete repository + tags
        fetch-depth: 0
 
-    - name: Mount bazel cache
-      uses: actions/cache@v1
-      if: matrix.mode != 'clean' && matrix.mode != 'coverage'
-      with:
-        path: "/home/runner/.cache/bazel"
-        key: bazel-${{ matrix.mode }}
-
     - name: Install Dependencies
       run: |
         set -x
@@ -113,6 +106,17 @@ jobs:
         ./.github/bin/set-compiler.sh 9
         ./.github/bin/install-bazel.sh
         ./.github/bin/install-python.sh
+
+    - name: Use ccache
+      if: matrix.mode != 'clean' && matrix.mode != 'coverage'
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: bazel-compile-${{ matrix.mode }}
+
+    - name: Set environment
+      run: |
+        export PATH=/usr/lib/ccache:$PATH
+        command -v g++ clang++
 
     - name: ${{ matrix.env.mode }} Verible
       run: ./.github/bin/build-and-test.sh


### PR DESCRIPTION
The bazel cache action is deprecated, and also does not
work correctly: it seems to restore an older version, while
the ccache rule attempts to version it to get a recent one.

Signed-off-by: Henner Zeller <h.zeller@acm.org>