### PR TITLE
Put the smoke-test results in the toplevel output.

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -208,7 +208,9 @@ for git_project in ${TEST_GIT_PROJECTS} ; do
   echo
 done
 
-echo "::group::There were a total of ${status_sum} new, undocumented issues."
+echo "::endgroup::"
+
+echo "There were a total of ${status_sum} new, undocumented issues."
 
 # Let's see if there are any issues that are fixed in the meantime.
 if [ ${#KnownIssue[@]} -ne 0 ]; then


### PR DESCRIPTION
That way, it is not necessary to unfold the part that
might contain interesting fixed issues.

Signed-off-by: Henner Zeller <hzeller@google.com>