### PR TITLE
Work around compilers that put same string literal constant in differ…

### DIFF
--- a/common/text/parser_verifier_test.cc
+++ b/common/text/parser_verifier_test.cc
@@ -91,9 +91,11 @@ TEST(ParserVerifierTest, AllUnmatched) {
 }
 
 TEST(ParserVerifierTest, PartialUnmatched) {
-  auto root = Node(Leaf(NOT_EOF, "foo"));
-  TokenSequence stream = {Token("foo"), Token("bar")};
-  TokenSequence unmatched_expected = {Token("bar")};
+  constexpr absl::string_view foo("foo");
+  constexpr absl::string_view bar("bar");
+  auto root = Node(Leaf(NOT_EOF, foo));
+  TokenSequence stream = {Token(foo), Token(bar)};
+  TokenSequence unmatched_expected = {Token(bar)};
 
   TokenStreamView view;
   InitTokenStreamView(stream, &view);
@@ -106,10 +108,14 @@ TEST(ParserVerifierTest, PartialUnmatched) {
 }
 
 TEST(ParserVerifierTest, SeveralPartialUnmatched) {
-  auto root = Node(Leaf(NOT_EOF, "foo"), Node(Leaf(NOT_EOF, "mee")));
-  TokenSequence stream = {Token("foo"), Token("bar1"), Token("bar2"),
-                          Token("mee")};
-  TokenSequence unmatched_expected = {Token("bar1"), Token("bar2")};
+  constexpr absl::string_view foo("foo");
+  constexpr absl::string_view bar1("bar1");
+  constexpr absl::string_view bar2("bar2");
+  constexpr absl::string_view mee("mee");
+
+  auto root = Node(Leaf(NOT_EOF, foo), Node(Leaf(NOT_EOF, mee)));
+  TokenSequence stream = {Token(foo), Token(bar1), Token(bar2), Token(mee)};
+  TokenSequence unmatched_expected = {Token(bar1), Token(bar2)};
 
   TokenStreamView view;
   InitTokenStreamView(stream, &view);

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -313,7 +313,8 @@ TEST(VerilogProjectTest, LookupFileOriginTest) {
 
 TEST(VerilogProjectTest, LookupFileOriginTestMoreFiles) {
   const auto tempdir = ::testing::TempDir();
-  const std::string sources_dir = JoinPath(tempdir, __FUNCTION__);
+  const std::string sources_dir =
+      JoinPath(tempdir, "LookupFileOriginTestMoreFiles");
   EXPECT_TRUE(CreateDir(sources_dir).ok());
   VerilogProject project(sources_dir, {});
   // no files yet


### PR DESCRIPTION
…ent places.

(MSVC: looking at you)

Also, don't use what comes out of `__FUNCTION__` as a filename as it
might not be a legal filename.

Signed-off-by: Henner Zeller <h.zeller@acm.org>