### PR TITLE
Given a Line/Column, find token at that point.

### DIFF
--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -147,6 +147,15 @@ TokenRange TextStructureView::TokenRangeOnLine(size_t lineno) const {
   }
 }
 
+TokenInfo TextStructureView::FindTokenAt(const LineColumn& pos) const {
+  if (pos.line < 0 || pos.column < 0) return EOFToken();
+  // Maybe do binary search here if we have a huge amount tokens per line.
+  for (const TokenInfo& token : TokenRangeOnLine(pos.line)) {
+    if (GetRangeForToken(token).PositionInRange(pos)) return token;
+  }
+  return EOFToken();
+}
+
 TokenInfo TextStructureView::EOFToken() const {
   return TokenInfo::EOFToken(Contents());
 }

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -107,6 +107,10 @@ class TextStructureView {
     return line_token_map_;
   }
 
+  // Given line/column, find token that is available there. If this is out of
+  // range, returns EOF.
+  TokenInfo FindTokenAt(const LineColumn& pos) const;
+
   // Create the EOF token given the contents.
   TokenInfo EOFToken() const;
 

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -216,6 +216,21 @@ TEST_F(TokenRangeTest, GetRangeOfTokenVerifyAllRangesExclusive) {
   }
 }
 
+TEST_F(TokenRangeTest, FindTokenAtPosition) {
+  EXPECT_EQ(data_.FindTokenAt({0, 0}).text(), "hello");
+  EXPECT_EQ(data_.FindTokenAt({0, 4}).text(), "hello");
+  EXPECT_EQ(data_.FindTokenAt({0, 5}).text(), ",");
+  EXPECT_EQ(data_.FindTokenAt({0, 6}).text(), " ");
+  EXPECT_EQ(data_.FindTokenAt({0, 7}).text(), "world");
+
+  // Out of range column: return last token in line.
+  EXPECT_EQ(data_.FindTokenAt({0, 200}).text(), "\n");
+
+  // Graceful handling of values out of range: EOF
+  EXPECT_TRUE(data_.FindTokenAt({-1, -1}).isEOF());
+  EXPECT_TRUE(data_.FindTokenAt({42, 7}).isEOF());
+}
+
 TEST_F(TokenRangeTest, GetRangeOfTokenEofTokenAcceptedUniversally) {
   // For the EOF token, the returned range should automatically be relative
   // to the TextView no matter where it comes from.


### PR DESCRIPTION
This is needed for operations in the language server which
often start with a cursor position.

Signed-off-by: Henner Zeller <hzeller@google.com>