### PR TITLE
Calculate Lines() and GetLineColumnMap() lazily once needed.

### DIFF
--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -63,7 +63,7 @@ TextStructureView::~TextStructureView() {
 
 void TextStructureView::Clear() {
   syntax_tree_ = nullptr;
-  lazy_line_info_.valid = false;
+  lazy_lines_info_.valid = false;
   line_token_map_.clear();
   tokens_view_.clear();
   tokens_.clear();
@@ -177,7 +177,7 @@ void TextStructureView::FocusOnSubtreeSpanningSubstring(int left_offset,
   TrimSyntaxTree(left_offset, right_offset);
   TrimTokensToSubstring(left_offset, right_offset);
   TrimContents(left_offset, length);
-  lazy_line_info_.valid = false;
+  lazy_lines_info_.valid = false;
   CalculateFirstTokensPerLine();
   const absl::Status status = InternalConsistencyCheck();
   CHECK(status.ok())
@@ -259,7 +259,7 @@ void TextStructureView::TrimContents(int left_offset, int length) {
   contents_ = contents_.substr(left_offset, length);
 }
 
-const TextStructureView::LineInfo& TextStructureView::LineInfo::Get(
+const TextStructureView::LinesInfo& TextStructureView::LinesInfo::Get(
     absl::string_view contents) {
   if (valid) return *this;
 
@@ -280,7 +280,7 @@ void TextStructureView::RebaseTokensToSuperstring(absl::string_view superstring,
   });
   // Assigning superstring for the sake of maintaining range invariants.
   contents_ = superstring;
-  lazy_line_info_.valid = false;
+  lazy_lines_info_.valid = false;
 }
 
 void TextStructureView::MutateTokens(const LeafMutator& mutator) {

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -44,9 +44,7 @@
 namespace verible {
 
 TextStructureView::TextStructureView(absl::string_view contents)
-    : contents_(contents),
-      lines_(absl::StrSplit(contents_, '\n')),  // SplitLines()
-      line_column_map_(lines_) {
+    : contents_(contents) {
   // more than sufficient memory as number-of-tokens <= bytes-in-file,
   // push_back() should never re-alloc because size <= initial capacity.
   tokens_.reserve(contents.length());
@@ -65,12 +63,11 @@ TextStructureView::~TextStructureView() {
 
 void TextStructureView::Clear() {
   syntax_tree_ = nullptr;
-  line_column_map_.Clear();
+  lazy_line_info_.valid = false;
   line_token_map_.clear();
   tokens_view_.clear();
   tokens_.clear();
   contents_ = contents_.substr(0, 0);  // clear
-  lines_.clear();
 }
 
 static bool TokenLocationLess(const TokenInfo& token, const char* offset) {
@@ -100,7 +97,7 @@ TokenStreamReferenceView TextStructureView::MakeTokenStreamReferenceView() {
 void TextStructureView::CalculateFirstTokensPerLine() {
   line_token_map_.clear();
   auto token_iter = tokens_.cbegin();
-  const auto& offset_map = line_column_map_.GetBeginningOfLineOffsets();
+  const auto& offset_map = GetLineColumnMap().GetBeginningOfLineOffsets();
   for (const auto offset : offset_map) {
     // TODO(fangism): linear search might be as competitive as binary search
     token_iter =
@@ -180,8 +177,7 @@ void TextStructureView::FocusOnSubtreeSpanningSubstring(int left_offset,
   TrimSyntaxTree(left_offset, right_offset);
   TrimTokensToSubstring(left_offset, right_offset);
   TrimContents(left_offset, length);
-  SplitLines();
-  RecalculateLineColumnMap();
+  lazy_line_info_.valid = false;
   CalculateFirstTokensPerLine();
   const absl::Status status = InternalConsistencyCheck();
   CHECK(status.ok())
@@ -263,8 +259,15 @@ void TextStructureView::TrimContents(int left_offset, int length) {
   contents_ = contents_.substr(left_offset, length);
 }
 
-void TextStructureView::SplitLines() {
-  lines_ = absl::StrSplit(contents_, '\n');
+const TextStructureView::LineInfo& TextStructureView::LineInfo::Get(
+    absl::string_view contents) {
+  if (valid) return *this;
+
+  lines = absl::StrSplit(contents, '\n');
+  line_column_map.reset(new LineColumnMap(contents));
+  valid = true;
+
+  return *this;
 }
 
 void TextStructureView::RebaseTokensToSuperstring(absl::string_view superstring,
@@ -277,8 +280,7 @@ void TextStructureView::RebaseTokensToSuperstring(absl::string_view superstring,
   });
   // Assigning superstring for the sake of maintaining range invariants.
   contents_ = superstring;
-  // Re-split lines.
-  SplitLines();
+  lazy_line_info_.valid = false;
 }
 
 void TextStructureView::MutateTokens(const LeafMutator& mutator) {
@@ -359,12 +361,13 @@ absl::Status TextStructureView::FastTokenRangeConsistencyCheck() const {
 
 absl::Status TextStructureView::FastLineRangeConsistencyCheck() const {
   VLOG(2) << __FUNCTION__;
-  if (!lines_.empty()) {
-    if (lines_.front().cbegin() != contents_.cbegin()) {
+  const auto& lines = Lines();
+  if (!lines.empty()) {
+    if (lines.front().cbegin() != contents_.cbegin()) {
       return absl::InternalError(
           "First line does not match beginning of text.");
     }
-    if (lines_.back().cend() != contents_.cend()) {
+    if (lines.back().cend() != contents_.cend()) {
       return absl::InternalError("Last line does not match end of text.");
     }
   }

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -76,7 +76,7 @@ class TextStructureView {
   absl::string_view Contents() const { return contents_; }
 
   const std::vector<absl::string_view>& Lines() const {
-    return lazy_line_info_.Get(contents_).lines;
+    return lazy_lines_info_.Get(contents_).lines;
   }
 
   const ConcreteSyntaxTree& SyntaxTree() const { return syntax_tree_; }
@@ -96,7 +96,7 @@ class TextStructureView {
   TokenStreamReferenceView MakeTokenStreamReferenceView();
 
   const LineColumnMap& GetLineColumnMap() const {
-    return *lazy_line_info_.Get(contents_).line_column_map;
+    return *lazy_lines_info_.Get(contents_).line_column_map;
   }
 
   // Given a byte offset, return the line/column
@@ -169,7 +169,7 @@ class TextStructureView {
   // TokenInfo::right() to calculate byte offsets, useful for diagnostics.
   absl::string_view contents_;
 
-  struct LineInfo {
+  struct LinesInfo {
     bool valid = false;
 
     // Line-by-line view of contents_.
@@ -178,10 +178,10 @@ class TextStructureView {
     // Map to translate byte-offsets to line and column for diagnostics.
     std::unique_ptr<LineColumnMap> line_column_map;
 
-    const LineInfo& Get(absl::string_view contents);
+    const LinesInfo& Get(absl::string_view contents);
   };
   // Mutable as we fill it lazily on request; conceptually the data is const.
-  mutable LineInfo lazy_line_info_;
+  mutable LinesInfo lazy_lines_info_;
 
   // Tokens that constitute the original file (contents_).
   // This should always be terminated with a sentinel EOF token.


### PR DESCRIPTION
This in particular helps performance for expanding subtrees
that frequently rebase tokens.

Signed-off-by: Henner Zeller <h.zeller@acm.org>