### PR TITLE
Remove ubuntu groovy release.

### DIFF
--- a/releasing/supported_bases.txt
+++ b/releasing/supported_bases.txt
@@ -2,5 +2,4 @@ centos:7
 centos:8
 ubuntu:bionic
 ubuntu:focal
-ubuntu:groovy
 ubuntu:xenial


### PR DESCRIPTION
The Release file in the repository is gone for the security updates, so the apt-get update seems to fail because of that. https://github.com/chipsalliance/verible/runs/4798055615?check_suite_focus=true

Unless there is a simpler work-around, given that Groovy is a short-term distribution and reached [EOL last summer](https://fridge.ubuntu.com/2021/07/25/ubuntu-20-10-groovy-gorilla-end-of-life-reached-on-july-22-2021/), not having a release seems fine.