### PR TITLE
Add convenience function: TextStructureView::GetRangeForToken().

### DIFF
--- a/common/strings/line_column_map.h
+++ b/common/strings/line_column_map.h
@@ -38,20 +38,29 @@ struct LineColumn {
   int line;    // 0-based index
   int column;  // 0-based index
 
-  bool operator==(const LineColumn& r) const {
+  constexpr bool operator==(const LineColumn& r) const {
     return line == r.line && column == r.column;
   }
+  constexpr bool operator<(const LineColumn& r) const {
+    if (line < r.line) return true;
+    if (line > r.line) return false;
+    return column < r.column;
+  }
+  constexpr bool operator>=(const LineColumn& r) const { return !(*this < r); }
 };
 
 std::ostream& operator<<(std::ostream&, const LineColumn&);
 
 // A complete range.
 struct LineColumnRange {
-  LineColumn start;
-  LineColumn end;
+  LineColumn start;  // Inclusive
+  LineColumn end;    // Exclusive
 
-  bool operator==(const LineColumnRange& r) const {
+  constexpr bool operator==(const LineColumnRange& r) const {
     return start == r.start && end == r.end;
+  }
+  constexpr bool PositionInRange(const LineColumn& pos) const {
+    return pos >= start && pos < end;
   }
 };
 

--- a/common/strings/line_column_map_test.cc
+++ b/common/strings/line_column_map_test.cc
@@ -179,5 +179,32 @@ TEST(LineColumnMapTest, Lookup) {
   }
 }
 
+TEST(LineColumnTest, LineColumnComparison) {
+  constexpr LineColumn before_line{.line = 41, .column = 1};
+  constexpr LineColumn before_col{.line = 42, .column = 1};
+  constexpr LineColumn center{.line = 42, .column = 8};
+  constexpr LineColumn after_col{.line = 42, .column = 8};
+
+  EXPECT_LT(before_line, center);
+  EXPECT_LT(before_col, center);
+  EXPECT_EQ(center, center);
+  EXPECT_GE(center, center);
+  EXPECT_GE(after_col, center);
+}
+
+TEST(LineColumnTest, LineColumnRangeComparison) {
+  constexpr LineColumnRange range{{.line = 42, .column = 17},
+                                  {.line = 42, .column = 22}};
+
+  constexpr LineColumn before{.line = 42, .column = 16};
+  constexpr LineColumn inside_start{.line = 42, .column = 17};
+  constexpr LineColumn inside_end{.line = 42, .column = 21};
+  constexpr LineColumn outside_after_end{.line = 42, .column = 22};
+
+  EXPECT_FALSE(range.PositionInRange(before));
+  EXPECT_TRUE(range.PositionInRange(inside_start));
+  EXPECT_TRUE(range.PositionInRange(inside_end));
+  EXPECT_FALSE(range.PositionInRange(outside_after_end));
+}
 }  // namespace
 }  // namespace verible

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -129,6 +129,12 @@ TokenRange TextStructureView::TokenRangeSpanningOffsets(size_t lower,
 
 LineColumnRange TextStructureView::GetRangeForToken(
     const TokenInfo& token) const {
+  if (token.isEOF()) {
+    // In particular some unit tests pass in an artificial EOF token, not a
+    // EOF token generated from this view. So handle this directly.
+    const LineColumn eofPos = GetLineColAtOffset(Contents().length());
+    return {eofPos, eofPos};
+  }
   return {GetLineColAtOffset(token.left(Contents())),
           GetLineColAtOffset(token.right(Contents()))};
 }

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -127,6 +127,12 @@ TokenRange TextStructureView::TokenRangeSpanningOffsets(size_t lower,
   return make_range(left, right);
 }
 
+LineColumnRange TextStructureView::GetRangeForToken(
+    const TokenInfo& token) const {
+  return {GetLineColAtOffset(token.left(Contents())),
+          GetLineColAtOffset(token.right(Contents()))};
+}
+
 TokenRange TextStructureView::TokenRangeOnLine(size_t lineno) const {
   if (lineno + 1 < line_token_map_.size()) {
     return make_range(line_token_map_[lineno], line_token_map_[lineno + 1]);

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -95,9 +95,13 @@ class TextStructureView {
 
   const LineColumnMap& GetLineColumnMap() const { return line_column_map_; }
 
+  // Given a byte offset, return the line/column
   LineColumn GetLineColAtOffset(int bytes_offset) const {
     return line_column_map_.GetLineColAtOffset(contents_, bytes_offset);
   }
+
+  // Convenience function: Given the token, return the range it covers.
+  LineColumnRange GetRangeForToken(const TokenInfo& token) const;
 
   const std::vector<TokenSequence::const_iterator>& GetLineTokenMap() const {
     return line_token_map_;

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -204,6 +204,25 @@ TEST_F(TokenRangeTest, CalculateFirstTokensPerLineTest) {
   EXPECT_EQ(line_token_map[3], tokens.begin() + 11);
 }
 
+TEST_F(TokenRangeTest, GetRangeOfTokenVerifyAllRangesExclusive) {
+  // Bulk testing: let's see that we constantly progress in emitted ranges.
+  LineColumnRange previous{{0, 0}, {0, 0}};
+  for (const TokenInfo& token : data_.TokenStream()) {
+    LineColumnRange token_range = data_.GetRangeForToken(token);
+    EXPECT_EQ(token_range.start, previous.end);
+    EXPECT_LT(previous.end, token_range.end);
+    EXPECT_GE(token_range.end, token_range.start);
+    previous = token_range;
+  }
+}
+
+TEST_F(TokenRangeTest, GetRangeOfTokenEofTokenAcceptedUniversally) {
+  // For the EOF token, the returned range should automatically be relative
+  // to the TextView no matter where it comes from.
+  EXPECT_EQ(data_.GetRangeForToken(data_.EOFToken()),
+            data_.GetRangeForToken(TokenInfo::EOFToken()));
+}
+
 // Checks that when lower == upper, returned range is empty.
 TEST_F(TokenRangeTest, TokenRangeSpanningOffsetsEmpty) {
   const size_t test_offsets[] = {0, 1, 4, 12, 18, 22, 26};

--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -147,11 +147,8 @@ verible::lsp::Range DocumentSymbolFiller::RangeFromLeaf(
 
 verible::lsp::Range DocumentSymbolFiller::RangeFromToken(
     const verible::TokenInfo &token) const {
-  verible::LineColumn start =
-      text_view_.GetLineColAtOffset(token.left(text_view_.Contents()));
-  verible::LineColumn end =
-      text_view_.GetLineColAtOffset(token.right(text_view_.Contents()));
-  return {.start = {.line = start.line, .character = start.column},
-          .end = {.line = end.line, .character = end.column}};
+  const verible::LineColumnRange range = text_view_.GetRangeForToken(token);
+  return {.start = {.line = range.start.line, .character = range.start.column},
+          .end = {.line = range.end.line, .character = range.end.column}};
 }
 }  // namespace verilog

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -30,16 +30,14 @@ static verible::lsp::Diagnostic ViolationToDiagnostic(
     const verilog::LintViolationWithStatus &v,
     const verible::TextStructureView &text) {
   const verible::LintViolation &violation = *v.violation;
-  verible::LineColumn start =
-      text.GetLineColAtOffset(violation.token.left(text.Contents()));
-  verible::LineColumn end =
-      text.GetLineColAtOffset(violation.token.right(text.Contents()));
+  const verible::LineColumnRange range = text.GetRangeForToken(violation.token);
   const char *fix_msg = violation.autofixes.empty() ? "" : " (fix available)";
   return verible::lsp::Diagnostic{
       .range =
           {
-              .start = {.line = start.line, .character = start.column},
-              .end = {.line = end.line, .character = end.column},
+              .start = {.line = range.start.line,
+                        .character = range.start.column},
+              .end = {.line = range.end.line, .character = range.end.column},
           },
       .message = absl::StrCat(violation.reason, " ", v.status->url, "[",
                               v.status->lint_rule_name, "]", fix_msg),


### PR DESCRIPTION
There are various places in which we need the line column range
for a token. Put that in one place.

Signed-off-by: Henner Zeller <hzeller@google.com>