### PR TITLE
Make sure a library used for testing is tagged as such.

### DIFF
--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -185,6 +185,7 @@ cc_library(
 
 cc_library(
     name = "token_partition_tree_test_utils",
+    testonly = 1,
     srcs = ["token_partition_tree_test_utils.cc"],
     hdrs = ["token_partition_tree_test_utils.h"],
     deps = [


### PR DESCRIPTION
That way, it is not accidentally used in final binaries.

Signed-off-by: Henner Zeller <hzeller@google.com>