### PR TITLE
Use Layout Optimizer to format nested function calls

### DIFF
--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "//common/text:concrete_syntax_leaf",
         "//common/text:token_info",
         "//common/util:container_iterator_range",
+        "//common/util:iterator_adaptors",
         "//common/util:logging",
         "//common/util:spacer",
         "@com_google_absl//absl/base:core_headers",

--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -110,6 +110,7 @@ cc_library(
         "layout_optimizer.cc",
         "layout_optimizer_internal.h",
     ],
+    hdrs = ["layout_optimizer.h"],
     deps = [
         ":basic_format_style",
         ":line_wrap_searcher",

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -840,8 +840,7 @@ static void CommitAlignmentDecisionToRow(
     }
     // Tag every subtree as having already been committed to alignment.
     partition->ApplyPostOrder([](TokenPartitionTree& node) {
-      node.Value().SetPartitionPolicy(
-          PartitionPolicyEnum::kSuccessfullyAligned);
+      node.Value().SetPartitionPolicy(PartitionPolicyEnum::kAlreadyFormatted);
     });
   }
 }

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -805,27 +805,6 @@ static std::vector<DeferredTokenAlignment> ComputeAlignedRowSpacings(
   return align_actions;
 }
 
-// Given a const_iterator and the original mutable container, return
-// the corresponding mutable iterator (without resorting to const_cast).
-// The 'Container' type is not deducible from function arguments alone.
-// TODO(fangism): provide this from common/util/iterator_adaptors.
-template <class Container>
-typename Container::iterator ConvertToMutableIterator(
-    typename Container::const_iterator const_iter,
-    typename Container::iterator base) {
-  const typename Container::const_iterator cbase(base);
-  return base + std::distance(cbase, const_iter);
-}
-
-static MutableFormatTokenRange ConvertToMutableFormatTokenRange(
-    const FormatTokenRange& const_range,
-    MutableFormatTokenRange::iterator base) {
-  using array_type = std::vector<PreFormatToken>;
-  return MutableFormatTokenRange(
-      ConvertToMutableIterator<array_type>(const_range.begin(), base),
-      ConvertToMutableIterator<array_type>(const_range.end(), base));
-}
-
 static const AlignmentRow* RightmostSubcolumnWithTokens(
     const AlignmentRow& node) {
   if (!node.Value().tokens.empty()) return &node;

--- a/common/formatting/format_token.cc
+++ b/common/formatting/format_token.cc
@@ -23,6 +23,7 @@
 #include "common/strings/display_utils.h"
 #include "common/strings/range.h"
 #include "common/text/token_info.h"
+#include "common/util/iterator_adaptors.h"
 #include "common/util/logging.h"
 #include "common/util/spacer.h"
 
@@ -295,6 +296,14 @@ void PreserveSpacesOnDisabledTokenRanges(
     // start next iteration search from previous iteration's end
     saved_iter = disable_range.end();
   }
+}
+
+MutableFormatTokenRange ConvertToMutableFormatTokenRange(
+    const FormatTokenRange& const_range,
+    MutableFormatTokenRange::iterator base) {
+  return MutableFormatTokenRange(
+      ConvertToMutableIterator(const_range.begin(), base),
+      ConvertToMutableIterator(const_range.end(), base));
 }
 
 }  // namespace verible

--- a/common/formatting/format_token.h
+++ b/common/formatting/format_token.h
@@ -175,6 +175,13 @@ using FormatTokenRange =
 using MutableFormatTokenRange =
     container_iterator_range<std::vector<PreFormatToken>::iterator>;
 
+// Given a const_range and a mutable iterator to the original mutable container,
+// return the corresponding mutable iterator range (without resorting to
+// const_cast).
+MutableFormatTokenRange ConvertToMutableFormatTokenRange(
+    const FormatTokenRange& const_range,
+    MutableFormatTokenRange::iterator base);
+
 // Enumeration for the final decision about spacing between tokens.
 // Related enum: SpacingConstraint.
 // These values are also used during line wrap searching and optimization.

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -83,10 +83,7 @@ void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
           case PartitionPolicyEnum::kFitOnLineElseExpand: {
             absl::FixedArray<LayoutFunction> layouts(subnode.Children().size());
             std::transform(subnode.Children().begin(), subnode.Children().end(),
-                           layouts.begin(),
-                           [&TraverseTree](const TokenPartitionTree& subnode) {
-                             return TraverseTree(subnode);
-                           });
+                           layouts.begin(), TraverseTree);
             return factory.Wrap(layouts.begin(), layouts.end());
           }
 
@@ -94,10 +91,7 @@ void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
           case PartitionPolicyEnum::kTabularAlignment: {
             absl::FixedArray<LayoutFunction> layouts(subnode.Children().size());
             std::transform(subnode.Children().begin(), subnode.Children().end(),
-                           layouts.begin(),
-                           [&TraverseTree](const TokenPartitionTree& subnode) {
-                             return TraverseTree(subnode);
-                           });
+                           layouts.begin(), TraverseTree);
             return factory.Stack(layouts.begin(), layouts.end());
           }
 

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Improve code formatting by optimizing token partitions layout with
-// algorithm documented in https://research.google/pubs/pub44667/
-// (similar tool for R language: https://github.com/google/rfmt)
+// Implementation of a code layout optimizer described by
+// Phillip Yelland in "A New Approach to Optimal Code Formatting"
+// (https://research.google/pubs/pub44667/) and originally implemented
+// in rfmt (https://github.com/google/rfmt).
 
 #include "common/formatting/layout_optimizer.h"
 

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -32,9 +32,9 @@
 
 namespace verible {
 
-void OptimizeTokenPartitionTree(TokenPartitionTree* node,
-                                std::vector<PreFormatToken>* ftokens,
-                                const BasicFormatStyle& style) {
+void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
+                                TokenPartitionTree* node,
+                                std::vector<PreFormatToken>* ftokens) {
   CHECK_NOTNULL(node);
 
   VLOG(4) << __FUNCTION__ << ", before:\n" << *node;

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -524,7 +524,7 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
         auto uwline = layout_tree.Value().ToUnwrappedLine();
         uwline.SetIndentationSpaces(current_indentation_spaces_);
         // Prevent SearchLineWraps from processing optimized lines.
-        uwline.SetPartitionPolicy(PartitionPolicyEnum::kSuccessfullyAligned);
+        uwline.SetPartitionPolicy(PartitionPolicyEnum::kAlreadyFormatted);
         active_unwrapped_line_ = &unwrapped_lines_.emplace_back(uwline);
       } else {
         active_unwrapped_line_->SpanUpToToken(

--- a/common/formatting/layout_optimizer.h
+++ b/common/formatting/layout_optimizer.h
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Implementation details of layout_optimizer.cc exported for tests.
+// Implementation of a code layout optimizer described by
+// Phillip Yelland in "A New Approach to Optimal Code Formatting"
+// (https://research.google/pubs/pub44667/) and originally implemented
+// in rfmt (https://github.com/google/rfmt).
 
 #ifndef VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_H_
 #define VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_H_

--- a/common/formatting/layout_optimizer.h
+++ b/common/formatting/layout_optimizer.h
@@ -36,6 +36,7 @@ namespace verible {
 // Handles formatting of TokenPartitionTree nodes with
 // kOptimalFunctionCallLayout partition policy.
 void OptimizeTokenPartitionTree(TokenPartitionTree* node,
+                                std::vector<PreFormatToken>* ftokens,
                                 const BasicFormatStyle& style);
 
 }  // namespace verible

--- a/common/formatting/layout_optimizer.h
+++ b/common/formatting/layout_optimizer.h
@@ -1,0 +1,43 @@
+// Copyright 2017-2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation details of layout_optimizer.cc exported for tests.
+
+#ifndef VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_H_
+#define VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_H_
+
+#include <algorithm>
+#include <iterator>
+#include <ostream>
+#include <type_traits>
+#include <vector>
+
+#include "absl/container/fixed_array.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "common/formatting/basic_format_style.h"
+#include "common/formatting/token_partition_tree.h"
+#include "common/formatting/unwrapped_line.h"
+#include "common/util/vector_tree.h"
+
+namespace verible {
+
+// Handles formatting of TokenPartitionTree nodes with
+// kOptimalFunctionCallLayout partition policy.
+void OptimizeTokenPartitionTree(TokenPartitionTree* node,
+                                const BasicFormatStyle& style);
+
+}  // namespace verible
+
+#endif  // VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_H_

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -627,7 +627,6 @@ class TreeReconstructor {
       : current_indentation_spaces_(indentation_spaces), style_(style) {}
   ~TreeReconstructor() = default;
 
-  // Delete standard interfaces
   TreeReconstructor(const TreeReconstructor&) = delete;
   TreeReconstructor(TreeReconstructor&&) = delete;
   TreeReconstructor& operator=(const TreeReconstructor&) = delete;

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -70,6 +70,8 @@ class LayoutItem {
         must_wrap_(!tokens_.empty() && tokens_.front().before.break_decision ==
                                            SpacingOptions::MustWrap) {}
 
+  // Multiple LayoutFunctionSegments can store copies of the same layout.
+  // The objects are copied mostly in LayoutFunctionFactory::* functions.
   LayoutItem(const LayoutItem&) = default;
   LayoutItem& operator=(const LayoutItem&) = default;
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -78,15 +78,17 @@ class LayoutItem {
 
   LayoutType Type() const { return type_; }
 
-  // Returns "hard" indent, which is never removed when the layout is joined
-  // with another layout.
+  // Indentation used for a layout when it is placed at the beginning of a line.
+  // Effective indentation in this case is a sum of the item's and its
+  // ancestors' indetation
   int IndentationSpaces() const { return indentation_; }
 
-  // Sets "hard" indent, which is never removed when the layout is joined
-  // with another layout.
+  // Sets indentation used for a layout when it is placed at the beginning of
+  // a line.
   void SetIndentationSpaces(int indent) { indentation_ = indent; }
 
-  // Returns amount of spaces before first token.
+  // Returns number of spaces required before the first token. The spaces are
+  // used when the layout is appended to a non-empty line.
   int SpacesBefore() const { return spaces_before_; }
 
   // Returns whether to force line break just before this layout.

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -123,7 +123,6 @@ class LayoutItem {
 
     UnwrappedLine uwline(0, tokens_.begin());
     uwline.SpanUpToToken(tokens_.end());
-    uwline.SetPartitionPolicy(PartitionPolicyEnum::kAlwaysExpand);
     return uwline;
   }
 
@@ -632,7 +631,8 @@ class TreeReconstructor {
 
   void TraverseTree(const LayoutTree& layout_tree);
 
-  void ReplaceTokenPartitionTreeNode(TokenPartitionTree* node) const;
+  void ReplaceTokenPartitionTreeNode(
+      TokenPartitionTree* node, std::vector<PreFormatToken>* ftokens) const;
 
  private:
   std::vector<UnwrappedLine> unwrapped_lines_;

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -618,6 +618,32 @@ class LayoutFunctionFactory {
   const BasicFormatStyle& style_;
 };
 
+class TreeReconstructor {
+ public:
+  TreeReconstructor(int indentation_spaces, const BasicFormatStyle& style)
+      : current_indentation_spaces_(indentation_spaces), style_(style) {}
+  ~TreeReconstructor() = default;
+
+  // Delete standard interfaces
+  TreeReconstructor(const TreeReconstructor&) = delete;
+  TreeReconstructor(TreeReconstructor&&) = delete;
+  TreeReconstructor& operator=(const TreeReconstructor&) = delete;
+  TreeReconstructor& operator=(TreeReconstructor&&) = delete;
+
+  void TraverseTree(const LayoutTree& layout_tree);
+
+  void ReplaceTokenPartitionTreeNode(TokenPartitionTree* node) const;
+
+ private:
+  std::vector<UnwrappedLine> unwrapped_lines_;
+
+  UnwrappedLine* active_unwrapped_line_ = nullptr;
+
+  int current_indentation_spaces_;
+
+  const BasicFormatStyle& style_;
+};
+
 }  // namespace verible
 
 #endif  // VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_INTERNAL_H_

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -159,8 +159,6 @@ TEST_F(LayoutTest, AsUnwrappedLine) {
 
   const auto uwline = layout_short.ToUnwrappedLine();
   EXPECT_EQ(uwline.IndentationSpaces(), 0);
-  EXPECT_EQ(uwline.PartitionPolicy(), PartitionPolicyEnum::kAlwaysExpand);
-
   EXPECT_EQ(uwline.TokensRange().begin(), short_line.TokensRange().begin());
   EXPECT_EQ(uwline.TokensRange().end(), short_line.TokensRange().end());
 }
@@ -1851,7 +1849,8 @@ TEST_F(TreeReconstructorTest, SingleLine) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree(UnwrappedLine(0, begin));
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{single_line,  //
@@ -1878,7 +1877,8 @@ TEST_F(TreeReconstructorTest, HorizontalLayoutWithOneLine) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{uwline,  //
@@ -1911,7 +1911,8 @@ TEST_F(TreeReconstructorTest, HorizontalLayoutSingleLines) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree(UnwrappedLine(0, begin));
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected(all,  //
@@ -1944,7 +1945,8 @@ TEST_F(TreeReconstructorTest, EmptyHorizontalLayout) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{all,  //
@@ -1970,7 +1972,8 @@ TEST_F(TreeReconstructorTest, VerticalLayoutWithOneLine) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{uwline,  //
@@ -2003,7 +2006,8 @@ TEST_F(TreeReconstructorTest, VerticalLayoutSingleLines) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{all,               //
@@ -2037,7 +2041,8 @@ TEST_F(TreeReconstructorTest, EmptyVerticalLayout) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{all,               //
@@ -2083,7 +2088,8 @@ TEST_F(TreeReconstructorTest, VerticallyJoinHorizontalLayouts) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{all,               //
@@ -2132,7 +2138,8 @@ TEST_F(TreeReconstructorTest, HorizontallyJoinVerticalLayouts) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{all,                //
@@ -2161,7 +2168,8 @@ TEST_F(TreeReconstructorTest, IndentSingleLine) {
   tree_reconstructor.TraverseTree(layout_tree);
 
   auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree,
+                                                   &pre_format_tokens_);
 
   using Tree = TokenPartitionTree;
   const Tree tree_expected{single_line,  //
@@ -2247,7 +2255,7 @@ TEST_F(OptimizeTokenPartitionTreeTest, OneLevelFunctionCall) {
 
   BasicFormatStyle style;
   style.column_limit = 40;
-  OptimizeTokenPartitionTree(&tree_under_test, style);
+  OptimizeTokenPartitionTree(&tree_under_test, &pre_format_tokens_, style);
 
   UnwrappedLine args_top_line(0, arg_a.TokensRange().begin());
   args_top_line.SpanUpToToken(arg_b.TokensRange().end());

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -2255,7 +2255,7 @@ TEST_F(OptimizeTokenPartitionTreeTest, OneLevelFunctionCall) {
 
   BasicFormatStyle style;
   style.column_limit = 40;
-  OptimizeTokenPartitionTree(&tree_under_test, &pre_format_tokens_, style);
+  OptimizeTokenPartitionTree(style, &tree_under_test, &pre_format_tokens_);
 
   UnwrappedLine args_top_line(0, arg_a.TokensRange().begin());
   args_top_line.SpanUpToToken(arg_b.TokensRange().end());

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+#include "common/formatting/layout_optimizer.h"
 
 #include <sstream>
 #include <string>
@@ -45,6 +47,10 @@ TEST(LayoutTypeTest, ToString) {
   EXPECT_EQ(ToString(LayoutType::kJuxtaposition), "juxtaposition");
   EXPECT_EQ(ToString(LayoutType::kStack), "stack");
   EXPECT_EQ(ToString(static_cast<LayoutType>(-1)), "???");
+}
+
+bool TokenRangeEqual(const UnwrappedLine& left, const UnwrappedLine& right) {
+  return left.TokensRange() == right.TokensRange();
 }
 
 class LayoutTest : public ::testing::Test, public UnwrappedLineMemoryHandler {
@@ -1812,6 +1818,463 @@ TEST_F(LayoutFunctionFactoryTest, IndentWithOtherCombinators) {
     };
     ExpectLayoutFunctionsEqual(lf, expected_lf, __LINE__);
   }
+}
+
+class TreeReconstructorTest : public ::testing::Test,
+                              public UnwrappedLineMemoryHandler {
+ public:
+  TreeReconstructorTest()
+      : sample_("first_line second_line third_line fourth_line"),
+        tokens_(absl::StrSplit(sample_, ' ')) {
+    for (const auto token : tokens_) {
+      ftokens_.emplace_back(TokenInfo{1, token});
+    }
+    CreateTokenInfos(ftokens_);
+  }
+
+ protected:
+  const std::string sample_;
+  const std::vector<absl::string_view> tokens_;
+  std::vector<TokenInfo> ftokens_;
+};
+
+TEST_F(TreeReconstructorTest, SingleLine) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine single_line(0, begin);
+  single_line.SpanUpToToken(begin + 1);
+
+  const auto layout_tree = LayoutTree(LayoutItem(single_line));
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree(UnwrappedLine(0, begin));
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{single_line,  //
+                           Tree{single_line}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, HorizontalLayoutWithOneLine) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine uwline(0, begin);
+  uwline.SpanUpToToken(begin + 1);
+
+  const auto layout_tree =
+      LayoutTree(LayoutItem(LayoutType::kJuxtaposition, 0, false),
+                 LayoutTree(LayoutItem(uwline)));
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{uwline,  //
+                           Tree{uwline}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, HorizontalLayoutSingleLines) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine left_line(0, begin);
+  left_line.SpanUpToToken(begin + 1);
+  UnwrappedLine right_line(0, begin + 1);
+  right_line.SpanUpToToken(begin + 2);
+  UnwrappedLine all(0, left_line.TokensRange().begin());
+  all.SpanUpToToken(right_line.TokensRange().end());
+
+  const auto layout_tree = LayoutTree(
+      LayoutItem(LayoutType::kJuxtaposition, 0,
+                 left_line.TokensRange().front().before.break_decision ==
+                     SpacingOptions::MustWrap),
+      LayoutTree(LayoutItem(left_line)), LayoutTree(LayoutItem(right_line)));
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree(UnwrappedLine(0, begin));
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected(all,  //
+                           Tree(all));
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, EmptyHorizontalLayout) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine upper_line(0, begin);
+  upper_line.SpanUpToToken(begin + 1);
+  UnwrappedLine lower_line(0, begin + 1);
+  lower_line.SpanUpToToken(begin + 2);
+  UnwrappedLine all(0, upper_line.TokensRange().begin());
+  all.SpanUpToToken(lower_line.TokensRange().end());
+
+  const auto layout_tree =
+      LayoutTree(LayoutItem(LayoutType::kJuxtaposition, 0, false),
+                 LayoutTree(LayoutItem(upper_line)),
+                 LayoutTree(LayoutItem(LayoutType::kJuxtaposition, 0, false)),
+                 LayoutTree(LayoutItem(lower_line)));
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{all,  //
+                           Tree{all}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, VerticalLayoutWithOneLine) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine uwline(0, begin);
+  uwline.SpanUpToToken(begin + 1);
+
+  const auto layout_tree = LayoutTree(LayoutItem(LayoutType::kStack, 0, false),
+                                      LayoutTree(LayoutItem(uwline)));
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{uwline,  //
+                           Tree{uwline}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, VerticalLayoutSingleLines) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine upper_line(0, begin);
+  upper_line.SpanUpToToken(begin + 1);
+  UnwrappedLine lower_line(0, begin + 1);
+  lower_line.SpanUpToToken(begin + 2);
+  UnwrappedLine all(0, upper_line.TokensRange().begin());
+  all.SpanUpToToken(lower_line.TokensRange().end());
+
+  const auto layout_tree = LayoutTree(
+      LayoutItem(LayoutType::kStack, 0,
+                 upper_line.TokensRange().front().before.break_decision ==
+                     SpacingOptions::MustWrap),
+      LayoutTree(LayoutItem(upper_line)), LayoutTree(LayoutItem(lower_line)));
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{all,               //
+                           Tree{upper_line},  //
+                           Tree{lower_line}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, EmptyVerticalLayout) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine upper_line(0, begin);
+  upper_line.SpanUpToToken(begin + 1);
+  UnwrappedLine lower_line(0, begin + 1);
+  lower_line.SpanUpToToken(begin + 2);
+  UnwrappedLine all(0, upper_line.TokensRange().begin());
+  all.SpanUpToToken(lower_line.TokensRange().end());
+
+  const auto layout_tree =
+      LayoutTree(LayoutItem(LayoutType::kStack, 0, false),
+                 LayoutTree(LayoutItem(upper_line)),
+                 LayoutTree(LayoutItem(LayoutType::kStack, 0, false)),
+                 LayoutTree(LayoutItem(lower_line)));
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{all,               //
+                           Tree{upper_line},  //
+                           Tree{lower_line}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, VerticallyJoinHorizontalLayouts) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine first_line(0, begin);
+  first_line.SpanUpToToken(begin + 1);
+  UnwrappedLine second_line(0, begin + 1);
+  second_line.SpanUpToToken(begin + 2);
+  UnwrappedLine third_line(0, begin + 2);
+  third_line.SpanUpToToken(begin + 3);
+  UnwrappedLine fourth_line(0, begin + 3);
+  fourth_line.SpanUpToToken(begin + 4);
+
+  UnwrappedLine upper_line(0, first_line.TokensRange().begin());
+  upper_line.SpanUpToToken(second_line.TokensRange().end());
+  UnwrappedLine lower_line(0, third_line.TokensRange().begin());
+  lower_line.SpanUpToToken(fourth_line.TokensRange().end());
+
+  UnwrappedLine all(0, upper_line.TokensRange().begin());
+  all.SpanUpToToken(lower_line.TokensRange().end());
+  const LayoutTree layout_tree{
+      LayoutItem(LayoutType::kStack, 0, false),
+      LayoutTree(LayoutItem(LayoutType::kJuxtaposition, 0, false),
+                 LayoutTree(LayoutItem(first_line)),
+                 LayoutTree(LayoutItem(second_line))),
+      LayoutTree(LayoutItem(LayoutType::kJuxtaposition, 0, false),
+                 LayoutTree(LayoutItem(third_line)),
+                 LayoutTree(LayoutItem(fourth_line)))};
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{all,               //
+                           Tree{upper_line},  //
+                           Tree{lower_line}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, HorizontallyJoinVerticalLayouts) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine first_line(0, begin);
+  first_line.SpanUpToToken(begin + 1);
+  UnwrappedLine second_line(0, begin + 1);
+  second_line.SpanUpToToken(begin + 2);
+  UnwrappedLine third_line(0, begin + 2);
+  third_line.SpanUpToToken(begin + 3);
+  UnwrappedLine fourth_line(0, begin + 3);
+  fourth_line.SpanUpToToken(begin + 4);
+
+  UnwrappedLine upper_line(0, first_line.TokensRange().begin());
+  upper_line.SpanUpToToken(first_line.TokensRange().end());
+  UnwrappedLine middle_line(0, second_line.TokensRange().begin());
+  middle_line.SpanUpToToken(third_line.TokensRange().end());
+  UnwrappedLine bottom_line(0, fourth_line.TokensRange().begin());
+  bottom_line.SpanUpToToken(fourth_line.TokensRange().end());
+
+  UnwrappedLine all(0, upper_line.TokensRange().begin());
+  all.SpanUpToToken(bottom_line.TokensRange().end());
+
+  const LayoutTree layout_tree{
+      LayoutItem(LayoutType::kJuxtaposition, 0, false),
+      LayoutTree(LayoutItem(LayoutType::kStack, 0, false),
+                 LayoutTree(LayoutItem(first_line)),
+                 LayoutTree(LayoutItem(second_line))),
+      LayoutTree(LayoutItem(LayoutType::kStack, 0, false),
+                 LayoutTree(LayoutItem(third_line)),
+                 LayoutTree(LayoutItem(fourth_line)))};
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{all,                //
+                           Tree{upper_line},   //
+                           Tree{middle_line},  //
+                           Tree{bottom_line}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+}
+
+TEST_F(TreeReconstructorTest, IndentSingleLine) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+  BasicFormatStyle style;
+
+  UnwrappedLine single_line(0, begin);
+  single_line.SpanUpToToken(begin + 1);
+
+  const auto indent = 7;
+  LayoutTree layout_tree{LayoutItem(single_line)};
+  layout_tree.Value().SetIndentationSpaces(indent);
+
+  TreeReconstructor tree_reconstructor(0, style);
+  tree_reconstructor.TraverseTree(layout_tree);
+
+  auto optimized_tree = TokenPartitionTree{UnwrappedLine(0, begin)};
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(&optimized_tree);
+
+  using Tree = TokenPartitionTree;
+  const Tree tree_expected{single_line,  //
+                           Tree{single_line}};
+  const auto diff = DeepEqual(optimized_tree, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << optimized_tree << "\n";
+
+  EXPECT_EQ(optimized_tree.Children()[0].Value().IndentationSpaces(), indent);
+}
+
+class OptimizeTokenPartitionTreeTest : public ::testing::Test,
+                                       public UnwrappedLineMemoryHandler {
+ public:
+  OptimizeTokenPartitionTreeTest()
+      : sample_(
+            "function_fffffffffff( type_a_aaaa, "
+            "type_b_bbbbb, type_c_cccccc, "
+            "type_d_dddddddd, type_e_eeeeeeee, type_f_ffff);"),
+        tokens_(absl::StrSplit(sample_, ' ')) {
+    for (const auto token : tokens_) {
+      ftokens_.emplace_back(TokenInfo{1, token});
+    }
+    CreateTokenInfos(ftokens_);
+  }
+
+ protected:
+  const std::string sample_;
+  const std::vector<absl::string_view> tokens_;
+  std::vector<TokenInfo> ftokens_;
+};
+
+TEST_F(OptimizeTokenPartitionTreeTest, OneLevelFunctionCall) {
+  const auto& preformat_tokens = pre_format_tokens_;
+  const auto begin = preformat_tokens.begin();
+
+  UnwrappedLine function_name(0, begin);
+  function_name.SpanUpToToken(begin + 1);
+  UnwrappedLine arg_a(0, begin + 1);
+  arg_a.SpanUpToToken(begin + 2);
+  UnwrappedLine arg_b(0, begin + 2);
+  arg_b.SpanUpToToken(begin + 3);
+  UnwrappedLine arg_c(0, begin + 3);
+  arg_c.SpanUpToToken(begin + 4);
+  UnwrappedLine arg_d(0, begin + 4);
+  arg_d.SpanUpToToken(begin + 5);
+  UnwrappedLine arg_e(0, begin + 5);
+  arg_e.SpanUpToToken(begin + 6);
+  UnwrappedLine arg_f(0, begin + 6);
+  arg_f.SpanUpToToken(begin + 7);
+
+  function_name.SetPartitionPolicy(PartitionPolicyEnum::kAlwaysExpand);
+  arg_a.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+  arg_b.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+  arg_c.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+  arg_d.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+  arg_e.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+  arg_f.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+
+  UnwrappedLine header(0, function_name.TokensRange().begin());
+  header.SpanUpToToken(function_name.TokensRange().end());
+  UnwrappedLine args(0, arg_a.TokensRange().begin());
+  args.SpanUpToToken(arg_f.TokensRange().end());
+
+  header.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+  args.SetPartitionPolicy(PartitionPolicyEnum::kFitOnLineElseExpand);
+
+  UnwrappedLine all(0, header.TokensRange().begin());
+  all.SpanUpToToken(args.TokensRange().end());
+  all.SetPartitionPolicy(PartitionPolicyEnum::kOptimalFunctionCallLayout);
+
+  using Tree = TokenPartitionTree;
+  Tree tree_under_test{all,               //
+                       Tree{header},      //
+                       Tree{args,         //
+                            Tree{arg_a},  //
+                            Tree{arg_b},  //
+                            Tree{arg_c},  //
+                            Tree{arg_d},  //
+                            Tree{arg_e},  //
+                            Tree{arg_f}}};
+
+  BasicFormatStyle style;
+  style.column_limit = 40;
+  OptimizeTokenPartitionTree(&tree_under_test, style);
+
+  UnwrappedLine args_top_line(0, arg_a.TokensRange().begin());
+  args_top_line.SpanUpToToken(arg_b.TokensRange().end());
+  UnwrappedLine args_middle_line(0, arg_c.TokensRange().begin());
+  args_middle_line.SpanUpToToken(arg_d.TokensRange().end());
+  UnwrappedLine args_bottom_line(0, arg_e.TokensRange().begin());
+  args_bottom_line.SpanUpToToken(arg_f.TokensRange().end());
+
+  const Tree tree_expected{all,                     //
+                           Tree{header},            //
+                           Tree{args_top_line},     //
+                           Tree{args_middle_line},  //
+                           Tree{args_bottom_line}};
+
+  const auto diff = DeepEqual(tree_under_test, tree_expected, TokenRangeEqual);
+  EXPECT_EQ(diff.left, nullptr) << "Expected:\n"
+                                << tree_expected << "\nGot:\n"
+                                << tree_under_test << "\n";
+
+  // header
+  EXPECT_EQ(tree_under_test.Children()[0].Value().IndentationSpaces(), 0);
+  // args_top_line (wrapped)
+  EXPECT_EQ(tree_under_test.Children()[1].Value().IndentationSpaces(), 4);
+  // args_middle_line (wrapped)
+  EXPECT_EQ(tree_under_test.Children()[2].Value().IndentationSpaces(), 4);
+  // args_bottom_line (wrapped)
+  EXPECT_EQ(tree_under_test.Children()[3].Value().IndentationSpaces(), 4);
 }
 
 }  // namespace

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -46,6 +46,8 @@ std::ostream& operator<<(std::ostream& stream, PartitionPolicyEnum p) {
       return stream << "aligned-success";
     case PartitionPolicyEnum::kAppendFittingSubPartitions:
       return stream << "append-fitting-sub-partitions";
+    case PartitionPolicyEnum::kOptimalFunctionCallLayout:
+      return stream << "optimal-function-call-layout";
   }
   LOG(FATAL) << "Unknown partition policy " << int(p);
 }

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -42,8 +42,8 @@ std::ostream& operator<<(std::ostream& stream, PartitionPolicyEnum p) {
       return stream << "fit-else-expand";
     case PartitionPolicyEnum::kTabularAlignment:
       return stream << "tabular-alignment";
-    case PartitionPolicyEnum::kSuccessfullyAligned:
-      return stream << "aligned-success";
+    case PartitionPolicyEnum::kAlreadyFormatted:
+      return stream << "already-formatted";
     case PartitionPolicyEnum::kAppendFittingSubPartitions:
       return stream << "append-fitting-sub-partitions";
     case PartitionPolicyEnum::kOptimalFunctionCallLayout:

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -63,6 +63,10 @@ enum class PartitionPolicyEnum {
   // element It uses first subpartition length to compute indentation spaces or
   // FormatStyle.wrap_spaces when wrapping.
   kAppendFittingSubPartitions,
+
+  // Does optimizations on partition tree and its subpartitions.
+  // Currently it used for reshaping function calls partitions.
+  kOptimalFunctionCallLayout,
 };
 
 std::ostream& operator<<(std::ostream&, PartitionPolicyEnum);

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -51,12 +51,12 @@ enum class PartitionPolicyEnum {
   // columns that use space-padding to achieve vertical alignment.
   kTabularAlignment,
 
-  // Signal that this unwrapped line (a direct child of a partition marked with
-  // kTabularAlignment) has been successfully aligned with spacing padded.
-  // In this case, do NOT bother to call SearchLineWraps or perform any other
-  // spacing/wrapping optimization.
-  // Reserved for setting only from align.cc.
-  kSuccessfullyAligned,
+  // Signal that this unwrapped line has been successfully formatted with
+  // spacing added. In this case, do NOT bother to call SearchLineWraps or
+  // perform any other spacing/wrapping optimization.
+  // Reserved for setting only from policy-specific formatters, like Layout
+  // Optimizer and Tabular Aligner.
+  kAlreadyFormatted,
 
   // Treats subpartitions as units, and appends them to the same line as
   // long as they fit, else wrap them aligned to the position of the first

--- a/common/util/iterator_adaptors.h
+++ b/common/util/iterator_adaptors.h
@@ -50,6 +50,15 @@ reversed_view(T& t) {
   // in std:: when compiling with C++14 or newer.
 }
 
+// Given a const_iterator and a mutable iterator to the original mutable
+// container, return the corresponding mutable iterator (without resorting to
+// const_cast).
+template <class Iter, class ConstIter>
+Iter ConvertToMutableIterator(ConstIter const_iter, Iter base) {
+  auto cbase = ConstIter(base);
+  return base + std::distance(cbase, const_iter);
+}
+
 }  // namespace verible
 
 #endif  // VERIBLE_COMMON_UTIL_ITERATOR_ADAPTORS_H_

--- a/common/util/iterator_adaptors_test.cc
+++ b/common/util/iterator_adaptors_test.cc
@@ -86,11 +86,11 @@ TEST(ReversedViewTest, NonEmptySet) {
   EXPECT_THAT(reversed_view(v), ElementsAre(7, 6, 3));
 }
 
-TEST(ConvertToMutableIteratorTest, TemporaryTemporary) {
+TEST(ConvertToMutableIteratorTest, Convert) {
   std::vector<int> v{3, 6, 7};
   const std::vector<int>::const_iterator const_it = v.cbegin() + 1;
   auto it = ConvertToMutableIterator(const_it, v.begin());
-  EXPECT_TRUE((std::is_same_v<decltype(it), std::vector<int>::iterator>));
+  static_assert(std::is_same_v<decltype(it), std::vector<int>::iterator>);
   EXPECT_EQ(*it, 6);
   *it = 42;
   EXPECT_EQ(*it, 42);

--- a/common/util/iterator_adaptors_test.cc
+++ b/common/util/iterator_adaptors_test.cc
@@ -17,6 +17,7 @@
 #include <initializer_list>
 #include <list>
 #include <set>
+#include <type_traits>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -83,6 +84,17 @@ TEST(ReversedViewTest, EmptySet) {
 TEST(ReversedViewTest, NonEmptySet) {
   std::set<int> v{3, 6, 7};
   EXPECT_THAT(reversed_view(v), ElementsAre(7, 6, 3));
+}
+
+TEST(ConvertToMutableIteratorTest, TemporaryTemporary) {
+  std::vector<int> v{3, 6, 7};
+  const std::vector<int>::const_iterator const_it = v.cbegin() + 1;
+  auto it = ConvertToMutableIterator(const_it, v.begin());
+  EXPECT_TRUE((std::is_same_v<decltype(it), std::vector<int>::iterator>));
+  EXPECT_EQ(*it, 6);
+  *it = 42;
+  EXPECT_EQ(*it, 42);
+  EXPECT_EQ(v[1], 42);
 }
 
 }  // namespace

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -137,6 +137,7 @@ cc_library(
         ":tree_unwrapper",
         "//common/formatting:format_token",
         "//common/formatting:line_wrap_searcher",
+        "//common/formatting:layout_optimizer",
         "//common/formatting:token_partition_tree",
         "//common/formatting:unwrapped_line",
         "//common/formatting:verification",

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -749,7 +749,8 @@ Status Formatter::Format(const ExecutionControl& control) {
           verible::ReshapeFittingSubpartitions(&node, style_);
           break;
         case PartitionPolicyEnum::kOptimalFunctionCallLayout:
-          verible::OptimizeTokenPartitionTree(&node, style_);
+          verible::OptimizeTokenPartitionTree(
+              &node, &unwrapper_data.preformatted_tokens, style_);
           break;
         case PartitionPolicyEnum::kTabularAlignment:
           // TODO(b/145170750): Adjust inter-token spacing to achieve alignment,

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -22,6 +22,7 @@
 
 #include "absl/status/status.h"
 #include "common/formatting/format_token.h"
+#include "common/formatting/layout_optimizer.h"
 #include "common/formatting/line_wrap_searcher.h"
 #include "common/formatting/token_partition_tree.h"
 #include "common/formatting/unwrapped_line.h"
@@ -355,6 +356,7 @@ static void DeterminePartitionExpansion(
       LOG(FATAL) << "Got an uninitialized partition policy at: " << uwline;
       break;
     }
+    case PartitionPolicyEnum::kOptimalFunctionCallLayout:
     case PartitionPolicyEnum::kAlwaysExpand: {
       if (children.size() > 1) {
         node_view.Expand();
@@ -745,6 +747,9 @@ Status Formatter::Format(const ExecutionControl& control) {
         case PartitionPolicyEnum::kAppendFittingSubPartitions:
           // Reshape partition tree with kAppendFittingSubPartitions policy
           verible::ReshapeFittingSubpartitions(&node, style_);
+          break;
+        case PartitionPolicyEnum::kOptimalFunctionCallLayout:
+          verible::OptimizeTokenPartitionTree(&node, style_);
           break;
         case PartitionPolicyEnum::kTabularAlignment:
           // TODO(b/145170750): Adjust inter-token spacing to achieve alignment,

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -383,7 +383,7 @@ static void DeterminePartitionExpansion(
       break;
     }
 
-    case PartitionPolicyEnum::kSuccessfullyAligned:
+    case PartitionPolicyEnum::kAlreadyFormatted:
       VLOG(3) << "Aligned fits, un-expanding.";
       node_view.Unexpand();
       break;
@@ -783,7 +783,7 @@ Status Formatter::Format(const ExecutionControl& control) {
     // uwline.PartitionPolicy().
     if (continuation_comment_aligner.HandleLine(uwline, &formatted_lines_)) {
     } else if (uwline.PartitionPolicy() ==
-               PartitionPolicyEnum::kSuccessfullyAligned) {
+               PartitionPolicyEnum::kAlreadyFormatted) {
       // For partitions that were successfully aligned, do not search
       // line-wrapping, but instead accept the adjusted padded spacing.
       formatted_lines_.emplace_back(uwline);

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -750,7 +750,7 @@ Status Formatter::Format(const ExecutionControl& control) {
           break;
         case PartitionPolicyEnum::kOptimalFunctionCallLayout:
           verible::OptimizeTokenPartitionTree(
-              &node, &unwrapper_data.preformatted_tokens, style_);
+              style_, &node, &unwrapper_data.preformatted_tokens);
           break;
         case PartitionPolicyEnum::kTabularAlignment:
           // TODO(b/145170750): Adjust inter-token spacing to achieve alignment,

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -11761,8 +11761,7 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases40ColumnsLimit[] = {
      "  `uvm_info(\n"
      "      `gfn,\n"
      "      $sformatf(\n"
-     "          \"\\n  base_vseq: generate %0d pulse in channel %0d\"\n"
-     "              ,\n"
+     "          \"\\n  base_vseq: generate %0d pulse in channel %0d\",\n"
      "          cfg.num_pulses, i), UVM_DEBUG)\n"
      "endmodule\n"},
     {"module foo;`uvm_info(`gfn, $sformatf("
@@ -11773,8 +11772,7 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases40ColumnsLimit[] = {
      "  `uvm_info(\n"
      "      `gfn,\n"
      "      $sformatf(\n"
-     "          \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\"\n"
-     "              ,\n"
+     "          \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\",\n"
      "          cfg.convert2string()),\n"
      "      UVM_LOW)\n"  // FIXME: Wrapped by SearchLineWraps
      "endmodule\n"},
@@ -11808,8 +11806,7 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases60ColumnsLimit[] = {
      "  `uvm_info(\n"
      "      `gfn,\n"
      "      $sformatf(\n"
-     "          \"\\n  base_vseq: generate %0d pulse in channel %0d\"\n"
-     "              ,\n"
+     "          \"\\n  base_vseq: generate %0d pulse in channel %0d\",\n"
      "          cfg.num_pulses, i), UVM_DEBUG)\n"
      "endmodule\n"},
     {"module foo;`uvm_info(`gfn, $sformatf("
@@ -11820,8 +11817,7 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases60ColumnsLimit[] = {
      "  `uvm_info(\n"
      "      `gfn,\n"
      "      $sformatf(\n"
-     "          \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\"\n"
-     "              ,\n"
+     "          \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\",\n"
      "          cfg.convert2string()), UVM_LOW)\n"
      "endmodule\n"},
 };
@@ -11876,8 +11872,7 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases80ColumnsLimit[] = {
      "      `gfn,\n"
      "      $sformatf(\n"
      "          \"The data 0x%0h written to the signature address is formatted "
-     "incorrectly.\"\n"
-     "              ,\n"  // FIXME: Wrapped by SearchLineWraps
+     "incorrectly.\",\n"
      "          signature_data))\n"
      "endmodule\n"},
 };

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -6683,7 +6683,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "  `ppgJH3JoxhwyTmZ2dgPiuMQzpRAWiSs(\n"
         "      {xYtxuh6.FIMcVPEWfhtoI2FSe, xYtxuh6.ZVL5XASVGLYz32} == "
         "SqRgavM[15:2];\n"
-        "JgQLBG == 4'h0;, \"foo\")\n"
+        "JgQLBG == 4'h0;,\n"
+        "      \"foo\")\n"
         "endtask\n",
     },
 
@@ -11749,6 +11750,288 @@ TEST(FormatterEndToEndTest, PortDeclarationDimensionsAlignmentTest) {
 }
 
 // TODO(fangism): directed tests using style variations
+
+static constexpr FormatterTestCase kNestedFunctionsTestCases40ColumnsLimit[] = {
+    {"module foo;"
+     "`uvm_info(`gfn, $sformatf(\n"
+     "\"\\n  base_vseq: generate %0d pulse in channel %0d\", cfg.num_pulses, "
+     "i), UVM_DEBUG)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(\n"
+     "      `gfn,\n"
+     "      $sformatf(\n"
+     "          \"\\n  base_vseq: generate %0d pulse in channel %0d\"\n"
+     "              ,\n"
+     "          cfg.num_pulses, i), UVM_DEBUG)\n"
+     "endmodule\n"},
+    {"module foo;`uvm_info(`gfn, $sformatf("
+     "\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\","
+     "cfg.convert2string()), UVM_LOW)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(\n"
+     "      `gfn,\n"
+     "      $sformatf(\n"
+     "          \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\"\n"
+     "              ,\n"
+     "          cfg.convert2string()),\n"
+     "      UVM_LOW)\n"  // FIXME: Wrapped by SearchLineWraps
+     "endmodule\n"},
+};
+
+TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases40ColumnsLimit) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+
+  for (const auto& test_case : kNestedFunctionsTestCases40ColumnsLimit) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+static constexpr FormatterTestCase kNestedFunctionsTestCases60ColumnsLimit[] = {
+    {"module foo;"
+     "`uvm_info(`gfn, $sformatf(\n"
+     "\"\\n  base_vseq: generate %0d pulse in channel %0d\", cfg.num_pulses, "
+     "i), UVM_DEBUG)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(\n"
+     "      `gfn,\n"
+     "      $sformatf(\n"
+     "          \"\\n  base_vseq: generate %0d pulse in channel %0d\"\n"
+     "              ,\n"
+     "          cfg.num_pulses, i), UVM_DEBUG)\n"
+     "endmodule\n"},
+    {"module foo;`uvm_info(`gfn, $sformatf("
+     "\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\","
+     "cfg.convert2string()), UVM_LOW)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(\n"
+     "      `gfn,\n"
+     "      $sformatf(\n"
+     "          \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\"\n"
+     "              ,\n"
+     "          cfg.convert2string()), UVM_LOW)\n"
+     "endmodule\n"},
+};
+
+TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases60ColumnsLimit) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 60;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+
+  for (const auto& test_case : kNestedFunctionsTestCases60ColumnsLimit) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+static constexpr FormatterTestCase kNestedFunctionsTestCases80ColumnsLimit[] = {
+    {"module foo;"
+     "`uvm_info(`gfn, $sformatf(\n"
+     "\"\\n  base_vseq: generate %0d pulse in channel %0d\", cfg.num_pulses, "
+     "i), UVM_DEBUG)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(`gfn, $sformatf(\"\\n  base_vseq: generate %0d pulse in "
+     "channel %0d\",\n"
+     "                            cfg.num_pulses, i), UVM_DEBUG)\n"
+     "endmodule\n"},
+    {"module foo;`uvm_info(`gfn, $sformatf("
+     "\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\","
+     "cfg.convert2string()), UVM_LOW)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(\n"
+     "      `gfn, $sformatf(\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE "
+     "|----\\n %s\",\n"
+     "                      cfg.convert2string()), UVM_LOW)\n"
+     "endmodule\n"},
+    {"module x;"
+     "`uvm_fatal(`gfn, $sformatf("
+     "\"The data 0x%0h written to the signature address is formatted "
+     "incorrectly.\","
+     "signature_data))\n"
+     "endmodule",
+     "module x;\n"
+     "  `uvm_fatal(\n"
+     "      `gfn,\n"
+     "      $sformatf(\n"
+     "          \"The data 0x%0h written to the signature address is formatted "
+     "incorrectly.\"\n"
+     "              ,\n"  // FIXME: Wrapped by SearchLineWraps
+     "          signature_data))\n"
+     "endmodule\n"},
+};
+
+TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases80ColumnsLimit) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 80;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+
+  for (const auto& test_case : kNestedFunctionsTestCases80ColumnsLimit) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+static constexpr FormatterTestCase kNestedFunctionsTestCases100ColumnsLimit[] =
+    {
+        {"module foo;"
+         "`uvm_info(`gfn, $sformatf(\n"
+         "\"\\n  base_vseq: generate %0d pulse in channel %0d\", "
+         "cfg.num_pulses, i), UVM_DEBUG)\n"
+         "endmodule",
+         "module foo;\n"
+         "  `uvm_info(`gfn, $sformatf(\"\\n  base_vseq: generate %0d pulse in "
+         "channel %0d\", cfg.num_pulses, i),\n"
+         "            UVM_DEBUG)\n"
+         "endmodule\n"},
+        {"module foo;`uvm_info(`gfn, $sformatf("
+         "\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE |----\\n %s\","
+         "cfg.convert2string()), UVM_LOW)\n"
+         "endmodule",
+         "module foo;\n"
+         "  `uvm_info(\n"
+         "      `gfn, $sformatf(\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE "
+         "|----\\n %s\", cfg.convert2string()),\n"
+         "      UVM_LOW)\n"
+         "endmodule\n"},
+        {"module x;"
+         "`uvm_fatal(`gfn, $sformatf("
+         "\"The data 0x%0h written to the signature address is formatted "
+         "incorrectly.\","
+         "signature_data))\n"
+         "endmodule",
+         "module x;\n"
+         "  `uvm_fatal(\n"
+         "      `gfn, $sformatf(\"The data 0x%0h written to the signature "
+         "address is formatted incorrectly.\",\n"
+         "                      signature_data))\n"
+         "endmodule\n"},
+        {// nested modules, three-levels
+         "module x; module y; module z;"
+         "`uvm_fatal(`gfn, $sformatf("
+         "\"The data 0x%0h written to the signature address is formatted "
+         "incorrectly.\","
+         "signature_data))\n"
+         "endmodule endmodule endmodule",
+         "module x;\n"
+         "  module y;\n"
+         "    module z;\n"
+         "      `uvm_fatal(\n"
+         "          `gfn,\n"
+         "          $sformatf(\"The data 0x%0h written to the signature "
+         "address is formatted incorrectly.\",\n"
+         "                    signature_data))\n"
+         "    endmodule\n"
+         "  endmodule\n"
+         "endmodule\n"},
+};
+
+TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases100ColumnsLimit) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 100;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+
+  for (const auto& test_case : kNestedFunctionsTestCases100ColumnsLimit) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+static constexpr FormatterTestCase kFunctionCallsWithComments[] = {
+    {// no comments
+     "module foo;\n"
+     "`uvm_info(`gfn, \"xx\",\n"
+     "cfg.num_pulses, i, UVM_DEBUG)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(`gfn, \"xx\", cfg.num_pulses, i, UVM_DEBUG)\n"
+     "endmodule\n"},
+    {// one comment
+     "module foo;\n"
+     "`uvm_info(`gfn, \"xx\",  // yy\n"
+     "cfg.num_pulses, i, UVM_DEBUG)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(`gfn, \"xx\",  // yy\n"
+     "            cfg.num_pulses, i, UVM_DEBUG)\n"
+     "endmodule\n"},
+    {// two comments
+     "module foo;\n"
+     "`uvm_info(`gfn, \"xx\",  "
+     "    cfg.num_pulses, // xx\n"
+     " i, UVM_DEBUG)// uuu\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(`gfn, \"xx\", cfg.num_pulses,  // xx\n"
+     "            i, UVM_DEBUG)  // uuu\n"
+     "endmodule\n"},
+
+    {// nested function calls with comments
+     "module foo;"
+     "`uvm_info(`gfn, $sformatf(\"\\n  base_vseq: generate %0d"
+     " pulse in channel %0d\", cfg.num_pulses, // comment\n"
+     " i), UVM_DEBUG)\n"
+     "endmodule",
+     "module foo;\n"
+     "  `uvm_info(`gfn, $sformatf(\"\\n  base_vseq: generate %0d pulse in "
+     "channel %0d\",\n"
+     "                            cfg.num_pulses,  // comment\n"
+     "                            i), UVM_DEBUG)\n"
+     "endmodule\n"},
+};
+
+TEST(FormatterEndToEndTest, FunctionCallsWithComments) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 100;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+
+  for (const auto& test_case : kFunctionCallsWithComments) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
 
 }  // namespace
 }  // namespace formatter


### PR DESCRIPTION
Depends on: https://github.com/chipsalliance/verible/pull/1044
Fixes #30 

## Example

Input:

```systemverilog
`uvm_info(get_full_name(), $sformatf("Detect request with address: %0x", trans_collected.addr), UVM_HIGH)

`uvm_fatal(`gfn, $sformatf("The data 0x%0h written to the signature address is formatted incorrectly.", signature_data))
```

Results:

indent: 0 spaces
```systemverilog
`uvm_info(get_full_name(), $sformatf("Detect request with address: %0x", trans_collected.addr),
          UVM_HIGH)
`uvm_fatal(
    `gfn, $sformatf(
    "The data 0x%0h written to the signature address is formatted incorrectly.", signature_data))
```
indent: 2 spaces
```systemverilog
  `uvm_info(get_full_name(), $sformatf("Detect request with address: %0x", trans_collected.addr),
            UVM_HIGH)
  `uvm_fatal(
      `gfn, $sformatf("The data 0x%0h written to the signature address is formatted incorrectly.",
                      signature_data))
```
indent: 4 spaces
```systemverilog
    `uvm_info(get_full_name(), $sformatf("Detect request with address: %0x", trans_collected.addr),
              UVM_HIGH)
    `uvm_fatal(
        `gfn, $sformatf("The data 0x%0h written to the signature address is formatted incorrectly.",
                        signature_data))
```
indent: 6 spaces
```systemverilog
      `uvm_info(get_full_name(),
                $sformatf("Detect request with address: %0x", trans_collected.addr), UVM_HIGH)
      `uvm_fatal(
          `gfn,
          $sformatf("The data 0x%0h written to the signature address is formatted incorrectly.",
                    signature_data))
```
indent: 8 spaces
```systemverilog
        `uvm_info(get_full_name(),
                  $sformatf("Detect request with address: %0x", trans_collected.addr), UVM_HIGH)
        `uvm_fatal(
            `gfn,
            $sformatf("The data 0x%0h written to the signature address is formatted incorrectly.",
                      signature_data))
```
indent: 10 spaces
```systemverilog
          `uvm_info(get_full_name(),
                    $sformatf("Detect request with address: %0x", trans_collected.addr), UVM_HIGH)
          `uvm_fatal(
              `gfn,
              $sformatf("The data 0x%0h written to the signature address is formatted incorrectly.",
                        signature_data))
```
indent: 12 spaces
```systemverilog
            `uvm_info(get_full_name(),
                      $sformatf("Detect request with address: %0x", trans_collected.addr), UVM_HIGH)
            `uvm_fatal(
                `gfn,
                $sformatf(
                    "The data 0x%0h written to the signature address is formatted incorrectly.",
                    signature_data))
```

---

```diff
-          `uvm_info("alert_monitor", $sformatf(
-                    "[%s]: handshake status is %s",
-                    req.alert_esc_type.name(),
-                    req.alert_handshake_sta.name()
-                    ), UVM_HIGH)
+          `uvm_info(
+              "alert_monitor", $sformatf("[%s]: handshake status is %s", req.alert_esc_type.name(),
+                                         req.alert_handshake_sta.name()), UVM_HIGH)
```

```diff
-          `uvm_info("esc_monitor", $sformatf(
-                    "[%s]: handshake status is %s, timeout=%0b",
-                    req.alert_esc_type.name(),
-                    req.esc_handshake_sta.name(),
-                    req.ping_timeout
-                    ), UVM_HIGH)
+          `uvm_info(
+              "esc_monitor",
+              $sformatf("[%s]: handshake status is %s, timeout=%0b", req.alert_esc_type.name(),
+                        req.esc_handshake_sta.name(), req.ping_timeout), UVM_HIGH)
```

```diff
-    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-                                   r_alert_ping_send == local::r_alert_ping_send;
-        r_alert_rsp       == local::r_alert_rsp;
-        int_err           == 0; // TODO: current do not support alert_receiver int_err
-)
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(
+        req,
+        r_alert_ping_send == local::r_alert_ping_send;
+        r_alert_rsp       == local::r_alert_rsp;
+        int_err           == 0; // TODO: current do not support alert_receiver int_err
+)
```

```diff
-          `uvm_info(`gfn, $sformatf(
-                    "Current %0s alert status under_alert_handshake=%0b,\
-                    exp_alert=%0b, request ignored",
-                    alert_name,
-                    under_alert_handshake[alert_name],
-                    exp_alert[alert_name]
-                    ), UVM_MEDIUM)
+          `uvm_info(
+              `gfn,
+              $sformatf(
+                  "Current %0s alert status under_alert_handshake=%0b,\
+                    exp_alert=%0b, request ignored",
+                  alert_name, under_alert_handshake[alert_name], exp_alert[alert_name]), UVM_MEDIUM)
```

```diff
-          `uvm_info(`gfn, $sformatf(
-                    "\n\t ----| MESSAGE #%0d HAS ILLEGAL MODE MESSAGE IGNORED     |-----", good_cnt
-                    ), UVM_MEDIUM)
+          `uvm_info(
+              `gfn, $sformatf("\n\t ----| MESSAGE #%0d HAS ILLEGAL MODE MESSAGE IGNORED     |-----",
+                              good_cnt), UVM_MEDIUM)
```

```diff
-        `uvm_info(`gfn, $sformatf(
-                  "\n\t ----|   MESSAGE #%0d MATCHED  %s  |-----", good_cnt, msg.aes_mode.name()),
-                  UVM_MEDIUM)
+        `uvm_info(`gfn, $sformatf("\n\t ----|   MESSAGE #%0d MATCHED  %s  |-----", good_cnt,
+                                  msg.aes_mode.name()), UVM_MEDIUM)
```

```diff
-    `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data register %s", ral.status.convert2string()
-              ), UVM_DEBUG)
+    `uvm_info(
+        `gfn, $sformatf("\n\t ---| Polling for data register %s", ral.status.convert2string()),
+        UVM_DEBUG)
```

```diff
-    `uvm_info(`gfn, $sformatf("\n\t ---| Polling for data %s", ral.status.convert2string()),
-              UVM_DEBUG)
+    `uvm_info(
+        `gfn, $sformatf("\n\t ---| Polling for data %s", ral.status.convert2string()), UVM_DEBUG)
```

```diff
-          `uvm_info(`gfn, $sformatf(
-                    "\n\t ----| Saw expected Fatal alert - trying to recover \n\t ----| %s",
-                    status2string(
-                        status
-                    )
-                    ), UVM_MEDIUM)
+          `uvm_info(
+              `gfn,
+              $sformatf("\n\t ----| Saw expected Fatal alert - trying to recover \n\t ----| %s",
+                        status2string(status)), UVM_MEDIUM)
```

```diff
-          `uvm_info(`gfn, $sformatf(
-                    "\n  scl_i %0b sclval %0b", cfg.m_i2c_agent_cfg.vif.scl_i, sclval), UVM_DEBUG)
+          `uvm_info(
+              `gfn, $sformatf("\n  scl_i %0b sclval %0b", cfg.m_i2c_agent_cfg.vif.scl_i, sclval),
+              UVM_DEBUG)
```