### PR TITLE
Add explicit typed structure literals

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -96,6 +96,7 @@ declare -A KnownIssue
 
 #--- Opentitan
 KnownIssue[formatter:$BASE_TEST_DIR/opentitan/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv]=1006
+KnownIssue[formatter:$BASE_TEST_DIR/opentitan/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv]=1130
 # There is also bug 1008 which only shows up if compiled with asan
 
 #--- ivtest

--- a/verilog/CST/verilog_nonterminals.h
+++ b/verilog/CST/verilog_nonterminals.h
@@ -276,6 +276,7 @@ enum class NodeEnum {
   kMacroFormalArg,
   kAssignmentPattern,
   kPatternExpression,
+  kAssignmentPatternExpression,
   kMinTypMaxList,
   kConstRef,
   kInterfacePortHeader,

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -999,7 +999,12 @@ assignment_pattern
   | TK_LP '}'
     { $$ = MakeTaggedNode(N::kAssignmentPattern, $1, $2); }
   ;
-
+assignment_pattern_expression
+  : assignment_pattern
+    { $$ = move($1); }
+  | data_type_base assignment_pattern
+    { $$ = MakeTaggedNode(N::kAssignmentPatternExpression, $1, $2); }
+  ;
 structure_or_array_pattern_expression_list
   : structure_or_array_pattern_expression_list ',' structure_or_array_pattern_expression
     { $$ = ExtendNode($1, $2, $3); }
@@ -4662,7 +4667,7 @@ expr_primary
    { $$ = move($1); }
   | expr_primary_braces
     { $$ = move($1); }
-  | assignment_pattern
+  | assignment_pattern_expression
     { $$ = move($1); }
   ;
 expr_primary_parens

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -3004,13 +3004,18 @@ static const ParserTestCaseArray kModuleTests = {
     "  x5 = \'{bit:0};\n"
     "end\n"
     "endmodule",
-    /* TODO(b/149152101): optional assignment pattern expression type
     "module assignment_test3;\n"
     "initial begin\n"
     "  xx = byte\'{a, b, c};\n"
     "end\n"
     "endmodule",
-    */
+    // struct literals
+    "module struct_literal;\n"
+    "always_comb begin\n"
+    "  x = t_foo\'{bar: 0, boo: 1};\n"
+    "end\n"
+    "endmodule\n",
+
     // assertion items
     "module assertion_items;\n"
     "assert property ( A + B <= C );\n"


### PR DESCRIPTION
A naive attempt to fix  #717.

I have introduced a new node `kAssignmentPatternExpression` to handle the struct literals (inspired by the parser from [tree-sitter-verilog](https://github.com/tree-sitter/tree-sitter-verilog)).

I have zero experience with yacc so I've probably overlooked things. 
Any comments or feedback would be welcome.