### PR TITLE
Use bazel cache again - the ccache sees too many non-cacheable comman…

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -98,6 +98,13 @@ jobs:
        # Download complete repository + tags
        fetch-depth: 0
 
+    - name: Mount bazel cache
+      uses: actions/cache@v1
+      if: matrix.mode != 'clean' && matrix.mode != 'coverage'
+      with:
+        path: "/home/runner/.cache/bazel"
+        key: bazelcache-${{ matrix.mode }}
+
     - name: Install Dependencies
       run: |
         set -x
@@ -106,17 +113,6 @@ jobs:
         ./.github/bin/set-compiler.sh 9
         ./.github/bin/install-bazel.sh
         ./.github/bin/install-python.sh
-
-    - name: Use ccache
-      if: matrix.mode != 'clean' && matrix.mode != 'coverage'
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: bazel-compile-${{ matrix.mode }}
-
-    - name: Set environment
-      run: |
-        export PATH=/usr/lib/ccache:$PATH
-        command -v g++ clang++
 
     - name: ${{ matrix.env.mode }} Verible
       run: ./.github/bin/build-and-test.sh


### PR DESCRIPTION
…dline changes.

After experimenting #1033 turns out that using ccache would require more work
in the CI (it works locally, but I suspect that re-creating the build environment
in each pull request creates situations that things can not be cached).

This undoes #1032 but slightly renames the cache to get a fresh clean
slate to get the cache unstuck.

(bazel action is still deprecated and they suggest basilisk for
possibly things that go beyond caching. So we still should probably
implement bazel caching but in a way that is similar to how the
ccache action is implemented with timestamped versions).

Signed-off-by: Henner Zeller <h.zeller@acm.org>