### PR TITLE
Better name of LineColumnName::EndOffset()

### DIFF
--- a/common/strings/line_column_map.h
+++ b/common/strings/line_column_map.h
@@ -82,7 +82,8 @@ class LineColumnMap {
     return beginning_of_line_offsets_;
   }
 
-  int EndOffset() const {
+  // Byte-offset of start of last line after last newline in file.
+  int LastLineOffset() const {
     if (Empty()) return 0;
     return beginning_of_line_offsets_.back();
   }

--- a/common/strings/line_column_map_test.cc
+++ b/common/strings/line_column_map_test.cc
@@ -134,7 +134,7 @@ TEST(LineColumnMapTest, OffsetsFromLines) {
 TEST(LineColumnMapTest, EndOffsetNoLines) {
   const std::vector<absl::string_view> lines;
   const LineColumnMap map(lines);
-  EXPECT_EQ(map.EndOffset(), 0);
+  EXPECT_EQ(map.LastLineOffset(), 0);
 }
 
 struct EndOffsetTestCase {
@@ -154,7 +154,8 @@ TEST(LineColumnMapTest, EndOffsetVarious) {
   };
   for (const auto& test : kTestCases) {
     const LineColumnMap map(test.text);
-    EXPECT_EQ(map.EndOffset(), test.expected_offset) << "text:\n" << test.text;
+    EXPECT_EQ(map.LastLineOffset(), test.expected_offset) << "text:\n"
+                                                          << test.text;
   }
 }
 

--- a/verilog/formatting/comment_controls.cc
+++ b/verilog/formatting/comment_controls.cc
@@ -101,7 +101,7 @@ ByteOffsetSet EnabledLinesToDisabledByteRanges(
         return line_column_map.OffsetAtLine(n - 1);
       }));
   // Invert set to get disabled ranges.
-  const int end_byte = line_column_map.EndOffset();
+  const int end_byte = line_column_map.LastLineOffset();
   byte_offsets.Complement({0, end_byte});
   return byte_offsets;
 }


### PR DESCRIPTION
This is not the offset of the end of the file, but the offset
of the last line in the file.

Signed-off-by: Henner Zeller <h.zeller@acm.org>