### PR TITLE
Use absl containers, which are more efficient.

### DIFF
--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -62,6 +62,7 @@ cc_binary(
     visibility = ["//:__subpackages__"],
     deps = [
         "//common/util:init_command_line",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
     ],

--- a/common/tools/jcxxgen.cc
+++ b/common/tools/jcxxgen.cc
@@ -23,6 +23,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
@@ -148,7 +149,7 @@ static bool ParseObjectTypesFromFile(const std::string &filename,
 
 // Validate types and return if successful.
 static bool ValidateTypes(ObjectTypeVector *object_types) {
-  std::unordered_map<std::string, ObjectType *> typeByName;
+  absl::flat_hash_map<std::string, ObjectType *> typeByName;
 
   for (auto &obj : *object_types) {
     // We only insert types as they come, so that we can make sure they are
@@ -186,7 +187,7 @@ static bool ValidateTypes(ObjectTypeVector *object_types) {
 
     // Validate that we don't have properties with the same name twice in
     // one class (including superclasses)
-    std::unordered_map<std::string, const Property *> my_property_names;
+    absl::flat_hash_map<std::string, const Property *> my_property_names;
     for (const auto &p : obj->properties) {
       auto inserted = my_property_names.insert({p.name, &p});
       if (inserted.second) continue;

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -93,6 +93,7 @@ cc_library(
         "//verilog/analysis:verilog_project",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/container:btree",
     ],
 )
 

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/btree_map.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/str_cat.h"
@@ -295,7 +296,8 @@ KytheIndexingData ExtractKytheFacts(const IndexingFactNode& file_list,
 
   // Create a reverse map from resolved path to referenced path.
   // All string_views reference memory owned inside 'project'.
-  std::map<absl::string_view, absl::string_view, verible::StringViewCompare>
+  absl::btree_map<absl::string_view, absl::string_view,
+                  verible::StringViewCompare>
       file_path_reverse_map;
   for (const auto& file_entry : project) {
     const VerilogSourceFile& source(*file_entry.second);


### PR DESCRIPTION
Signed-off-by: Henner Zeller <hzeller@google.com>