### PR TITLE
Fix some clang-tidy warnings found by readability-qualified-auto.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,11 +3,18 @@
 # TODO(hzeller) fix and re-enable clang-analyzer checks.
 # TODO(hzeller) Looking over magic numbers might be good, but probably
 #               not worthwhile hard-failing
-# TODO(hzeller) Fix qualified auto readability suggestions and enable.
 # TODO(hzeller) Explore anofalloff suggestions.
+#
 # readability-make-member-function-const is great, but it also suggests that
 #    in cases where we return a non-const pointer. So good to check, not by
 #    default.
+#
+# readability-qualified-auto is useful in general, however it suggests
+#    to convert iterators (e.g. std::string_view::begin()) to the pointer it
+#    returns; however since the iterator is implementation defined, this is not
+#    a valid assertion. Running the check every now and then manually and
+#    fixing all the non-iterator cases is useful though. Off by default.
+##
 Checks: >
   clang-diagnostic-*,clang-analyzer-*,
   -clang-analyzer-core.NonNullParamChecker,
@@ -16,32 +23,33 @@ Checks: >
   abseil-*,-abseil-no-namespace,
   readability-*,
   -readability-braces-around-statements,
-  -readability-named-parameter,
-  -readability-isolate-declaration,
-  -readability-redundant-access-specifiers,
-  -readability-implicit-bool-conversion,
-  -readability-magic-numbers,
   -readability-else-after-return,
-  -readability-qualified-auto,
-  -readability-use-anyofallof,
-  -readability-make-member-function-const,
   -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-make-member-function-const,
+  -readability-named-parameter,
+  -readability-qualified-auto,
+  -readability-redundant-access-specifiers,
+  -readability-use-anyofallof,
   google-*,
   -google-readability-braces-around-statements,
   -google-readability-todo,
   performance-*,
   bugprone-*,
-  -bugprone-narrowing-conversions,
   -bugprone-branch-clone,
-  -bugprone-reserved-identifier,
-  -bugprone-move-forwarding-reference,
+  -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
+  -bugprone-move-forwarding-reference,
+  -bugprone-narrowing-conversions,
+  -bugprone-reserved-identifier,
   modernize-use-override,
   misc-*,
-  -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
-  -misc-unused-parameters,
+  -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,
+  -misc-unused-parameters,
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -99,8 +99,8 @@ void LintStatusFormatter::FormatLintRuleStatuses(
   std::set<LintViolationWithStatus> violations;
 
   // TODO(fangism): rewrite as a linear time merge of pre-ordered sub-sequences
-  for (auto& status : statuses) {
-    for (auto& violation : status.violations) {
+  for (const auto& status : statuses) {
+    for (const auto& violation : status.violations) {
       violations.insert(LintViolationWithStatus(&violation, &status));
     }
   }

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -365,7 +365,7 @@ static absl::Status WaiveCommandHandler(
           try {
             waiver->WaiveWithRegex(rule, regex);
           } catch (const std::regex_error& e) {
-            auto* reason = e.what();
+            const char* reason = e.what();
 
             return WaiveCommandError(regex_token_pos, waive_file,
                                      "Invalid regex: ", reason);

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -1179,7 +1179,7 @@ void FormatUsingOriginalSpacing(TokenPartitionRange partition_range) {
 
       // Remaining tokens
       for (auto it = tokens.begin() + 1; it != tokens.end(); ++it) {
-        auto& token = *it;
+        const auto& token = *it;
         const auto whitespace = token.OriginalLeadingSpaces();
         VLOG(5) << "token: \"" << EscapeString(whitespace)
                 << EscapeString(token.Text()) << '\"';

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -86,7 +86,7 @@ int AlreadyFormattedPartitionLength(const TokenPartitionTree& partition) {
   for (const auto& child : partition.Children()) {
     CHECK_EQ(child.Value().PartitionPolicy(), PartitionPolicyEnum::kInline);
     if (child.Value().TokensRange().begin() != tokens.begin()) {
-      auto& first_token = child.Value().TokensRange().front();
+      const auto& first_token = child.Value().TokensRange().front();
       // Substract spacing added in the loop above
       width -= first_token.before.spaces_required;
     }

--- a/common/strings/diff.cc
+++ b/common/strings/diff.cc
@@ -179,7 +179,7 @@ void LineDiffsToUnifiedDiff(std::ostream& stream, const LineDiffs& linediffs,
     int chunk_added_lines_count = 0;
 
     for (size_t i = 0; i < chunk.size(); ++i) {
-      auto& edit = chunk[i];
+      const auto& edit = chunk[i];
 
       if (edit.operation == Operation::INSERT) {
         chunk_added_lines_count += edit.end - edit.start;

--- a/common/text/concrete_syntax_tree.cc
+++ b/common/text/concrete_syntax_tree.cc
@@ -67,7 +67,7 @@ const SymbolPtr& SyntaxTreeNode::operator[](const size_t i) const {
 // visits self, then forwards visitor to every child
 void SyntaxTreeNode::Accept(TreeVisitorRecursive* visitor) const {
   visitor->Visit(*this);
-  for (auto& child : children_) {
+  for (const auto& child : children_) {
     if (child != nullptr) child->Accept(visitor);
   }
 }

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -36,7 +36,7 @@ static absl::Status ChangedLines(const SubcommandArgsRange& args,
     return absl::InvalidArgumentError(
         "Missing patchfile argument.  Use '-' for stdin.");
   }
-  const auto patchfile = args[0];
+  const char* patchfile = args[0];
   std::string patch_contents;
   if (auto status = verible::file::GetContents(patchfile, &patch_contents);
       !status.ok()) {
@@ -64,7 +64,7 @@ static absl::Status ApplyPick(const SubcommandArgsRange& args,
   if (args.empty()) {
     return absl::InvalidArgumentError("Missing patchfile argument.");
   }
-  const auto patchfile = args[0];
+  const char* patchfile = args[0];
   std::string patch_contents;
   if (auto status = verible::file::GetContents(patchfile, &patch_contents);
       !status.ok()) {

--- a/verilog/CST/port.cc
+++ b/verilog/CST/port.cc
@@ -62,7 +62,7 @@ const SyntaxTreeLeaf* GetIdentifierFromModulePortDeclaration(
 
 const SyntaxTreeLeaf* GetDirectionFromModulePortDeclaration(
     const Symbol& symbol) {
-  if (auto dir_symbol =
+  if (const auto* dir_symbol =
           GetSubtreeAsSymbol(symbol, NodeEnum::kPortDeclaration, 0)) {
     return &SymbolCastToLeaf(*dir_symbol);
   }

--- a/verilog/analysis/checkers/always_comb_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.cc
@@ -68,7 +68,8 @@ void AlwaysCombBlockingRule::HandleSymbol(const verible::Symbol& symbol,
   if (AlwaysCombMatcher().Matches(symbol, &manager)) {
     for (const auto& match :
          SearchSyntaxTree(symbol, NodekNonblockingAssignmentStatement())) {
-      auto* node = dynamic_cast<const verible::SyntaxTreeNode*>(match.match);
+      const auto* node =
+          dynamic_cast<const verible::SyntaxTreeNode*>(match.match);
 
       if (node == nullptr) continue;
 

--- a/verilog/analysis/checkers/forbidden_macro_rule.cc
+++ b/verilog/analysis/checkers/forbidden_macro_rule.cc
@@ -73,7 +73,7 @@ void ForbiddenMacroRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (MacroCallMatcher().Matches(symbol, &manager)) {
-    if (auto leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
+    if (const auto* leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
       const auto& imm = InvalidMacrosMap();
       if (imm.find(std::string(leaf->get().text())) != imm.end()) {
         violations_.insert(

--- a/verilog/analysis/checkers/forbidden_symbol_rule.cc
+++ b/verilog/analysis/checkers/forbidden_symbol_rule.cc
@@ -81,7 +81,7 @@ void ForbiddenSystemTaskFunctionRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (IdMatcher().Matches(symbol, &manager)) {
-    if (auto leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
+    if (const auto* leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
       const auto& ism = InvalidSymbolsMap();
       if (ism.find(std::string(leaf->get().text())) != ism.end()) {
         violations_.insert(

--- a/verilog/analysis/checkers/module_instantiation_rules.cc
+++ b/verilog/analysis/checkers/module_instantiation_rules.cc
@@ -125,7 +125,7 @@ void ModuleParameterRule::HandleSymbol(
 
   verible::matcher::BoundSymbolManager manager;
   if (ParamsMatcher().Matches(symbol, &manager)) {
-    if (auto list = manager.GetAs<verible::SyntaxTreeNode>("list")) {
+    if (const auto* list = manager.GetAs<verible::SyntaxTreeNode>("list")) {
       const auto& children = list->children();
       auto parameter_count = std::count_if(
           children.begin(), children.end(),
@@ -134,7 +134,7 @@ void ModuleParameterRule::HandleSymbol(
       // One positional parameter is permitted, but any more require all
       // parameters to be named.
       if (parameter_count > 1) {  // Determine the spanning location
-        const auto leaf_ptr = verible::GetLeftmostLeaf(*list);
+        const auto* leaf_ptr = verible::GetLeftmostLeaf(*list);
         const verible::TokenInfo token = ABSL_DIE_IF_NULL(leaf_ptr)->get();
         violations_.insert(verible::LintViolation(token, kMessage, context));
       }
@@ -159,13 +159,14 @@ void ModulePortRule::HandleSymbol(const verible::Symbol& symbol,
   verible::matcher::BoundSymbolManager manager;
 
   if (InstanceMatcher().Matches(symbol, &manager)) {
-    if (auto port_list_node = manager.GetAs<verible::SyntaxTreeNode>("list")) {
+    if (const auto* port_list_node =
+            manager.GetAs<verible::SyntaxTreeNode>("list")) {
       // Don't know how to handle unexpected non-portlist, so proceed
       if (!port_list_node->MatchesTag(NodeEnum::kPortActualList)) return;
 
       if (!IsPortListCompliant(*port_list_node)) {
         // Determine the leftmost location
-        const auto leaf_ptr = verible::GetLeftmostLeaf(*port_list_node);
+        const auto* leaf_ptr = verible::GetLeftmostLeaf(*port_list_node);
         const verible::TokenInfo token = ABSL_DIE_IF_NULL(leaf_ptr)->get();
         violations_.insert(verible::LintViolation(token, kMessage, context));
       }

--- a/verilog/analysis/checkers/parameter_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule.cc
@@ -92,7 +92,7 @@ void ParameterNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
 
     auto identifiers = GetAllParameterNameTokens(symbol);
 
-    for (auto id : identifiers) {
+    for (const auto* id : identifiers) {
       const auto param_name = id->text();
       uint32_t observed_style = 0;
       if (verible::IsUpperCamelCaseWithDigits(param_name))

--- a/verilog/analysis/checkers/plusarg_assignment_rule.cc
+++ b/verilog/analysis/checkers/plusarg_assignment_rule.cc
@@ -61,7 +61,7 @@ void PlusargAssignmentRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (IdMatcher().Matches(symbol, &manager)) {
-    if (auto leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
+    if (const auto* leaf = manager.GetAs<verible::SyntaxTreeLeaf>("name")) {
       if (kForbiddenFunctionName == leaf->get().text()) {
         violations_.insert(
             verible::LintViolation(leaf->get(), FormatReason(), context));

--- a/verilog/analysis/checkers/signal_name_style_rule.cc
+++ b/verilog/analysis/checkers/signal_name_style_rule.cc
@@ -87,14 +87,14 @@ void SignalNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
           LintViolation(identifier_leaf->get(), kMessage, context));
   } else if (NetMatcher().Matches(symbol, &manager)) {
     const auto identifier_leaves = GetIdentifiersFromNetDeclaration(symbol);
-    for (auto& leaf : identifier_leaves) {
+    for (const auto* leaf : identifier_leaves) {
       const auto name = leaf->text();
       if (!verible::IsLowerSnakeCaseWithDigits(name))
         violations_.insert(LintViolation(*leaf, kMessage, context));
     }
   } else if (DataMatcher().Matches(symbol, &manager)) {
     const auto identifier_leaves = GetIdentifiersFromDataDeclaration(symbol);
-    for (auto& leaf : identifier_leaves) {
+    for (const auto* leaf : identifier_leaves) {
       const auto name = leaf->text();
       if (!verible::IsLowerSnakeCaseWithDigits(name))
         violations_.insert(LintViolation(*leaf, kMessage, context));

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
@@ -85,7 +85,7 @@ static int digitBits(char digit, bool* is_lower_bound) {
 }
 
 static absl::string_view StripLeadingZeroes(absl::string_view str) {
-  auto it =
+  const absl::string_view::const_iterator it =
       std::find_if_not(str.begin(), str.end(), [](char c) { return c == '0'; });
   return str.substr(it - str.begin());
 }
@@ -152,8 +152,8 @@ void TruncatedNumericLiteralRule::HandleSymbol(
     const verible::Symbol& symbol, const SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (!NumberMatcher().Matches(symbol, &manager)) return;
-  const auto width_leaf = manager.GetAs<SyntaxTreeLeaf>("width");
-  const auto literal_node = manager.GetAs<SyntaxTreeNode>("literal");
+  const auto* width_leaf = manager.GetAs<SyntaxTreeLeaf>("width");
+  const auto* literal_node = manager.GetAs<SyntaxTreeNode>("literal");
   if (!width_leaf || !literal_node) return;
 
   const auto width_text = width_leaf->get().text();
@@ -161,8 +161,10 @@ void TruncatedNumericLiteralRule::HandleSymbol(
   if (!absl::SimpleAtoi(width_text, &width)) return;
 
   const auto& base_digit_part = literal_node->children();
-  auto base_leaf = down_cast<const SyntaxTreeLeaf*>(base_digit_part[0].get());
-  auto digits_leaf = down_cast<const SyntaxTreeLeaf*>(base_digit_part[1].get());
+  const auto* base_leaf =
+      down_cast<const SyntaxTreeLeaf*>(base_digit_part[0].get());
+  const auto* digits_leaf =
+      down_cast<const SyntaxTreeLeaf*>(base_digit_part[1].get());
 
   const auto base_text = base_leaf->get().text();
   const auto digits_text = digits_leaf->get().text();

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.cc
@@ -87,8 +87,8 @@ void UndersizedBinaryLiteralRule::HandleSymbol(
     const verible::Symbol& symbol, const SyntaxTreeContext& context) {
   verible::matcher::BoundSymbolManager manager;
   if (!NumberMatcher().Matches(symbol, &manager)) return;
-  const auto width_leaf = manager.GetAs<SyntaxTreeLeaf>("width");
-  const auto literal_node = manager.GetAs<SyntaxTreeNode>("literal");
+  const auto* width_leaf = manager.GetAs<SyntaxTreeLeaf>("width");
+  const auto* literal_node = manager.GetAs<SyntaxTreeNode>("literal");
   if (!width_leaf || !literal_node) return;
 
   const auto width_text = width_leaf->get().text();
@@ -96,8 +96,10 @@ void UndersizedBinaryLiteralRule::HandleSymbol(
   if (!absl::SimpleAtoi(width_text, &width)) return;
 
   const auto& base_digit_part = literal_node->children();
-  auto base_leaf = down_cast<const SyntaxTreeLeaf*>(base_digit_part[0].get());
-  auto digits_leaf = down_cast<const SyntaxTreeLeaf*>(base_digit_part[1].get());
+  const auto* base_leaf =
+      down_cast<const SyntaxTreeLeaf*>(base_digit_part[0].get());
+  const auto* digits_leaf =
+      down_cast<const SyntaxTreeLeaf*>(base_digit_part[1].get());
 
   const auto base_text = base_leaf->get().text();
   const auto digits_text = digits_leaf->get().text();

--- a/verilog/analysis/checkers/void_cast_rule.cc
+++ b/verilog/analysis/checkers/void_cast_rule.cc
@@ -95,7 +95,8 @@ void VoidCastRule::HandleSymbol(const verible::Symbol& symbol,
   // Check for forbidden function names
   verible::matcher::BoundSymbolManager manager;
   if (FunctionMatcher().Matches(symbol, &manager)) {
-    if (auto function_id = manager.GetAs<verible::SyntaxTreeLeaf>("id")) {
+    if (const auto* function_id =
+            manager.GetAs<verible::SyntaxTreeLeaf>("id")) {
       const auto& bfs = ForbiddenFunctionsSet();
       if (bfs.find(std::string(function_id->get().text())) != bfs.end()) {
         violations_.insert(LintViolation(function_id->get(),
@@ -107,8 +108,9 @@ void VoidCastRule::HandleSymbol(const verible::Symbol& symbol,
   // Check for forbidden calls to randomize
   manager.Clear();
   if (RandomizeMatcher().Matches(symbol, &manager)) {
-    if (auto randomize_node = manager.GetAs<verible::SyntaxTreeNode>("id")) {
-      auto leaf_ptr = verible::GetLeftmostLeaf(*randomize_node);
+    if (const auto* randomize_node =
+            manager.GetAs<verible::SyntaxTreeNode>("id")) {
+      const auto* leaf_ptr = verible::GetLeftmostLeaf(*randomize_node);
       const verible::TokenInfo token = ABSL_DIE_IF_NULL(leaf_ptr)->get();
       violations_.insert(LintViolation(
           token, "randomize() is forbidden within void casts", context));

--- a/verilog/analysis/verilog_excerpt_parse.cc
+++ b/verilog/analysis/verilog_excerpt_parse.cc
@@ -134,8 +134,8 @@ std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogWithMode(
           {"parse-as-property-spec", &AnalyzeVerilogPropertySpec},
           {"parse-as-library-map", &AnalyzeVerilogLibraryMap},
       };
-  auto func_ptr = FindOrNull(*func_map, mode);
-  if (func_ptr == nullptr) return nullptr;
+  const auto* func_ptr = FindOrNull(*func_map, mode);
+  if (!func_ptr) return nullptr;
   return (*func_ptr)(text, filename);
 }
 

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -84,8 +84,8 @@ std::set<LintViolationWithStatus> GetSortedViolations(
     const std::vector<LintRuleStatus>& statuses) {
   std::set<LintViolationWithStatus> violations;
 
-  for (auto& status : statuses) {
-    for (auto& violation : status.violations) {
+  for (const auto& status : statuses) {
+    for (const auto& violation : status.violations) {
       violations.insert(LintViolationWithStatus(&violation, &status));
     }
   }

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -68,10 +68,10 @@ const char* ProjectPolicy::MatchesAnyExclusions(
 }
 
 bool ProjectPolicy::IsValid() const {
-  for (const auto rule : disabled_rules) {
+  for (const auto& rule : disabled_rules) {
     if (!analysis::IsRegisteredLintRule(rule)) return false;
   }
-  for (const auto rule : enabled_rules) {
+  for (const auto& rule : enabled_rules) {
     if (!analysis::IsRegisteredLintRule(rule)) return false;
   }
   return true;
@@ -211,11 +211,11 @@ void LinterConfiguration::UseProjectPolicy(const ProjectPolicy& policy,
   if (const char* matched_path = policy.MatchesAnyPath(filename)) {
     VLOG(1) << "File \"" << filename << "\" matches path \"" << matched_path
             << "\" from project policy [" << policy.name << "], applying it.";
-    for (const auto rule : policy.disabled_rules) {
+    for (const auto& rule : policy.disabled_rules) {
       VLOG(1) << "  disabling rule: " << rule;
       TurnOff(rule);
     }
-    for (const auto rule : policy.enabled_rules) {
+    for (const auto& rule : policy.enabled_rules) {
       VLOG(1) << "  enabling rule: " << rule;
       TurnOn(rule);
     }

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -509,7 +509,7 @@ static void DeterminePartitionExpansion(
         // end
         const auto& children_tmp = node->Children();
         auto look_for_arglist = [](const partition_node_type& child) {
-          auto& node_view_child = child.Value();
+          const auto& node_view_child = child.Value();
           const UnwrappedLine& uwline_child = node_view_child.Value();
           return (uwline_child.Origin() &&
                   uwline_child.Origin()->Kind() == verible::SymbolKind::kNode &&

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -72,9 +72,9 @@ std::vector<verible::lsp::Diagnostic> CreateDiagnostics(
                   verible::AnalysisPhase phase, absl::string_view token_text,
                   absl::string_view context_line, const std::string &msg) {
           // Note: msg is currently empty and not useful.
-          const auto message = (phase == verible::AnalysisPhase::kLexPhase)
-                                   ? "token error"
-                                   : "syntax error";
+          const char *message = (phase == verible::AnalysisPhase::kLexPhase)
+                                    ? "token error"
+                                    : "syntax error";
           result.emplace_back(verible::lsp::Diagnostic{
               .range{.start{.line = range.start.line,
                             .character = range.start.column},

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -35,7 +35,7 @@ static absl::Status StripComments(const SubcommandArgsRange& args,
     return absl::InvalidArgumentError(
         "Missing file argument.  Use '-' for stdin.");
   }
-  const auto source_file = args[0];
+  const char* source_file = args[0];
   std::string source_contents;
   if (auto status = verible::file::GetContents(source_file, &source_contents);
       !status.ok()) {

--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -283,7 +283,7 @@ int main(int argc, char** argv) {
 
   int exit_status = 0;
   // All positional arguments are file names.  Exclude program name.
-  for (const auto filename :
+  for (const char* filename :
        verible::make_range(args.begin() + 1, args.end())) {
     std::string content;
     if (!verible::file::GetContents(filename, &content).ok()) {


### PR DESCRIPTION
Also organized the .clang-tidy rules to sort disabled rules.

Unfortunately, we can't have readability-qualified-auto on by
default, as it also suggests to qualify the return value of
absl::string_view::begin() with const auto* - which can be wrong
as absl::string_view might be typedefed to std::string_view whose
iterator type is implementation defined. So this change does
not touch any suggestions that involves iterators.

Signed-off-by: Henner Zeller <h.zeller@acm.org>