### PR TITLE
Add more detail to a check failure seen in some Kythe indexings.

### DIFF
--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -204,8 +204,13 @@ const SyntaxTreeLeaf& GetSubtreeAsLeaf(const S& symbol,
                                        E parent_must_be_node_enum,
                                        size_t child_position) {
   internal::MustBeCSTSymbolOrNode(symbol);
-  return SymbolCastToLeaf(*ABSL_DIE_IF_NULL(
-      GetSubtreeAsSymbol(symbol, parent_must_be_node_enum, child_position)));
+  const Symbol* subtree =
+      GetSubtreeAsSymbol(symbol, parent_must_be_node_enum, child_position);
+  // TODO(ikr): avoid this check-failure.
+  CHECK(subtree != nullptr)
+      << symbol.Kind() << " e:" << parent_must_be_node_enum
+      << " p:" << child_position;
+  return SymbolCastToLeaf(*subtree);
 }
 
 template <class S, class E>


### PR DESCRIPTION
For instance:

https://chipsalliance.github.io/sv-tests-results/#VeribleExtractor|TNoC|TNoC
https://chipsalliance.github.io/sv-tests-results/#VeribleExtractor|ariane|ariane
https://chipsalliance.github.io/sv-tests-results/#VeribleExtractor|earlgrey|earlgrey

This doesn't change any functionality, just improves logging of the particular case.