### PR TITLE
Disable use of cache in Windows for now

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -322,6 +322,8 @@ jobs:
 
     - name: Mount bazel cache
       uses: actions/cache@v2
+      # Currently, this is using >3GiB, bringing us well beyond 5GiB per repo
+      if: false
       with:
         path: "c:/users/runneradmin/_bazel_runneradmin"
         key: bazelcache_windows2_${{ steps.cache_timestamp.outputs.time }}


### PR DESCRIPTION
The Windows cache is using the most of all build caches
(over 3GiB), but it is also leas effective as the packaging of
the cache takes about 45 min vs. a 55min fresh build.

These 3GiB will then evict other caches so that
we have to re-build a lot of other parts of the CI: the
total cache size allowance is currently 5GiB [1].

So for now, let's disable it, but keep it prepared for a future
in which there is more space available and possibly the more
efficient zstd compression is used also on Windows.

[1]: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy

Related: https://github.com/actions/cache/issues/442
         https://github.com/actions/cache/issues/301

Signed-off-by: Henner Zeller <h.zeller@acm.org>