### PR TITLE
Fix incremental editing to take UTF-8 characters into account.

### DIFF
--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -98,6 +98,7 @@ cc_library(
     deps = [
         ":json-rpc-dispatcher",
         ":lsp-protocol",
+        "//common/strings:utf8",
         "@com_google_absl//absl/strings",
     ]
 )

--- a/common/strings/utf8.h
+++ b/common/strings/utf8.h
@@ -25,6 +25,33 @@ inline int utf8_len(absl::string_view str) {
   return std::count_if(str.begin(), str.end(),
                        [](char c) { return (c & 0xc0) != 0x80; });
 }
+
+// Returns the substring starting from the given character
+// of the UTF8-encoded string.
+inline absl::string_view utf8_substr(absl::string_view str,
+                                     size_t character_pos) {
+  // Strategy: whenever we see a start of a utf8 codepoint bump the expected
+  // remaining by number of expected bytes
+  size_t remaining = character_pos;
+  absl::string_view::const_iterator it;
+  for (it = str.begin(); remaining && it != str.end(); ++it, --remaining) {
+    if ((*it & 0xE0) == 0xC0)
+      remaining += 1;
+    else if ((*it & 0xF0) == 0xE0)
+      remaining += 2;
+    else if ((*it & 0xF8) == 0xF0)
+      remaining += 3;
+  }
+  return str.substr(it - str.begin());
+}
+
+inline absl::string_view utf8_substr(absl::string_view str,
+                                     size_t character_pos,
+                                     size_t character_len) {
+  const absl::string_view prefix = utf8_substr(str, character_pos);
+  const absl::string_view chop_end = utf8_substr(prefix, character_len);
+  return {prefix.data(), prefix.length() - chop_end.length()};
+}
 }  // namespace verible
 
 #endif  // VERIBLE_COMMON_STRINGS_UTF8_H_

--- a/common/strings/utf8_test.cc
+++ b/common/strings/utf8_test.cc
@@ -23,12 +23,76 @@ TEST(UTF8Util, Utf8LenTest) {
   EXPECT_EQ(utf8_len(""), 0);
   EXPECT_EQ(utf8_len("regular ASCII"), 13);
   EXPECT_EQ(utf8_len("\n\r\t \v"), 5);
-  EXPECT_EQ(utf8_len("¯"), 1);  // two byte encoding
-  EXPECT_EQ(utf8_len("‱"), 1);  // three byte encoding
-  EXPECT_EQ(utf8_len("𝅘𝅥𝅯"), 1);  // four byte encoding
+
+  EXPECT_EQ(strlen("¯"), 2);  // two byte encoding
+  EXPECT_EQ(utf8_len("¯¯"), 2);
+
+  EXPECT_EQ(strlen("ä"), 2);
+  EXPECT_EQ(utf8_len("ää"), 2);
+
+  EXPECT_EQ(strlen("‱"), 3);  // three byte encoding
+  EXPECT_EQ(utf8_len("‱‱"), 2);
+
+  EXPECT_EQ(strlen("😀"), 4);  // four byte encoding`
+  EXPECT_EQ(utf8_len("😀😀"), 2);
+
+  // Something practical
   EXPECT_EQ(utf8_len("Heizölrückstoßabdämpfung"), 24);
   EXPECT_EQ(utf8_len(R"(¯\_(ツ)_/¯)"), 9);
 }
 
+TEST(UTF8Util, Utf8SubstrPrefixTest) {
+  EXPECT_EQ(utf8_substr("ä", 0), "ä");
+  EXPECT_EQ(utf8_substr("ä", 1), "");
+
+  // Can deal with regular characters
+  EXPECT_EQ(utf8_substr("abc", 0), "abc");
+  EXPECT_EQ(utf8_substr("abc", 1), "bc");
+  EXPECT_EQ(utf8_substr("abc", 2), "c");
+  EXPECT_EQ(utf8_substr("abc", 3), "");
+  EXPECT_EQ(utf8_substr("abc", 42), "");  // Graceful handling of overlength
+
+  // Two byte encoding
+  EXPECT_EQ(utf8_substr("äöü", 0), "äöü");
+  EXPECT_EQ(utf8_substr("äöü", 1), "öü");
+  EXPECT_EQ(utf8_substr("äöü", 2), "ü");
+  EXPECT_EQ(utf8_substr("äöü", 3), "");
+  EXPECT_EQ(utf8_substr("äöü", 42), "");
+  EXPECT_EQ(utf8_substr("¯¯¯", 1), "¯¯");
+
+  // Three byte encoding
+  EXPECT_EQ(utf8_substr("‱‱‱", 0), "‱‱‱");
+  EXPECT_EQ(utf8_substr("‱‱‱", 1), "‱‱");
+  EXPECT_EQ(utf8_substr("‱‱‱", 2), "‱");
+  EXPECT_EQ(utf8_substr("‱‱‱", 3), "");
+  EXPECT_EQ(utf8_substr("‱‱‱", 42), "");
+
+  // Four byte encoding
+  EXPECT_EQ(utf8_substr("😀🙂😐", 0), "😀🙂😐");
+  EXPECT_EQ(utf8_substr("😀🙂😐", 1), "🙂😐");
+  EXPECT_EQ(utf8_substr("😀🙂😐", 2), "😐");
+  EXPECT_EQ(utf8_substr("😀🙂😐", 3), "");
+  EXPECT_EQ(utf8_substr("😀🙂😐", 42), "");
+
+  EXPECT_EQ(utf8_substr("Heizölrückstoßabdämpfung", 14), "abdämpfung");
+}
+
+TEST(UTF8Util, Utf8SubstrRangeTest) {
+  // Can deal with regular characters
+  EXPECT_EQ(utf8_substr("abc", 1, 1), "b");
+  EXPECT_EQ(utf8_substr("abc", 1, 2), "bc");
+  EXPECT_EQ(utf8_substr("abc", 42, 2), "");  // Graceful handling of overlength
+
+  EXPECT_EQ(utf8_substr("äöü", 1, 1), "ö");
+  EXPECT_EQ(utf8_substr("äöü", 1, 2), "öü");
+
+  EXPECT_EQ(utf8_substr("😀‱ü", 0, 1), "😀");
+  EXPECT_EQ(utf8_substr("😀‱ü", 1, 1), "‱");
+  EXPECT_EQ(utf8_substr("😀‱ü", 2, 1), "ü");
+
+  EXPECT_EQ(utf8_substr("Heizölrückstoßabdämpfung", 0, 6), "Heizöl");
+  EXPECT_EQ(utf8_substr("Heizölrückstoßabdämpfung", 6, 8), "rückstoß");
+  EXPECT_EQ(utf8_substr("Heizölrückstoßabdämpfung", 14, 10), "abdämpfung");
+}
 }  // namespace
 }  // namespace verible


### PR DESCRIPTION
The `character` value given in the JSON protocol is to be
interpreted as number of characters since beginning of the
line, _not_ bytes.

Addresses first part of issue #1047

Signed-off-by: Henner Zeller <h.zeller@acm.org>