### PR TITLE
Add nvim-lspconfig to language server documentation

### DIFF
--- a/verilog/tools/ls/README.md
+++ b/verilog/tools/ls/README.md
@@ -84,7 +84,15 @@ to get it started up on our Verilog/SystemVerilog projects.
 
 ### Neovim
 
-TBD (similar to [Vim](#vim) ?)
+Make sure to have version `0.5.0` or newer and install the [nvim-lpsconfig](https://github.com/neovim/nvim-lspconfig/) plugin.
+Enable the verible config:
+
+```lua
+-- init.lua
+require'lspconfig'.verible.setup {}
+```
+
+See https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#verible for configuration options.
 
 ### Sublime
 


### PR DESCRIPTION
Add documentation on how to enable the verible language server with neovim using the built-in client.