### PR TITLE
Switch to latest version of googletest.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,15 +14,12 @@ http_archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
 )
 
-# Intermediate version of googletest. The last published release v1.10.0 does
-# not obey TEST_TMPDIR environment variable and sets testing::TempDir() to
-# /tmp which is problematic for consecuitve tests.
-# (on Linux. On Mac, it still writes to /tmp which hopefully is fixed soon)
+# Googletest
 http_archive(
     name = "com_google_googletest",
-    sha256 = "065be63080da17335f680bca846e7c298895ca5bb6d241d0ee28ff3c3aa29e7c",
-    strip_prefix = "googletest-23ef29555ef4789f555f1ba8c51b4c52975f0907",
-    urls = ["https://github.com/google/googletest/archive/23ef29555ef4789f555f1ba8c51b4c52975f0907.zip"],
+    sha256 = "353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a",
+    strip_prefix = "googletest-release-1.11.0",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip"],
 )
 
 http_archive(


### PR DESCRIPTION
We had to use an intermediate version before that
fixed an issue. But now a new release is available.

Signed-off-by: Henner Zeller <h.zeller@acm.org>