### PR TITLE
Basic implementation of language server document highlight.

### DIFF
--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -49,6 +49,11 @@ TextDocumentContentChangeEvent:
   range?: Range     # Range optional; if no range given, full document replace
   text: string
 
+# For hover or highlight
+TextDocumentPositionParams:
+  textDocument: TextDocumentIdentifier
+  position: Position
+
 # -- Text document notifiations. These allow us to keep track of the content.
 DidOpenTextDocumentParams:      # textDocument/didOpen
   textDocument: TextDocumentItem
@@ -108,3 +113,11 @@ DocumentSymbol:
   # children: DocumentSymbol[]. Since we can't to that recursively in jcxxgen,
   # these are directly emitted as json
   children?: object = nullptr
+
+# -- textDocument/documentHighlight
+DocumentHighlightParams:
+  <: TextDocumentPositionParams
+
+DocumentHighlight:         # response documentHighlight is [] of this.
+  range: Range
+  # there is also a highlight kind to distinguish read/write

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "//common/text:text_structure",
         "//verilog/analysis:verilog_analyzer",
         "//verilog/analysis:verilog_linter",
+        "//verilog/parser:verilog_token_enum",
         "@jsonhpp",
     ],
 )

--- a/verilog/tools/ls/README.md
+++ b/verilog/tools/ls/README.md
@@ -17,7 +17,8 @@ progress
   - [x] Provide code actions for autofixes provided by lint rules
   - [x] Generate file symbol outline ('navigation tree')
   - [ ] Provide formatting.
-  - [ ] Highlight all the symbols that are the same as current under cursor.
+  - [x] Highlight all the symbols that are the same as current under cursor.
+    - [ ] Take scope and type into account to only highlight _same_ symbols.
   - [ ] Find definition of symbol even if in another file.
   - [ ] Rename refactor a symbol
 

--- a/verilog/tools/ls/verible-lsp-adapter.h
+++ b/verilog/tools/ls/verible-lsp-adapter.h
@@ -42,5 +42,13 @@ std::vector<verible::lsp::CodeAction> GenerateLinterCodeActions(
 nlohmann::json CreateDocumentSymbolOutline(
     const BufferTracker *tracker, const verible::lsp::DocumentSymbolParams &p,
     bool kate_compatible_tags = true);
+
+// Give a position in a document, return ranges in the buffer that should
+// be hi-lit.
+// Current implementation: if cursor is over a symbol, highlight all symbols
+// with the same name (NB: Does _not_ take scoping into account yet).
+std::vector<verible::lsp::DocumentHighlight> CreateHighlightRanges(
+    const BufferTracker *tracker,
+    const verible::lsp::DocumentHighlightParams &p);
 }  // namespace verilog
 #endif  // VERILOG_TOOLS_LS_VERIBLE_LSP_ADAPTER_H

--- a/verilog/tools/ls/verible-lsp-adapter.h
+++ b/verilog/tools/ls/verible-lsp-adapter.h
@@ -43,8 +43,8 @@ nlohmann::json CreateDocumentSymbolOutline(
     const BufferTracker *tracker, const verible::lsp::DocumentSymbolParams &p,
     bool kate_compatible_tags = true);
 
-// Give a position in a document, return ranges in the buffer that should
-// be hi-lit.
+// Given a position in a document, return ranges in the buffer that should
+// be highlighted.
 // Current implementation: if cursor is over a symbol, highlight all symbols
 // with the same name (NB: Does _not_ take scoping into account yet).
 std::vector<verible::lsp::DocumentHighlight> CreateHighlightRanges(


### PR DESCRIPTION
If the cursor is on a symbol, this will highlight all the symbols
in the buffer with the same name (it does _not_ take naming
scopes into account yet).

Signed-off-by: Henner Zeller <hzeller@google.com>