### PR TITLE
Use host m4/flex/bison on linux

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -132,7 +132,7 @@ jobs:
       run: |
         set -x
         source ./.github/settings.sh
-        sudo apt -qq -y install clang-10
+        sudo apt -qq -y install clang-10 flex bison
         ./.github/bin/set-compiler.sh 9
         ./.github/bin/install-bazel.sh
         ./.github/bin/install-python.sh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Verible's code base is written in C++.
 To build, you need the [bazel] build system and a C++17 compatible compiler
 (e.g. >= g++-9), as well as python3.
 
+Linux systems also require the following tools: m4, flex, bison.
+
 Use your package manager to install the dependencies; on a system with
 the nix package manager simply run `nix-shell` to get a build environment.
 

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -32,10 +32,12 @@ def genyacc(
         outs = [header_out, source_out] + extra_outs,
         cmd = select({
             "@platforms//os:windows": "$(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
+            "@platforms//os:linux": "bison --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
             "//conditions:default": "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
         }),
         toolchains = select({
             "@platforms//os:windows": ["@rules_bison//bison:current_bison_toolchain"],
+            "@platforms//os:linux": [], # use host m4/bison
             "//conditions:default": [
                 "@rules_bison//bison:current_bison_toolchain",
                 "@rules_m4//m4:current_m4_toolchain",

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -26,10 +26,12 @@ def genlex(name, src, out):
         outs = [out],
         cmd = select({
             "@platforms//os:windows": "$(FLEX) --outfile=$@ $<",
+            "@platforms//os:linux": "flex --outfile=$@ $<",
             "//conditions:default": "M4=$(M4) $(FLEX) --outfile=$@ $<",
         }),
         toolchains = select({
             "@platforms//os:windows": ["@rules_flex//flex:current_flex_toolchain"],
+            "@platforms//os:linux": [], # use host m4/flex tools
             "//conditions:default": [
                 "@rules_flex//flex:current_flex_toolchain",
                 "@rules_m4//m4:current_m4_toolchain",

--- a/verilog/parser/BUILD
+++ b/verilog/parser/BUILD
@@ -128,6 +128,7 @@ cc_library(
         "//conditions:default": [
             "-Wno-implicit-fallthrough",
             "-Wno-type-limits",
+            "-Wno-unreachable-code",
         ],
     }),
     deps = [

--- a/verilog/parser/BUILD
+++ b/verilog/parser/BUILD
@@ -122,7 +122,7 @@ record_recovered_syntax_errors(
 cc_library(
     name = "verilog_y_cc",
     srcs = ["verilog-final.tab.cc"],
-    hdrs = ["verilog_parse_interface.h"],
+    hdrs = ["verilog_parse_interface.h", "verilog.tab.hh"],
     copts = select({
         "@platforms//os:windows": [],
         "//conditions:default": [


### PR DESCRIPTION
This should allow us to skip the problematic update of the m4 dependency. Other operating systems can keep using the outdated version, Linux should be allowed to use host tools.


Closes #1122 
Closes #957