### PR TITLE
Add full-file formatting in the language server.

### DIFF
--- a/verilog/formatting/formatter.h
+++ b/verilog/formatting/formatter.h
@@ -69,9 +69,18 @@ struct ExecutionControl {
 // Formats Verilog/SystemVerilog source code.
 // 'lines' controls which lines have formattting explicitly enabled.
 // If this is empty, interpret as all lines enabled for formatting.
+// Does verification of the resulting format (re-parse and compare) and
+// convergence test (if enabled in "control")
 absl::Status FormatVerilog(absl::string_view text, absl::string_view filename,
                            const FormatStyle& style,
                            std::ostream& formatted_stream,
+                           const verible::LineNumberSet& lines = {},
+                           const ExecutionControl& control = {});
+// Ditto, but with TextStructureView as input and std::string as output.
+// This does verification of the resulting format, but _no_ convergence test.
+absl::Status FormatVerilog(const verible::TextStructureView& text_structure,
+                           absl::string_view filename, const FormatStyle& style,
+                           std::string* formatted_text,
                            const verible::LineNumberSet& lines = {},
                            const ExecutionControl& control = {});
 
@@ -86,11 +95,7 @@ absl::Status FormatVerilogRange(absl::string_view full_content,
                                 std::ostream& formatted_stream,
                                 const verible::Interval<int>& line_range,
                                 const ExecutionControl& control = {});
-
-// Format and emit only lines in "line_range" interval [min, max) from
-// text_structure using "style". Emits _only_ the formatted code in the range
-// to "formatted_stream".
-// Used for interactive formatting, e.g. in editors.
+// Ditto, with TextStructureView as input.
 absl::Status FormatVerilogRange(const verible::TextStructureView& structure,
                                 const FormatStyle& style,
                                 std::ostream& formatted_stream,

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -38,7 +38,6 @@ cc_library(
         "//verilog/analysis:verilog_linter",
         "//verilog/parser:verilog_token_enum",
         "//verilog/formatting:formatter",
-        "//verilog/formatting:format_style",
         "//verilog/formatting:format_style_init",
         "@jsonhpp",
     ],

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -35,6 +35,7 @@ static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
 ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
                            absl::string_view content)
     : version_(version),
+      uri_(uri),
       parser_(verilog::VerilogAnalyzer::AnalyzeAutomaticMode(content, uri)) {
   std::cerr << "Analyzed " << uri << " lex:" << parser_->LexStatus()
             << "; parser:" << parser_->ParseStatus() << std::endl;

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -49,9 +49,11 @@ class ParsedBuffer {
   }
 
   int64_t version() const { return version_; }
+  const std::string &uri() const { return uri_; }
 
  private:
   const int64_t version_;
+  const std::string uri_;
   std::unique_ptr<verilog::VerilogAnalyzer> parser_;
   std::vector<verible::LintRuleStatus> lint_statuses_;
 };

--- a/verilog/tools/ls/verible-lsp-adapter.h
+++ b/verilog/tools/ls/verible-lsp-adapter.h
@@ -51,7 +51,7 @@ std::vector<verible::lsp::DocumentHighlight> CreateHighlightRanges(
     const BufferTracker *tracker,
     const verible::lsp::DocumentHighlightParams &p);
 
-// Format given range (or whole document) and emit and edit.
+// Format given range (or whole document) and emit an edit.
 std::vector<verible::lsp::TextEdit> FormatRange(
     const BufferTracker *tracker,
     const verible::lsp::DocumentFormattingParams &p);

--- a/verilog/tools/ls/verible-verilog-ls_test.sh
+++ b/verilog/tools/ls/verible-verilog-ls_test.sh
@@ -67,6 +67,7 @@ awk '/^{/ { printf("Content-Length: %d\r\n\r\n%s", length($0), $0)}' > ${TMP_IN}
 {"jsonrpc":"2.0", "id":31, "method":"textDocument/rangeFormatting","params":{"textDocument":{"uri":"file://fmt.sv"},"range":{"start":{"line":1,"character":0},"end":{"line":1,"character":1}}}}
 {"jsonrpc":"2.0", "id":32, "method":"textDocument/rangeFormatting","params":{"textDocument":{"uri":"file://fmt.sv"},"range":{"start":{"line":2,"character":0},"end":{"line":2,"character":1}}}}
 {"jsonrpc":"2.0", "id":33, "method":"textDocument/rangeFormatting","params":{"textDocument":{"uri":"file://fmt.sv"},"range":{"start":{"line":1,"character":0},"end":{"line":3,"character":0}}}}
+{"jsonrpc":"2.0", "id":34, "method":"textDocument/formatting","params":{"textDocument":{"uri":"file://fmt.sv"}}}
 
 {"jsonrpc":"2.0", "id":100, "method":"shutdown","params":{}}
 EOF
@@ -201,6 +202,15 @@ cat > "${JSON_EXPECTED}" <<EOF
        "result": [
            {"newText":"  assign a = 1;\n  assign b = 2;\nendmodule\n","range":{"end":{"character":0,"line":3},"start":{"character":0,"line":1}}}
         ]
+    }
+  },
+  {
+    "json_contains":{
+       "id":34,
+       "result": [{
+           "newText": "module fmt ();\n  assign a = 1;\n  assign b = 2;\nendmodule\n",
+           "range":   {"end":{"character":0,"line":3},"start":{"character":0,"line":0}}
+        }]
     }
   },
 

--- a/verilog/tools/ls/verilog_ls.cc
+++ b/verilog/tools/ls/verilog_ls.cc
@@ -63,7 +63,8 @@ static InitializeResult InitializeServer(const nlohmann::json &params) {
       },
       {"codeActionProvider", true},               // Autofixes for lint errors
       {"documentSymbolProvider", true},           // Symbol-outline of file
-      {"documentRangeFormattingProvider", true},  // format selection
+      {"documentRangeFormattingProvider", true},  // Format selection
+      {"documentFormattingProvider", true},       // Full file format
       {"documentHighlightProvider", true},        // Highlight same symbol
   };
 
@@ -160,6 +161,12 @@ int main(int argc, char *argv[]) {
 
   dispatcher.AddRequestHandler(  // format range of file
       "textDocument/rangeFormatting",
+      [&parsed_buffers](const verible::lsp::DocumentFormattingParams &p) {
+        return verilog::FormatRange(
+            parsed_buffers.FindBufferTrackerOrNull(p.textDocument.uri), p);
+      });
+  dispatcher.AddRequestHandler(  // format entire file
+      "textDocument/formatting",
       [&parsed_buffers](const verible::lsp::DocumentFormattingParams &p) {
         return verilog::FormatRange(
             parsed_buffers.FindBufferTrackerOrNull(p.textDocument.uri), p);


### PR DESCRIPTION
For this formatting option, the regular FormatVerilog() is
used that does a validation step over the whole file to make
sure the file is not messed-up accidentally.

For that, factor out the internal part of FormatVerilog() that
takes a text structure (which is what we have available in the
language server) and writes to a string; this is then used in
the original FormatVerilog() that does additional checks.

Signed-off-by: Henner Zeller <h.zeller@acm.org>