### PR TITLE
Reduce CHECK()-fails: Make tree utils return pointers to be able to return invalid situations

### DIFF
--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -96,7 +96,7 @@ const SyntaxTreeLeaf& CheckLeafEnum(const SyntaxTreeLeaf& leaf,
 
 namespace internal {
 template <typename S>
-void MustBeCSTSymbolOrNode(S&) {
+void StaticAssertMustBeCSTSymbolOrNode(S&) {
   typedef typename std::remove_const<S>::type base_type;
   static_assert(std::is_same<base_type, Symbol>::value ||
                     std::is_same<base_type, SyntaxTreeNode>::value,
@@ -111,7 +111,7 @@ void MustBeCSTSymbolOrNode(S&) {
 template <typename E, typename S>
 typename match_const<SyntaxTreeNode, S>::type& CheckSymbolAsNode(S& symbol,
                                                                  E node_enum) {
-  internal::MustBeCSTSymbolOrNode(symbol);
+  internal::StaticAssertMustBeCSTSymbolOrNode(symbol);
   return CheckNodeEnum(SymbolCastToNode(symbol), node_enum);
 }
 
@@ -168,34 +168,39 @@ const SyntaxTreeLeaf* CheckOptionalSymbolAsLeaf(const std::nullptr_t& symbol,
 template <typename E, typename S>
 typename match_const<Symbol, S>::type* GetSubtreeAsSymbol(
     S& symbol, E parent_must_be_node_enum, size_t child_position) {
-  internal::MustBeCSTSymbolOrNode(symbol);
-  return CheckNodeEnum(SymbolCastToNode(symbol),
-                       parent_must_be_node_enum)[child_position]
-      .get();
+  internal::StaticAssertMustBeCSTSymbolOrNode(symbol);
+  if (symbol.Kind() != SymbolKind::kNode) return nullptr;
+  auto& node = SymbolCastToNode(symbol);
+  if (node.children().size() <= child_position) return nullptr;
+  return CheckNodeEnum(node, parent_must_be_node_enum)[child_position].get();
 }
 
 // Same as GetSubtreeAsSymbol, but casts the result to a node.
 // S can be {const,non-const}x{Symbol,SyntaxTreeNode}
 // constness is deduced from S and reflected in the return type.
 template <class S, class E>
-typename match_const<SyntaxTreeNode, S>::type& GetSubtreeAsNode(
+typename match_const<SyntaxTreeNode, S>::type* GetSubtreeAsNode(
     S& symbol, E parent_must_be_node_enum, size_t child_position) {
-  internal::MustBeCSTSymbolOrNode(symbol);
-  return SymbolCastToNode(*ABSL_DIE_IF_NULL(
-      GetSubtreeAsSymbol(symbol, parent_must_be_node_enum, child_position)));
+  internal::StaticAssertMustBeCSTSymbolOrNode(symbol);
+  auto* tree =
+      GetSubtreeAsSymbol(symbol, parent_must_be_node_enum, child_position);
+  if (!tree) return nullptr;
+  if (tree->Kind() != SymbolKind::kNode) return nullptr;
+  return &SymbolCastToNode(*tree);
 }
 
 // This variant further checks the returned node's enumeration.
 // S can be {const,non-const}x{Symbol,SyntaxTreeNode}
 // constness is deduced from S and reflected in the return type.
 template <class S, class E>
-typename match_const<SyntaxTreeNode, S>::type& GetSubtreeAsNode(
+typename match_const<SyntaxTreeNode, S>::type* GetSubtreeAsNode(
     S& symbol, E parent_must_be_node_enum, size_t child_position,
     E child_must_be_node_enum) {
-  internal::MustBeCSTSymbolOrNode(symbol);
-  return CheckNodeEnum(
-      GetSubtreeAsNode(symbol, parent_must_be_node_enum, child_position),
-      child_must_be_node_enum);
+  internal::StaticAssertMustBeCSTSymbolOrNode(symbol);
+  auto* tree =
+      GetSubtreeAsNode(symbol, parent_must_be_node_enum, child_position);
+  if (!tree) return nullptr;
+  return &CheckNodeEnum(*tree, child_must_be_node_enum);
 }
 
 // Same as GetSubtreeAsSymbol, but casts the result to a leaf.
@@ -204,7 +209,7 @@ template <class S, class E>
 const SyntaxTreeLeaf* GetSubtreeAsLeaf(const S& symbol,
                                        E parent_must_be_node_enum,
                                        size_t child_position) {
-  internal::MustBeCSTSymbolOrNode(symbol);
+  internal::StaticAssertMustBeCSTSymbolOrNode(symbol);
   const Symbol* subtree =
       GetSubtreeAsSymbol(symbol, parent_must_be_node_enum, child_position);
   if (!subtree) return nullptr;
@@ -214,7 +219,7 @@ const SyntaxTreeLeaf* GetSubtreeAsLeaf(const S& symbol,
 template <class S, class E>
 E GetSubtreeNodeEnum(const S& symbol, E parent_must_be_node_enum,
                      size_t child_position) {
-  internal::MustBeCSTSymbolOrNode(symbol);
+  internal::StaticAssertMustBeCSTSymbolOrNode(symbol);
   return static_cast<E>(
       GetSubtreeAsNode(symbol, parent_must_be_node_enum, child_position)
           .Tag()

--- a/common/text/tree_utils_test.cc
+++ b/common/text/tree_utils_test.cc
@@ -1190,7 +1190,7 @@ TEST(SymbolCastToLeafTest, InvalidInputNode) {
 
 TEST(GetSubtreeAsSymbolTest, OutOfBounds) {
   auto root = TNode(1);
-  EXPECT_DEATH(GetSubtreeAsSymbol(*root, 1, 0), "");
+  EXPECT_EQ(GetSubtreeAsSymbol(*root, 1, 0), nullptr);
 }
 
 TEST(GetSubtreeAsSymbolTest, WrongParentIntegerTag) {
@@ -1414,12 +1414,12 @@ TEST(GetSubtreeAsSymbolTest, ValidAccessAtIndexOne) {
 TEST(GetSubtreeAsNodeTest, ValidatedFoundNodeEnum) {
   auto root = TNode(FakeEnum::kZero, TNode(FakeEnum::kOne));
   const auto& child = GetSubtreeAsNode(*root, FakeEnum::kZero, 0);
-  EXPECT_EQ(FakeEnum(child.Tag().tag), FakeEnum::kOne);
+  EXPECT_EQ(FakeEnum(child->Tag().tag), FakeEnum::kOne);
 }
 
 TEST(GetSubtreeAsNodeTest, GotLeafInsteadOfNode) {
   auto root = TNode(FakeEnum::kZero, Leaf(1, "foo"));
-  EXPECT_DEATH(GetSubtreeAsNode(*root, FakeEnum::kZero, 0), "");
+  EXPECT_EQ(GetSubtreeAsNode(*root, FakeEnum::kZero, 0), nullptr);
 }
 
 TEST(GetSubtreeAsNodeTest, ValidatedFoundNodeEnumChildMatches) {

--- a/verilog/CST/DPI.cc
+++ b/verilog/CST/DPI.cc
@@ -25,7 +25,7 @@ std::vector<verible::TreeSearchMatch> FindAllDPIImports(const Symbol& root) {
   return SearchSyntaxTree(root, NodekDPIImportItem());
 }
 
-const SyntaxTreeNode& GetDPIImportPrototype(const Symbol& symbol) {
+const SyntaxTreeNode* GetDPIImportPrototype(const Symbol& symbol) {
   return GetSubtreeAsNode(symbol, NodeEnum::kDPIImportItem, 5);
 }
 

--- a/verilog/CST/DPI.h
+++ b/verilog/CST/DPI.h
@@ -75,7 +75,7 @@ verible::SymbolPtr MakeDPIImport(T0&& keyword, T1&& spec, T2&& property,
 std::vector<verible::TreeSearchMatch> FindAllDPIImports(const verible::Symbol&);
 
 // Returns the function/task prototype.
-const verible::SyntaxTreeNode& GetDPIImportPrototype(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetDPIImportPrototype(const verible::Symbol&);
 
 }  // namespace verilog
 

--- a/verilog/CST/DPI_test.cc
+++ b/verilog/CST/DPI_test.cc
@@ -120,7 +120,7 @@ TEST(GetDPIImportPrototypeTest, Various) {
           std::vector<TreeSearchMatch> prototypes;
           for (const auto& dpi_import : dpi_imports) {
             prototypes.push_back(TreeSearchMatch{
-                &GetDPIImportPrototype(*dpi_import.match), /* no context */});
+                GetDPIImportPrototype(*dpi_import.match), /* no context */});
           }
           return prototypes;
         });

--- a/verilog/CST/class.h
+++ b/verilog/CST/class.h
@@ -36,10 +36,10 @@ std::vector<verible::TreeSearchMatch> FindAllHierarchyExtensions(
     const verible::Symbol&);
 
 // Returns the full header of a class.
-const verible::SyntaxTreeNode& GetClassHeader(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetClassHeader(const verible::Symbol&);
 
 // Returns the leaf node for class name.
-const verible::SyntaxTreeLeaf& GetClassName(const verible::Symbol&);
+const verible::SyntaxTreeLeaf* GetClassName(const verible::Symbol&);
 
 // Returns the node that spans the extended class name(if exists).
 // e.g from "class my_class extends other_class;" return "other_class".
@@ -52,7 +52,7 @@ const verible::SyntaxTreeNode* GetExtendedClass(const verible::Symbol&);
 const verible::SyntaxTreeLeaf* GetClassEndLabel(const verible::Symbol&);
 
 // Returns the node spanning class's Item list.
-const verible::SyntaxTreeNode& GetClassItemList(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetClassItemList(const verible::Symbol&);
 
 // Returns the identifier from node tagged with kHierarchyExtension.
 // e.g from "instance1.x" => return "x".
@@ -67,7 +67,7 @@ const verible::SyntaxTreeNode* GetParamDeclarationListFromClassDeclaration(
 
 // Returns the node spanning the class constructor body (tagged with
 // kStatementList) from node tagged with kClassConstructor.
-const verible::SyntaxTreeNode& GetClassConstructorStatementList(
+const verible::SyntaxTreeNode* GetClassConstructorStatementList(
     const verible::Symbol& class_constructor);
 
 // Returns the leaf spanning the "new" keyword from class constructor.

--- a/verilog/CST/class_test.cc
+++ b/verilog/CST/class_test.cc
@@ -78,7 +78,7 @@ TEST(GetClassNameTest, ClassName) {
           std::vector<TreeSearchMatch> names;
           for (const auto& decl : decls) {
             const auto& type = GetClassName(*decl.match);
-            names.push_back(TreeSearchMatch{&type, {/* ignored context */}});
+            names.push_back(TreeSearchMatch{type, {/* ignored context */}});
           }
           return names;
         });
@@ -262,8 +262,7 @@ TEST(GetClassConstructorTest, GetConstructorBody) {
           for (const auto& constructor : constructors) {
             const auto& body =
                 GetClassConstructorStatementList(*constructor.match);
-            bodies.emplace_back(
-                TreeSearchMatch{&body, {/* ignored context */}});
+            bodies.emplace_back(TreeSearchMatch{body, {/* ignored context */}});
           }
           return bodies;
         });

--- a/verilog/CST/declaration.cc
+++ b/verilog/CST/declaration.cc
@@ -83,7 +83,7 @@ std::vector<verible::TreeSearchMatch> FindAllVariableDeclarationAssignment(
 }
 
 // Don't want to expose kInstantiationBase because it is an artificial grouping.
-static const SyntaxTreeNode& GetInstantiationBaseFromDataDeclaration(
+static const SyntaxTreeNode* GetInstantiationBaseFromDataDeclaration(
     const Symbol& data_declaration) {
   return GetSubtreeAsNode(data_declaration, NodeEnum::kDataDeclaration, 1,
                           NodeEnum::kInstantiationBase);
@@ -96,25 +96,26 @@ const SyntaxTreeNode* GetQualifiersOfDataDeclaration(
   return verible::CheckOptionalSymbolAsNode(quals, NodeEnum::kQualifierList);
 }
 
-const SyntaxTreeNode& GetInstantiationTypeOfDataDeclaration(
+const SyntaxTreeNode* GetInstantiationTypeOfDataDeclaration(
     const Symbol& data_declaration) {
-  return GetSubtreeAsNode(
-      GetInstantiationBaseFromDataDeclaration(data_declaration),
-      NodeEnum::kInstantiationBase, 0);
+  const auto* base = GetInstantiationBaseFromDataDeclaration(data_declaration);
+  if (!base) return nullptr;
+  return GetSubtreeAsNode(*base, NodeEnum::kInstantiationBase, 0);
 }
 
-const SyntaxTreeNode& GetInstanceListFromDataDeclaration(
+const SyntaxTreeNode* GetInstanceListFromDataDeclaration(
     const Symbol& data_declaration) {
-  return GetSubtreeAsNode(
-      GetInstantiationBaseFromDataDeclaration(data_declaration),
-      NodeEnum::kInstantiationBase, 1);
+  const auto* base = GetInstantiationBaseFromDataDeclaration(data_declaration);
+  if (!base) return nullptr;
+  return GetSubtreeAsNode(*base, NodeEnum::kInstantiationBase, 1);
 }
 
 const verible::SyntaxTreeNode* GetParamListFromDataDeclaration(
     const verible::Symbol& data_declaration) {
-  const SyntaxTreeNode& instantiation_type =
+  const SyntaxTreeNode* instantiation_type =
       GetInstantiationTypeOfDataDeclaration(data_declaration);
-  return GetParamListFromInstantiationType(instantiation_type);
+  if (!instantiation_type) return nullptr;
+  return GetParamListFromInstantiationType(*instantiation_type);
 }
 
 const verible::TokenInfo& GetModuleInstanceNameTokenInfoFromGateInstance(
@@ -133,7 +134,7 @@ const verible::TokenInfo& GetInstanceNameTokenInfoFromRegisterVariable(
   return ABSL_DIE_IF_NULL(instance_name)->get();
 }
 
-const verible::SyntaxTreeNode& GetParenGroupFromModuleInstantiation(
+const verible::SyntaxTreeNode* GetParenGroupFromModuleInstantiation(
     const verible::Symbol& gate_instance) {
   return GetSubtreeAsNode(gate_instance, NodeEnum::kGateInstance, 2,
                           NodeEnum::kParenGroup);
@@ -174,23 +175,24 @@ const verible::SyntaxTreeNode* GetTrailingExpressionFromRegisterVariable(
 
 const verible::SyntaxTreeNode* GetPackedDimensionFromDataDeclaration(
     const verible::Symbol& data_declaration) {
-  const verible::SyntaxTreeNode& instantiation_type =
+  const verible::SyntaxTreeNode* instantiation_type =
       GetInstantiationTypeOfDataDeclaration(data_declaration);
+  if (!instantiation_type) return nullptr;
   const verible::Symbol* data_type = verible::GetSubtreeAsSymbol(
-      instantiation_type, NodeEnum::kInstantiationType, 0);
+      *instantiation_type, NodeEnum::kInstantiationType, 0);
   if (data_type == nullptr) return nullptr;
 
   return GetPackedDimensionFromDataType(*data_type);
 }
 
-const verible::SyntaxTreeNode& GetUnpackedDimensionFromRegisterVariable(
+const verible::SyntaxTreeNode* GetUnpackedDimensionFromRegisterVariable(
     const verible::Symbol& register_variable) {
   return verible::GetSubtreeAsNode(register_variable,
                                    NodeEnum::kRegisterVariable, 1,
                                    NodeEnum::kUnpackedDimensions);
 }
 
-const verible::SyntaxTreeNode&
+const verible::SyntaxTreeNode*
 GetUnpackedDimensionFromVariableDeclarationAssign(
     const verible::Symbol& variable_declaration_assign) {
   return verible::GetSubtreeAsNode(variable_declaration_assign,
@@ -200,26 +202,27 @@ GetUnpackedDimensionFromVariableDeclarationAssign(
 
 const verible::Symbol* GetTypeIdentifierFromDataDeclaration(
     const verible::Symbol& data_declaration) {
-  const SyntaxTreeNode& instantiation_type =
+  const SyntaxTreeNode* instantiation_type =
       GetInstantiationTypeOfDataDeclaration(data_declaration);
-
+  if (!instantiation_type) return nullptr;
   const verible::Symbol* identifier =
-      GetTypeIdentifierFromInstantiationType(instantiation_type);
+      GetTypeIdentifierFromInstantiationType(*instantiation_type);
   if (identifier != nullptr) {
     return identifier;
   }
 
   const verible::Symbol* base_type =
-      GetBaseTypeFromInstantiationType(instantiation_type);
+      GetBaseTypeFromInstantiationType(*instantiation_type);
   if (base_type == nullptr) return nullptr;
   return GetTypeIdentifierFromBaseType(*base_type);
 }
 
 const verible::SyntaxTreeNode* GetStructOrUnionOrEnumTypeFromDataDeclaration(
     const verible::Symbol& data_declaration) {
-  const SyntaxTreeNode& instantiation_type =
+  const SyntaxTreeNode* instantiation_type =
       GetInstantiationTypeOfDataDeclaration(data_declaration);
-  return GetStructOrUnionOrEnumTypeFromInstantiationType(instantiation_type);
+  if (!instantiation_type) return nullptr;
+  return GetStructOrUnionOrEnumTypeFromInstantiationType(*instantiation_type);
 }
 
 }  // namespace verilog

--- a/verilog/CST/declaration.h
+++ b/verilog/CST/declaration.h
@@ -93,11 +93,6 @@ std::vector<verible::TreeSearchMatch> FindAllGateInstances(
 std::vector<verible::TreeSearchMatch> FindAllVariableDeclarationAssignment(
     const verible::Symbol&);
 
-// Returns node tagged with unqualified id from node tagged with
-// kReferenceCallBase.
-const verible::SyntaxTreeNode& GetUnqualifiedIdFromReferenceCallBase(
-    const verible::Symbol&);
-
 // For a given data declaration (includes module instantiation), returns the
 // subtree containing qualifiers.  e.g. from "const foo bar, baz;",
 // this returns the subtree spanning "const".  Returns nullptr if there
@@ -110,7 +105,7 @@ const verible::SyntaxTreeNode* GetQualifiersOfDataDeclaration(
 // this returns the subtree spanning "foo #(...)".
 // It is possible for type to be implicit, in which case, the node
 // will be an empty subtree.
-const verible::SyntaxTreeNode& GetInstantiationTypeOfDataDeclaration(
+const verible::SyntaxTreeNode* GetInstantiationTypeOfDataDeclaration(
     const verible::Symbol& data_declaration);
 
 // For a given data declaration returns the node spanning param declaration
@@ -121,12 +116,12 @@ const verible::SyntaxTreeNode* GetParamListFromDataDeclaration(
 // For a given data declaration (includes module instantiation), returns the
 // subtree containing instances.  e.g. from "foo bar..., baz...;",
 // this returns the subtree spanning "bar..., baz..."
-const verible::SyntaxTreeNode& GetInstanceListFromDataDeclaration(
+const verible::SyntaxTreeNode* GetInstanceListFromDataDeclaration(
     const verible::Symbol& data_declaration);
 
 // For a given module gate instance return the node spanning the paren group.
 // e.g "module_type instance(a, b, c)" return the node spanning "(a, b, c)".
-const verible::SyntaxTreeNode& GetParenGroupFromModuleInstantiation(
+const verible::SyntaxTreeNode* GetParenGroupFromModuleInstantiation(
     const verible::Symbol& gate_instance);
 
 // For a given gate instance subtree returns the TokenInfo of the module name.
@@ -162,12 +157,12 @@ const verible::SyntaxTreeNode* GetPackedDimensionFromDataDeclaration(
     const verible::Symbol& data_declaration);
 
 // Extracts kUnpackedDimensions node from nodes tagged with kRegisterVariable.
-const verible::SyntaxTreeNode& GetUnpackedDimensionFromRegisterVariable(
+const verible::SyntaxTreeNode* GetUnpackedDimensionFromRegisterVariable(
     const verible::Symbol& register_variable);
 
 // Extracts kUnpackedDimensions node from nodes tagged with
 // kVariableDeclarationAssign.
-const verible::SyntaxTreeNode&
+const verible::SyntaxTreeNode*
 GetUnpackedDimensionFromVariableDeclarationAssign(
     const verible::Symbol& variable_declaration_assign);
 

--- a/verilog/CST/declaration_test.cc
+++ b/verilog/CST/declaration_test.cc
@@ -221,7 +221,7 @@ TEST(FindAllGateInstancesTest, FindArgumentListOfGateInstance) {
             const auto& paren_group =
                 GetParenGroupFromModuleInstantiation(*decl.match);
             paren_groups.emplace_back(
-                TreeSearchMatch{&paren_group, {/* ignored context */}});
+                TreeSearchMatch{paren_group, {/* ignored context */}});
           }
           return paren_groups;
         });
@@ -342,7 +342,7 @@ TEST(GetTypeOfDataDeclarationTest, ExplicitTypes) {
           for (const auto& decl : decls) {
             const auto& type =
                 GetInstantiationTypeOfDataDeclaration(*decl.match);
-            types.emplace_back(TreeSearchMatch{&type, {/* ignored context */}});
+            types.emplace_back(TreeSearchMatch{type, {/* ignored context */}});
           }
           return types;
         });
@@ -492,7 +492,7 @@ TEST(GetInstanceListFromDataDeclarationTest, InstanceLists) {
           for (const auto& decl : decls) {
             const auto& insts = GetInstanceListFromDataDeclaration(*decl.match);
             inst_lists.push_back(
-                TreeSearchMatch{&insts, {/* ignored context */}});
+                TreeSearchMatch{insts, {/* ignored context */}});
           }
 
           return inst_lists;
@@ -794,7 +794,7 @@ TEST(GetVariableDeclarationAssign,
             const auto& unpacked_dimension =
                 GetUnpackedDimensionFromVariableDeclarationAssign(*decl.match);
             unpacked_dimensions.emplace_back(
-                TreeSearchMatch{&unpacked_dimension, {/* ignored context */}});
+                TreeSearchMatch{unpacked_dimension, {/* ignored context */}});
           }
           return unpacked_dimensions;
         });
@@ -854,7 +854,7 @@ TEST(FindAllRegisterVariablesTest, FindUnpackedDimensionOfRegisterVariable) {
             const auto& unpacked_dimension =
                 GetUnpackedDimensionFromRegisterVariable(*decl.match);
             unpacked_dimensions.emplace_back(
-                TreeSearchMatch{&unpacked_dimension, {/* ignored context */}});
+                TreeSearchMatch{unpacked_dimension, {/* ignored context */}});
           }
           return unpacked_dimensions;
         });

--- a/verilog/CST/functions.cc
+++ b/verilog/CST/functions.cc
@@ -58,12 +58,12 @@ std::vector<verible::TreeSearchMatch> FindAllFunctionOrTaskCallsExtension(
   return verible::SearchSyntaxTree(root, NodekMethodCallExtension());
 }
 
-const verible::SyntaxTreeNode& GetFunctionHeader(const Symbol& function_decl) {
+const verible::SyntaxTreeNode* GetFunctionHeader(const Symbol& function_decl) {
   return GetSubtreeAsNode(function_decl, NodeEnum::kFunctionDeclaration, 0,
                           NodeEnum::kFunctionHeader);
 }
 
-const verible::SyntaxTreeNode& GetFunctionPrototypeHeader(
+const verible::SyntaxTreeNode* GetFunctionPrototypeHeader(
     const Symbol& function_decl) {
   return GetSubtreeAsNode(function_decl, NodeEnum::kFunctionPrototype, 0,
                           NodeEnum::kFunctionHeader);
@@ -86,23 +86,23 @@ const Symbol* GetFunctionHeaderFormalPortsGroup(const Symbol& function_header) {
 }
 
 const Symbol* GetFunctionLifetime(const Symbol& function_decl) {
-  const auto& header = GetFunctionHeader(function_decl);
-  return GetFunctionHeaderLifetime(header);
+  const auto* header = GetFunctionHeader(function_decl);
+  return header ? GetFunctionHeaderLifetime(*header) : nullptr;
 }
 
 const Symbol* GetFunctionReturnType(const Symbol& function_decl) {
-  const auto& header = GetFunctionHeader(function_decl);
-  return GetFunctionHeaderReturnType(header);
+  const auto* header = GetFunctionHeader(function_decl);
+  return header ? GetFunctionHeaderReturnType(*header) : nullptr;
 }
 
 const Symbol* GetFunctionId(const Symbol& function_decl) {
-  const auto& header = GetFunctionHeader(function_decl);
-  return GetFunctionHeaderId(header);
+  const auto* header = GetFunctionHeader(function_decl);
+  return header ? GetFunctionHeaderId(*header) : nullptr;
 }
 
 const Symbol* GetFunctionFormalPortsGroup(const Symbol& function_decl) {
-  const auto& header = GetFunctionHeader(function_decl);
-  return GetFunctionHeaderFormalPortsGroup(header);
+  const auto* header = GetFunctionHeader(function_decl);
+  return header ? GetFunctionHeaderFormalPortsGroup(*header) : nullptr;
 }
 
 const verible::SyntaxTreeLeaf* GetFunctionName(
@@ -111,7 +111,7 @@ const verible::SyntaxTreeLeaf* GetFunctionName(
   return ABSL_DIE_IF_NULL(GetIdentifier(*function_id));
 }
 
-const verible::SyntaxTreeNode& GetLocalRootFromFunctionCall(
+const verible::SyntaxTreeNode* GetLocalRootFromFunctionCall(
     const verible::Symbol& function_call) {
   return GetSubtreeAsNode(function_call, NodeEnum::kFunctionCall, 0,
                           NodeEnum::kLocalRoot);
@@ -119,47 +119,47 @@ const verible::SyntaxTreeNode& GetLocalRootFromFunctionCall(
 
 const verible::SyntaxTreeNode* GetIdentifiersFromFunctionCall(
     const verible::Symbol& function_call) {
-  const verible::SyntaxTreeNode& local_root = GetSubtreeAsNode(
+  const verible::SyntaxTreeNode* local_root = GetSubtreeAsNode(
       function_call, NodeEnum::kFunctionCall, 0, NodeEnum::kLocalRoot);
-  const verible::Symbol& identifier = GetIdentifiersFromLocalRoot(local_root);
-  if (identifier.Kind() != verible::SymbolKind::kNode) {
-    return nullptr;
-  }
+  if (!local_root) return nullptr;
+  const verible::Symbol& identifier = GetIdentifiersFromLocalRoot(*local_root);
+  if (identifier.Kind() != verible::SymbolKind::kNode) return nullptr;
   return &verible::SymbolCastToNode(identifier);
 }
 
 const verible::SyntaxTreeLeaf* GetFunctionCallName(
     const verible::Symbol& function_call) {
-  const auto& local_root = GetLocalRootFromFunctionCall(function_call);
+  const auto* local_root = GetLocalRootFromFunctionCall(function_call);
+  if (!local_root) return nullptr;
+  const auto* unqualified_id = GetSubtreeAsNode(
+      *local_root, NodeEnum::kLocalRoot, 0, NodeEnum::kUnqualifiedId);
+  if (!unqualified_id) return nullptr;
 
-  const auto& unqualified_id = GetSubtreeAsNode(
-      local_root, NodeEnum::kLocalRoot, 0, NodeEnum::kUnqualifiedId);
-
-  return ABSL_DIE_IF_NULL(GetIdentifier(unqualified_id));
+  return GetIdentifier(*unqualified_id);
 }
 
-const verible::SyntaxTreeLeaf& GetFunctionCallNameFromCallExtension(
+const verible::SyntaxTreeLeaf* GetFunctionCallNameFromCallExtension(
     const verible::Symbol& function_call) {
-  const auto& unqualified_id =
+  const auto* unqualified_id =
       GetSubtreeAsNode(function_call, NodeEnum::kMethodCallExtension, 1,
                        NodeEnum::kUnqualifiedId);
-
-  return *ABSL_DIE_IF_NULL(GetIdentifier(unqualified_id));
+  if (!unqualified_id) return nullptr;
+  return GetIdentifier(*unqualified_id);
 }
 
-const verible::SyntaxTreeNode& GetFunctionBlockStatementList(
+const verible::SyntaxTreeNode* GetFunctionBlockStatementList(
     const verible::Symbol& function_decl) {
   return verible::GetSubtreeAsNode(function_decl,
                                    NodeEnum::kFunctionDeclaration, 2);
 }
 
-const verible::SyntaxTreeNode& GetParenGroupFromCall(
+const verible::SyntaxTreeNode* GetParenGroupFromCall(
     const verible::Symbol& function_call) {
   return verible::GetSubtreeAsNode(function_call, NodeEnum::kFunctionCall, 1,
                                    NodeEnum::kParenGroup);
 }
 
-const verible::SyntaxTreeNode& GetParenGroupFromCallExtension(
+const verible::SyntaxTreeNode* GetParenGroupFromCallExtension(
     const verible::Symbol& function_call) {
   return verible::GetSubtreeAsNode(
       function_call, NodeEnum::kMethodCallExtension, 2, NodeEnum::kParenGroup);

--- a/verilog/CST/functions.h
+++ b/verilog/CST/functions.h
@@ -105,11 +105,11 @@ std::vector<verible::TreeSearchMatch> FindAllFunctionOrTaskCallsExtension(
     const verible::Symbol&);
 
 // Returns the function declaration header (return type, id, ports)
-const verible::SyntaxTreeNode& GetFunctionHeader(
+const verible::SyntaxTreeNode* GetFunctionHeader(
     const verible::Symbol& function_decl);
 
 // Returns the function prototype header (return type, id, ports)
-const verible::SyntaxTreeNode& GetFunctionPrototypeHeader(
+const verible::SyntaxTreeNode* GetFunctionPrototypeHeader(
     const verible::Symbol& function_decl);
 
 // FunctionHeader accessors
@@ -152,7 +152,7 @@ const verible::Symbol* GetFunctionId(const verible::Symbol& function_decl);
 const verible::SyntaxTreeLeaf* GetFunctionName(const verible::Symbol&);
 
 // Returns local root node from node tagged with kFunctionCall.
-const verible::SyntaxTreeNode& GetLocalRootFromFunctionCall(
+const verible::SyntaxTreeNode* GetLocalRootFromFunctionCall(
     const verible::Symbol&);
 
 // Return the node spanning identifier for the function call node.
@@ -166,20 +166,20 @@ const verible::SyntaxTreeLeaf* GetFunctionCallName(const verible::Symbol&);
 
 // Returns leaf node for function name in function call extension.
 // e.g class_name.my_function(); return leaf node for "my_function".
-const verible::SyntaxTreeLeaf& GetFunctionCallNameFromCallExtension(
+const verible::SyntaxTreeLeaf* GetFunctionCallNameFromCallExtension(
     const verible::Symbol&);
 
 // Returns the function declaration body.
-const verible::SyntaxTreeNode& GetFunctionBlockStatementList(
+const verible::SyntaxTreeNode* GetFunctionBlockStatementList(
     const verible::Symbol&);
 
 // Return the node spanning the paren group of function call.
 // e.g my_function(a, b, c) return the node spanning (a, b, c).
-const verible::SyntaxTreeNode& GetParenGroupFromCall(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetParenGroupFromCall(const verible::Symbol&);
 
 // Return the node spanning the paren group of function call extension.
 // e.g my_class.my_function(a, b, c) return the node spanning (a, b, c).
-const verible::SyntaxTreeNode& GetParenGroupFromCallExtension(
+const verible::SyntaxTreeNode* GetParenGroupFromCallExtension(
     const verible::Symbol&);
 
 }  // namespace verilog

--- a/verilog/CST/functions_test.cc
+++ b/verilog/CST/functions_test.cc
@@ -169,7 +169,7 @@ TEST(FindAllFunctionPrototypesTest, Various) {
           std::vector<TreeSearchMatch> headers;
           for (const auto& proto : protos) {
             headers.push_back(TreeSearchMatch{
-                &GetFunctionPrototypeHeader(*proto.match), /* no context */});
+                GetFunctionPrototypeHeader(*proto.match), /* no context */});
           }
           return headers;
         });
@@ -210,7 +210,7 @@ TEST(FunctionPrototypesReturnTypesTest, Various) {
           std::vector<TreeSearchMatch> returns;
           for (const auto& proto : protos) {
             const auto* return_type = GetFunctionHeaderReturnType(
-                GetFunctionPrototypeHeader(*proto.match));
+                *GetFunctionPrototypeHeader(*proto.match));
             if (return_type == nullptr) continue;
             if (verible::StringSpanOfSymbol(*return_type).empty()) continue;
             returns.push_back(TreeSearchMatch{return_type, /* no context */});
@@ -258,7 +258,7 @@ TEST(FunctionPrototypesIdsTest, Various) {
           std::vector<TreeSearchMatch> ids;
           for (const auto& proto : protos) {
             const auto* id =
-                GetFunctionHeaderId(GetFunctionPrototypeHeader(*proto.match));
+                GetFunctionHeaderId(*GetFunctionPrototypeHeader(*proto.match));
             if (id == nullptr) continue;
             if (verible::StringSpanOfSymbol(*id).empty()) continue;
             ids.push_back(TreeSearchMatch{id, /* no context */});
@@ -353,7 +353,7 @@ TEST(GetFunctionHeaderTest, DeclarationHeader) {
           std::vector<TreeSearchMatch> headers;
           for (const auto& decl : function_declarations) {
             const auto& function_node = SymbolCastToNode(*decl.match);
-            headers.push_back(TreeSearchMatch{&GetFunctionHeader(function_node),
+            headers.push_back(TreeSearchMatch{GetFunctionHeader(function_node),
                                               /* no context */});
           }
           return headers;
@@ -624,7 +624,7 @@ TEST(GetFunctionHeaderTest, GetFunctionClassCallName) {
           for (const auto& Call : calls) {
             const auto& name =
                 GetFunctionCallNameFromCallExtension(*Call.match);
-            names.emplace_back(TreeSearchMatch{&name, {/* ignored context */}});
+            names.emplace_back(TreeSearchMatch{name, {/* ignored context */}});
           }
           return names;
         });
@@ -672,7 +672,7 @@ TEST(GetFunctionBlockStatement, GetFunctionBody) {
           for (const auto& decl : decls) {
             const auto& body = GetFunctionBlockStatementList(*decl.match);
             functions_body.push_back(
-                TreeSearchMatch{&body, {/* ignored context */}});
+                TreeSearchMatch{body, {/* ignored context */}});
           }
           return functions_body;
         });
@@ -739,7 +739,7 @@ TEST(FunctionCallTest, GetFunctionCallArguments) {
           for (const auto& decl : instances) {
             const auto& paren_group = GetParenGroupFromCall(*decl.match);
             paren_groups.emplace_back(
-                TreeSearchMatch{&paren_group, {/* ignored context */}});
+                TreeSearchMatch{paren_group, {/* ignored context */}});
           }
           return paren_groups;
         });
@@ -772,7 +772,7 @@ TEST(FunctionCallTest, GetFunctionCallExtensionArguments) {
             const auto& paren_group =
                 GetParenGroupFromCallExtension(*decl.match);
             paren_groups.emplace_back(
-                TreeSearchMatch{&paren_group, {/* ignored context */}});
+                TreeSearchMatch{paren_group, {/* ignored context */}});
           }
           return paren_groups;
         });

--- a/verilog/CST/macro.cc
+++ b/verilog/CST/macro.cc
@@ -62,13 +62,15 @@ const TokenInfo& GetMacroGenericItemId(const Symbol& s) {
       ->get();
 }
 
-const SyntaxTreeNode& GetMacroCallParenGroup(const Symbol& s) {
+const SyntaxTreeNode* GetMacroCallParenGroup(const Symbol& s) {
   return GetSubtreeAsNode(s, NodeEnum::kMacroCall, 1, NodeEnum::kParenGroup);
 }
 
-const SyntaxTreeNode& GetMacroCallArgs(const Symbol& s) {
+const SyntaxTreeNode* GetMacroCallArgs(const Symbol& s) {
   // See structure of (CST) MakeParenGroup().
-  return GetSubtreeAsNode(GetMacroCallParenGroup(s), NodeEnum::kParenGroup, 1,
+  const SyntaxTreeNode* parent = GetMacroCallParenGroup(s);
+  if (!parent) return nullptr;
+  return GetSubtreeAsNode(*parent, NodeEnum::kParenGroup, 1,
                           NodeEnum::kMacroArgList);
 }
 

--- a/verilog/CST/macro.h
+++ b/verilog/CST/macro.h
@@ -55,10 +55,10 @@ const verible::TokenInfo& GetMacroCallId(const verible::Symbol&);
 const verible::TokenInfo& GetMacroGenericItemId(const verible::Symbol&);
 
 // Returns the node containing the macro call paren group
-const verible::SyntaxTreeNode& GetMacroCallParenGroup(const verible::Symbol& s);
+const verible::SyntaxTreeNode* GetMacroCallParenGroup(const verible::Symbol& s);
 
 // Returns the node containing the macro call arguments (without parentheses).
-const verible::SyntaxTreeNode& GetMacroCallArgs(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetMacroCallArgs(const verible::Symbol&);
 
 // Returns true if there are no macro call args, e.g. `foo().
 bool MacroCallArgsIsEmpty(const verible::SyntaxTreeNode&);

--- a/verilog/CST/macro_test.cc
+++ b/verilog/CST/macro_test.cc
@@ -134,9 +134,9 @@ TEST(MacroCallArgsTest, Emptiness) {
     const auto& root = analyzer.Data().SyntaxTree();
     const auto macro_calls = FindAllMacroCalls(*ABSL_DIE_IF_NULL(root));
     ASSERT_FALSE(macro_calls.empty());
-    const auto& args = GetMacroCallArgs(*macro_calls.front().match);
-    EXPECT_EQ(MacroCallArgsIsEmpty(args), test.expect_empty) << "code:\n"
-                                                             << test.code;
+    const auto* args = GetMacroCallArgs(*macro_calls.front().match);
+    EXPECT_EQ(MacroCallArgsIsEmpty(*args), test.expect_empty) << "code:\n"
+                                                              << test.code;
     // TODO(b/151371397): check exact substrings
   }
 }

--- a/verilog/CST/module.cc
+++ b/verilog/CST/module.cc
@@ -65,7 +65,7 @@ const SyntaxTreeNode& GetModuleHeader(const Symbol& module_declaration) {
   return verible::SymbolCastToNode(*module_node[0].get());
 }
 
-const SyntaxTreeNode& GetInterfaceHeader(const Symbol& module_symbol) {
+const SyntaxTreeNode* GetInterfaceHeader(const Symbol& module_symbol) {
   return verible::GetSubtreeAsNode(module_symbol,
                                    NodeEnum::kInterfaceDeclaration, 0,
                                    NodeEnum::kModuleHeader);
@@ -77,10 +77,10 @@ const verible::SyntaxTreeLeaf* GetModuleName(const Symbol& s) {
 }
 
 const TokenInfo& GetInterfaceNameToken(const Symbol& s) {
-  const auto& header_node = GetInterfaceHeader(s);
-  const verible::SyntaxTreeLeaf* name_leaf =
-      verible::GetSubtreeAsLeaf(header_node, NodeEnum::kModuleHeader, 2);
+  const auto* header_node = GetInterfaceHeader(s);
   // TODO(hzeller): bubble up nullptr.
+  const verible::SyntaxTreeLeaf* name_leaf = verible::GetSubtreeAsLeaf(
+      *ABSL_DIE_IF_NULL(header_node), NodeEnum::kModuleHeader, 2);
   return ABSL_DIE_IF_NULL(name_leaf)->get();
 }
 
@@ -99,8 +99,8 @@ const SyntaxTreeNode* GetModulePortDeclarationList(
       nullptr) {
     return nullptr;
   }
-  return &verible::GetSubtreeAsNode(*paren_group, NodeEnum::kParenGroup, 1,
-                                    NodeEnum::kPortDeclarationList);
+  return verible::GetSubtreeAsNode(*paren_group, NodeEnum::kParenGroup, 1,
+                                   NodeEnum::kPortDeclarationList);
 }
 
 const verible::SyntaxTreeLeaf* GetModuleEndLabel(
@@ -137,9 +137,10 @@ const verible::SyntaxTreeNode* GetParamDeclarationListFromModuleDeclaration(
 
 const verible::SyntaxTreeNode* GetParamDeclarationListFromInterfaceDeclaration(
     const verible::Symbol& interface_declaration) {
-  const auto& header_node = GetInterfaceHeader(interface_declaration);
+  const auto* header_node = GetInterfaceHeader(interface_declaration);
+  if (!header_node) return nullptr;
   const verible::Symbol* param_declaration_list =
-      verible::GetSubtreeAsSymbol(header_node, NodeEnum::kModuleHeader, 4);
+      verible::GetSubtreeAsSymbol(*header_node, NodeEnum::kModuleHeader, 4);
   return verible::CheckOptionalSymbolAsNode(
       param_declaration_list, NodeEnum::kFormalParameterListDeclaration);
 }

--- a/verilog/CST/module.h
+++ b/verilog/CST/module.h
@@ -74,7 +74,7 @@ std::vector<verible::TreeSearchMatch> FindAllProgramDeclarations(
 const verible::SyntaxTreeNode& GetModuleHeader(const verible::Symbol&);
 
 // Returns the full header of an interface (params, ports, etc...).
-const verible::SyntaxTreeNode& GetInterfaceHeader(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetInterfaceHeader(const verible::Symbol&);
 
 // Extract the subnode of a module declaration that is the module name or
 // nullptr if not found.

--- a/verilog/CST/package.cc
+++ b/verilog/CST/package.cc
@@ -38,9 +38,10 @@ std::vector<verible::TreeSearchMatch> FindAllPackageImportItems(
   return SearchSyntaxTree(root, NodekPackageImportItem());
 }
 
-const verible::TokenInfo& GetPackageNameToken(const verible::Symbol& s) {
-  // TODO(hzeller): bubble up nullptr.
-  return ABSL_DIE_IF_NULL(GetPackageNameLeaf(s))->get();
+const verible::TokenInfo* GetPackageNameToken(const verible::Symbol& s) {
+  const auto* package_name = GetPackageNameLeaf(s);
+  if (!package_name) return nullptr;
+  return &GetPackageNameLeaf(s)->get();
 }
 
 const verible::SyntaxTreeLeaf* GetPackageNameLeaf(const verible::Symbol& s) {
@@ -64,7 +65,7 @@ const verible::Symbol* GetPackageItemList(
                                      NodeEnum::kPackageDeclaration, 4);
 }
 
-const verible::SyntaxTreeNode& GetScopePrefixFromPackageImportItem(
+const verible::SyntaxTreeNode* GetScopePrefixFromPackageImportItem(
     const verible::Symbol& package_import_item) {
   return verible::GetSubtreeAsNode(package_import_item,
                                    NodeEnum::kPackageImportItem, 0,
@@ -73,9 +74,9 @@ const verible::SyntaxTreeNode& GetScopePrefixFromPackageImportItem(
 
 const verible::SyntaxTreeLeaf* GetImportedPackageName(
     const verible::Symbol& package_import_item) {
-  return verible::GetSubtreeAsLeaf(
-      GetScopePrefixFromPackageImportItem(package_import_item),
-      NodeEnum::kScopePrefix, 0);
+  const auto* prefix = GetScopePrefixFromPackageImportItem(package_import_item);
+  if (!prefix) return nullptr;
+  return verible::GetSubtreeAsLeaf(*prefix, NodeEnum::kScopePrefix, 0);
 }
 
 const verible::SyntaxTreeLeaf* GeImportedItemNameFromPackageImportItem(

--- a/verilog/CST/package.h
+++ b/verilog/CST/package.h
@@ -35,7 +35,7 @@ std::vector<verible::TreeSearchMatch> FindAllPackageImportItems(
     const verible::Symbol& root);
 
 // Extract the subnode of a package declaration that is the package name.
-const verible::TokenInfo& GetPackageNameToken(const verible::Symbol&);
+const verible::TokenInfo* GetPackageNameToken(const verible::Symbol&);
 
 // Return the node spanning the name of the package.
 const verible::SyntaxTreeLeaf* GetPackageNameLeaf(const verible::Symbol& s);
@@ -51,7 +51,7 @@ const verible::Symbol* GetPackageItemList(
 
 // Extracts the node spanning the ScopePrefix node within PackageImportItem
 // node.
-const verible::SyntaxTreeNode& GetScopePrefixFromPackageImportItem(
+const verible::SyntaxTreeNode* GetScopePrefixFromPackageImportItem(
     const verible::Symbol& package_import_item);
 
 // Extracts package name for package import (node tagged with

--- a/verilog/CST/package_test.cc
+++ b/verilog/CST/package_test.cc
@@ -315,8 +315,7 @@ TEST(GetPackageNameTokenTest, RootIsNotAPackage) {
   EXPECT_OK(analyzer.Analyze());
   const auto& root = analyzer.Data().SyntaxTree();
   // Root node is a description list, not a package.
-  EXPECT_DEATH(GetPackageNameToken(*ABSL_DIE_IF_NULL(root)),
-               "kDescriptionList vs. kPackageDeclaration");
+  EXPECT_EQ(GetPackageNameToken(*ABSL_DIE_IF_NULL(root)), nullptr);
 }
 
 TEST(GetPackageNameTokenTest, ValidPackage) {
@@ -328,8 +327,8 @@ TEST(GetPackageNameTokenTest, ValidPackage) {
   const auto& package_node =
       down_cast<const SyntaxTreeNode&>(*package_declarations.front().match);
   // Root node is a description list, not a package.
-  const auto& token = GetPackageNameToken(package_node);
-  EXPECT_EQ(token.text(), "foo");
+  const auto* token = GetPackageNameToken(package_node);
+  EXPECT_EQ(token->text(), "foo");
 }
 
 TEST(GetPackageNameTest, GetPackageEndLabelName) {

--- a/verilog/CST/parameters.cc
+++ b/verilog/CST/parameters.cc
@@ -159,7 +159,7 @@ const verible::SyntaxTreeNode* GetTypeAssignmentFromParamDeclaration(
     const auto& type_symbol = verible::GetSubtreeAsNode(
         *assignment_symbol, NodeEnum::kTypeAssignmentList, 0,
         NodeEnum::kTypeAssignment);
-    return &type_symbol;
+    return type_symbol;
   }
 
   return nullptr;

--- a/verilog/CST/port.h
+++ b/verilog/CST/port.h
@@ -56,7 +56,7 @@ const verible::SyntaxTreeLeaf* GetIdentifierFromPortReference(
     const verible::Symbol&);
 
 // Extracts the node tagged with kPortReference from a node tagged with kPort.
-const verible::SyntaxTreeNode& GetPortReferenceFromPort(const verible::Symbol&);
+const verible::SyntaxTreeNode* GetPortReferenceFromPort(const verible::Symbol&);
 
 // Find all task/function port declarations.
 std::vector<verible::TreeSearchMatch> FindAllTaskFunctionPortDeclarations(
@@ -82,7 +82,7 @@ const verible::SyntaxTreeLeaf* GetIdentifierFromTaskFunctionPortItem(
     const verible::Symbol&);
 
 // Extract the unpacked dimensions from a task/function port item.
-const verible::SyntaxTreeNode& GetUnpackedDimensionsFromTaskFunctionPortItem(
+const verible::SyntaxTreeNode* GetUnpackedDimensionsFromTaskFunctionPortItem(
     const verible::Symbol&);
 
 // Returns the leaf node containing the name of the actual named port.

--- a/verilog/CST/port_test.cc
+++ b/verilog/CST/port_test.cc
@@ -295,7 +295,7 @@ TEST(GetAllPortReferences, GetPortReferenceIdentifier) {
           std::vector<TreeSearchMatch> types;
           for (const auto& decl : decls) {
             const auto* type = GetIdentifierFromPortReference(
-                GetPortReferenceFromPort(*decl.match));
+                *GetPortReferenceFromPort(*decl.match));
             types.push_back(TreeSearchMatch{type, {/* ignored context */}});
           }
           return types;
@@ -388,10 +388,10 @@ TEST(FunctionPort, GetUnpackedDimensions) {
 
           std::vector<TreeSearchMatch> dimensions;
           for (const auto& port : ports) {
-            const auto& dimension =
+            const auto* dimension =
                 GetUnpackedDimensionsFromTaskFunctionPortItem(*port.match);
             dimensions.emplace_back(
-                TreeSearchMatch{&dimension, {/* ignored context */}});
+                TreeSearchMatch{dimension, {/* ignored context */}});
           }
           return dimensions;
         });

--- a/verilog/CST/statement.cc
+++ b/verilog/CST/statement.cc
@@ -26,6 +26,7 @@
 #include "common/text/tree_utils.h"
 #include "verilog/CST/declaration.h"
 #include "verilog/CST/identifier.h"
+#include "verilog/CST/type.h"
 #include "verilog/CST/verilog_matchers.h"  // IWYU pragma: keep
 
 namespace verilog {
@@ -51,24 +52,24 @@ static const SyntaxTreeNode& GetGenericStatementBody(
   return SymbolCastToNode(*node.children().back());
 }
 
-const SyntaxTreeNode& GetIfClauseGenerateBody(const Symbol& if_clause) {
+const SyntaxTreeNode* GetIfClauseGenerateBody(const Symbol& if_clause) {
   const auto& body_node = GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(if_clause), NodeEnum::kGenerateIfClause));
   return GetSubtreeAsNode(body_node, NodeEnum::kGenerateIfBody, 0);
 }
 
-const SyntaxTreeNode& GetElseClauseGenerateBody(const Symbol& else_clause) {
+const SyntaxTreeNode* GetElseClauseGenerateBody(const Symbol& else_clause) {
   const auto& body_node = GetGenericStatementBody(CheckNodeEnum(
       SymbolCastToNode(else_clause), NodeEnum::kGenerateElseClause));
   return GetSubtreeAsNode(body_node, NodeEnum::kGenerateElseBody, 0);
 }
 
-const SyntaxTreeNode& GetLoopGenerateBody(const Symbol& loop) {
-  return GetGenericStatementBody(
+const SyntaxTreeNode* GetLoopGenerateBody(const Symbol& loop) {
+  return &GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(loop), NodeEnum::kLoopGenerateConstruct));
 }
 
-const SyntaxTreeNode& GetConditionalGenerateIfClause(
+const SyntaxTreeNode* GetConditionalGenerateIfClause(
     const Symbol& conditional) {
   return GetSubtreeAsNode(conditional, NodeEnum::kConditionalGenerateConstruct,
                           0, NodeEnum::kGenerateIfClause);
@@ -85,19 +86,19 @@ const SyntaxTreeNode* GetConditionalGenerateElseClause(
                         NodeEnum::kGenerateElseClause);
 }
 
-const SyntaxTreeNode& GetIfClauseStatementBody(const Symbol& if_clause) {
+const SyntaxTreeNode* GetIfClauseStatementBody(const Symbol& if_clause) {
   const auto& body_node = GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(if_clause), NodeEnum::kIfClause));
   return GetSubtreeAsNode(body_node, NodeEnum::kIfBody, 0);
 }
 
-const SyntaxTreeNode& GetElseClauseStatementBody(const Symbol& else_clause) {
+const SyntaxTreeNode* GetElseClauseStatementBody(const Symbol& else_clause) {
   const auto& body_node = GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(else_clause), NodeEnum::kElseClause));
   return GetSubtreeAsNode(body_node, NodeEnum::kElseBody, 0);
 }
 
-const SyntaxTreeNode& GetConditionalStatementIfClause(
+const SyntaxTreeNode* GetConditionalStatementIfClause(
     const Symbol& conditional) {
   return GetSubtreeAsNode(conditional, NodeEnum::kConditionalStatement, 0,
                           NodeEnum::kIfClause);
@@ -113,7 +114,7 @@ const SyntaxTreeNode* GetConditionalStatementElseClause(
   return &CheckNodeEnum(SymbolCastToNode(*else_ptr), NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode& GetAssertionStatementAssertClause(
+const SyntaxTreeNode* GetAssertionStatementAssertClause(
     const Symbol& assertion_statement) {
   return GetSubtreeAsNode(assertion_statement, NodeEnum::kAssertionStatement, 0,
                           NodeEnum::kAssertionClause);
@@ -136,7 +137,7 @@ const SyntaxTreeNode* GetAssertionStatementElseClause(
   return &CheckNodeEnum(SymbolCastToNode(*else_ptr), NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode& GetAssumeStatementAssumeClause(
+const SyntaxTreeNode* GetAssumeStatementAssumeClause(
     const Symbol& assume_statement) {
   return GetSubtreeAsNode(assume_statement, NodeEnum::kAssumeStatement, 0,
                           NodeEnum::kAssumeClause);
@@ -173,7 +174,7 @@ const SyntaxTreeNode* GetWaitStatementBody(const Symbol& wait_statement) {
       GetSubtreeAsSymbol(body_node, NodeEnum::kWaitBody, 0));
 }
 
-const SyntaxTreeNode& GetAssertPropertyStatementAssertClause(
+const SyntaxTreeNode* GetAssertPropertyStatementAssertClause(
     const Symbol& assert_property_statement) {
   return GetSubtreeAsNode(assert_property_statement,
                           NodeEnum::kAssertPropertyStatement, 0,
@@ -197,7 +198,7 @@ const SyntaxTreeNode* GetAssertPropertyStatementElseClause(
   return &CheckNodeEnum(SymbolCastToNode(*else_ptr), NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode& GetAssumePropertyStatementAssumeClause(
+const SyntaxTreeNode* GetAssumePropertyStatementAssumeClause(
     const Symbol& assume_property_statement) {
   return GetSubtreeAsNode(assume_property_statement,
                           NodeEnum::kAssumePropertyStatement, 0,
@@ -221,7 +222,7 @@ const SyntaxTreeNode* GetAssumePropertyStatementElseClause(
   return &CheckNodeEnum(SymbolCastToNode(*else_ptr), NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode& GetExpectPropertyStatementExpectClause(
+const SyntaxTreeNode* GetExpectPropertyStatementExpectClause(
     const Symbol& expect_property_statement) {
   return GetSubtreeAsNode(expect_property_statement,
                           NodeEnum::kExpectPropertyStatement, 0,
@@ -261,39 +262,39 @@ const SyntaxTreeNode* GetCoverSequenceStatementBody(
       GetSubtreeAsSymbol(body_node, NodeEnum::kCoverSequenceBody, 0));
 }
 
-const SyntaxTreeNode& GetLoopStatementBody(const Symbol& loop) {
-  return GetGenericStatementBody(
+const SyntaxTreeNode* GetLoopStatementBody(const Symbol& loop) {
+  return &GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(loop), NodeEnum::kForLoopStatement));
 }
 
-const SyntaxTreeNode& GetDoWhileStatementBody(const Symbol& do_while) {
+const SyntaxTreeNode* GetDoWhileStatementBody(const Symbol& do_while) {
   return GetSubtreeAsNode(SymbolCastToNode(do_while),
                           NodeEnum::kDoWhileLoopStatement, 1);
 }
 
-const SyntaxTreeNode& GetForeverStatementBody(const Symbol& forever) {
-  return GetGenericStatementBody(CheckNodeEnum(
+const SyntaxTreeNode* GetForeverStatementBody(const Symbol& forever) {
+  return &GetGenericStatementBody(CheckNodeEnum(
       SymbolCastToNode(forever), NodeEnum::kForeverLoopStatement));
 }
 
-const SyntaxTreeNode& GetForeachStatementBody(const Symbol& foreach) {
-  return GetGenericStatementBody(CheckNodeEnum(
+const SyntaxTreeNode* GetForeachStatementBody(const Symbol& foreach) {
+  return &GetGenericStatementBody(CheckNodeEnum(
       SymbolCastToNode(foreach), NodeEnum::kForeachLoopStatement));
 }
 
-const SyntaxTreeNode& GetRepeatStatementBody(const Symbol& repeat) {
-  return GetGenericStatementBody(
+const SyntaxTreeNode* GetRepeatStatementBody(const Symbol& repeat) {
+  return &GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(repeat), NodeEnum::kRepeatLoopStatement));
 }
 
-const SyntaxTreeNode& GetWhileStatementBody(const Symbol& while_stmt) {
-  return GetGenericStatementBody(CheckNodeEnum(SymbolCastToNode(while_stmt),
-                                               NodeEnum::kWhileLoopStatement));
+const SyntaxTreeNode* GetWhileStatementBody(const Symbol& while_stmt) {
+  return &GetGenericStatementBody(CheckNodeEnum(SymbolCastToNode(while_stmt),
+                                                NodeEnum::kWhileLoopStatement));
 }
 
-const SyntaxTreeNode& GetProceduralTimingControlStatementBody(
+const SyntaxTreeNode* GetProceduralTimingControlStatementBody(
     const Symbol& proc_timing_control) {
-  return GetGenericStatementBody(
+  return &GetGenericStatementBody(
       CheckNodeEnum(SymbolCastToNode(proc_timing_control),
                     NodeEnum::kProceduralTimingControlStatement));
 }
@@ -302,31 +303,31 @@ const SyntaxTreeNode* GetAnyControlStatementBody(const Symbol& statement) {
   switch (NodeEnum(SymbolCastToNode(statement).Tag().tag)) {
     // generate
     case NodeEnum::kGenerateIfClause:
-      return &GetIfClauseGenerateBody(statement);
+      return GetIfClauseGenerateBody(statement);
     case NodeEnum::kGenerateElseClause:
-      return &GetElseClauseGenerateBody(statement);
+      return GetElseClauseGenerateBody(statement);
     case NodeEnum::kLoopGenerateConstruct:
-      return &GetLoopGenerateBody(statement);
+      return GetLoopGenerateBody(statement);
 
     // statements
     case NodeEnum::kIfClause:
-      return &GetIfClauseStatementBody(statement);
+      return GetIfClauseStatementBody(statement);
     case NodeEnum::kElseClause:
-      return &GetElseClauseStatementBody(statement);
+      return GetElseClauseStatementBody(statement);
     case NodeEnum::kForLoopStatement:
-      return &GetLoopStatementBody(statement);
+      return GetLoopStatementBody(statement);
     case NodeEnum::kDoWhileLoopStatement:
-      return &GetDoWhileStatementBody(statement);
+      return GetDoWhileStatementBody(statement);
     case NodeEnum::kForeverLoopStatement:
-      return &GetForeverStatementBody(statement);
+      return GetForeverStatementBody(statement);
     case NodeEnum::kForeachLoopStatement:
-      return &GetForeachStatementBody(statement);
+      return GetForeachStatementBody(statement);
     case NodeEnum::kRepeatLoopStatement:
-      return &GetRepeatStatementBody(statement);
+      return GetRepeatStatementBody(statement);
     case NodeEnum::kWhileLoopStatement:
-      return &GetWhileStatementBody(statement);
+      return GetWhileStatementBody(statement);
     case NodeEnum::kProceduralTimingControlStatement:
-      return &GetProceduralTimingControlStatementBody(statement);
+      return GetProceduralTimingControlStatementBody(statement);
 
     // immediate assertions
     case NodeEnum::kAssertionClause:
@@ -361,25 +362,25 @@ const SyntaxTreeNode* GetAnyConditionalIfClause(const Symbol& conditional) {
   switch (NodeEnum(SymbolCastToNode(conditional).Tag().tag)) {
     // generate
     case NodeEnum::kConditionalGenerateConstruct:
-      return &GetConditionalGenerateIfClause(conditional);
+      return GetConditionalGenerateIfClause(conditional);
 
     // statement
     case NodeEnum::kConditionalStatement:
-      return &GetConditionalStatementIfClause(conditional);
+      return GetConditionalStatementIfClause(conditional);
 
       // immediate assertions
     case NodeEnum::kAssertionStatement:
-      return &GetAssertionStatementAssertClause(conditional);
+      return GetAssertionStatementAssertClause(conditional);
     case NodeEnum::kAssumeStatement:
-      return &GetAssumeStatementAssumeClause(conditional);
+      return GetAssumeStatementAssumeClause(conditional);
 
       // concurrent assertions
     case NodeEnum::kAssertPropertyStatement:
-      return &GetAssertPropertyStatementAssertClause(conditional);
+      return GetAssertPropertyStatementAssertClause(conditional);
     case NodeEnum::kAssumePropertyStatement:
-      return &GetAssumePropertyStatementAssumeClause(conditional);
+      return GetAssumePropertyStatementAssumeClause(conditional);
     case NodeEnum::kExpectPropertyStatement:
-      return &GetExpectPropertyStatementExpectClause(conditional);
+      return GetExpectPropertyStatementExpectClause(conditional);
 
     default:
       return nullptr;
@@ -427,32 +428,33 @@ const verible::SyntaxTreeNode* GetDataTypeFromForInitialization(
 }
 
 // Returns the variable name leaf from for loop initialization.
-const verible::SyntaxTreeLeaf& GetVariableNameFromForInitialization(
+const verible::SyntaxTreeLeaf* GetVariableNameFromForInitialization(
     const verible::Symbol& for_initialization) {
   const Symbol* child = verible::GetSubtreeAsSymbol(
       for_initialization, NodeEnum::kForInitialization, 2);
   if (child->Kind() == verible::SymbolKind::kLeaf) {
-    return SymbolCastToLeaf(*child);
+    return &SymbolCastToLeaf(*child);
   }
-  return *AutoUnwrapIdentifier(GetUnqualifiedIdFromReferenceCallBase(
-      verible::GetSubtreeAsNode(*child, NodeEnum::kLPValue, 0)));
+  const verible::SyntaxTreeNode* lpvalue =
+      verible::GetSubtreeAsNode(*child, NodeEnum::kLPValue, 0);
+  return AutoUnwrapIdentifier(*GetUnqualifiedIdFromReferenceCallBase(*lpvalue));
 }
 
 // Returns the rhs expression from for loop initialization.
-const verible::SyntaxTreeNode& GetExpressionFromForInitialization(
+const verible::SyntaxTreeNode* GetExpressionFromForInitialization(
     const verible::Symbol& for_initialization) {
   return verible::GetSubtreeAsNode(for_initialization,
                                    NodeEnum::kForInitialization, 4,
                                    NodeEnum::kExpression);
 }
 
-const verible::SyntaxTreeNode& GetGenerateBlockBegin(
+const verible::SyntaxTreeNode* GetGenerateBlockBegin(
     const verible::Symbol& generate_block) {
   return verible::GetSubtreeAsNode(generate_block, NodeEnum::kGenerateBlock, 0,
                                    NodeEnum::kBegin);
 }
 
-const verible::SyntaxTreeNode& GetGenerateBlockEnd(
+const verible::SyntaxTreeNode* GetGenerateBlockEnd(
     const verible::Symbol& generate_block) {
   return verible::GetSubtreeAsNode(generate_block, NodeEnum::kGenerateBlock, 2,
                                    NodeEnum::kEnd);

--- a/verilog/CST/statement.h
+++ b/verilog/CST/statement.h
@@ -38,18 +38,18 @@ std::vector<verible::TreeSearchMatch> FindAllGenerateBlocks(
 // TODO(fangism): consider moving the *GenerateBody functions to generate.{h,cc}
 
 // Returns the generate-item body of a generate-if construct.
-const verible::SyntaxTreeNode& GetIfClauseGenerateBody(
+const verible::SyntaxTreeNode* GetIfClauseGenerateBody(
     const verible::Symbol& if_clause);
 
 // Returns the generate-item body of a generate-else construct.
-const verible::SyntaxTreeNode& GetElseClauseGenerateBody(
+const verible::SyntaxTreeNode* GetElseClauseGenerateBody(
     const verible::Symbol& else_clause);
 
 // Returns the generate-item body of a generate-for-loop construct.
-const verible::SyntaxTreeNode& GetLoopGenerateBody(const verible::Symbol& loop);
+const verible::SyntaxTreeNode* GetLoopGenerateBody(const verible::Symbol& loop);
 
 // Returns the if-clause of a generate-if construct.
-const verible::SyntaxTreeNode& GetConditionalGenerateIfClause(
+const verible::SyntaxTreeNode* GetConditionalGenerateIfClause(
     const verible::Symbol& conditional);
 
 // Returns the else-clause of a generate-if construct, or nullptr.
@@ -60,16 +60,16 @@ const verible::SyntaxTreeNode* GetConditionalGenerateElseClause(
 
 // For if-conditional statement blocks, return the construct's
 // statement body (which should be some form of statement list).
-const verible::SyntaxTreeNode& GetIfClauseStatementBody(
+const verible::SyntaxTreeNode* GetIfClauseStatementBody(
     const verible::Symbol& if_clause);
 
 // For else-clause statement blocks, return the construct's
 // statement body (which should be some form of statement list).
-const verible::SyntaxTreeNode& GetElseClauseStatementBody(
+const verible::SyntaxTreeNode* GetElseClauseStatementBody(
     const verible::Symbol& else_clause);
 
 // Returns the if-clause of a conditional statement construct.
-const verible::SyntaxTreeNode& GetConditionalStatementIfClause(
+const verible::SyntaxTreeNode* GetConditionalStatementIfClause(
     const verible::Symbol& conditional);
 
 // Returns the else-clause of a conditional statement construct, or nullptr.
@@ -79,7 +79,7 @@ const verible::SyntaxTreeNode* GetConditionalStatementElseClause(
 // Immediate assertion statements
 
 // Returns the assert-clause of an assertion statement, or nullptr.
-const verible::SyntaxTreeNode& GetAssertionStatementAssertClause(
+const verible::SyntaxTreeNode* GetAssertionStatementAssertClause(
     const verible::Symbol& assertion_statement);
 
 // Returns the else-clause of an assertion statement, or nullptr.
@@ -87,7 +87,7 @@ const verible::SyntaxTreeNode* GetAssertionStatementElseClause(
     const verible::Symbol& assertion_statement);
 
 // Returns the assume-clause of an assume statement, or nullptr.
-const verible::SyntaxTreeNode& GetAssumeStatementAssumeClause(
+const verible::SyntaxTreeNode* GetAssumeStatementAssumeClause(
     const verible::Symbol& assume_statement);
 
 // Returns the else-clause of an assume statement, or nullptr.
@@ -105,7 +105,7 @@ const verible::SyntaxTreeNode* GetWaitStatementBody(
 // Concurrent assertion statements
 
 // Returns the assert-clause of an assert property statement, or nullptr.
-const verible::SyntaxTreeNode& GetAssertPropertyStatementAssertClause(
+const verible::SyntaxTreeNode* GetAssertPropertyStatementAssertClause(
     const verible::Symbol& assert_property_statement);
 
 // Returns the else-clause of an assert property statement, or nullptr.
@@ -113,7 +113,7 @@ const verible::SyntaxTreeNode* GetAssertPropertyStatementElseClause(
     const verible::Symbol& assert_property_statement);
 
 // Returns the assume-clause of an assume property statement, or nullptr.
-const verible::SyntaxTreeNode& GetAssumePropertyStatementAssumeClause(
+const verible::SyntaxTreeNode* GetAssumePropertyStatementAssumeClause(
     const verible::Symbol& assume_property_statement);
 
 // Returns the else-clause of an assume property statement, or nullptr.
@@ -121,7 +121,7 @@ const verible::SyntaxTreeNode* GetAssumePropertyStatementElseClause(
     const verible::Symbol& assume_property_statement);
 
 // Returns the expect-clause of an expect property statement, or nullptr.
-const verible::SyntaxTreeNode& GetExpectPropertyStatementExpectClause(
+const verible::SyntaxTreeNode* GetExpectPropertyStatementExpectClause(
     const verible::Symbol& expect_property_statement);
 
 // Returns the else-clause of an expect property statement, or nullptr.
@@ -131,33 +131,33 @@ const verible::SyntaxTreeNode* GetExpectPropertyStatementElseClause(
 // Loop-like statements
 
 // For loop statement blocks, return the looped statement body.
-const verible::SyntaxTreeNode& GetLoopStatementBody(
+const verible::SyntaxTreeNode* GetLoopStatementBody(
     const verible::Symbol& loop);
 
 // For do-while statement blocks, return the looped statement body.
-const verible::SyntaxTreeNode& GetDoWhileStatementBody(
+const verible::SyntaxTreeNode* GetDoWhileStatementBody(
     const verible::Symbol& do_while);
 
 // Return the statement body of forever blocks.
-const verible::SyntaxTreeNode& GetForeverStatementBody(
+const verible::SyntaxTreeNode* GetForeverStatementBody(
     const verible::Symbol& forever);
 
 // Return the statement body of foreach blocks.
-const verible::SyntaxTreeNode& GetForeachStatementBody(
+const verible::SyntaxTreeNode* GetForeachStatementBody(
     const verible::Symbol& foreach);
 
 // Return the statement body of repeat blocks.
-const verible::SyntaxTreeNode& GetRepeatStatementBody(
+const verible::SyntaxTreeNode* GetRepeatStatementBody(
     const verible::Symbol& repeat);
 
 // Return the statement body of while blocks.
-const verible::SyntaxTreeNode& GetWhileStatementBody(
+const verible::SyntaxTreeNode* GetWhileStatementBody(
     const verible::Symbol& while_stmt);
 
 // TODO(fangism): case-items
 
 // Return the statement body of procedural timing constructs.
-const verible::SyntaxTreeNode& GetProceduralTimingControlStatementBody(
+const verible::SyntaxTreeNode* GetProceduralTimingControlStatementBody(
     const verible::Symbol& proc_timing_control);
 
 // Combines all of the above Get*StatementBody.
@@ -179,19 +179,19 @@ const verible::SyntaxTreeNode* GetDataTypeFromForInitialization(
     const verible::Symbol&);
 
 // Returns the variable name leaf from for loop initialization.
-const verible::SyntaxTreeLeaf& GetVariableNameFromForInitialization(
+const verible::SyntaxTreeLeaf* GetVariableNameFromForInitialization(
     const verible::Symbol&);
 
 // Returns the rhs expression from for loop initialization.
-const verible::SyntaxTreeNode& GetExpressionFromForInitialization(
+const verible::SyntaxTreeNode* GetExpressionFromForInitialization(
     const verible::Symbol&);
 
 // Returns the 'begin' node of a generate block.
-const verible::SyntaxTreeNode& GetGenerateBlockBegin(
+const verible::SyntaxTreeNode* GetGenerateBlockBegin(
     const verible::Symbol& generate_block);
 
 // Returns the 'end' node of a generate block.
-const verible::SyntaxTreeNode& GetGenerateBlockEnd(
+const verible::SyntaxTreeNode* GetGenerateBlockEnd(
     const verible::Symbol& generate_block);
 
 }  // namespace verilog

--- a/verilog/CST/statement_test.cc
+++ b/verilog/CST/statement_test.cc
@@ -1175,7 +1175,7 @@ TEST(FindAllForLoopsInitializations, FindForInitializationNames) {
             const auto& variable_name =
                 GetVariableNameFromForInitialization(*instance.match);
             names.emplace_back(
-                TreeSearchMatch{&variable_name, {/* ignored context */}});
+                TreeSearchMatch{variable_name, {/* ignored context */}});
           }
           return names;
         });
@@ -1252,7 +1252,7 @@ TEST(FindAllForLoopsInitializations, FindForInitializationExpressions) {
             const auto& expression =
                 GetExpressionFromForInitialization(*instance.match);
             expressions.emplace_back(
-                TreeSearchMatch{&expression, {/* ignored context */}});
+                TreeSearchMatch{expression, {/* ignored context */}});
           }
           return expressions;
         });
@@ -1309,7 +1309,7 @@ TEST(GetGenerateBlockBeginTest, Various) {
           for (const auto& block : blocks) {
             const auto& begin = GetGenerateBlockBegin(*block.match);
             begins.emplace_back(
-                TreeSearchMatch{&begin, {/* ignored context */}});
+                TreeSearchMatch{begin, {/* ignored context */}});
           }
           return begins;
         });
@@ -1366,7 +1366,7 @@ TEST(GetGenerateBlockEndTest, Various) {
           std::vector<TreeSearchMatch> ends;
           for (const auto& block : blocks) {
             const auto& end = GetGenerateBlockEnd(*block.match);
-            ends.emplace_back(TreeSearchMatch{&end, {/* ignored context */}});
+            ends.emplace_back(TreeSearchMatch{end, {/* ignored context */}});
           }
           return ends;
         });

--- a/verilog/CST/tasks.cc
+++ b/verilog/CST/tasks.cc
@@ -42,12 +42,12 @@ std::vector<verible::TreeSearchMatch> FindAllTaskHeaders(
   return verible::SearchSyntaxTree(root, NodekTaskHeader());
 }
 
-const verible::SyntaxTreeNode& GetTaskHeader(const verible::Symbol& task_decl) {
+const verible::SyntaxTreeNode* GetTaskHeader(const verible::Symbol& task_decl) {
   return verible::GetSubtreeAsNode(task_decl, NodeEnum::kTaskDeclaration, 0,
                                    NodeEnum::kTaskHeader);
 }
 
-const verible::SyntaxTreeNode& GetTaskPrototypeHeader(
+const verible::SyntaxTreeNode* GetTaskPrototypeHeader(
     const verible::Symbol& task_proto) {
   return verible::GetSubtreeAsNode(task_proto, NodeEnum::kTaskPrototype, 0,
                                    NodeEnum::kTaskHeader);
@@ -63,21 +63,21 @@ const verible::Symbol* GetTaskHeaderId(const verible::Symbol& task_header) {
 }
 
 const verible::Symbol* GetTaskLifetime(const verible::Symbol& task_decl) {
-  const auto& header = GetTaskHeader(task_decl);
-  return GetTaskHeaderLifetime(header);
+  const auto* header = GetTaskHeader(task_decl);
+  return header ? GetTaskHeaderLifetime(*header) : nullptr;
 }
 
 const verible::Symbol* GetTaskId(const verible::Symbol& task_decl) {
-  const auto& header = GetTaskHeader(task_decl);
-  return GetTaskHeaderId(header);
+  const auto* header = GetTaskHeader(task_decl);
+  return header ? GetTaskHeaderId(*header) : nullptr;
 }
 
 const verible::SyntaxTreeLeaf* GetTaskName(const verible::Symbol& task_decl) {
   const auto* function_id = GetTaskId(task_decl);
-  return GetIdentifier(*function_id);
+  return function_id ? GetIdentifier(*function_id) : nullptr;
 }
 
-const verible::SyntaxTreeNode& GetTaskStatementList(
+const verible::SyntaxTreeNode* GetTaskStatementList(
     const verible::Symbol& task_decl) {
   return verible::GetSubtreeAsNode(task_decl, NodeEnum::kTaskDeclaration, 1,
                                    NodeEnum::kStatementList);

--- a/verilog/CST/tasks.h
+++ b/verilog/CST/tasks.h
@@ -35,10 +35,10 @@ std::vector<verible::TreeSearchMatch> FindAllTaskPrototypes(
     const verible::Symbol&);
 
 // Returns the task declaration header
-const verible::SyntaxTreeNode& GetTaskHeader(const verible::Symbol& task_decl);
+const verible::SyntaxTreeNode* GetTaskHeader(const verible::Symbol& task_decl);
 
 // Returns the task prototype header
-const verible::SyntaxTreeNode& GetTaskPrototypeHeader(
+const verible::SyntaxTreeNode* GetTaskPrototypeHeader(
     const verible::Symbol& task_proto);
 
 // task header accessors
@@ -63,7 +63,7 @@ const verible::Symbol* GetTaskId(const verible::Symbol& task_decl);
 const verible::SyntaxTreeLeaf* GetTaskName(const verible::Symbol& task_decl);
 
 // Returns the task declaration body.
-const verible::SyntaxTreeNode& GetTaskStatementList(
+const verible::SyntaxTreeNode* GetTaskStatementList(
     const verible::Symbol& task_decl);
 
 }  // namespace verilog

--- a/verilog/CST/tasks_test.cc
+++ b/verilog/CST/tasks_test.cc
@@ -131,7 +131,7 @@ TEST(FindAllTaskPrototypesTest, Various) {
           for (const auto& proto :
                FindAllTaskPrototypes(*ABSL_DIE_IF_NULL(root))) {
             headers.push_back(TreeSearchMatch{
-                &GetTaskPrototypeHeader(*proto.match), /* no context */});
+                GetTaskPrototypeHeader(*proto.match), /* no context */});
           }
           return headers;
         });
@@ -161,8 +161,8 @@ TEST(TaskPrototypesIdsTest, Various) {
           std::vector<TreeSearchMatch> ids;
           for (const auto& proto :
                FindAllTaskPrototypes(*ABSL_DIE_IF_NULL(root))) {
-            const auto& header = GetTaskPrototypeHeader(*proto.match);
-            const auto* id = ABSL_DIE_IF_NULL(GetTaskHeaderId(header));
+            const auto* header = GetTaskPrototypeHeader(*proto.match);
+            const auto* id = ABSL_DIE_IF_NULL(GetTaskHeaderId(*header));
             EXPECT_TRUE(verible::SymbolCastToNode(*id).MatchesTag(
                 NodeEnum::kUnqualifiedId));
             ids.push_back(TreeSearchMatch{id, /* no context */});
@@ -233,7 +233,7 @@ TEST(GetTaskHeaderTest, DeclarationsHeader) {
           for (const auto& decl : task_declarations) {
             const auto& task_node = verible::SymbolCastToNode(*decl.match);
             headers.push_back(
-                TreeSearchMatch{&GetTaskHeader(task_node), /* no context */});
+                TreeSearchMatch{GetTaskHeader(task_node), /* no context */});
           }
           return headers;
         });
@@ -408,7 +408,7 @@ TEST(GetTaskHeaderTest, GetTaskBody) {
           std::vector<TreeSearchMatch> bodies;
           for (const auto& decl : decls) {
             const auto& body = GetTaskStatementList(*decl.match);
-            bodies.push_back(TreeSearchMatch{&body, {/* ignored context */}});
+            bodies.push_back(TreeSearchMatch{body, {/* ignored context */}});
           }
           return bodies;
         });

--- a/verilog/CST/type.cc
+++ b/verilog/CST/type.cc
@@ -34,8 +34,8 @@ using verible::SymbolPtr;
 using verible::SyntaxTreeNode;
 
 static SymbolPtr ReinterpretReferenceAsType(Symbol& reference) {  // NOLINT
-  SyntaxTreeNode& local_root(verible::GetSubtreeAsNode(
-      reference, NodeEnum::kReference, 0, NodeEnum::kLocalRoot));
+  SyntaxTreeNode& local_root(*ABSL_DIE_IF_NULL(verible::GetSubtreeAsNode(
+      reference, NodeEnum::kReference, 0, NodeEnum::kLocalRoot)));
   auto& children(local_root.mutable_children());
   CHECK(!children.empty());
   // kLocalRoot has multiple constructions in verilog.y
@@ -151,20 +151,20 @@ const verible::SyntaxTreeNode* GetPackedDimensionFromDataType(
   return verible::CheckOptionalSymbolAsNode(pdim, NodeEnum::kPackedDimensions);
 }
 
-static const verible::SyntaxTreeNode& GetDataTypeFromInstantiationType(
+static const verible::SyntaxTreeNode* GetDataTypeFromInstantiationType(
     const verible::Symbol& instantiation_type) {
   return verible::GetSubtreeAsNode(instantiation_type,
                                    NodeEnum::kInstantiationType, 0);
   // returned node could be kDataType or kInterfaceType
 }
 
-static const verible::SyntaxTreeNode& GetReferenceFromReferenceCallBase(
+static const verible::SyntaxTreeNode* GetReferenceFromReferenceCallBase(
     const verible::Symbol& reference_call_base) {
   return verible::GetSubtreeAsNode(reference_call_base,
                                    NodeEnum::kReferenceCallBase, 0);
 }
 
-static const verible::SyntaxTreeNode& GetLocalRootFromReference(
+static const verible::SyntaxTreeNode* GetLocalRootFromReference(
     const verible::Symbol& reference) {
   return verible::GetSubtreeAsNode(reference, NodeEnum::kReference, 0);
 }
@@ -175,13 +175,15 @@ const verible::Symbol& GetIdentifiersFromLocalRoot(
       verible::GetSubtreeAsSymbol(local_root, NodeEnum::kLocalRoot, 0));
 }
 
-const verible::SyntaxTreeNode& GetUnqualifiedIdFromReferenceCallBase(
+const verible::SyntaxTreeNode* GetUnqualifiedIdFromReferenceCallBase(
     const verible::Symbol& reference_call_base) {
-  const verible::SyntaxTreeNode& reference =
+  const verible::SyntaxTreeNode* reference =
       GetReferenceFromReferenceCallBase(reference_call_base);
-  const verible::SyntaxTreeNode& local_root =
-      GetLocalRootFromReference(reference);
-  return verible::SymbolCastToNode(GetIdentifiersFromLocalRoot(local_root));
+  if (!reference) return nullptr;
+  const verible::SyntaxTreeNode* local_root =
+      GetLocalRootFromReference(*reference);
+  if (!local_root) return nullptr;
+  return &verible::SymbolCastToNode(GetIdentifiersFromLocalRoot(*local_root));
 }
 
 const verible::SyntaxTreeNode* GetStructOrUnionOrEnumTypeFromDataType(
@@ -206,7 +208,7 @@ const verible::SyntaxTreeNode* GetStructOrUnionOrEnumTypeFromDataType(
 const verible::SyntaxTreeNode* GetStructOrUnionOrEnumTypeFromInstantiationType(
     const verible::Symbol& instantiation_type) {
   const verible::Symbol* type =
-      &GetDataTypeFromInstantiationType(instantiation_type);
+      GetDataTypeFromInstantiationType(instantiation_type);
   if (type == nullptr || NodeEnum(type->Tag().tag) != NodeEnum::kDataType) {
     return nullptr;
   }
@@ -215,12 +217,13 @@ const verible::SyntaxTreeNode* GetStructOrUnionOrEnumTypeFromInstantiationType(
 
 const verible::Symbol* GetBaseTypeFromInstantiationType(
     const verible::Symbol& instantiation_type) {
-  const verible::SyntaxTreeNode& data_type =
+  const verible::SyntaxTreeNode* data_type =
       GetDataTypeFromInstantiationType(instantiation_type);
-  if (NodeEnum(data_type.Tag().tag) != NodeEnum::kDataType) {
+  if (!data_type) return nullptr;
+  if (NodeEnum(data_type->Tag().tag) != NodeEnum::kDataType) {
     return nullptr;
   }
-  return GetBaseTypeFromDataType(data_type);
+  return GetBaseTypeFromDataType(*data_type);
 }
 
 const verible::SyntaxTreeNode* GetParamListFromUnqualifiedId(
@@ -270,10 +273,11 @@ GetSymbolIdentifierFromDataTypeImplicitIdDimensions(
 
 const verible::SyntaxTreeLeaf* GetNonprimitiveTypeOfDataTypeImplicitDimensions(
     const verible::Symbol& data_type_implicit_id_dimensions) {
-  const verible::SyntaxTreeNode& type_node =
+  const verible::SyntaxTreeNode* type_node =
       verible::GetSubtreeAsNode(data_type_implicit_id_dimensions,
                                 NodeEnum::kDataTypeImplicitIdDimensions, 0);
-  const verible::Symbol* identifier = GetBaseTypeFromDataType(type_node);
+  if (!type_node) return nullptr;
+  const verible::Symbol* identifier = GetBaseTypeFromDataType(*type_node);
   if (identifier == nullptr ||
       identifier->Kind() != verible::SymbolKind::kLeaf) {
     return nullptr;
@@ -284,8 +288,8 @@ const verible::SyntaxTreeLeaf* GetNonprimitiveTypeOfDataTypeImplicitDimensions(
 const verible::SyntaxTreeNode* GetReferencedTypeOfTypeDeclaration(
     const verible::Symbol& type_declaration) {
   // Could be a kForwardTypeDeclaration, which could be empty.
-  return &verible::GetSubtreeAsNode(type_declaration,
-                                    NodeEnum::kTypeDeclaration, 1);
+  return verible::GetSubtreeAsNode(type_declaration, NodeEnum::kTypeDeclaration,
+                                   1);
 }
 
 const verible::SyntaxTreeLeaf* GetSymbolIdentifierFromEnumName(
@@ -300,13 +304,14 @@ const verible::SyntaxTreeLeaf* GetTypeIdentifierFromInterfaceType(
 
 const verible::Symbol* GetTypeIdentifierFromInstantiationType(
     const verible::Symbol& instantiation_type) {
-  const verible::SyntaxTreeNode& data_type =
+  const verible::SyntaxTreeNode* data_type =
       GetDataTypeFromInstantiationType(instantiation_type);
-  if (NodeEnum(data_type.Tag().tag) == NodeEnum::kDataType) {
-    return GetTypeIdentifierFromDataType(data_type);
+  if (!data_type) return nullptr;
+  if (NodeEnum(data_type->Tag().tag) == NodeEnum::kDataType) {
+    return GetTypeIdentifierFromDataType(*data_type);
   }
-  if (NodeEnum(data_type.Tag().tag) == NodeEnum::kInterfaceType) {
-    return GetTypeIdentifierFromInterfaceType(data_type);
+  if (NodeEnum(data_type->Tag().tag) == NodeEnum::kInterfaceType) {
+    return GetTypeIdentifierFromInterfaceType(*data_type);
   }
   return nullptr;
 }

--- a/verilog/CST/type.h
+++ b/verilog/CST/type.h
@@ -153,7 +153,7 @@ const verible::Symbol& GetIdentifiersFromLocalRoot(
     const verible::Symbol& local_root);
 
 // Extracts kUnqualifiedId node from nodes tagged with kReferenceCallBase.
-const verible::SyntaxTreeNode& GetUnqualifiedIdFromReferenceCallBase(
+const verible::SyntaxTreeNode* GetUnqualifiedIdFromReferenceCallBase(
     const verible::Symbol& reference_call_base);
 
 // Returns the node tagged with kStructType, kEnumType or kUnionType from node

--- a/verilog/analysis/checkers/banned_declared_name_patterns_rule.cc
+++ b/verilog/analysis/checkers/banned_declared_name_patterns_rule.cc
@@ -68,11 +68,12 @@ void BannedDeclaredNamePatternsRule::HandleNode(
       break;
     }
     case NodeEnum::kPackageDeclaration: {
-      const auto& pack_match = GetPackageNameToken(node);
-      absl::string_view pack_id = pack_match.text();
-
-      if (absl::EqualsIgnoreCase(pack_id, "ILLEGALNAME")) {
-        violations_.insert(LintViolation(pack_match, kMessage));
+      const verible::TokenInfo* pack_match = GetPackageNameToken(node);
+      if (pack_match) {
+        absl::string_view pack_id = pack_match->text();
+        if (absl::EqualsIgnoreCase(pack_id, "ILLEGALNAME")) {
+          violations_.insert(LintViolation(*pack_match, kMessage));
+        }
       }
       break;
     }

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -97,13 +97,14 @@ void PackageFilenameRule::Lint(const TextStructureView& text_structure,
 
   // Report a violation on every package declaration, potentially.
   for (const auto& package_match : package_matches) {
-    const verible::TokenInfo& package_name_token =
+    const verible::TokenInfo* package_name_token =
         GetPackageNameToken(*package_match.match);
-    absl::string_view package_id = package_name_token.text();
+    if (!package_name_token) continue;
+    absl::string_view package_id = package_name_token->text();
     auto package_id_plus_suffix = absl::StrCat(package_id, optional_suffix);
     if ((package_id != unitname) && (package_id_plus_suffix != unitname)) {
       violations_.insert(verible::LintViolation(
-          package_name_token,
+          *package_name_token,
           absl::StrCat(kMessage, "declaration: \"", package_id,
                        "\" vs. basename(file): \"", unitname, "\"")));
     }

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -553,9 +553,10 @@ static bool IsAlignableDeclaration(const SyntaxTreeNode& node) {
   // * it declares exactly one identifier
   switch (static_cast<NodeEnum>(node.Tag().tag)) {
     case NodeEnum::kDataDeclaration: {
-      const SyntaxTreeNode& instances(GetInstanceListFromDataDeclaration(node));
-      if (FindAllRegisterVariables(instances).size() > 1) return false;
-      return FindAllGateInstances(instances).empty();
+      const SyntaxTreeNode* instances(GetInstanceListFromDataDeclaration(node));
+      if (!instances) return false;
+      if (FindAllRegisterVariables(*instances).size() > 1) return false;
+      return FindAllGateInstances(*instances).empty();
     }
     case NodeEnum::kNetDeclaration: {
       return FindAllNetVariables(node).size() <= 1;

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -827,8 +827,9 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
       // In the case of else-if, suppress further indentation, deferring to
       // the conditional construct.
       const auto& subnode = GetSubtreeAsNode(node, tag, 0);
-      const auto next_indent =
-          NodeIsConditionalOrBlock(subnode) ? 0 : style_.indentation_spaces;
+      const auto next_indent = subnode && NodeIsConditionalOrBlock(*subnode)
+                                   ? 0
+                                   : style_.indentation_spaces;
       VisitIndentedSection(node, next_indent,
                            PartitionPolicyEnum::kFitOnLineElseExpand);
       break;

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -728,8 +728,8 @@ void IndexingFactsTreeExtractor::ExtractModuleOrInterfaceOrProgramHeader(
       has_propagated_type = true;
       ExtractModulePort(port_node, has_propagated_type);
     } else if (tag == NodeEnum::kPort) {
-      ExtractModulePort(GetPortReferenceFromPort(port_node),
-                        has_propagated_type);
+      const SyntaxTreeNode* ref_port = GetPortReferenceFromPort(port_node);
+      if (ref_port) ExtractModulePort(*ref_port, has_propagated_type);
     }
   }
 }
@@ -882,9 +882,9 @@ void IndexingFactsTreeExtractor::ExtractModuleInstantiation(
     {
       const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                                 &module_instance_node);
-      const SyntaxTreeNode& paren_group =
+      const SyntaxTreeNode* paren_group =
           GetParenGroupFromModuleInstantiation(*instance.match);
-      Visit(paren_group);
+      if (paren_group) Visit(*paren_group);
     }
 
     type_node.NewChild(std::move(module_instance_node));
@@ -986,8 +986,8 @@ void IndexingFactsTreeExtractor::ExtractMacroCall(
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &macro_node);
 
-    const SyntaxTreeNode& macro_call_args = GetMacroCallArgs(macro_call);
-    Visit(macro_call_args);
+    const SyntaxTreeNode* macro_call_args = GetMacroCallArgs(macro_call);
+    if (macro_call_args) Visit(*macro_call_args);
   }
 
   facts_tree_context_.top().NewChild(std::move(macro_node));
@@ -1016,9 +1016,9 @@ void IndexingFactsTreeExtractor::ExtractClassConstructor(
     ExtractFunctionOrTaskOrConstructorPort(class_constructor);
 
     // Extract constructor body.
-    const SyntaxTreeNode& constructor_body =
+    const SyntaxTreeNode* constructor_body =
         GetClassConstructorStatementList(class_constructor);
-    Visit(constructor_body);
+    if (constructor_body) Visit(*constructor_body);
   }
 
   facts_tree_context_.top().NewChild(std::move(constructor_node));
@@ -1030,9 +1030,9 @@ void IndexingFactsTreeExtractor::ExtractPureVirtualFunction(
       IndexingNodeData{IndexingFactType::kFunctionOrTaskForwardDeclaration});
 
   // Extract function header.
-  const SyntaxTreeNode& function_header =
+  const SyntaxTreeNode* function_header =
       GetFunctionPrototypeHeader(function_prototype);
-  ExtractFunctionHeader(function_header, function_node);
+  if (function_header) ExtractFunctionHeader(*function_header, function_node);
 
   facts_tree_context_.top().NewChild(std::move(function_node));
 }
@@ -1043,8 +1043,8 @@ void IndexingFactsTreeExtractor::ExtractPureVirtualTask(
       IndexingNodeData{IndexingFactType::kFunctionOrTaskForwardDeclaration});
 
   // Extract task header.
-  const SyntaxTreeNode& task_header = GetTaskPrototypeHeader(task_prototype);
-  ExtractTaskHeader(task_header, task_node);
+  const SyntaxTreeNode* task_header = GetTaskPrototypeHeader(task_prototype);
+  if (task_header) ExtractTaskHeader(*task_header, task_node);
 
   facts_tree_context_.top().NewChild(std::move(task_node));
 }
@@ -1055,17 +1055,17 @@ void IndexingFactsTreeExtractor::ExtractFunctionDeclaration(
       IndexingNodeData{IndexingFactType::kFunctionOrTask});
 
   // Extract function header.
-  const SyntaxTreeNode& function_header =
+  const SyntaxTreeNode* function_header =
       GetFunctionHeader(function_declaration_node);
-  ExtractFunctionHeader(function_header, function_node);
+  if (function_header) ExtractFunctionHeader(*function_header, function_node);
 
   {
     // Extract function body.
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &function_node);
-    const SyntaxTreeNode& function_body =
+    const SyntaxTreeNode* function_body =
         GetFunctionBlockStatementList(function_declaration_node);
-    Visit(function_body);
+    if (function_body) Visit(*function_body);
   }
 
   facts_tree_context_.top().NewChild(std::move(function_node));
@@ -1077,15 +1077,15 @@ void IndexingFactsTreeExtractor::ExtractTaskDeclaration(
       IndexingNodeData{IndexingFactType::kFunctionOrTask});
 
   // Extract task header.
-  const SyntaxTreeNode& task_header = GetTaskHeader(task_declaration_node);
-  ExtractTaskHeader(task_header, task_node);
+  const SyntaxTreeNode* task_header = GetTaskHeader(task_declaration_node);
+  if (task_header) ExtractTaskHeader(*task_header, task_node);
 
   {
     // Extract task body.
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_, &task_node);
-    const SyntaxTreeNode& task_body =
+    const SyntaxTreeNode* task_body =
         GetTaskStatementList(task_declaration_node);
-    Visit(task_body);
+    if (task_body) Visit(*task_body);
   }
 
   facts_tree_context_.top().NewChild(std::move(task_node));
@@ -1176,9 +1176,9 @@ void IndexingFactsTreeExtractor::ExtractFunctionOrTaskOrConstructorPort(
             packed_dim->Accept(this);
           }
 
-          const SyntaxTreeNode& unpacked_dimension =
+          const SyntaxTreeNode* unpacked_dimension =
               GetUnpackedDimensionsFromTaskFunctionPortItem(*port.match);
-          unpacked_dimension.Accept(this);
+          if (unpacked_dimension) unpacked_dimension->Accept(this);
         }
 
         facts_tree_context_.top().NewChild(std::move(variable_node));
@@ -1205,9 +1205,9 @@ void IndexingFactsTreeExtractor::ExtractFunctionOrTaskOrConstructorPort(
           packed_dim->Accept(this);
         }
 
-        const SyntaxTreeNode& unpacked_dimension =
+        const SyntaxTreeNode* unpacked_dimension =
             GetUnpackedDimensionsFromTaskFunctionPortItem(*port.match);
-        unpacked_dimension.Accept(this);
+        if (unpacked_dimension) unpacked_dimension->Accept(this);
       }
 
       facts_tree_context_.top().NewChild(std::move(type_node));
@@ -1242,9 +1242,9 @@ void IndexingFactsTreeExtractor::ExtractFunctionOrTaskCall(
   {
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &function_node);
-    const SyntaxTreeNode& arguments = GetParenGroupFromCall(function_call_node);
+    const SyntaxTreeNode* arguments = GetParenGroupFromCall(function_call_node);
     // Extract function or task parameters.
-    Visit(arguments);
+    if (arguments) Visit(*arguments);
   }
 
   facts_tree_context_.top().NewChild(std::move(function_node));
@@ -1265,16 +1265,19 @@ void IndexingFactsTreeExtractor::ExtractMethodCallExtension(
     return;
   }
 
-  function_node.Value().AppendAnchor(
-      Anchor(GetFunctionCallNameFromCallExtension(call_extension_node).get()));
+  {
+    const SyntaxTreeLeaf* fun_call =
+        GetFunctionCallNameFromCallExtension(call_extension_node);
+    if (fun_call) function_node.Value().AppendAnchor(Anchor(fun_call->get()));
+  }
 
   {
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &function_node);
-    const SyntaxTreeNode& arguments =
+    const SyntaxTreeNode* arguments =
         GetParenGroupFromCallExtension(call_extension_node);
     // parameters.
-    Visit(arguments);
+    if (arguments) Visit(*arguments);
   }
 
   facts_tree_context_.top().NewChild(std::move(function_node));
@@ -1303,8 +1306,9 @@ void IndexingFactsTreeExtractor::ExtractClassDeclaration(
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &class_node);
     // Extract class name.
-    facts_tree_context_.top().Value().AppendAnchor(
-        Anchor(GetClassName(class_declaration).get()));
+    const SyntaxTreeLeaf* class_name = GetClassName(class_declaration);
+    if (class_name)
+      facts_tree_context_.top().Value().AppendAnchor(Anchor(class_name->get()));
 
     // Extract class name after endclass.
     const SyntaxTreeLeaf* class_end_name = GetClassEndLabel(class_declaration);
@@ -1342,8 +1346,8 @@ void IndexingFactsTreeExtractor::ExtractClassDeclaration(
     }
 
     // Visit class body.
-    const SyntaxTreeNode& class_item_list = GetClassItemList(class_declaration);
-    Visit(class_item_list);
+    const SyntaxTreeNode* class_item_list = GetClassItemList(class_declaration);
+    if (class_item_list) Visit(*class_item_list);
   }
 
   facts_tree_context_.top().NewChild(std::move(class_node));
@@ -1395,9 +1399,9 @@ void IndexingFactsTreeExtractor::ExtractRegisterVariable(
   {
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &variable_node);
-    const SyntaxTreeNode& unpacked_dimension =
+    const SyntaxTreeNode* unpacked_dimension =
         GetUnpackedDimensionFromRegisterVariable(register_variable);
-    Visit(unpacked_dimension);
+    if (unpacked_dimension) Visit(*unpacked_dimension);
 
     const SyntaxTreeNode* expression =
         GetTrailingExpressionFromRegisterVariable(register_variable);
@@ -1423,10 +1427,10 @@ void IndexingFactsTreeExtractor::ExtractVariableDeclarationAssignment(
   {
     const IndexingFactsTreeContext::AutoPop p(&facts_tree_context_,
                                               &variable_node);
-    const SyntaxTreeNode& unpacked_dimension =
+    const SyntaxTreeNode* unpacked_dimension =
         GetUnpackedDimensionFromVariableDeclarationAssign(
             variable_declaration_assignment);
-    Visit(unpacked_dimension);
+    if (unpacked_dimension) Visit(*unpacked_dimension);
 
     const SyntaxTreeNode* expression =
         GetTrailingExpressionFromVariableDeclarationAssign(
@@ -1615,10 +1619,12 @@ void IndexingFactsTreeExtractor::ExtractForInitialization(
     const SyntaxTreeNode& for_initialization) {
   // Extracts the variable name from for initialization.
   // e.g from "int i = 0"; ==> extracts "i".
-  const SyntaxTreeLeaf& variable_name =
+  const SyntaxTreeLeaf* variable_name =
       GetVariableNameFromForInitialization(for_initialization);
-  facts_tree_context_.top().NewChild(IndexingNodeData(
-      IndexingFactType::kVariableDefinition, Anchor(variable_name.get())));
+  if (variable_name) {
+    facts_tree_context_.top().NewChild(IndexingNodeData(
+        IndexingFactType::kVariableDefinition, Anchor(variable_name->get())));
+  }
 
   // Extracts the data the in case it contains packed or unpacked dimension.
   // e.g bit [x : y] var [x : y].
@@ -1630,9 +1636,9 @@ void IndexingFactsTreeExtractor::ExtractForInitialization(
 
   // Extracts the RHS of the declaration.
   // e.g int i = x; ==> extracts "x".
-  const SyntaxTreeNode& expression =
+  const SyntaxTreeNode* expression =
       GetExpressionFromForInitialization(for_initialization);
-  Visit(expression);
+  if (expression) Visit(*expression);
 }
 
 // Returns string_view of `text` with outermost double-quotes removed.

--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -85,20 +85,24 @@ void DocumentSymbolFiller::Visit(const verible::SyntaxTreeNode &node) {
       break;
 
     case verilog::NodeEnum::kClassDeclaration: {
-      const auto &class_name_leaf = verilog::GetClassName(node);
-      is_visible_node = true;
-      node_symbol.kind = verible::lsp::SymbolKind::Class;
-      node_symbol.selectionRange = RangeFromToken(class_name_leaf.get());
-      node_symbol.name = std::string(class_name_leaf.get().text());
+      const auto *class_name_leaf = verilog::GetClassName(node);
+      if (class_name_leaf) {
+        is_visible_node = true;
+        node_symbol.kind = verible::lsp::SymbolKind::Class;
+        node_symbol.selectionRange = RangeFromToken(class_name_leaf->get());
+        node_symbol.name = std::string(class_name_leaf->get().text());
+      }
       break;
     }
 
     case verilog::NodeEnum::kPackageDeclaration: {
-      const auto &package_name = verilog::GetPackageNameToken(node);
-      is_visible_node = true;
-      node_symbol.kind = verible::lsp::SymbolKind::Package;
-      node_symbol.selectionRange = RangeFromToken(package_name);
-      node_symbol.name = std::string(package_name.text());
+      const auto *package_name = verilog::GetPackageNameToken(node);
+      if (package_name) {
+        is_visible_node = true;
+        node_symbol.kind = verible::lsp::SymbolKind::Package;
+        node_symbol.selectionRange = RangeFromToken(*package_name);
+        node_symbol.name = std::string(package_name->text());
+      }
       break;
     }
 


### PR DESCRIPTION
Make it simpler to deal with unexpected syntax tree shape: return nullptr instead of CHECK()-failing.

Background: improve the resilience of Kythe indexing.