### PR TITLE
Move FormatStyle flag initialization into separate library.

### DIFF
--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -63,6 +63,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "basic_format_style_init",
+    srcs = ["basic_format_style_init.cc"],
+    hdrs = ["basic_format_style_init.h"],
+    deps = [
+        ":basic_format_style",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
 cc_test(
     name = "basic_format_style_test",
     srcs = ["basic_format_style_test.cc"],

--- a/common/formatting/basic_format_style.h
+++ b/common/formatting/basic_format_style.h
@@ -42,6 +42,8 @@ struct BasicFormatStyle {
 
   // Penalty added to solution for each introduced line break.
   int line_break_penalty = 2;
+
+  // -- Note: when adding new fields, add them in basic_format_style_init.cc
 };
 
 // Control how a section of code is indented.

--- a/common/formatting/basic_format_style_init.cc
+++ b/common/formatting/basic_format_style_init.cc
@@ -1,0 +1,52 @@
+// Copyright 2017-2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/formatting/basic_format_style_init.h"
+
+#include "absl/flags/flag.h"
+
+ABSL_FLAG(int, indentation_spaces, 2,
+          "Each indentation level adds this many spaces.");
+
+ABSL_FLAG(int, wrap_spaces, 4,
+          "Each wrap level adds this many spaces.  This applies when the first "
+          "element after an open-group section is wrapped.  Otherwise, the "
+          "indentation level is set to the column position of the open-group "
+          "operator.");
+
+ABSL_FLAG(int, column_limit, 100,
+          "Target line length limit to stay under when formatting.");
+
+ABSL_FLAG(int, over_column_limit_penalty, 100,
+          "For penalty minimization, this represents the baseline penalty "
+          "value of exceeding the column limit.  Additional penalty of 1 is "
+          "incurred for each character over this limit");
+
+ABSL_FLAG(int, line_break_penalty, 2,
+          "Penalty added to solution for each introduced line break.");
+
+namespace verible {
+void InitializeFromFlags(BasicFormatStyle *style) {
+#define STYLE_FROM_FLAG(name) style->name = absl::GetFlag(FLAGS_##name)
+
+  // Simply in the sequence as declared in struct BasicFormatStyle
+  STYLE_FROM_FLAG(indentation_spaces);
+  STYLE_FROM_FLAG(wrap_spaces);
+  STYLE_FROM_FLAG(column_limit);
+  STYLE_FROM_FLAG(over_column_limit_penalty);
+  STYLE_FROM_FLAG(line_break_penalty);
+
+#undef STYLE_FROM_FLAG
+}
+}  // namespace verible

--- a/common/formatting/basic_format_style_init.h
+++ b/common/formatting/basic_format_style_init.h
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_INIT_H_
-#define VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_INIT_H_
+#ifndef VERIBLE_COMMON_FORMATTING_BASIC_FORMAT_STYLE_INIT_H_
+#define VERIBLE_COMMON_FORMATTING_BASIC_FORMAT_STYLE_INIT_H_
 
-#include "verilog/formatting/format_style.h"
+#include "common/formatting/basic_format_style.h"
 
-namespace verilog {
-namespace formatter {
+namespace verible {
 
 // Initialize format style from flags.
-void InitializeFromFlags(FormatStyle *style);
+void InitializeFromFlags(BasicFormatStyle *style);
 
 // TODO: initialize from configuration file.
 // https://github.com/chipsalliance/verible/issues/898
 // Possibly using common/text/config_utils.h
-}  // namespace formatter
-}  // namespace verilog
-#endif  // VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_INIT_H_
+}  // namespace verible
+#endif  // VERIBLE_COMMON_FORMATTING_BASIC_FORMAT_STYLE_INIT_H_

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -239,6 +239,17 @@ cc_library(
 )
 
 cc_library(
+    name = "format_style_init",
+    srcs = ["format_style_init.cc"],
+    hdrs = ["format_style_init.h"],
+    deps = [
+        ":format_style",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
     name = "token_annotator",
     srcs = ["token_annotator.cc"],
     hdrs = ["token_annotator.h"],

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -244,6 +244,7 @@ cc_library(
     hdrs = ["format_style_init.h"],
     deps = [
         ":format_style",
+        "//common/formatting:basic_format_style_init",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
     ],

--- a/verilog/formatting/format_style.h
+++ b/verilog/formatting/format_style.h
@@ -34,6 +34,15 @@ struct FormatStyle : public verible::BasicFormatStyle {
 
   FormatStyle(const FormatStyle&) = default;
 
+  /*
+   * InitializeFromFlags() [format_style_init.h] provides flags that are
+   * named like these fields and allow configuration on the command line.
+   * So field foo here can be configured with flag --foo
+   */
+
+  // TODO(hzeller): some of these are plural, some singular. Come up with
+  // a consistent scheme.
+
   // Control indentation amount for port declarations.
   IndentationStyle port_declarations_indentation = IndentationStyle::kWrap;
 
@@ -103,6 +112,8 @@ struct FormatStyle : public verible::BasicFormatStyle {
 
   // Compact binary expressions inside indexing / bit selection operators
   bool compact_indexing_and_selections = true;
+
+  // -- Note: when adding new fields, add them in format_style_init.cc
 
   // TODO(fangism): introduce the following knobs:
   //

--- a/verilog/formatting/format_style_init.cc
+++ b/verilog/formatting/format_style_init.cc
@@ -1,0 +1,126 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/formatting/format_style_init.h"
+
+#include "absl/flags/flag.h"
+
+using verible::AlignmentPolicy;
+using verible::IndentationStyle;
+
+ABSL_FLAG(bool, try_wrap_long_lines, false,
+          "If true, let the formatter attempt to optimize line wrapping "
+          "decisions where wrapping is needed, else leave them unformatted.  "
+          "This is a short-term measure to reduce risk-of-harm.");
+
+ABSL_FLAG(bool, expand_coverpoints, false,
+          "If true, always expand coverpoints.");
+
+// These flags exist in the short term to disable formatting of some regions.
+// Do not expect to be able to use these in the long term, once they find
+// a better home in a configuration struct.
+
+// "indent" means 2 spaces, "wrap" means 4 spaces.
+ABSL_FLAG(IndentationStyle, port_declarations_indentation,
+          IndentationStyle::kWrap, "Indent port declarations: {indent,wrap}");
+ABSL_FLAG(IndentationStyle, formal_parameters_indentation,
+          IndentationStyle::kWrap, "Indent formal parameters: {indent,wrap}");
+ABSL_FLAG(IndentationStyle, named_parameter_indentation,
+          IndentationStyle::kWrap,
+          "Indent named parameter assignments: {indent,wrap}");
+ABSL_FLAG(IndentationStyle, named_port_indentation, IndentationStyle::kWrap,
+          "Indent named port connections: {indent,wrap}");
+
+// For most of the following in this group, kInferUserIntent is a reasonable
+// default behavior because it allows for user-control with minimal invasiveness
+// and burden on the user.
+ABSL_FLAG(AlignmentPolicy, port_declarations_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format port declarations: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, struct_union_members_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format struct/union members: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, named_parameter_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format named actual parameters: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, named_port_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format named port connections: {align,flush-left,preserve,infer}");
+ABSL_FLAG(
+    AlignmentPolicy, net_variable_alignment,  //
+    AlignmentPolicy::kInferUserIntent,
+    "Format net/variable declarations: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, formal_parameters_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format formal parameters: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, class_member_variables_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format class member variables: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, case_items_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format case items: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, assignment_statement_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format various assignments: {align,flush-left,preserve,infer}");
+
+ABSL_FLAG(bool, port_declarations_right_align_packed_dimensions, false,
+          "If true, packed dimensions in contexts with enabled alignment are "
+          "aligned to the right.");
+
+ABSL_FLAG(bool, port_declarations_right_align_unpacked_dimensions, false,
+          "If true, unpacked dimensions in contexts with enabled alignment are "
+          "aligned to the right.");
+
+namespace verilog {
+namespace formatter {
+void InitializeFromFlags(FormatStyle *style) {
+  // formatting style flags
+  style->try_wrap_long_lines = absl::GetFlag(FLAGS_try_wrap_long_lines);
+  style->expand_coverpoints = absl::GetFlag(FLAGS_expand_coverpoints);
+
+  // various indentation control
+  style->port_declarations_indentation =
+      absl::GetFlag(FLAGS_port_declarations_indentation);
+  style->formal_parameters_indentation =
+      absl::GetFlag(FLAGS_formal_parameters_indentation);
+  style->named_parameter_indentation =
+      absl::GetFlag(FLAGS_named_parameter_indentation);
+  style->named_port_indentation = absl::GetFlag(FLAGS_named_port_indentation);
+
+  // various alignment control
+  style->port_declarations_alignment =
+      absl::GetFlag(FLAGS_port_declarations_alignment);
+  style->struct_union_members_alignment =
+      absl::GetFlag(FLAGS_struct_union_members_alignment);
+  style->named_parameter_alignment =
+      absl::GetFlag(FLAGS_named_parameter_alignment);
+  style->named_port_alignment = absl::GetFlag(FLAGS_named_port_alignment);
+  style->module_net_variable_alignment =
+      absl::GetFlag(FLAGS_net_variable_alignment);
+  style->formal_parameters_alignment =
+      absl::GetFlag(FLAGS_formal_parameters_alignment);
+  style->class_member_variable_alignment =
+      absl::GetFlag(FLAGS_class_member_variables_alignment);
+  style->case_items_alignment = absl::GetFlag(FLAGS_case_items_alignment);
+  style->assignment_statement_alignment =
+      absl::GetFlag(FLAGS_assignment_statement_alignment);
+
+  style->port_declarations_right_align_packed_dimensions =
+      absl::GetFlag(FLAGS_port_declarations_right_align_packed_dimensions);
+  style->port_declarations_right_align_unpacked_dimensions =
+      absl::GetFlag(FLAGS_port_declarations_right_align_unpacked_dimensions);
+}
+
+}  // namespace formatter
+}  // namespace verilog

--- a/verilog/formatting/format_style_init.cc
+++ b/verilog/formatting/format_style_init.cc
@@ -58,22 +58,31 @@ ABSL_FLAG(AlignmentPolicy, named_port_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format named port connections: {align,flush-left,preserve,infer}");
 ABSL_FLAG(
-    AlignmentPolicy, net_variable_alignment,  //
+    AlignmentPolicy, module_net_variable_alignment,  //
     AlignmentPolicy::kInferUserIntent,
     "Format net/variable declarations: {align,flush-left,preserve,infer}");
 ABSL_FLAG(AlignmentPolicy, formal_parameters_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format formal parameters: {align,flush-left,preserve,infer}");
-ABSL_FLAG(AlignmentPolicy, class_member_variables_alignment,
+ABSL_FLAG(AlignmentPolicy, class_member_variable_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format class member variables: {align,flush-left,preserve,infer}");
 ABSL_FLAG(AlignmentPolicy, case_items_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format case items: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, distribution_items_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Aligh distribution items: {align,flush-left,preserve,infer}");
 ABSL_FLAG(AlignmentPolicy, assignment_statement_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format various assignments: {align,flush-left,preserve,infer}");
+ABSL_FLAG(AlignmentPolicy, enum_assignment_statement_alignment,
+          AlignmentPolicy::kInferUserIntent,
+          "Format assignments with enums: {align,flush-left,preserve,infer}");
 
+ABSL_FLAG(bool, compact_indexing_and_selections, true,
+          "Use compact binary expressions inside indexing / bit selection "
+          "operators");
 ABSL_FLAG(bool, port_declarations_right_align_packed_dimensions, false,
           "If true, packed dimensions in contexts with enabled alignment are "
           "aligned to the right.");
@@ -82,44 +91,45 @@ ABSL_FLAG(bool, port_declarations_right_align_unpacked_dimensions, false,
           "If true, unpacked dimensions in contexts with enabled alignment are "
           "aligned to the right.");
 
+// -- Deprecated flags. These were typos. Remove after 2022-01-01
+ABSL_RETIRED_FLAG(
+    AlignmentPolicy, net_variable_alignment,  //
+    AlignmentPolicy::kInferUserIntent,
+    "Format net/variable declarations: {align,flush-left,preserve,infer}");
+
+ABSL_RETIRED_FLAG(
+    AlignmentPolicy, class_member_variables_alignment,
+    AlignmentPolicy::kInferUserIntent,
+    "Format class member variables: {align,flush-left,preserve,infer}");
+
 namespace verilog {
 namespace formatter {
 void InitializeFromFlags(FormatStyle *style) {
-  // formatting style flags
-  style->try_wrap_long_lines = absl::GetFlag(FLAGS_try_wrap_long_lines);
-  style->expand_coverpoints = absl::GetFlag(FLAGS_expand_coverpoints);
+#define STYLE_FROM_FLAG(name) style->name = absl::GetFlag(FLAGS_##name)
 
-  // various indentation control
-  style->port_declarations_indentation =
-      absl::GetFlag(FLAGS_port_declarations_indentation);
-  style->formal_parameters_indentation =
-      absl::GetFlag(FLAGS_formal_parameters_indentation);
-  style->named_parameter_indentation =
-      absl::GetFlag(FLAGS_named_parameter_indentation);
-  style->named_port_indentation = absl::GetFlag(FLAGS_named_port_indentation);
+  // Simply in the sequence as declared in struct FormatStyle
+  STYLE_FROM_FLAG(port_declarations_indentation);
+  STYLE_FROM_FLAG(port_declarations_alignment);
+  STYLE_FROM_FLAG(struct_union_members_alignment);
+  STYLE_FROM_FLAG(named_parameter_indentation);
+  STYLE_FROM_FLAG(named_parameter_alignment);
+  STYLE_FROM_FLAG(named_port_indentation);
+  STYLE_FROM_FLAG(named_port_alignment);
+  STYLE_FROM_FLAG(module_net_variable_alignment);
+  STYLE_FROM_FLAG(assignment_statement_alignment);
+  STYLE_FROM_FLAG(enum_assignment_statement_alignment);
+  STYLE_FROM_FLAG(formal_parameters_indentation);
+  STYLE_FROM_FLAG(formal_parameters_alignment);
+  STYLE_FROM_FLAG(class_member_variable_alignment);
+  STYLE_FROM_FLAG(case_items_alignment);
+  STYLE_FROM_FLAG(distribution_items_alignment);
+  STYLE_FROM_FLAG(port_declarations_right_align_packed_dimensions);
+  STYLE_FROM_FLAG(port_declarations_right_align_unpacked_dimensions);
+  STYLE_FROM_FLAG(try_wrap_long_lines);
+  STYLE_FROM_FLAG(expand_coverpoints);
+  STYLE_FROM_FLAG(compact_indexing_and_selections);
 
-  // various alignment control
-  style->port_declarations_alignment =
-      absl::GetFlag(FLAGS_port_declarations_alignment);
-  style->struct_union_members_alignment =
-      absl::GetFlag(FLAGS_struct_union_members_alignment);
-  style->named_parameter_alignment =
-      absl::GetFlag(FLAGS_named_parameter_alignment);
-  style->named_port_alignment = absl::GetFlag(FLAGS_named_port_alignment);
-  style->module_net_variable_alignment =
-      absl::GetFlag(FLAGS_net_variable_alignment);
-  style->formal_parameters_alignment =
-      absl::GetFlag(FLAGS_formal_parameters_alignment);
-  style->class_member_variable_alignment =
-      absl::GetFlag(FLAGS_class_member_variables_alignment);
-  style->case_items_alignment = absl::GetFlag(FLAGS_case_items_alignment);
-  style->assignment_statement_alignment =
-      absl::GetFlag(FLAGS_assignment_statement_alignment);
-
-  style->port_declarations_right_align_packed_dimensions =
-      absl::GetFlag(FLAGS_port_declarations_right_align_packed_dimensions);
-  style->port_declarations_right_align_unpacked_dimensions =
-      absl::GetFlag(FLAGS_port_declarations_right_align_unpacked_dimensions);
+#undef STYLE_FROM_FLAG
 }
 
 }  // namespace formatter

--- a/verilog/formatting/format_style_init.cc
+++ b/verilog/formatting/format_style_init.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2021 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #include "verilog/formatting/format_style_init.h"
 
 #include "absl/flags/flag.h"
+#include "common/formatting/basic_format_style_init.h"
 
 using verible::AlignmentPolicy;
 using verible::IndentationStyle;
@@ -105,6 +106,8 @@ ABSL_RETIRED_FLAG(
 namespace verilog {
 namespace formatter {
 void InitializeFromFlags(FormatStyle *style) {
+  verible::InitializeFromFlags(style);  // Initialize BasicFormatStyle
+
 #define STYLE_FROM_FLAG(name) style->name = absl::GetFlag(FLAGS_##name)
 
   // Simply in the sequence as declared in struct FormatStyle

--- a/verilog/formatting/format_style_init.h
+++ b/verilog/formatting/format_style_init.h
@@ -1,0 +1,31 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_INIT_H_
+#define VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_INIT_H_
+
+#include "verilog/formatting/format_style.h"
+
+namespace verilog {
+namespace formatter {
+
+// Initialize format style from flags.
+void InitializeFromFlags(FormatStyle *style);
+
+// TODO: initialize from configuration file.
+// https://github.com/chipsalliance/verible/issues/898
+// Possibly using common/text/config_utils.h
+}  // namespace formatter
+}  // namespace verilog
+#endif  // VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_INIT_H_

--- a/verilog/tools/formatter/BUILD
+++ b/verilog/tools/formatter/BUILD
@@ -17,6 +17,7 @@ cc_binary(
         "//common/util:interval_set",
         "//common/util:logging",
         "//verilog/formatting:format_style",
+        "//verilog/formatting:format_style_init",
         "//verilog/formatting:formatter",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:usage",

--- a/verilog/tools/formatter/README.md
+++ b/verilog/tools/formatter/README.md
@@ -18,13 +18,21 @@ To pipe from stdin, use '-' as <file>.
       {align,flush-left,preserve,infer}); default: infer;
     --case_items_alignment (Format case items:
       {align,flush-left,preserve,infer}); default: infer;
-    --class_member_variables_alignment (Format class member variables:
+    --class_member_variable_alignment (Format class member variables:
+      {align,flush-left,preserve,infer}); default: infer;
+    --compact_indexing_and_selections (Use compact binary expressions inside
+      indexing / bit selection operators); default: true;
+    --distribution_items_alignment (Aligh distribution items:
+      {align,flush-left,preserve,infer}); default: infer;
+    --enum_assignment_statement_alignment (Format assignments with enums:
       {align,flush-left,preserve,infer}); default: infer;
     --expand_coverpoints (If true, always expand coverpoints.); default: false;
     --formal_parameters_alignment (Format formal parameters:
       {align,flush-left,preserve,infer}); default: infer;
     --formal_parameters_indentation (Indent formal parameters: {indent,wrap});
       default: wrap;
+    --module_net_variable_alignment (Format net/variable declarations:
+      {align,flush-left,preserve,infer}); default: infer;
     --named_parameter_alignment (Format named actual parameters:
       {align,flush-left,preserve,infer}); default: infer;
     --named_parameter_indentation (Indent named parameter assignments:
@@ -33,8 +41,6 @@ To pipe from stdin, use '-' as <file>.
       {align,flush-left,preserve,infer}); default: infer;
     --named_port_indentation (Indent named port connections: {indent,wrap});
       default: wrap;
-    --net_variable_alignment (Format net/variable declarations:
-      {align,flush-left,preserve,infer}); default: infer;
     --port_declarations_alignment (Format port declarations:
       {align,flush-left,preserve,infer}); default: infer;
     --port_declarations_indentation (Indent port declarations: {indent,wrap});

--- a/verilog/tools/formatter/README.md
+++ b/verilog/tools/formatter/README.md
@@ -13,6 +13,21 @@ get a full set of avilable flags using the `--helpfull` flag.
 usage: verible-verilog-format [options] <file> [<file...>]
 To pipe from stdin, use '-' as <file>.
 
+  Flags from common/formatting/basic_format_style_init.cc:
+    --column_limit (Target line length limit to stay under when formatting.);
+      default: 100;
+    --indentation_spaces (Each indentation level adds this many spaces.);
+      default: 2;
+    --line_break_penalty (Penalty added to solution for each introduced line
+      break.); default: 2;
+    --over_column_limit_penalty (For penalty minimization, this represents the
+      baseline penalty value of exceeding the column limit. Additional penalty
+      of 1 is incurred for each character over this limit); default: 100;
+    --wrap_spaces (Each wrap level adds this many spaces. This applies when the
+      first element after an open-group section is wrapped. Otherwise, the
+      indentation level is set to the column position of the open-group
+      operator.); default: 4;
+
   Flags from verilog/formatting/format_style_init.cc:
     --assignment_statement_alignment (Format various assignments:
       {align,flush-left,preserve,infer}); default: infer;

--- a/verilog/tools/formatter/README.md
+++ b/verilog/tools/formatter/README.md
@@ -4,13 +4,52 @@
 freshness: { owner: 'hzeller' reviewed: '2020-10-07' }
 *-->
 
-`verible-verilog-format` is the SystemVerilog formatter tool.
+`verible-verilog-format` is the SystemVerilog formatter tool. You can can
+get a full set of avilable flags using the `--helpfull` flag.
 
 ## Usage
 
 ```
-usage: verible-verilog-format [options] <file>
+usage: verible-verilog-format [options] <file> [<file...>]
 To pipe from stdin, use '-' as <file>.
+
+  Flags from verilog/formatting/format_style_init.cc:
+    --assignment_statement_alignment (Format various assignments:
+      {align,flush-left,preserve,infer}); default: infer;
+    --case_items_alignment (Format case items:
+      {align,flush-left,preserve,infer}); default: infer;
+    --class_member_variables_alignment (Format class member variables:
+      {align,flush-left,preserve,infer}); default: infer;
+    --expand_coverpoints (If true, always expand coverpoints.); default: false;
+    --formal_parameters_alignment (Format formal parameters:
+      {align,flush-left,preserve,infer}); default: infer;
+    --formal_parameters_indentation (Indent formal parameters: {indent,wrap});
+      default: wrap;
+    --named_parameter_alignment (Format named actual parameters:
+      {align,flush-left,preserve,infer}); default: infer;
+    --named_parameter_indentation (Indent named parameter assignments:
+      {indent,wrap}); default: wrap;
+    --named_port_alignment (Format named port connections:
+      {align,flush-left,preserve,infer}); default: infer;
+    --named_port_indentation (Indent named port connections: {indent,wrap});
+      default: wrap;
+    --net_variable_alignment (Format net/variable declarations:
+      {align,flush-left,preserve,infer}); default: infer;
+    --port_declarations_alignment (Format port declarations:
+      {align,flush-left,preserve,infer}); default: infer;
+    --port_declarations_indentation (Indent port declarations: {indent,wrap});
+      default: wrap;
+    --port_declarations_right_align_packed_dimensions (If true, packed
+      dimensions in contexts with enabled alignment are aligned to the right.);
+      default: false;
+    --port_declarations_right_align_unpacked_dimensions (If true, unpacked
+      dimensions in contexts with enabled alignment are aligned to the right.);
+      default: false;
+    --struct_union_members_alignment (Format struct/union members:
+      {align,flush-left,preserve,infer}); default: infer;
+    --try_wrap_long_lines (If true, let the formatter attempt to optimize line
+      wrapping decisions where wrapping is needed, else leave them unformatted.
+      This is a short-term measure to reduce risk-of-harm.); default: false;
 
   Flags from verilog/tools/formatter/verilog_format.cc:
     --failsafe_success (If true, always exit with 0 status, even if there were
@@ -37,6 +76,7 @@ To pipe from stdin, use '-' as <file>.
     --stdin_name (When using '-' to read from stdin, this gives an alternate
       name for diagnostic purposes. Otherwise this is ignored.);
       default: "<stdin>";
+    --verbose (Be more verbose.); default: false;
     --verify_convergence (If true, and not incrementally formatting with
       --lines, verify that re-formatting the formatted output yields no further
       changes, i.e. formatting is convergent.); default: true;


### PR DESCRIPTION
Having it a separate library allows to use it also in other
binaries (such as the language server). Also this provides
a context to implement other initialization from a configuration
file.

The first commit does _not_ change or add any flags, but this is in
preparation to provide additional flags for previously not flag-configured fields.

The second commit fixes some typos in flags (by [retiring them](https://abseil.io/docs/cpp/guides/flags#removing--retiring-flags)), simplify the initialization with a macro to avoid typos and add previously missing flags.

Third commit adds flags for the basic formatting configuration, fixing #1046 