### PR TITLE
Add new partition policy: kInline

### DIFF
--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -43,6 +43,7 @@ cc_test(
         ":align",
         ":format_token",
         ":token_partition_tree",
+        ":token_partition_tree_test_utils",
         ":unwrapped_line_test_utils",
         "//common/text:tree_builder_test_util",
         "//common/util:range",
@@ -145,6 +146,7 @@ cc_test(
         ":basic_format_style",
         ":layout_optimizer",
         ":token_partition_tree",
+        ":token_partition_tree_test_utils",
         ":unwrapped_line",
         ":unwrapped_line_test_utils",
         "//common/strings:split",
@@ -178,6 +180,18 @@ cc_library(
         "//common/util:spacer",
         "//common/util:top_n",
         "//common/util:vector_tree",
+    ],
+)
+
+cc_library(
+    name = "token_partition_tree_test_utils",
+    srcs = ["token_partition_tree_test_utils.cc"],
+    hdrs = ["token_partition_tree_test_utils.h"],
+    deps = [
+        ":format_token",
+        ":token_partition_tree",
+        ":unwrapped_line",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -201,6 +201,7 @@ cc_test(
     deps = [
         ":format_token",
         ":token_partition_tree",
+        ":token_partition_tree_test_utils",
         ":unwrapped_line",
         ":unwrapped_line_test_utils",
         "//common/util:container_iterator_range",

--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -173,6 +173,7 @@ cc_library(
         "//common/text:tree_utils",
         "//common/util:algorithm",
         "//common/util:container_iterator_range",
+        "//common/util:iterator_adaptors",
         "//common/util:logging",
         "//common/util:spacer",
         "//common/util:top_n",

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -269,23 +269,16 @@ class AlignablePartitionGroup {
   }
 
   // This executes alignment, depending on the alignment_policy.
-  // 'full_text' is the original text buffer that spans all string_views
-  // referenced by format tokens and token partition trees.
   // 'column_limit' is the maximum text width allowed post-alignment.
-  // 'ftokens' is the original mutable array of formatting tokens from which
-  // token partition trees were created.
-  void Align(absl::string_view full_text, int column_limit,
-             std::vector<PreFormatToken>* ftokens) const;
+  void Align(int column_limit) const;
 
  private:
   struct GroupAlignmentData;
-  static GroupAlignmentData CalculateAlignmentSpacings(
+  static AlignablePartitionGroup::GroupAlignmentData CalculateAlignmentSpacings(
       const std::vector<TokenPartitionIterator>& rows,
-      const AlignmentCellScannerFunction& cell_scanner_gen,
-      MutableFormatTokenRange::iterator ftoken_base, int column_limit);
+      const AlignmentCellScannerFunction& cell_scanner_gen, int column_limit);
 
-  void ApplyAlignment(const GroupAlignmentData& align_data,
-                      MutableFormatTokenRange::iterator ftoken_base) const;
+  void ApplyAlignment(const GroupAlignmentData& align_data) const;
 
  private:
   // The set of partitions to treat as rows for tabular alignment.
@@ -494,6 +487,11 @@ AlignmentCellScannerFunction AlignmentCellScannerGenerator(
   };
 }
 
+// Converts partitions from 'partition_range' into partitions with
+// kAlreadyFormatted/kInline policies that emulate original spacing of token
+// range spanned by them.
+void FormatUsingOriginalSpacing(TokenPartitionRange partition_range);
+
 // This aligns sections of text by modifying the spacing between tokens.
 // 'partition_ptr' is a partition that can span one or more sections of
 // code to align.  The partitions themselves are not reshaped, however,
@@ -539,7 +537,7 @@ void TabularAlignTokens(
     int column_limit, absl::string_view full_text,
     const ByteOffsetSet& disabled_byte_ranges,
     const ExtractAlignmentGroupsFunction& extract_alignment_groups,
-    TokenPartitionTree* partition_ptr, std::vector<PreFormatToken>* ftokens);
+    TokenPartitionTree* partition_ptr);
 
 }  // namespace verible
 

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -274,7 +274,7 @@ class AlignablePartitionGroup {
 
  private:
   struct GroupAlignmentData;
-  static AlignablePartitionGroup::GroupAlignmentData CalculateAlignmentSpacings(
+  static GroupAlignmentData CalculateAlignmentSpacings(
       const std::vector<TokenPartitionIterator>& rows,
       const AlignmentCellScannerFunction& cell_scanner_gen, int column_limit);
 

--- a/common/formatting/format_token.cc
+++ b/common/formatting/format_token.cc
@@ -298,12 +298,4 @@ void PreserveSpacesOnDisabledTokenRanges(
   }
 }
 
-MutableFormatTokenRange ConvertToMutableFormatTokenRange(
-    const FormatTokenRange& const_range,
-    MutableFormatTokenRange::iterator base) {
-  return MutableFormatTokenRange(
-      ConvertToMutableIterator(const_range.begin(), base),
-      ConvertToMutableIterator(const_range.end(), base));
-}
-
 }  // namespace verible

--- a/common/formatting/format_token.h
+++ b/common/formatting/format_token.h
@@ -175,13 +175,6 @@ using FormatTokenRange =
 using MutableFormatTokenRange =
     container_iterator_range<std::vector<PreFormatToken>::iterator>;
 
-// Given a const_range and a mutable iterator to the original mutable container,
-// return the corresponding mutable iterator range (without resorting to
-// const_cast).
-MutableFormatTokenRange ConvertToMutableFormatTokenRange(
-    const FormatTokenRange& const_range,
-    MutableFormatTokenRange::iterator base);
-
 // Enumeration for the final decision about spacing between tokens.
 // Related enum: SpacingConstraint.
 // These values are also used during line wrap searching and optimization.

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -576,12 +576,13 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
       CHECK(layout_tree.Children().empty());
 
       if (current_node_ == nullptr) {
-        auto uwline = layout.ToUnwrappedLine();
-        uwline.SetIndentationSpaces(current_indentation_spaces_);
-        uwline.SetPartitionPolicy(PartitionPolicyEnum::kAlreadyFormatted);
+        auto uwline = UnwrappedLine(current_indentation_spaces_,
+                                    layout.TokensRange().begin(),
+                                    PartitionPolicyEnum::kAlreadyFormatted);
+        uwline.SpanUpToToken(layout.TokensRange().end());
         current_node_ = tree_.NewChild(uwline);
       } else {
-        const auto tokens = layout.ToUnwrappedLine().TokensRange();
+        const auto tokens = layout.TokensRange();
         CHECK(current_node_->Value().TokensRange().end() == tokens.begin());
 
         current_node_->Value().SpanUpToToken(tokens.end());

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -34,16 +34,13 @@
 namespace verible {
 
 void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
-                                TokenPartitionTree* node,
-                                std::vector<PreFormatToken>* ftokens) {
+                                TokenPartitionTree* node) {
   CHECK_NOTNULL(node);
-  CHECK_NOTNULL(ftokens);
-
   VLOG(4) << __FUNCTION__ << ", before:\n" << *node;
 
   const auto optimizer = TokenPartitionsLayoutOptimizer(style);
   const auto indentation = node->Value().IndentationSpaces();
-  optimizer.Optimize(indentation, node, ftokens);
+  optimizer.Optimize(indentation, node);
 
   VLOG(4) << __FUNCTION__ << ", after:\n" << *node;
 }
@@ -68,6 +65,35 @@ void AdoptLayoutAndFlattenIfSameType(const LayoutTree& source,
   } else {
     destination->AdoptSubtree(source);
   }
+}
+
+int AlreadyFormattedPartitionLength(const TokenPartitionTree& partition) {
+  auto tokens = partition.Value().TokensRange();
+  if (tokens.empty()) return 0;
+  int width = 0;
+
+  width += partition.Value().IndentationSpaces();
+  width += tokens.front().Length();
+
+  for (const auto& token : make_range(tokens.begin() + 1, tokens.end())) {
+    // TODO(mglb): either handle tokens with kPreserve break_decision, or
+    // explicitly check for their absence. Preserved space is currently expected
+    // to be emulated with kAlreadyFormatted/kInline partitions. Only tabular
+    // aligner creates such partitions.
+    width += token.before.spaces_required + token.Length();
+  }
+
+  for (const auto& child : partition.Children()) {
+    CHECK_EQ(child.Value().PartitionPolicy(), PartitionPolicyEnum::kInline);
+    if (child.Value().TokensRange().begin() != tokens.begin()) {
+      auto& first_token = child.Value().TokensRange().front();
+      // Substract spacing added in the loop above
+      width -= first_token.before.spaces_required;
+    }
+    width += child.Value().IndentationSpaces();
+  }
+
+  return width;
 }
 
 // Largest possible column value, used as infinity.
@@ -175,22 +201,6 @@ LayoutFunction LayoutFunctionFactory::Line(const UnwrappedLine& uwline) const {
          style_.over_column_limit_penalty},
     };
   }
-}
-
-LayoutFunction LayoutFunctionFactory::Juxtaposition(
-    std::initializer_list<LayoutFunction> lfs) const {
-  auto lfs_container = make_container_range(lfs.begin(), lfs.end());
-
-  if (lfs_container.empty()) return LayoutFunction();
-  if (lfs_container.size() == 1) return lfs_container.front();
-
-  LayoutFunction incremental = lfs_container.front();
-  lfs_container.pop_front();
-  for (auto& lf : lfs_container) {
-    incremental = Juxtaposition(incremental, lf);
-  }
-
-  return incremental;
 }
 
 LayoutFunction LayoutFunctionFactory::Indent(const LayoutFunction& lf,
@@ -423,11 +433,9 @@ LayoutFunction LayoutFunctionFactory::Choice(
   return result;
 }
 
-void TokenPartitionsLayoutOptimizer::Optimize(
-    int indentation, TokenPartitionTree* node,
-    std::vector<PreFormatToken>* ftokens) const {
+void TokenPartitionsLayoutOptimizer::Optimize(int indentation,
+                                              TokenPartitionTree* node) const {
   CHECK_NOTNULL(node);
-  CHECK_NOTNULL(ftokens);
   CHECK_GE(indentation, 0);
 
   const LayoutFunction layout_function = CalculateOptimalLayout(*node);
@@ -439,24 +447,59 @@ void TokenPartitionsLayoutOptimizer::Optimize(
   CHECK(iter != layout_function.end());
   VLOG(4) << __FUNCTION__ << ", layout:\n" << iter->layout;
 
-  TreeReconstructor tree_reconstructor(indentation, style_);
+  TreeReconstructor tree_reconstructor(indentation);
   tree_reconstructor.TraverseTree(iter->layout);
-  tree_reconstructor.ReplaceTokenPartitionTreeNode(node, ftokens);
+  tree_reconstructor.ReplaceTokenPartitionTreeNode(node);
 }
 
 LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
     const TokenPartitionTree& node) const {
-  const auto policy = node.Value().PartitionPolicy();
-
-  if (node.is_leaf()) {
-    return factory_.Line(node.Value());
-  }
+  if (node.is_leaf()) return factory_.Line(node.Value());
 
   const auto calculate_optimal_layout_func =
       std::bind(&TokenPartitionsLayoutOptimizer::CalculateOptimalLayout, this,
                 std::placeholders::_1);
 
-  switch (policy) {
+  switch (node.Value().PartitionPolicy()) {
+    case PartitionPolicyEnum::kInline: {
+      // Shouldn't happen - the partition with this policy should always
+      // be a leaf. Anyway, try to handle it without aborting.
+      LOG(ERROR) << "Partition node with kInline policy should be "
+                    "a leaf. Dropping its children. Partition node:\n"
+                 << node << "\n\n*** Please file a bug. ***";
+      return factory_.Line(node.Value());
+    }
+
+    case PartitionPolicyEnum::kAlreadyFormatted: {
+      // When not a leaf, it contains partitions with kInline
+      // policy. Pack them horizontally.
+      const bool all_children_are_inlines =
+          std::all_of(node.Children().begin(), node.Children().end(),
+                      [](const TokenPartitionTree& child) {
+                        return child.Value().PartitionPolicy() ==
+                               PartitionPolicyEnum::kInline;
+                      });
+      LOG_IF(ERROR, !all_children_are_inlines)
+          << "Partition node with kAlreadyFormatted policy should not "
+             "contain children with policies other than kInline. "
+             "Partition node:\n"
+          << node << "\n\n*** Please file a bug. ***";
+
+      absl::FixedArray<LayoutFunction> slice_lfs(node.Children().size());
+      std::transform(node.Children().begin(), node.Children().end(),
+                     slice_lfs.begin(), calculate_optimal_layout_func);
+
+      slice_lfs.front().SetMustWrap(true);
+
+      // Preserve spacing of the first sublayout. This has to be done because
+      // the first layout in a line uses IndentationSpaces instead of
+      // SpacesBefore.
+      const auto indent = node.Children().front().Value().IndentationSpaces();
+      slice_lfs.front() = factory_.Indent(slice_lfs.front(), indent);
+
+      return factory_.Juxtaposition(slice_lfs.begin(), slice_lfs.end());
+    }
+
     case PartitionPolicyEnum::kOptimalFunctionCallLayout: {
       // Support only function/macro/system calls for now
       CHECK_EQ(node.Children().size(), 2);
@@ -492,6 +535,14 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
       return factory_.Wrap(layouts.begin(), layouts.end());
     }
 
+    default:
+      // Stack layout is probably syntax-safe in all situations. Try it without
+      // aborting.
+      LOG(ERROR) << "Unsupported partition policy: "
+                 << node.Value().PartitionPolicy()
+                 << ". Defaulting to stack layout. Partition node:\n"
+                 << node << "\n\n*** Please file a bug. ***";
+      [[fallthrough]];
     case PartitionPolicyEnum::kAlwaysExpand:
     case PartitionPolicyEnum::kTabularAlignment: {
       absl::FixedArray<LayoutFunction> layouts(node.Children().size());
@@ -505,40 +556,58 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
       // kOptimalFunctionCallLayout strategy could then be implemented
       // directly in TreeUnwrapper. It would also allow for proper
       // handling of other policies (e.g. kTabularAlignment) in subtrees.
-
-    default: {
-      LOG(FATAL) << "Unsupported policy: " << policy << "\n"
-                 << "Node:\n"
-                 << node;
-      return LayoutFunction();
-    }
   }
 }
 
 void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
-  const auto relative_indentation = layout_tree.Value().IndentationSpaces();
+  const auto& layout = layout_tree.Value();
+  const auto relative_indentation = layout.IndentationSpaces();
   const ValueSaver<int> indent_saver(
       &current_indentation_spaces_,
       current_indentation_spaces_ + relative_indentation);
   // Setting indentation for a line that is going to be appended is invalid and
   // probably has been done for some reason that is not going to work as
   // intended.
-  LOG_IF(WARNING,
-         ((relative_indentation > 0) && (active_unwrapped_line_ != nullptr)))
+  LOG_IF(WARNING, ((relative_indentation > 0) && (current_node_ != nullptr)))
       << "Discarding indentation of a line that's going to be appended.";
 
-  switch (layout_tree.Value().Type()) {
+  switch (layout.Type()) {
     case LayoutType::kLine: {
       CHECK(layout_tree.Children().empty());
-      if (active_unwrapped_line_ == nullptr) {
-        auto uwline = layout_tree.Value().ToUnwrappedLine();
+
+      if (current_node_ == nullptr) {
+        auto uwline = layout.ToUnwrappedLine();
         uwline.SetIndentationSpaces(current_indentation_spaces_);
-        // Prevent SearchLineWraps from processing optimized lines.
         uwline.SetPartitionPolicy(PartitionPolicyEnum::kAlreadyFormatted);
-        active_unwrapped_line_ = &unwrapped_lines_.emplace_back(uwline);
+        current_node_ = tree_.NewChild(uwline);
       } else {
-        const auto tokens = layout_tree.Value().ToUnwrappedLine().TokensRange();
-        active_unwrapped_line_->SpanUpToToken(tokens.end());
+        const auto tokens = layout.ToUnwrappedLine().TokensRange();
+        CHECK(current_node_->Value().TokensRange().end() == tokens.begin());
+
+        current_node_->Value().SpanUpToToken(tokens.end());
+
+        auto& slices = current_node_->Children();
+        // TODO(mglb): add support for break_decision == Preserve
+        if (layout.SpacesBefore() == tokens.front().before.spaces_required) {
+          // No need for separate inline partition
+          if (!slices.empty())
+            slices.back().Value().SpanUpToToken(tokens.end());
+          return;
+        }
+
+        // Wrap previous tokens in the line
+        if (slices.empty()) {
+          current_node_->NewChild(
+              UnwrappedLine(0, current_node_->Value().TokensRange().begin(),
+                            PartitionPolicyEnum::kInline));
+        }
+        slices.back().Value().SpanUpToToken(tokens.begin());
+
+        // Wrap tokens from current layout
+        auto slice = UnwrappedLine(layout.SpacesBefore(), tokens.begin(),
+                                   PartitionPolicyEnum::kInline);
+        slice.SpanUpToToken(tokens.end());
+        current_node_->NewChild(slice);
       }
       return;
     }
@@ -562,9 +631,9 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
 
       // Calculate indent for 2nd and further lines.
       int indentation = current_indentation_spaces_;
-      if (active_unwrapped_line_ != nullptr) {
-        indentation = FitsOnLine(*active_unwrapped_line_, style_).final_column +
-                      layout_tree.Value().SpacesBefore();
+      if (current_node_ != nullptr) {
+        indentation = AlreadyFormattedPartitionLength(*current_node_) +
+                      layout.SpacesBefore();
       }
 
       // Append first child
@@ -575,7 +644,7 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
                                          indentation);
       for (const auto& child : make_range(layout_tree.Children().begin() + 1,
                                           layout_tree.Children().end())) {
-        active_unwrapped_line_ = nullptr;
+        current_node_ = nullptr;
         TraverseTree(child);
       }
       return;
@@ -584,40 +653,22 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
 }
 
 void TreeReconstructor::ReplaceTokenPartitionTreeNode(
-    TokenPartitionTree* node, std::vector<PreFormatToken>* ftokens) const {
+    TokenPartitionTree* node) {
   CHECK_NOTNULL(node);
-  CHECK_NOTNULL(ftokens);
-  CHECK(!unwrapped_lines_.empty());
+  CHECK(!tree_.Children().empty());
 
-  const auto& first_line = unwrapped_lines_.front();
-  const auto& last_line = unwrapped_lines_.back();
+  if (tree_.Children().size() == 1) {
+    *node = std::move(tree_.Children().front());
+  } else {
+    const auto& first_line = tree_.Children().front().Value();
+    const auto& last_line = tree_.Children().back().Value();
 
-  node->Value() = UnwrappedLine(first_line);
-  node->Value().SpanUpToToken(last_line.TokensRange().end());
-  node->Value().SetIndentationSpaces(current_indentation_spaces_);
-  node->Value().SetPartitionPolicy(
-      PartitionPolicyEnum::kOptimalFunctionCallLayout);
-
-  node->Children().clear();
-  for (auto& uwline : unwrapped_lines_) {
-    if (!uwline.IsEmpty()) {
-      auto line_ftokens = ConvertToMutableFormatTokenRange(uwline.TokensRange(),
-                                                           ftokens->begin());
-
-      // Discard first token's original spacing (the partition has already
-      // proper indentation set).
-      line_ftokens.front().before.break_decision = SpacingOptions::MustWrap;
-      line_ftokens.front().before.spaces_required = 0;
-      line_ftokens.pop_front();
-
-      for (auto& line_ftoken : line_ftokens) {
-        SpacingOptions& decision = line_ftoken.before.break_decision;
-        if (decision == SpacingOptions::Undecided) {
-          decision = SpacingOptions::MustAppend;
-        }
-      }
-    }
-    node->AdoptSubtree(uwline);
+    node->Value() = UnwrappedLine(current_indentation_spaces_,
+                                  first_line.TokensRange().begin(),
+                                  PartitionPolicyEnum::kAlwaysExpand);
+    node->Value().SpanUpToToken(last_line.TokensRange().end());
+    node->Children().clear();
+    node->AdoptSubtreesFrom(&tree_);
   }
 }
 

--- a/common/formatting/layout_optimizer.h
+++ b/common/formatting/layout_optimizer.h
@@ -38,7 +38,6 @@ namespace verible {
 
 // Handles formatting of TokenPartitionTree 'node' that uses
 // PartitionPolicyEnum::kOptimalFunctionCallLayout partition policy.
-// 'ftokens' is used to get mutable iterators to tokens of formatted partitions.
 // The function changes only tokens that are spanned by the passed partitions
 // tree.
 //
@@ -73,8 +72,7 @@ namespace verible {
 //   }
 // }
 void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
-                                TokenPartitionTree* node,
-                                std::vector<PreFormatToken>* ftokens);
+                                TokenPartitionTree* node);
 
 }  // namespace verible
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -140,14 +140,11 @@ class LayoutItem {
     return len;
   }
 
-  // Returns the item as UnwrappedLine.
+  // Returns tokens range spanned by the Line item.
   // Can be called only on Line items.
-  UnwrappedLine ToUnwrappedLine() const {
+  FormatTokenRange TokensRange() const {
     CHECK_EQ(type_, LayoutType::kLine);
-
-    UnwrappedLine uwline(0, tokens_.begin());
-    uwline.SpanUpToToken(tokens_.end());
-    return uwline;
+    return tokens_;
   }
 
   friend bool operator==(const LayoutItem& lhs, const LayoutItem& rhs) {

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -58,17 +58,33 @@ class LayoutItem {
       : type_(type),
         indentation_(indentation),
         spaces_before_(spacing),
-        must_wrap_(must_wrap) {}
+        must_wrap_(must_wrap) {
+    CHECK_GE(indentation_, 0);
+    CHECK_GE(spaces_before_, 0);
+  }
 
   // Creates Line item from UnwrappedLine.
   explicit LayoutItem(const UnwrappedLine& uwline, int indentation = 0)
       : type_(LayoutType::kLine),
         indentation_(indentation),
         tokens_(uwline.TokensRange()),
-        spaces_before_(!tokens_.empty() ? tokens_.front().before.spaces_required
-                                        : 0),
-        must_wrap_(!tokens_.empty() && tokens_.front().before.break_decision ==
-                                           SpacingOptions::MustWrap) {}
+        spaces_before_(SpacesRequiredBeforeUnwrappedLine(uwline)),
+        must_wrap_(UnwrappedLineMustWrap(uwline)) {
+    CHECK_GE(indentation_, 0);
+    CHECK_GE(spaces_before_, 0);
+  }
+
+  // Creates Line item from UnwrappedLine.
+  explicit LayoutItem(const UnwrappedLine& uwline, bool must_wrap,
+                      int indentation)
+      : type_(LayoutType::kLine),
+        indentation_(indentation),
+        tokens_(uwline.TokensRange()),
+        spaces_before_(SpacesRequiredBeforeUnwrappedLine(uwline)),
+        must_wrap_(must_wrap) {
+    CHECK_GE(indentation_, 0);
+    CHECK_GE(spaces_before_, 0);
+  }
 
   // Multiple LayoutFunctionSegments can store copies of the same layout.
   // The objects are copied mostly in LayoutFunctionFactory::* functions.
@@ -96,6 +112,9 @@ class LayoutItem {
   // Returns whether to force line break just before this layout.
   bool MustWrap() const { return must_wrap_; }
 
+  // Sets whether to force line break just before this layout.
+  void SetMustWrap(bool must_wrap) { must_wrap_ = must_wrap; }
+
   // Returns textual representation of spanned tokens for Line items, empty
   // string for other item types.
   std::string Text() const {
@@ -113,6 +132,7 @@ class LayoutItem {
     if (tokens_.empty()) return 0;
     int len = 0;
     for (const auto& token : tokens_) {
+      // TODO (mglb): support all possible break_decisions
       len += token.before.spaces_required;
       len += token.Length();
     }
@@ -138,6 +158,27 @@ class LayoutItem {
   }
 
  private:
+  static bool UnwrappedLineMustWrap(const UnwrappedLine& uwline) {
+    if (uwline.TokensRange().empty()) return false;
+
+    const auto policy = uwline.PartitionPolicy();
+    if (policy == PartitionPolicyEnum::kInline) return false;
+    if (policy == PartitionPolicyEnum::kAlreadyFormatted) return true;
+
+    auto break_decision = uwline.TokensRange().front().before.break_decision;
+    return (break_decision == SpacingOptions::MustWrap);
+  }
+
+  static int SpacesRequiredBeforeUnwrappedLine(const UnwrappedLine& uwline) {
+    const auto tokens = uwline.TokensRange();
+    const auto policy = uwline.PartitionPolicy();
+    const auto indentation = uwline.IndentationSpaces();
+
+    if (policy == PartitionPolicyEnum::kInline) return indentation;
+    if (tokens.empty()) return 0;
+    return tokens.front().before.spaces_required;
+  }
+
   LayoutType type_;
   int indentation_;
   FormatTokenRange tokens_;
@@ -273,6 +314,12 @@ class LayoutFunction {
                         return segment.layout.Value().MustWrap() == must_wrap;
                       }));
     return must_wrap;
+  }
+
+  // Sets whether to force line break just before this layout.
+  void SetMustWrap(bool must_wrap) {
+    for (auto& segment : segments_)
+      segment.layout.Value().SetMustWrap(must_wrap);
   }
 
  private:
@@ -514,7 +561,32 @@ class LayoutFunctionFactory {
   //     First First First First First First
   //     First First First Second Second Second
   //                       Second Second
-  LayoutFunction Juxtaposition(std::initializer_list<LayoutFunction> lfs) const;
+  LayoutFunction Juxtaposition(
+      std::initializer_list<LayoutFunction> lfs) const {
+    return Juxtaposition(lfs.begin(), lfs.end());
+  }
+
+  // See Juxtaposition(std::initializer_list<LayoutFunction> lfs).
+  //
+  // Iterator: iterator type that dereferences to LayoutFunction.
+  template <class Iterator>
+  LayoutFunction Juxtaposition(Iterator begin, Iterator end) const {
+    static_assert(IsIteratorDereferencingTo<Iterator, LayoutFunction>,
+                  "Iterator's value type must be LayoutFunction.");
+
+    auto lfs_container = make_container_range(begin, end);
+
+    if (lfs_container.empty()) return LayoutFunction();
+    if (lfs_container.size() == 1) return lfs_container.front();
+
+    LayoutFunction incremental = lfs_container.front();
+    lfs_container.pop_front();
+    for (auto& lf : lfs_container) {
+      incremental = Juxtaposition(incremental, lf);
+    }
+
+    return incremental;
+  }
 
   // Creates the piecewise minimum function of a set of LayoutFunctions.
   //
@@ -634,8 +706,7 @@ class TokenPartitionsLayoutOptimizer {
   TokenPartitionsLayoutOptimizer& operator=(TokenPartitionsLayoutOptimizer&&) =
       delete;
 
-  void Optimize(int indentation, TokenPartitionTree* node,
-                std::vector<PreFormatToken>* ftokens) const;
+  void Optimize(int indentation, TokenPartitionTree* node) const;
 
   LayoutFunction CalculateOptimalLayout(const TokenPartitionTree& node) const;
 
@@ -646,8 +717,8 @@ class TokenPartitionsLayoutOptimizer {
 
 class TreeReconstructor {
  public:
-  TreeReconstructor(int indentation_spaces, const BasicFormatStyle& style)
-      : current_indentation_spaces_(indentation_spaces), style_(style) {}
+  explicit TreeReconstructor(int indentation_spaces)
+      : current_indentation_spaces_(indentation_spaces) {}
   ~TreeReconstructor() = default;
 
   TreeReconstructor(const TreeReconstructor&) = delete;
@@ -657,17 +728,13 @@ class TreeReconstructor {
 
   void TraverseTree(const LayoutTree& layout_tree);
 
-  void ReplaceTokenPartitionTreeNode(
-      TokenPartitionTree* node, std::vector<PreFormatToken>* ftokens) const;
+  void ReplaceTokenPartitionTreeNode(TokenPartitionTree* node);
 
  private:
-  std::vector<UnwrappedLine> unwrapped_lines_;
-
-  UnwrappedLine* active_unwrapped_line_ = nullptr;
+  TokenPartitionTree tree_;
+  TokenPartitionTree* current_node_ = nullptr;
 
   int current_indentation_spaces_;
-
-  const BasicFormatStyle& style_;
 };
 
 }  // namespace verible

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -317,19 +317,17 @@ TEST_F(LayoutTest, StackLayoutItemToString) {
   }
 }
 
-TEST_F(LayoutTest, AsUnwrappedLine) {
-  const auto& preformat_tokens = pre_format_tokens_;
-  const auto begin = preformat_tokens.begin();
+TEST_F(LayoutTest, TokensRange) {
+  const auto begin = pre_format_tokens_.begin();
 
   UnwrappedLine short_line(0, begin);
   short_line.SpanUpToToken(begin + 1);
 
   LayoutItem layout_short(short_line);
 
-  const auto uwline = layout_short.ToUnwrappedLine();
-  EXPECT_EQ(uwline.IndentationSpaces(), 0);
-  EXPECT_EQ(uwline.TokensRange().begin(), short_line.TokensRange().begin());
-  EXPECT_EQ(uwline.TokensRange().end(), short_line.TokensRange().end());
+  const auto tokens = layout_short.TokensRange();
+  EXPECT_EQ(tokens.begin(), short_line.TokensRange().begin());
+  EXPECT_EQ(tokens.end(), short_line.TokensRange().end());
 }
 
 TEST_F(LayoutTest, LineLayout) {
@@ -346,6 +344,8 @@ TEST_F(LayoutTest, LineLayout) {
     EXPECT_EQ(layout.MustWrap(), false);
     EXPECT_EQ(layout.Length(), 10);
     EXPECT_EQ(layout.Text(), "short_line");
+    EXPECT_EQ(layout.TokensRange().begin(), begin);
+    EXPECT_EQ(layout.TokensRange().end(), begin + 1);
   }
   {
     UnwrappedLine empty_line(0, begin);
@@ -357,6 +357,8 @@ TEST_F(LayoutTest, LineLayout) {
     EXPECT_EQ(layout.MustWrap(), false);
     EXPECT_EQ(layout.Length(), 0);
     EXPECT_EQ(layout.Text(), "");
+    EXPECT_EQ(layout.TokensRange().begin(), begin);
+    EXPECT_EQ(layout.TokensRange().end(), begin);
   }
 }
 

--- a/common/formatting/token_partition_tree.h
+++ b/common/formatting/token_partition_tree.h
@@ -124,6 +124,14 @@ void IndentButPreserveOtherSpacing(TokenPartitionRange partition_range,
                                    absl::string_view full_text,
                                    std::vector<PreFormatToken>* ftokens);
 
+// Finalizes formatting of a partition with kAlreadyFormatted policy and
+// optional kTokenModifer subpartitions.
+// Spacing described by the partitions is applied to underlying tokens. All
+// subpartitions of the passed node are removed.
+void ApplyAlreadyFormattedPartitionPropertiesToTokens(
+    TokenPartitionTree* already_formatted_partition_node,
+    std::vector<PreFormatToken>* ftokens);
+
 // Merges the two subpartitions of tree at index pos and pos+1.
 void MergeConsecutiveSiblings(TokenPartitionTree* tree, size_t pos);
 

--- a/common/formatting/token_partition_tree_test_utils.cc
+++ b/common/formatting/token_partition_tree_test_utils.cc
@@ -1,0 +1,80 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/formatting/token_partition_tree_test_utils.h"
+
+#include <vector>
+
+#include "common/formatting/format_token.h"
+#include "common/formatting/token_partition_tree.h"
+#include "common/formatting/unwrapped_line.h"
+#include "gtest/gtest.h"
+
+namespace verible {
+
+namespace {
+
+bool PartitionsEqual(const UnwrappedLine& left, const UnwrappedLine& right) {
+  return (left.TokensRange() == right.TokensRange()) &&
+         (left.IndentationSpaces() == right.IndentationSpaces()) &&
+         (left.PartitionPolicy() == right.PartitionPolicy()) &&
+         (left.Origin() == right.Origin());
+}
+
+}  // namespace
+
+TokenPartitionTree TokenPartitionTreeBuilder::build(
+    const std::vector<verible::PreFormatToken>& tokens) const {
+  TokenPartitionTree node;
+
+  auto& child_nodes = node.Children();
+  child_nodes.reserve(children_.size());
+  for (const auto& child : children_) {
+    node.NewChild(child.build(tokens));
+  }
+
+  FormatTokenRange node_tokens;
+  if (token_indexes_range_.first < 0) {
+    CHECK(!child_nodes.empty());
+    CHECK_LT(token_indexes_range_.second, 0);
+    node_tokens.set_begin(child_nodes.front().Value().TokensRange().begin());
+    node_tokens.set_end(child_nodes.back().Value().TokensRange().end());
+  } else {
+    CHECK_GE(token_indexes_range_.second, token_indexes_range_.first);
+    node_tokens.set_begin(tokens.begin() + token_indexes_range_.first);
+    node_tokens.set_end(tokens.begin() + token_indexes_range_.second);
+  }
+
+  node.Value() = UnwrappedLine(indent_, node_tokens.begin(), policy_);
+  node.Value().SpanUpToToken(node_tokens.end());
+  return node;
+}
+
+::testing::AssertionResult TokenPartitionTreesEqualPredFormat(
+    const char* actual_expr, const char* expected_expr,
+    const TokenPartitionTree& actual, const TokenPartitionTree& expected) {
+  const auto diff = DeepEqual(actual, expected, PartitionsEqual);
+  if (diff.left != nullptr) {
+    return ::testing::AssertionFailure()
+           << "Expected equality of these trees:\n"
+              "Actual:\n"
+           << actual
+           << "\n"
+              "Expected:\n"
+           << expected << "\n";
+  }
+  return ::testing::AssertionSuccess();
+}
+
+}  // namespace verible

--- a/common/formatting/token_partition_tree_test_utils.h
+++ b/common/formatting/token_partition_tree_test_utils.h
@@ -1,0 +1,116 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_COMMON_FORMATTING_TOKEN_PARTITION_TREE_TEST_UTILS_H_
+#define VERIBLE_COMMON_FORMATTING_TOKEN_PARTITION_TREE_TEST_UTILS_H_
+
+#include <utility>
+#include <vector>
+
+#include "common/formatting/format_token.h"
+#include "common/formatting/token_partition_tree.h"
+#include "common/formatting/unwrapped_line.h"
+#include "gtest/gtest.h"
+
+namespace verible {
+
+// Helper class for creating TokenPartitionTree hierarchy using compact and easy
+// to read/write/modify syntax. Its main advantage is token range deduction from
+// child nodes and specification of token range using indexes instead of
+// iterators.
+//
+// Example use:
+//
+//   using TPT = TokenPartitionTreeBuilder;
+//   const auto tree =
+//       TPT(PartitionPolicyEnum::kAlwaysExpand,
+//       {
+//           TPT({0, 1}, PartitionPolicyEnum::kAlreadyFormatted),
+//           TPT(4, {1, 3}, PartitionPolicyEnum::kAlreadyFormatted),
+//           TPT(4, {3, 5}, PartitionPolicyEnum::kAlreadyFormatted),
+//           TPT(4, {5, 7}, PartitionPolicyEnum::kAlreadyFormatted),
+//       })
+//       .build(pre_format_tokens_);
+//
+class TokenPartitionTreeBuilder {
+ public:
+  TokenPartitionTreeBuilder(
+      int indent, std::pair<int, int> token_indexes_range,
+      PartitionPolicyEnum policy,
+      std::initializer_list<TokenPartitionTreeBuilder> children = {})
+      : indent_(indent),
+        token_indexes_range_(token_indexes_range),
+        policy_(policy),
+        children_(children) {}
+
+  TokenPartitionTreeBuilder(
+      int indent, PartitionPolicyEnum policy,
+      std::initializer_list<TokenPartitionTreeBuilder> children = {})
+      : indent_(indent), policy_(policy), children_(children) {}
+
+  TokenPartitionTreeBuilder(
+      int indent, std::pair<int, int> token_indexes_range,
+      std::initializer_list<TokenPartitionTreeBuilder> children = {})
+      : indent_(indent),
+        token_indexes_range_(token_indexes_range),
+        children_(children) {}
+
+  TokenPartitionTreeBuilder(
+      std::pair<int, int> token_indexes_range, PartitionPolicyEnum policy,
+      std::initializer_list<TokenPartitionTreeBuilder> children = {})
+      : token_indexes_range_(token_indexes_range),
+        policy_(policy),
+        children_(children) {}
+
+  explicit TokenPartitionTreeBuilder(
+      std::pair<int, int> token_indexes_range,
+      std::initializer_list<TokenPartitionTreeBuilder> children = {})
+      : token_indexes_range_(token_indexes_range), children_(children) {}
+
+  TokenPartitionTreeBuilder(
+      PartitionPolicyEnum policy,
+      std::initializer_list<TokenPartitionTreeBuilder> children)
+      : policy_(policy), children_(children) {}
+
+  explicit TokenPartitionTreeBuilder(
+      std::initializer_list<TokenPartitionTreeBuilder> children)
+      : children_(children) {}
+
+  // Builds TokenPartitionTree. Token indexes used during construction are
+  // replaced with iterators from 'tokens' vector.
+  TokenPartitionTree build(
+      const std::vector<verible::PreFormatToken>& tokens) const;
+
+ private:
+  int indent_ = 0;
+  std::pair<int, int> token_indexes_range_ = {-1, -1};
+  PartitionPolicyEnum policy_ = PartitionPolicyEnum::kUninitialized;
+
+  const std::vector<TokenPartitionTreeBuilder> children_;
+};
+
+// Tests whetherTokenPartitionTrees 'actual' and 'expected' are equal. The
+// function compares the trees structure and values of all corresponding nodes.
+// Intended for use with EXPECT_PRED_FORMAT2(), e.g.:
+//
+//   EXPECT_PRED_FORMAT2(TokenPartitionTreesEqualPredFormat, actual_tree,
+//                       expected_tree);
+//
+::testing::AssertionResult TokenPartitionTreesEqualPredFormat(
+    const char* actual_expr, const char* expected_expr,
+    const TokenPartitionTree& actual, const TokenPartitionTree& expected);
+
+}  // namespace verible
+
+#endif  // VERIBLE_COMMON_FORMATTING_TOKEN_PARTITION_TREE_TEST_UTILS_H_

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -44,6 +44,8 @@ std::ostream& operator<<(std::ostream& stream, PartitionPolicyEnum p) {
       return stream << "tabular-alignment";
     case PartitionPolicyEnum::kAlreadyFormatted:
       return stream << "already-formatted";
+    case PartitionPolicyEnum::kInline:
+      return stream << "inline";
     case PartitionPolicyEnum::kAppendFittingSubPartitions:
       return stream << "append-fitting-sub-partitions";
     case PartitionPolicyEnum::kOptimalFunctionCallLayout:

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -51,12 +51,35 @@ enum class PartitionPolicyEnum {
   // columns that use space-padding to achieve vertical alignment.
   kTabularAlignment,
 
-  // Signal that this unwrapped line has been successfully formatted with
-  // spacing added. In this case, do NOT bother to call SearchLineWraps or
-  // perform any other spacing/wrapping optimization.
-  // Reserved for setting only from policy-specific formatters, like Layout
-  // Optimizer and Tabular Aligner.
+  // Signal that this unwrapped line has been already formatted. In this case,
+  // do NOT bother to call SearchLineWraps or perform any other wrapping
+  // optimization. Partitions with this policy can contain kInline
+  // subpartitions.
+  // Reserved for policy-specific formatters, like Layout Optimizer and Tabular
+  // Aligner.
   kAlreadyFormatted,
+
+  // Represents slice of kAlreadyFormatted line.
+  //
+  // The partition replaces spacing before its first token (i.e. token's
+  // '.before.spaces_required' value) with number of spaces equal to
+  // IndentationSpaces(). When the first token is at the beginning of a line,
+  // the spacing is added to line's indentation.
+  //
+  // The policy is intended to add non-permanent spacing between tokens in
+  // situations where multiple token partition trees with different token
+  // spacings can coexist (e.g. in multiple layouts passed to Layout Optimizer).
+  //
+  // Invariants:
+  // * Can exist only inside kAlreadyFormatted partition node.
+  // * All siblings (if they exist) of kInline partition must themselves
+  //   be kInline partitions.
+  // * kInline node must be a leaf.
+  //
+  // See ApplyAlreadyFormattedPartitionPropertiesToTokens() for a code that
+  // finalizes kAlreadyFormatted partition and applies kInline spacing to
+  // tokens.
+  kInline,
 
   // Treats subpartitions as units, and appends them to the same line as
   // long as they fit, else wrap them aligned to the position of the first

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -57,6 +57,9 @@ enum class PartitionPolicyEnum {
   // subpartitions.
   // Reserved for policy-specific formatters, like Layout Optimizer and Tabular
   // Aligner.
+  //
+  // Currently lines with this policy are generated in Tabular Aligner and
+  // Layout Optimizer. They are supported as an input in Layout Optimizer.
   kAlreadyFormatted,
 
   // Represents slice of kAlreadyFormatted line.
@@ -79,6 +82,9 @@ enum class PartitionPolicyEnum {
   // See ApplyAlreadyFormattedPartitionPropertiesToTokens() for a code that
   // finalizes kAlreadyFormatted partition and applies kInline spacing to
   // tokens.
+  //
+  // Currently partitions with this policy are generated in Tabular Aligner and
+  // Layout Optimizer. They are supported as an input in Layout Optimizer.
   kInline,
 
   // Treats subpartitions as units, and appends them to the same line as

--- a/common/formatting/unwrapped_line_test.cc
+++ b/common/formatting/unwrapped_line_test.cc
@@ -38,6 +38,16 @@ TEST(PartitionPolicyTest, Printing) {
     stream << PartitionPolicyEnum::kFitOnLineElseExpand;
     EXPECT_EQ(stream.str(), "fit-else-expand");
   }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kAlreadyFormatted;
+    EXPECT_EQ(stream.str(), "already-formatted");
+  }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kInline;
+    EXPECT_EQ(stream.str(), "inline");
+  }
 }
 
 // This test fixture inherits from UnwrappedLineMemoryHandler so that

--- a/common/formatting/verification.cc
+++ b/common/formatting/verification.cc
@@ -31,14 +31,14 @@ absl::Status ReformatMustMatch(absl::string_view original_text,
     diff_stream << formatting_diffs;
     std::ostringstream lines_stream;
     lines_stream << lines;
-    return absl::DataLossError(
-        absl::StrCat("Re-formatted text does not match formatted text; "
-                     "formatting failed to converge!  Please file a bug.\n"
-                     "Original: --lines: ",
-                     lines_stream.str(), "\n", original_text,  //
-                     "Formatted:\n", formatted_text,           //
-                     "Re-formatted:\n", reformatted_text,      //
-                     "Diffs are:\n", diff_stream.str()));
+    return absl::DataLossError(absl::StrCat(
+        "Re-formatted text does not match formatted text; "
+        "formatting failed to converge!  Please file a bug.\n"
+        "========== Original: --lines: ==========",
+        lines_stream.str(), "\n", original_text,                         //
+        "============== Formatted: ==============\n", formatted_text,    //
+        "============= Re-formatted: ============\n", reformatted_text,  //
+        "============== Diffs are: ==============\n", diff_stream.str()));
   }
   return absl::OkStatus();
 }

--- a/common/formatting/verification_test.cc
+++ b/common/formatting/verification_test.cc
@@ -27,8 +27,9 @@ TEST(ReformatMustMatch, ReformatDifferent) {
       ReformatMustMatch("foo  bar ;\n", lines, "foo bar;\n", "foo  bar;\n");
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), absl::StatusCode::kDataLoss);
-  EXPECT_TRUE(
-      absl::StrContains(status.message(), "Re-formatted:\nfoo  bar;\n"));
+  EXPECT_TRUE(absl::StrContains(status.message(),
+                                "============= Re-formatted: ============\n"
+                                "foo  bar;\n"));
 }
 
 TEST(ReformatMustMatch, ReformatSame) {

--- a/common/strings/display_utils.cc
+++ b/common/strings/display_utils.cc
@@ -14,6 +14,7 @@
 
 #include "common/strings/display_utils.h"
 
+#include <iomanip>
 #include <iostream>
 
 namespace verible {
@@ -30,6 +31,48 @@ std::ostream& operator<<(std::ostream& stream, const AutoTruncate& trunc) {
   const auto tail_start = length - tail_length;
   return stream << text.substr(0, head_length) << kEllipses
                 << text.substr(tail_start, tail_length);
+}
+
+std::ostream& operator<<(std::ostream& stream, const EscapeString& vis) {
+  for (const unsigned char c : vis.text) {
+    switch (c) {
+      case '\a':
+        stream << "\\a";
+        break;
+      case '\b':
+        stream << "\\b";
+        break;
+      case '\f':
+        stream << "\\f";
+        break;
+      case '\n':
+        stream << "\\n";
+        break;
+      case '\r':
+        stream << "\\r";
+        break;
+      case '\t':
+        stream << "\\t";
+        break;
+      case '\v':
+        stream << "\\v";
+        break;
+
+      case '\\':
+      case '\'':
+      case '\"':
+        stream << "\\" << c;
+        break;
+
+      default:
+        if (c < 0x20 || c > 0x7E)
+          stream << "\\x" << std::hex << std::setw(2) << std::setfill('0')
+                 << static_cast<unsigned>(c);
+        else
+          stream << c;
+    }
+  }
+  return stream;
 }
 
 std::ostream& operator<<(std::ostream& stream, const VisualizeWhitespace& vis) {

--- a/common/strings/display_utils.h
+++ b/common/strings/display_utils.h
@@ -37,6 +37,19 @@ struct AutoTruncate {
 
 std::ostream& operator<<(std::ostream&, const AutoTruncate& trunc);
 
+// To help visualize strings with non-alphanumeric characters, this stream
+// adapter prints special characters escaped using C escape sequences, without
+// modifying or copying the original string.
+//
+// usage: stream << EscapeString(text);
+struct EscapeString {
+  const absl::string_view text;  // original text to be printed
+
+  explicit EscapeString(absl::string_view text) : text(text) {}
+};
+
+std::ostream& operator<<(std::ostream&, const EscapeString& vis);
+
 // To help visualize strings that consist of whitespace, this stream adapter
 // prints spaces, tabs, and newlines with alternate text, without modifying or
 // copying the original string.

--- a/common/strings/display_utils_test.cc
+++ b/common/strings/display_utils_test.cc
@@ -79,6 +79,31 @@ TEST(VisualizeWhitespaceTest, OtherSubstitutions) {
   }
 }
 
+TEST(EscapeStringTest, Various) {
+  constexpr std::pair<absl::string_view, absl::string_view> kTestCases[] = {
+      {"", ""},
+      {"abc", "abc"},
+      {"ABC", "ABC"},
+      {"123", "123"},
+      {"a\nb\r\nc", R"(a\nb\r\nc)"},
+      {"  a\nb  \r\nc  ", R"(  a\nb  \r\nc  )"},
+      {"    \x01\x02\x03\x04\x05\x06\x07", R"(    \x01\x02\x03\x04\x05\x06\a)"},
+      {"\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", R"(\b\t\n\v\f\r\x0e\x0f)"},
+      {"\x10\x11\x12\x13\x14\x15\x16\x17",
+       R"(\x10\x11\x12\x13\x14\x15\x16\x17)"},
+      {"\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f",
+       R"(\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f)"},
+      {R"( ' " \ \\ )", R"( \' \" \\ \\\\ )"},
+      {" ~", " ~"},
+      {"\x7f\x80\xfe\xff", R"(\x7f\x80\xfe\xff)"},
+  };
+  for (const auto& test : kTestCases) {
+    std::ostringstream stream;
+    stream << EscapeString{test.first};
+    EXPECT_EQ(stream.str(), test.second);
+  }
+}
+
 typedef std::vector<int> IntVector;
 
 // Normally a definition like the following would appear in a header

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -155,6 +155,7 @@ cc_library(
         "//common/util:range",
         "//common/util:spacer",
         "//common/util:vector_tree",
+        "//common/util:vector_tree_iterators",
         "//verilog/CST:declaration",
         "//verilog/CST:module",
         "//verilog/analysis:verilog_analyzer",

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -52,7 +52,6 @@ using verible::ColumnSchemaScanner;
 using verible::down_cast;
 using verible::ExtractAlignmentGroupsFunction;
 using verible::FormatTokenRange;
-using verible::MutableFormatTokenRange;
 using verible::PreFormatToken;
 using verible::Symbol;
 using verible::SyntaxTreeLeaf;
@@ -1511,8 +1510,7 @@ static std::vector<AlignablePartitionGroup> AlignDistItems(
 void TabularAlignTokenPartitions(const FormatStyle& style,
                                  absl::string_view full_text,
                                  const ByteOffsetSet& disabled_byte_ranges,
-                                 TokenPartitionTree* partition_ptr,
-                                 std::vector<PreFormatToken>* ftokens) {
+                                 TokenPartitionTree* partition_ptr) {
   VLOG(1) << __FUNCTION__;
   auto& partition = *partition_ptr;
   auto& uwline = partition.Value();
@@ -1555,7 +1553,7 @@ void TabularAlignTokenPartitions(const FormatStyle& style,
 
   verible::TabularAlignTokens(style.column_limit, full_text,
                               disabled_byte_ranges, extract_alignment_groups,
-                              &partition, ftokens);
+                              &partition);
 
   VLOG(1) << "end of " << __FUNCTION__;
 }

--- a/verilog/formatting/align.h
+++ b/verilog/formatting/align.h
@@ -28,14 +28,11 @@ namespace formatter {
 
 // For certain Verilog language construct groups, vertically align some
 // tokens by inserting padding-spaces.
-// 'ftokens' is only used to provide a base mutable iterator for the purpose
-// of being able to modify inter-token spacing.
 // TODO(fangism): pass in disabled formatting ranges
 void TabularAlignTokenPartitions(
     const FormatStyle& style, absl::string_view full_text,
     const verible::ByteOffsetSet& disabled_byte_ranges,
-    verible::TokenPartitionTree* partition_ptr,
-    std::vector<verible::PreFormatToken>* ftokens);
+    verible::TokenPartitionTree* partition_ptr);
 
 }  // namespace formatter
 }  // namespace verilog

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -761,8 +761,7 @@ Status Formatter::Format(const ExecutionControl& control) {
           verible::ReshapeFittingSubpartitions(style_, &node);
           break;
         case PartitionPolicyEnum::kOptimalFunctionCallLayout:
-          verible::OptimizeTokenPartitionTree(
-              style_, &node, &unwrapper_data.preformatted_tokens);
+          verible::OptimizeTokenPartitionTree(style_, &node);
           break;
         case PartitionPolicyEnum::kTabularAlignment:
           // TODO(b/145170750): Adjust inter-token spacing to achieve alignment,

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -868,6 +868,7 @@ void Formatter::Emit(std::ostream& stream) const {
   for (const auto& line : formatted_lines_) {
     // TODO(fangism): The handling of preserved spaces before tokens is messy:
     // some of it is handled here, some of it is inside FormattedToken.
+    // TODO(mglb): Test empty line handling when this method becomes testable.
     const auto front_offset =
         line.Tokens().empty() ? position
                               : line.Tokens().front().token->left(full_text);

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -828,7 +828,9 @@ void Formatter::Emit(std::ostream& stream) const {
   for (const auto& line : formatted_lines_) {
     // TODO(fangism): The handling of preserved spaces before tokens is messy:
     // some of it is handled here, some of it is inside FormattedToken.
-    const auto front_offset = line.Tokens().front().token->left(full_text);
+    const auto front_offset =
+        line.Tokens().empty() ? position
+                              : line.Tokens().front().token->left(full_text);
     const absl::string_view leading_whitespace(
         full_text.substr(position, front_offset - position));
     FormatWhitespaceWithDisabledByteRanges(full_text, leading_whitespace,
@@ -837,8 +839,10 @@ void Formatter::Emit(std::ostream& stream) const {
     // already cover the space up to the front token, in which case,
     // the left-indentation for this line should be suppressed to avoid
     // being printed twice.
-    line.FormattedText(stream, !disabled_ranges_.Contains(front_offset));
-    position = line.Tokens().back().token->right(full_text);
+    if (!line.Tokens().empty()) {
+      line.FormattedText(stream, !disabled_ranges_.Contains(front_offset));
+      position = line.Tokens().back().token->right(full_text);
+    }
   }
   // Handle trailing spaces after last token.
   const absl::string_view trailing_whitespace(full_text.substr(position));

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -769,8 +769,7 @@ Status Formatter::Format(const ExecutionControl& control) {
           // but leave partitioning intact.
           // This relies on inter-token spacing having already been annotated.
           TabularAlignTokenPartitions(style_, full_text, disabled_ranges_,
-                                      &node,
-                                      &unwrapper_data.preformatted_tokens);
+                                      &node);
           break;
         default:
           break;


### PR DESCRIPTION
The partition with `kInline` policy replaces spacing before its first token (i.e. token's '.before.spaces_required' value) with number of spaces equal to IndentationSpaces().
When the first token is at the beginning of a line, the spacing is added to line's indentation.
`kInline` complements `kAlreadyFormatted` partition policy, and can exist only inside partitions with such policy.
The tokens (their spacing) themselves are modified near the end of formatting pipeline, just before final partition tree is converted into a list of UnwrappedLines.

The policy is intended to add non-permanent spacing between tokens in situations where multiple token partition trees with different token spacings can coexist (e.g. in multiple layouts passed to Layout Optimizer).

Currently partitions with this policy are generated in Tabular Aligner and Layout Optimizer, where they replaced direct token spacing modification. They are supported as an input in Layout Optimizer.