### PR TITLE
Update hash of googletest library as it (benignly) changed upstream.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ http_archive(
 # Googletest
 http_archive(
     name = "com_google_googletest",
-    sha256 = "353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a",
+    sha256 = "63afcb1690b2139b2d9c7ad1df3de87697530fb1fd6869622cff26c77a3b0cfb",
     strip_prefix = "googletest-release-1.11.0",
     urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip"],
 )


### PR DESCRIPTION
The sha256sum hash of
https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip

Changed from
`353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a`  old/release-1.11.0.zip
`63afcb1690b2139b2d9c7ad1df3de87697530fb1fd6869622cff26c77a3b0cfb`  new/release-1.11.0.zip

Investigation by @mglb revealed that there is no change in content for any file inside
the archive, just timestamps changed. Now why that was happening is a different question,
but the change is benign so ok to update our expectation of the hash.

Fixes #1168

Signed-off-by: Henner Zeller <h.zeller@acm.org>