### PR TITLE
Use bazel cache also for macos and windows.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -72,7 +72,7 @@ case "$MODE" in
     ;;
 
   asan|asan-clang)
-    bazel test --config=asan $BAZEL_OPTS -c fastbuild //...
+    bazel test --config=asan --test_output=errors $BAZEL_OPTS -c fastbuild //...
     ;;
 
   coverage)
@@ -84,7 +84,7 @@ case "$MODE" in
     ;;
 
   compile|compile-clang|clean)
-    bazel build --keep_going $BAZEL_OPTS //...
+    bazel build --keep_going $BAZEL_OPTS :install-binaries
     ;;
 
   smoke-test)

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -98,12 +98,19 @@ jobs:
        # Download complete repository + tags
        fetch-depth: 0
 
+    - name: Create Cache Timestamp
+      id: cache_timestamp
+      uses: nanzm/get-time-action@v1.1
+      with:
+        format: 'YYYY-MM-DD-HH-mm-ss'
+
     - name: Mount bazel cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       if: matrix.mode != 'clean' && matrix.mode != 'coverage'
       with:
         path: "/home/runner/.cache/bazel"
-        key: bazelcache-${{ matrix.mode }}
+        key: bazelcache_${{ matrix.mode }}_${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: bazelcache_${{ matrix.mode }}_
 
     - name: Install Dependencies
       run: |
@@ -266,8 +273,21 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Create Cache Timestamp
+      id: cache_timestamp
+      uses: nanzm/get-time-action@v1.1
+      with:
+        format: 'YYYY-MM-DD-HH-mm-ss'
+
+    - name: Mount bazel cache
+      uses: actions/cache@v2
+      with:
+        path: "/private/var/tmp/_bazel_runner"
+        key: bazelcache_macos_${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: bazelcache_macos_
+
     - name: Tests
-      run: bazel test --test_output=errors --cxxopt=-Wno-range-loop-analysis ...
+      run: bazel test --test_output=errors --cxxopt=-Wno-range-loop-analysis //...
 
 
   WindowsBuild:
@@ -278,11 +298,29 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Create Cache Timestamp
+      id: cache_timestamp
+      uses: nanzm/get-time-action@v1.1
+      with:
+        format: 'YYYY-MM-DD-HH-mm-ss'
+
+    # TODO: there seems to be a permission problem in accessing the
+    # bazel dir. Result: no caching is happening.
+    - name: Mount bazel cache
+      uses: actions/cache@v2
+      with:
+        path: "c:/users/runneradmin/_bazel_runneradmin"
+        key: bazelcache_windows_${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: bazelcache_windows_
+
     - name: Install dependencies
       run: choco install llvm
 
-    - name: Tests
-      run: bazel test --test_output=errors ...
+    - name: Debug bazel directory settings
+      run: bazel info
 
-    - name: Build Verible
-      run: bazel build -c opt //...
+    - name: Tests
+      run: bazel test --test_output=errors //...
+
+    - name: Build Verible Binaries
+      run: bazel build -c opt :install-binaries


### PR DESCRIPTION
Always store caches with the latest timestamp and have them find
in reverse order from the internal cache store.
This works around the one-time cache writing of the actions/cache
action and provides the feature we want: use the latest known cache
as a starting point for a new build.

This is based on a blog post found here:    
https://cristianadam.eu/20200113/speeding-up-c-plus-plus-github-actions-using-ccache/

Caching for windows is added in the CI, but there seems to be a
permission problem preventing actually storing it. To be fixed
later.
    
To reduce cache sizes in attempt to stay below the available 5GiB
space, make the compile actions just compile the :install-binaries
