### PR TITLE
Simplify @jsonhpp dependency in jcxxgen.bzl

### DIFF
--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -283,8 +283,8 @@ cc_library(
         "//verilog/formatting:__pkg__",
     ],
     deps = [
-       "utf8",
-       "@com_google_absl//absl/strings"
+        ":utf8",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/common/tools/jcxxgen.bzl
+++ b/common/tools/jcxxgen.bzl
@@ -41,5 +41,5 @@ def jcxxgen(name, src, out, namespace = ""):
     native.cc_library(
         name = name,
         hdrs = [out],
-        deps = ["@jsonhpp//:jsonhpp"],
+        deps = ["@jsonhpp"],
     )


### PR DESCRIPTION
Also fix indentation in common/strings/BUILD

Signed-off-by: Henner Zeller <hzeller@google.com>