### PR TITLE
Only clang-tidy files whose content hash changed

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -13,16 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TIDY_OUT=${TMPDIR:-/tmp}/clang-tidy.out
+set -u
+TMPDIR="${TMPDIR:-/tmp}"
 
-CLANG_TIDY=clang-tidy-12
+readonly PARALLEL_COUNT=$(nproc)
+readonly FILES_PER_INVOCATION=5
 
+readonly CLANG_TIDY_SEEN_CACHE=${TMPDIR}/clang-tidy-hashes.cache
+touch ${CLANG_TIDY_SEEN_CACHE}  # Just in case it is not there yet
+
+readonly FILES_TO_PROCESS=${TMPDIR}/clang-tidy-files.list
+readonly TIDY_OUT=${TMPDIR}/clang-tidy.out
+
+readonly CLANG_TIDY=clang-tidy-12
 hash ${CLANG_TIDY} || exit 2  # make sure it is installed.
 
-# First, build the compilation database.
-bazel build :compdb > /dev/null 2>&1
+echo ::group::Build compilation database
 
-EXEC_ROOT=$(bazel info execution_root)
+# First, build the compilation database.
+time bazel build :compdb > /dev/null 2>&1
+
+readonly EXEC_ROOT=$(bazel info execution_root)
 
 # Fix up the __EXEC_ROOT__ to the path used by bazel.
 cat bazel-bin/compile_commands.json \
@@ -34,20 +45,46 @@ cat bazel-bin/compile_commands.json \
 # for now.
 # Also, exclude kythe for now, as it is somehwat noisy and should be
 # addressed separately.
+#
+# We create a hash of each file content to only have to look at new files.
+# (TODO: could the tidy result be different if an include content changes ?
+#  Then we have to do g++ -E (using compilation database knowing about -I etc.)
+#  or combine hashes of all mentioned #includes that are also in our list)
 find . -name "*.cc" -and -not -name "*test*.cc" \
      -or -name "*.h" -and -not -name "*test*.h" \
   | grep -v "verilog/tools/kythe" \
-  | xargs -P$(nproc) -n 5 -- \
-          ${CLANG_TIDY} --quiet 2>/dev/null \
-  | sed "s|$EXEC_ROOT/||g" > ${TIDY_OUT}
+  | xargs md5sum | sort \
+  > ${CLANG_TIDY_SEEN_CACHE}.new
 
+join -v2 ${CLANG_TIDY_SEEN_CACHE} ${CLANG_TIDY_SEEN_CACHE}.new \
+  | awk '{print $2}' | sort > ${FILES_TO_PROCESS}
 
-cat ${TIDY_OUT}
+echo "::group::$(wc -l < ${FILES_TO_PROCESS}) files to process"
+cat ${FILES_TO_PROCESS}
+echo "::endgroup::"
 
-if [ -s ${TIDY_OUT} ]; then
-   echo "There were clang-tidy warnings. Please fix"
-   exit 1
+if [ -s ${FILES_TO_PROCESS} ]; then
+  echo "::group::Run ${PARALLEL_COUNT} parallel invocations of ${CLANG_TIDY} in chunks of ${FILES_PER_INVOCATION} files."
+
+  cat ${FILES_TO_PROCESS} \
+    | xargs -P${PARALLEL_COUNT} -n ${FILES_PER_INVOCATION} -- \
+            ${CLANG_TIDY} --quiet 2>/dev/null \
+    | sed "s|$EXEC_ROOT/||g" > ${TIDY_OUT}
+
+  cat ${TIDY_OUT}
+
+  echo "::endgroup::"
+
+  if [ -s ${TIDY_OUT} ]; then
+    echo "::error::There were clang-tidy warnings. Please fix"
+    exit 1
+  fi
+else
+  echo "Skipping clang-tidy run: nothing to do"
 fi
+
+# No complaints. We can cache this list now as baseline for next time.
+cp ${CLANG_TIDY_SEEN_CACHE}.new ${CLANG_TIDY_SEEN_CACHE}
 
 echo "No clang-tidy complaints.😎"
 exit 0

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -60,6 +60,22 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt -qq -y install clang-tidy-12
+        echo "TMPDIR=/tmp" >> $GITHUB_ENV
+
+    - name: Create Cache Timestamp
+      id: cache_timestamp
+      uses: nanzm/get-time-action@v1.1
+      with:
+        format: 'YYYY-MM-DD-HH-mm-ss'
+
+    - name: Retrieve cached results
+      uses: actions/cache@v2
+      with:
+        path: |
+          /tmp/clang-tidy-hashes.cache
+          /home/runner/.cache/bazel
+        key: clang-tidy-${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: clang-tidy-
 
     - name: Run clang tidy
       run: ./.github/bin/run-clang-tidy.sh


### PR DESCRIPTION
clang-tidy takes almost 30min in the CI, so let's remember the
content hashes of all files we processed so that we only have to
look at changed files.

Signed-off-by: Henner Zeller <hzeller@google.com>