### PR TITLE
Don't assume the compiler will place the same string-literals in same…

### DIFF
--- a/common/lexer/token_stream_adapter_test.cc
+++ b/common/lexer/token_stream_adapter_test.cc
@@ -38,16 +38,18 @@ class FakeTokenSequenceLexer : public Lexer, public FakeLexer {
 };
 
 TEST(MakeTokenGeneratorTest, Generate) {
+  static constexpr absl::string_view abc("abc");
+  static constexpr absl::string_view xyz("xyz");
   FakeTokenSequenceLexer lexer;
   std::initializer_list<TokenInfo> tokens = {
-      {1, "abc"},
-      {2, "xyz"},
+      {1, abc},
+      {2, xyz},
       {TK_EOF, ""},
   };
   lexer.SetTokensData(tokens);
   auto generator = MakeTokenGenerator(&lexer);
-  EXPECT_EQ(generator(), TokenInfo(1, "abc"));
-  EXPECT_EQ(generator(), TokenInfo(2, "xyz"));
+  EXPECT_EQ(generator(), TokenInfo(1, abc));
+  EXPECT_EQ(generator(), TokenInfo(2, xyz));
   EXPECT_TRUE(generator().isEOF());
   // cannot call this generator any further after an EOF
 }

--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -92,6 +92,7 @@ cc_test(
     deps = [
         ":concrete_syntax_leaf",
         ":token_info",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/text/concrete_syntax_leaf_test.cc
+++ b/common/text/concrete_syntax_leaf_test.cc
@@ -16,6 +16,7 @@
 
 #include "common/text/concrete_syntax_leaf.h"
 
+#include "absl/strings/string_view.h"
 #include "common/text/token_info.h"
 #include "gtest/gtest.h"
 
@@ -30,12 +31,17 @@ TEST(ValueSymbolTest, EqualityArity1Args) {
   EXPECT_EQ(info1, info2);
 }
 
-TEST(ValueSymbolTest, EqualityArity2Args) {
-  SyntaxTreeLeaf value1(5, "Foo");
-  TokenInfo info1(5, "Foo");
-  auto info2 = value1.get();
-  EXPECT_EQ(info1, info2);
-}
+TEST(ValueSymbolTest, InequalityDifferentStringLocations) {
+  // Check that two tokens with the same text content but different
+  // location are _not_ considered equal.
+  constexpr absl::string_view longtext("foofoo");
+  constexpr absl::string_view first = longtext.substr(0, 3);
+  constexpr absl::string_view second = longtext.substr(3);
 
+  SyntaxTreeLeaf value1(10, first);
+  TokenInfo info1(10, second);
+  auto info2 = value1.get();
+  EXPECT_NE(info1, info2);
+}
 }  // namespace
 }  // namespace verible

--- a/common/util/with_reason_test.cc
+++ b/common/util/with_reason_test.cc
@@ -14,6 +14,7 @@
 
 #include "common/util/with_reason.h"
 
+#include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -36,26 +37,26 @@ static WithReason<const char*> FizzBuzzer(int i) {
 
 TEST(WithReason, Fizz) {
   const auto result = FizzBuzzer(6);
-  EXPECT_EQ(result.value, "fizz");
-  EXPECT_EQ(result.reason, "value is only divisible by 3.");
+  EXPECT_STREQ(result.value, "fizz") << result.value;
+  EXPECT_STREQ(result.reason, "value is only divisible by 3.") << result.reason;
 }
 
 TEST(WithReason, Buzz) {
   const auto result = FizzBuzzer(10);
-  EXPECT_EQ(result.value, "buzz");
-  EXPECT_EQ(result.reason, "value is only divisible by 5.");
+  EXPECT_STREQ(result.value, "buzz");
+  EXPECT_STREQ(result.reason, "value is only divisible by 5.");
 }
 
 TEST(WithReason, Neither) {
   const auto result = FizzBuzzer(16);
-  EXPECT_EQ(result.value, ".");
-  EXPECT_EQ(result.reason, "value is neither divisible by 3 nor 5.");
+  EXPECT_STREQ(result.value, ".");
+  EXPECT_STREQ(result.reason, "value is neither divisible by 3 nor 5.");
 }
 
 TEST(WithReason, Both) {
   const auto result = FizzBuzzer(30);
-  EXPECT_EQ(result.value, "fizzbuzz");
-  EXPECT_EQ(result.reason, "value is divisible by 3 and 5.");
+  EXPECT_STREQ(result.value, "fizzbuzz");
+  EXPECT_STREQ(result.reason, "value is divisible by 3 and 5.");
 }
 
 }  // namespace


### PR DESCRIPTION
… location.

A run with msvc showed, that even string literals with the exact same
content can be end up at _different_ addresses :(