### PR TITLE
Use const references instead of const value in range loops.

### DIFF
--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -432,7 +432,7 @@ absl::Status LintWaiverBuilder::ApplyExternalWaivers(
   std::vector<TokenRange> commands = lexer.GetCommandsTokenRanges();
 
   bool all_commands_ok = true;
-  for (const auto c_range : commands) {
+  for (const auto& c_range : commands) {
     const auto command = make_container_range(c_range.begin(), c_range.end());
 
     command_pos = line_map.GetLineColAtOffset(

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -411,7 +411,7 @@ static void CopyTokensAndView(TokenSequence* destination,
                               const TokenViewRange& view_source) {
   // Translate token_view's iterators into array indices, adjusting for the
   // number of pre-existing tokens.
-  for (const auto token_iter : view_source) {
+  for (const auto& token_iter : view_source) {
     view_indices->push_back(destination->size() +
                             std::distance(token_source.begin(), token_iter));
   }

--- a/common/text/token_stream_view.cc
+++ b/common/text/token_stream_view.cc
@@ -38,7 +38,7 @@ void FilterTokenStreamView(const TokenFilterPredicate& keep,
                            const TokenStreamView& src, TokenStreamView* dest) {
   dest->clear();
   dest->reserve(src.size() / 2);  // Estimate size of filtered result.
-  for (const auto iter : src) {
+  for (const auto& iter : src) {
     if (keep(*iter)) {
       dest->push_back(iter);
     }


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>