### PR TITLE
Add FormatVerilogRange() formatting functions that only formats and

### DIFF
--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -208,7 +208,14 @@ class FormattedExcerpt {
 
   // Prints formatted text.  If indent is true, include the spacing
   // that is to the left of the first token.
-  std::ostream& FormattedText(std::ostream&, bool indent) const;
+  // Only tokens for which include_token_p() return true are emitted (default:
+  // always emit).
+  // TODO(hzeller): instead of "indent" parameter, handle that with the
+  // include_token_p() predicate ?
+  std::ostream& FormattedText(
+      std::ostream&, bool indent,
+      const std::function<bool(const TokenInfo&)>& include_token_p =
+          [](const TokenInfo&) { return true; }) const;
 
   // Returns formatted code as a string.
   std::string Render() const;

--- a/common/formatting/unwrapped_line_test.cc
+++ b/common/formatting/unwrapped_line_test.cc
@@ -283,6 +283,25 @@ TEST_F(UnwrappedLineTest, FormattedTextNonEmptyWithIndent) {
   EXPECT_EQ(expected, stream.str());
 }
 
+TEST_F(UnwrappedLineTest, FormattedTextSelectiveIncludeToken) {
+  const std::vector<TokenInfo> tokens = {
+      {0, "test_token1"}, {1, "test_token2"}, {2, "test_token3"}};
+  CreateTokenInfos(tokens);
+  UnwrappedLine uwline(4, pre_format_tokens_.begin());
+  AddFormatTokens(&uwline);
+  for (auto& t : pre_format_tokens_) {
+    t.before.spaces_required = 2;
+  }
+  FormattedExcerpt output(uwline);
+  std::ostringstream stream;
+  // Choose to not include test_token2 in output.
+  output.FormattedText(stream, false, [](const TokenInfo& t) {
+    return t.text() != "test_token2";
+  });
+  const char expected[] = R"(test_token1  test_token3)";
+  EXPECT_EQ(expected, stream.str());
+}
+
 // Make sure that formatting methods all handle the empty tokens case.
 TEST_F(UnwrappedLineTest, FormattedTextPreserveSpacesNoTokens) {
   const std::vector<TokenInfo> tokens;

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -162,6 +162,7 @@ cc_library(
         "//verilog/analysis:verilog_equivalence",
         "//verilog/parser:verilog_token_enum",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
     ],
 )
 

--- a/verilog/formatting/comment_controls.h
+++ b/verilog/formatting/comment_controls.h
@@ -46,7 +46,8 @@ verible::ByteOffsetSet EnabledLinesToDisabledByteRanges(
 // Output is written to 'stream'.
 void FormatWhitespaceWithDisabledByteRanges(
     absl::string_view text_base, absl::string_view space_text,
-    const verible::ByteOffsetSet& disabled_ranges, std::ostream& stream);
+    const verible::ByteOffsetSet& disabled_ranges, bool include_disabled_ranges,
+    std::ostream& stream);
 
 }  // namespace formatter
 }  // namespace verilog

--- a/verilog/formatting/comment_controls_test.cc
+++ b/verilog/formatting/comment_controls_test.cc
@@ -322,8 +322,9 @@ struct FormatWhitespaceTestCase {
 TEST(FormatWhitespaceWithDisabledByteRangesTest, InvalidSubstring) {
   const absl::string_view foo("foo"), bar("bar");
   std::ostringstream stream;
-  EXPECT_DEATH(FormatWhitespaceWithDisabledByteRanges(foo, bar, {}, stream),
-               "IsSubRange");
+  EXPECT_DEATH(
+      FormatWhitespaceWithDisabledByteRanges(foo, bar, {}, true, stream),
+      "IsSubRange");
 }
 
 TEST(FormatWhitespaceWithDisabledByteRangesTest, EmptyStrings) {
@@ -382,7 +383,7 @@ TEST(FormatWhitespaceWithDisabledByteRangesTest, EmptyStrings) {
         test.substring_range.first,
         test.substring_range.second - test.substring_range.first);
     FormatWhitespaceWithDisabledByteRanges(test.full_text, substr,
-                                           test.disabled_ranges, stream);
+                                           test.disabled_ranges, true, stream);
     EXPECT_EQ(stream.str(), test.expected)
         << "text: \"" << test.full_text << "\", sub: \"" << substr
         << "\", disabled: " << test.disabled_ranges;

--- a/verilog/formatting/formatter.h
+++ b/verilog/formatting/formatter.h
@@ -20,6 +20,7 @@
 
 #include "absl/status/status.h"
 #include "common/strings/position.h"
+#include "common/text/text_structure.h"
 #include "verilog/formatting/format_style.h"
 
 namespace verilog {
@@ -73,6 +74,28 @@ absl::Status FormatVerilog(absl::string_view text, absl::string_view filename,
                            std::ostream& formatted_stream,
                            const verible::LineNumberSet& lines = {},
                            const ExecutionControl& control = {});
+
+// Format only lines in line_range interval [min, max) in "full_content"
+// using "style". Emits _only_ the formatted code in the range
+// to "formatted_stream".
+// Used for interactive formatting, e.g. in editors and does not do convergence
+// tests.
+absl::Status FormatVerilogRange(absl::string_view full_content,
+                                absl::string_view filename,
+                                const FormatStyle& style,
+                                std::ostream& formatted_stream,
+                                const verible::Interval<int>& line_range,
+                                const ExecutionControl& control = {});
+
+// Format and emit only lines in "line_range" interval [min, max) from
+// text_structure using "style". Emits _only_ the formatted code in the range
+// to "formatted_stream".
+// Used for interactive formatting, e.g. in editors.
+absl::Status FormatVerilogRange(const verible::TextStructureView& structure,
+                                const FormatStyle& style,
+                                std::ostream& formatted_stream,
+                                const verible::Interval<int>& line_range,
+                                const ExecutionControl& control = {});
 
 }  // namespace formatter
 }  // namespace verilog

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -12031,21 +12031,14 @@ TEST(FormatterEndToEndTest, FunctionCallsWithComments) {
 
 // first consecutive non-whitespace part of string.
 absl::string_view firstWord(absl::string_view str) {
-  const char* const end = str.data() + str.length();
-  const char* start_word = str.data();
-  while (start_word < end && isspace(*start_word)) start_word++;
-  const char* end_word = start_word;
-  while (end_word < end && !isspace(*end_word)) end_word++;
-  return absl::string_view(start_word, end_word - start_word);
+  return *absl::StrSplit(str, absl::ByAnyChar(" \t\n"), absl::SkipWhitespace())
+              .begin();
 }
 
 absl::string_view lastWord(absl::string_view str) {
-  const char* const begin = str.data();
-  const char* end_word = str.data() + str.length() - 1;
-  while (end_word > begin && isspace(*end_word)) end_word--;
-  const char* start_word = end_word;
-  while (start_word > begin && !isspace(*start_word)) start_word--;
-  return absl::string_view(start_word + 1, end_word - start_word);
+  std::vector<absl::string_view> words =
+      absl::StrSplit(str, absl::ByAnyChar(" \t\n"), absl::SkipWhitespace());
+  return words.back();
 }
 
 TEST(FormatterEndToEndTest, RangeFormattingOnlyEmittingRelevantLines) {


### PR DESCRIPTION
emits a range of lines.

This is needed for use in the language server that generally only
requests a user-requested sub-set of lines to be formatted.

We can't just use the regular FormatVerilog() with a sub-range,
as it is not possible to determine which of the formatted output
lines correspond to the original region, hence we need a function
that _only_ outputs the code from the original region.

Signed-off-by: Henner Zeller <h.zeller@acm.org>