### PR TITLE
Handle null scopes gracefully in ReferenceExtendsInheritance().

### DIFF
--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -1058,6 +1058,18 @@ void KytheFactsExtractor::ReferenceExtendsInheritance(
     return;
   }
 
+  // TODO(hzeller): should this have been detected before ?
+  // NULL vname is not encountered, but NULL scope. Issue #1128
+  if (!definitions.back().first) {
+    LOG(ERROR) << "ReferenceExtendsInheritance: NULL vname";
+    return;
+  }
+  if (!definitions.back().second) {
+    LOG(ERROR) << "ReferenceExtendsInheritance: NULL scope for vname "
+               << *definitions.back().first;
+    return;
+  }
+
   // Create kythe facts for extends.
   const VName& derived_class_vname = vnames_context_.top();
   CreateEdge(derived_class_vname, kEdgeExtends, *definitions.back().first);


### PR DESCRIPTION
This is a stop-gap as these null scopes were encountered in the
field, further analysis is needed.

Issues #1128

Signed-off-by: Henner Zeller <h.zeller@acm.org>