### PR TITLE
Removed CentOS 8 release as it is EOL

### DIFF
--- a/releasing/README.md
+++ b/releasing/README.md
@@ -12,9 +12,10 @@ RedHat Enterprise Linux support).
 Currently supported Linux distributions are:
 
 - CentOS 7
-- CentOS 8
 - Ubuntu Xenial (16.04 LTS)
 - Ubuntu Bionic (18.04 LTS)
 - Ubuntu Eoan (19.10)
 - Ubuntu Focal (20.04 LTS)
 - Ubuntu Groovy (20.10)
+
+Note that CentOS 8 was EOL on December 2021 but CentOS 7 is still supported until 2024.

--- a/releasing/centos/8/compiler.dockerstage
+++ b/releasing/centos/8/compiler.dockerstage
@@ -1,9 +1,0 @@
-# Link libstdc++ statically so people don't have to install devtoolset-9
-# just to use verible.
-ENV BAZEL_LINKOPTS "-static-libstdc++:-lm -static-libstdc++:-lrt"
-ENV BAZEL_LINKLIBS "-l%:libstdc++.a"
-
-# Get a newer GCC version
-RUN yum install -y --nogpgcheck gcc-toolset-9-toolchain
-
-SHELL [ "scl", "enable", "gcc-toolset-9" ]

--- a/releasing/docker-run.sh
+++ b/releasing/docker-run.sh
@@ -72,8 +72,7 @@ case "$TARGET_OS" in
   ;;
   centos)
     # Compiler
-    [ "$TARGET_VERSION" = 8 ] && _version="$TARGET_VERSION" || _version="common"
-    cat ${TARGET_OS}/${_version}/compiler.dockerstage >> ${OUT_DIR}/Dockerfile
+    cat ${TARGET_OS}/common/compiler.dockerstage >> ${OUT_DIR}/Dockerfile
     # Bazel
     cat ${TARGET_OS}/common/bazel.dockerstage >> ${OUT_DIR}/Dockerfile
   ;;

--- a/releasing/supported_bases.txt
+++ b/releasing/supported_bases.txt
@@ -1,5 +1,4 @@
 centos:7
-centos:8
 ubuntu:bionic
 ubuntu:focal
 ubuntu:jammy


### PR DESCRIPTION
CentOS 8 is EOL and fails to build as a consequence

Closes #1165 