### PR TITLE
Use character based line columns

### DIFF
--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -125,7 +125,8 @@ void LintStatusFormatter::FormatLintRuleStatuses(
       *stream << " (autofix available)";
     }
     *stream << std::endl;
-    auto cursor = line_column_map_(violation.violation->token.left(base));
+    auto cursor = line_column_map_.GetLineColAtOffset(
+        base, violation.violation->token.left(base));
     if (cursor.line < static_cast<int>(lines.size())) {
       *stream << lines[cursor.line] << std::endl;
       *stream << verible::Spacer(cursor.column) << "^" << std::endl;
@@ -143,7 +144,9 @@ void LintStatusFormatter::FormatViolation(std::ostream* stream,
                                           absl::string_view rule_name) const {
   // TODO(fangism): Use the context member to print which named construct or
   // design element the violation appears in (or full stack thereof).
-  (*stream) << path << ':' << line_column_map_(violation.token.left(base))
+  (*stream) << path << ':'
+            << line_column_map_.GetLineColAtOffset(base,
+                                                   violation.token.left(base))
             << ": " << violation.reason << ' ' << url << " [" << rule_name
             << ']';
 }

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -238,6 +238,25 @@ TEST(LintRuleStatusFormatterTestWithContext, MultipleStatusesSimpleOutput) {
   RunLintStatusesTest(test, true);
 }
 
+TEST(LintRuleStatusFormatterTestWithContext, PointToCorrectUtf8Char) {
+  SymbolPtr root = Node();
+  static const int dont_care_tag = 0;
+  constexpr absl::string_view text("äöüß\n");
+  //                                ^ä^ü
+  LintStatusTest test = {
+      "rule",
+      "URL",
+      "some/file.sv",
+      text,
+      {{"reason1", TokenInfo(dont_care_tag, text.substr(0, 2)),
+        "some/file.sv:1:1: reason1 URL "
+        "[rule]\näöüß\n"},
+       {"reason2", TokenInfo(dont_care_tag, text.substr(strlen("äö"), 2)),
+        "some/file.sv:1:3: reason2 URL "
+        "[rule]\näöüß\n  "}}};
+  RunLintStatusesTest(test, true);
+}
+
 TEST(AutoFixTest, ValidUseCases) {
   //                                       0123456789abcdef
   static constexpr absl::string_view text("This is an image");

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -69,7 +69,7 @@ void LintWaiver::RegexToLines(absl::string_view contents,
       for (std::cregex_iterator i(contents.begin(), contents.end(), *re);
            i != std::cregex_iterator(); i++) {
         std::cmatch match = *i;
-        WaiveOneLine(rule.first, line_map(match.position()).line);
+        WaiveOneLine(rule.first, line_map.LineAtOffset(match.position()));
       }
     }
   }
@@ -251,7 +251,8 @@ static absl::Status WaiveCommandHandler(
   LineColumn regex_token_pos = {};
 
   for (const auto& token : tokens) {
-    token_pos = line_map(token.left(waive_content));
+    token_pos =
+        line_map.GetLineColAtOffset(waive_content, token.left(waive_content));
 
     switch (token.token_enum()) {
       case CFG_TK_COMMAND:
@@ -434,7 +435,8 @@ absl::Status LintWaiverBuilder::ApplyExternalWaivers(
   for (const auto c_range : commands) {
     const auto command = make_container_range(c_range.begin(), c_range.end());
 
-    command_pos = line_map(command.begin()->left(waivers_config_content));
+    command_pos = line_map.GetLineColAtOffset(
+        waivers_config_content, command.begin()->left(waivers_config_content));
 
     if (command[0].token_enum() == CFG_TK_COMMENT) {
       continue;

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -282,7 +282,10 @@ cc_library(
         "//verilog/analysis:__pkg__",
         "//verilog/formatting:__pkg__",
     ],
-    deps = ["@com_google_absl//absl/strings"],
+    deps = [
+       "utf8",
+       "@com_google_absl//absl/strings"
+    ],
 )
 
 cc_test(

--- a/common/strings/line_column_map.h
+++ b/common/strings/line_column_map.h
@@ -75,8 +75,17 @@ class LineColumnMap {
     return beginning_of_line_offsets_[index];
   }
 
-  // Translate byte-offset into line and column.
-  LineColumn operator()(int bytes_offset) const;
+  // Get line number at the given byte offset.
+  int LineAtOffset(int bytes_offset) const;
+
+  // Get line and column at the given offset. The column takes multi-byte
+  // encodings into account, so the column represents the true character not
+  // simply the byte-offset within the line.
+  //
+  // TODO(hzeller): technically, we don't need the base as we already got it
+  // in the constructor, but change separately after lifetime questions have
+  // been considered.
+  LineColumn GetLineColAtOffset(absl::string_view base, int bytes_offset) const;
 
   const std::vector<int>& GetBeginningOfLineOffsets() const {
     return beginning_of_line_offsets_;

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -95,6 +95,10 @@ class TextStructureView {
 
   const LineColumnMap& GetLineColumnMap() const { return line_column_map_; }
 
+  LineColumn GetLineColAtOffset(int bytes_offset) const {
+    return line_column_map_.GetLineColAtOffset(contents_, bytes_offset);
+  }
+
   const std::vector<TokenSequence::const_iterator>& GetLineTokenMap() const {
     return line_token_map_;
   }
@@ -201,7 +205,7 @@ class TextStructureView {
   // the contents_ string view.
   absl::Status SyntaxTreeConsistencyCheck() const;
 
-private:
+ private:
   void RecalculateLineColumnMap() {
     line_column_map_ = LineColumnMap(contents_);
   }

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -481,7 +481,7 @@ static void AppendLintRuleStatuses(
           [&](const verible::LintViolation& violation) {
             // Lookup the line number on which the offending token resides.
             const size_t offset = violation.token.left(text_base);
-            const size_t line = line_map(offset).line;
+            const size_t line = line_map.LineAtOffset(offset);
             // Check that line number against the set of waived lines.
             const bool waived =
                 LintWaiver::LineNumberSetContains(*waived_lines, line);

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -484,7 +484,8 @@ static void PrintLargestPartitions(
     stream << hline << "\n[" << partition->Size() << " tokens";
     if (!partition->IsEmpty()) {
       stream << ", starting at line:col "
-             << line_column_map(
+             << line_column_map.GetLineColAtOffset(
+                    base_text,
                     partition->TokensRange().front().token->left(base_text));
     }
     stream << "]: " << *partition << std::endl;
@@ -616,7 +617,9 @@ class ContinuationCommentAligner {
  private:
   int GetTokenColumn(const verible::TokenInfo* token) {
     CHECK_NOTNULL(token);
-    const int column = line_column_map_(token->left(base_text_)).column;
+    const int column =
+        line_column_map_.GetLineColAtOffset(base_text_, token->left(base_text_))
+            .column;
     CHECK_GE(column, 0);
     return column;
   }


### PR DESCRIPTION
Output token columns to be _character_ not _byte_-offset in line.
    
Take multi-byte characters into account.
    
Remove the non-descript operator() in LineColumnMap and replace
with GetLineColAtOffset(). Also add such a convenience method
in text view to reduce abstraction leakage. Ideally, we would
actually never have to deal with 'raw' LineColumnMaps inside
code, only with attached text view.
    
The GetLineColAtOffset() needs the original text to correctly
count UTF8-characters in the line in question; this should
probably be replaced with either
  * remembering the original string-view from constructing
    the LineColumnMap (but CAVE: lifetime issues)
  * or maybe a sub-structure that remembers multi-byte
     offset within a line.
 For now, this is not a big deal as the original string-view
 always is available.
    
Fixes #1047 #1059
