### PR TITLE
Use clang-tidy-11 as this checks for google-runtime-references.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -25,7 +25,9 @@ touch ${CLANG_TIDY_SEEN_CACHE}  # Just in case it is not there yet
 readonly FILES_TO_PROCESS=${TMPDIR}/clang-tidy-files.list
 readonly TIDY_OUT=${TMPDIR}/clang-tidy.out
 
-readonly CLANG_TIDY=clang-tidy-12
+# Using clang-tidy-11 as it still checks for google-runtime-references,
+# non-const references - which is the preferred style in this project.
+readonly CLANG_TIDY=clang-tidy-11
 hash ${CLANG_TIDY} || exit 2  # make sure it is installed.
 
 echo ::group::Build compilation database

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt -qq -y install clang-tidy-12
+        sudo apt -qq -y install clang-tidy-11
         echo "TMPDIR=/tmp" >> $GITHUB_ENV
 
     - name: Create Cache Timestamp


### PR DESCRIPTION
The mandate to not use Non-const references but pointers
have been removed from the google style-guide. However, for
readability this is still the preferred style in this project.
clang-tidy-11 still checks for that.

Signed-off-by: Henner Zeller <hzeller@google.com>