### PR TITLE
Revert "Use host m4/flex/bison on linux"

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -132,7 +132,7 @@ jobs:
       run: |
         set -x
         source ./.github/settings.sh
-        sudo apt -qq -y install clang-10 flex bison
+        sudo apt -qq -y install clang-10
         ./.github/bin/set-compiler.sh 9
         ./.github/bin/install-bazel.sh
         ./.github/bin/install-python.sh

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Verible's code base is written in C++.
 To build, you need the [bazel] build system and a C++17 compatible compiler
 (e.g. >= g++-9), as well as python3.
 
-Linux systems also require the following tools: m4, flex, bison.
-
 Use your package manager to install the dependencies; on a system with
 the nix package manager simply run `nix-shell` to get a build environment.
 

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -32,12 +32,10 @@ def genyacc(
         outs = [header_out, source_out] + extra_outs,
         cmd = select({
             "@platforms//os:windows": "$(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-            "@platforms//os:linux": "bison --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
             "//conditions:default": "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
         }),
         toolchains = select({
             "@platforms//os:windows": ["@rules_bison//bison:current_bison_toolchain"],
-            "@platforms//os:linux": [], # use host m4/bison
             "//conditions:default": [
                 "@rules_bison//bison:current_bison_toolchain",
                 "@rules_m4//m4:current_m4_toolchain",

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -26,12 +26,10 @@ def genlex(name, src, out):
         outs = [out],
         cmd = select({
             "@platforms//os:windows": "$(FLEX) --outfile=$@ $<",
-            "@platforms//os:linux": "flex --outfile=$@ $<",
             "//conditions:default": "M4=$(M4) $(FLEX) --outfile=$@ $<",
         }),
         toolchains = select({
             "@platforms//os:windows": ["@rules_flex//flex:current_flex_toolchain"],
-            "@platforms//os:linux": [], # use host m4/flex tools
             "//conditions:default": [
                 "@rules_flex//flex:current_flex_toolchain",
                 "@rules_m4//m4:current_m4_toolchain",

--- a/verilog/parser/BUILD
+++ b/verilog/parser/BUILD
@@ -122,13 +122,12 @@ record_recovered_syntax_errors(
 cc_library(
     name = "verilog_y_cc",
     srcs = ["verilog-final.tab.cc"],
-    hdrs = ["verilog_parse_interface.h", "verilog.tab.hh"],
+    hdrs = ["verilog_parse_interface.h"],
     copts = select({
         "@platforms//os:windows": [],
         "//conditions:default": [
             "-Wno-implicit-fallthrough",
             "-Wno-type-limits",
-            "-Wno-unreachable-code",
         ],
     }),
     deps = [


### PR DESCRIPTION
Reverts chipsalliance/verible#1132

This needs more work as releases stop working with it as the releases need a local bison/flex installed ; a first attempt to do this in #1135 showed that this then creates issues with older versions of bison/flex.

So we probably need an approach in which we _optionally_ can choose to use to use the local m4; something along the lines of [this comment](https://github.com/chipsalliance/verible/pull/1132#issuecomment-1006614936)

But for now, revert this to unbreak.