### PR TITLE
Improve macro call formatting

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -97,17 +97,13 @@ declare -A KnownIssue
 
 #--- Opentitan
 KnownIssue[formatter:$BASE_TEST_DIR/opentitan/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv]=1006
-KnownIssue[formatter:$BASE_TEST_DIR/opentitan/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv]=1130
 # There is also bug 1008 which only shows up if compiled with asan
 
 #--- ivtest
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/stask_sens_null_arg.v]=1010
-KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/sv_macro.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/sv_port_default14.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/pr1763333.v]=1010
-KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/br_gh72a.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/blankport.v]=1010
-KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/br_gh72b_fail.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/param_times.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/sv_default_port_value1.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/sv_default_port_value3.v]=1010

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -518,10 +518,10 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
     case PartitionPolicyEnum::kStack:
     case PartitionPolicyEnum::kAlwaysExpand:
     case PartitionPolicyEnum::kTabularAlignment: {
-      int indentation = node.Value().IndentationSpaces();
+      const int indentation = node.Value().IndentationSpaces();
       std::transform(node.Children().begin(), node.Children().end(),
                      layouts.begin(), [=](const TokenPartitionTree& n) {
-                       int relative_indentation =
+                       const int relative_indentation =
                            n.Value().IndentationSpaces() - indentation;
                        if (relative_indentation < 0) {
                          VLOG(0)
@@ -588,9 +588,9 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
         juxtaposition = factory_.Juxtaposition(layouts.begin(), layouts.end());
       }
 
-      int indentation = node.Value().IndentationSpaces();
+      const int indentation = node.Value().IndentationSpaces();
       for (int i = 0; i < static_cast<int>(layouts.size()); ++i) {
-        int relative_indentation =
+        const int relative_indentation =
             node.Children()[i].Value().IndentationSpaces() - indentation;
         layouts[i] = factory_.Indent(layouts[i], relative_indentation);
       }

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -484,7 +484,18 @@ void TokenPartitionsLayoutOptimizer::Optimize(int indentation,
 
 LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
     const TokenPartitionTree& node) const {
-  if (node.is_leaf()) return factory_.Line(node.Value());
+  if (node.is_leaf()) {
+    // Wrapping complexity is n*(n+1)/2.
+    constexpr int kWrapTokensLimit = 25;
+
+    if (node.Value().PartitionPolicy() == PartitionPolicyEnum::kWrap &&
+        node.Value().TokensRange().size() > 1 &&
+        node.Value().TokensRange().size() < kWrapTokensLimit) {
+      return factory_.WrappedLine(node.Value());
+    } else {
+      return factory_.Line(node.Value());
+    }
+  }
 
   // Traverse and calculate children layouts
 

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -188,6 +188,21 @@ LayoutFunction::const_iterator LayoutFunction::AtOrToTheLeftOf(
   return it - 1;
 }
 
+LayoutFunction LayoutFunctionFactory::WrappedLine(
+    const UnwrappedLine& uwline) const {
+  const auto tokens = uwline.TokensRange();
+  auto token_lfs = absl::FixedArray<LayoutFunction>(tokens.size());
+
+  auto lf = token_lfs.begin();
+  for (auto t = tokens.begin(); t != tokens.end(); ++t) {
+    auto token_line = UnwrappedLine(0, t);
+    token_line.SpanNextToken();
+    *lf = Line(token_line);
+    ++lf;
+  }
+  return Wrap(token_lfs.begin(), token_lfs.end(), true, style_.wrap_spaces);
+}
+
 LayoutFunction LayoutFunctionFactory::Line(const UnwrappedLine& uwline) const {
   auto layout = LayoutTree(LayoutItem(uwline));
   const auto span = layout.Value().Length();

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -60,6 +60,8 @@ void AdoptLayoutAndFlattenIfSameType(const LayoutTree& source,
     const auto& first_subitem = source.Children().front().Value();
     CHECK(src_item.MustWrap() == first_subitem.MustWrap());
     CHECK(src_item.SpacesBefore() == first_subitem.SpacesBefore());
+    destination->Children().reserve(destination->Children().size() +
+                                    source.Children().size());
     for (const auto& sublayout : source.Children())
       destination->AdoptSubtree(sublayout);
   } else {

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -225,9 +225,7 @@ LayoutFunction LayoutFunctionFactory::Indent(const LayoutFunction& lf,
     const float new_intercept =
         segment->CostAt(column) -
         style_.over_column_limit_penalty * std::max(columns_over_limit, 0);
-    const int new_gradient =
-        segment->gradient -
-        style_.over_column_limit_penalty * (columns_over_limit >= 0);
+    const int new_gradient = segment->gradient;
 
     auto new_layout = segment->layout;
     new_layout.Value().SetIndentationSpaces(

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -505,7 +505,6 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
     case PartitionPolicyEnum::kJuxtaposition:
     case PartitionPolicyEnum::kAlreadyFormatted:
     case PartitionPolicyEnum::kWrap:
-    case PartitionPolicyEnum::kOptimalFunctionCallLayout:
     case PartitionPolicyEnum::kFitOnLineElseExpand:
     case PartitionPolicyEnum::kAppendFittingSubPartitions:
     case PartitionPolicyEnum::kJuxtapositionOrIndentedStack: {
@@ -635,29 +634,6 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
       layouts.front() = factory_.Indent(layouts.front(), indent);
 
       return factory_.Juxtaposition(layouts.begin(), layouts.end());
-    }
-
-    case PartitionPolicyEnum::kOptimalFunctionCallLayout: {
-      // Support only function/macro/system calls for now
-      CHECK_EQ(node.Children().size(), 2);
-      auto& header = layouts[0];
-      auto& args = layouts[1];
-
-      auto stack_layout = factory_.Stack({
-          header,
-          factory_.Indent(args, style_.wrap_spaces),
-      });
-      if (args.MustWrap()) {
-        return stack_layout;
-      }
-      auto juxtaposed_layout = factory_.Juxtaposition({
-          header,
-          args,
-      });
-      return factory_.Choice({
-          std::move(juxtaposed_layout),
-          std::move(stack_layout),
-      });
     }
 
     case PartitionPolicyEnum::kAppendFittingSubPartitions:

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -558,10 +558,10 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
       return factory_.Stack(layouts.begin(), layouts.end());
     case PartitionPolicyEnum::kWrap: {
       if (VLOG_IS_ON(0) && node.Children().size() > 2) {
-        int second_indentation = node.Children()[1].Value().IndentationSpaces();
+        const int indentation = node.Children()[1].Value().IndentationSpaces();
         for (const auto& child : iterator_range(node.Children().begin() + 2,
                                                 node.Children().end())) {
-          if (child.Value().IndentationSpaces() != second_indentation) {
+          if (child.Value().IndentationSpaces() != indentation) {
             VLOG(0) << "Indentations of subpartitions from the second to the "
                        "last are not equal. Using indentation of the second "
                        "subpartition as a hanging indentation. Parent node:\n"
@@ -569,7 +569,7 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
           }
         }
       }
-      int hanging_indentation =
+      const int hanging_indentation =
           (node.Children().size() > 1)
               ? (node.Children()[1].Value().IndentationSpaces() -
                  node.Value().IndentationSpaces())

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -589,7 +589,7 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
       }
 
       const int indentation = node.Value().IndentationSpaces();
-      for (int i = 0; i < static_cast<int>(layouts.size()); ++i) {
+      for (size_t i = 0; i < layouts.size(); ++i) {
         const int relative_indentation =
             node.Children()[i].Value().IndentationSpaces() - indentation;
         layouts[i] = factory_.Indent(layouts[i], relative_indentation);

--- a/common/formatting/layout_optimizer.h
+++ b/common/formatting/layout_optimizer.h
@@ -36,7 +36,7 @@
 
 namespace verible {
 
-// Handles formatting of `node` using Layout Optimizer.
+// Handles formatting of `node` using LayoutOptimizer.
 void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
                                 TokenPartitionTree* node);
 

--- a/common/formatting/layout_optimizer.h
+++ b/common/formatting/layout_optimizer.h
@@ -36,41 +36,7 @@
 
 namespace verible {
 
-// Handles formatting of TokenPartitionTree 'node' that uses
-// PartitionPolicyEnum::kOptimalFunctionCallLayout partition policy.
-// The function changes only tokens that are spanned by the passed partitions
-// tree.
-//
-// It is designed to format function calls and requires specific partition
-// tree structure:
-//
-//   <function call node, policy: kOptimalFunctionCallLayout> {
-//     <function header> { ... },
-//     <function arguments> { ... }
-//   }
-//
-// Nested kOptimalFunctionCallLayout partitions are supported.
-//
-// EXAMPLE INPUT TREE
-//
-// Code: `uvm_info(`gfn, $sformatf("%0d %0d\n", cfg.num_pulses, i), UVM_DEBUG)
-//
-// Partition tree:
-// { (>>[...], policy: optimal-function-call-layout) // call:
-//   { (>>[`uvm_info (]) }                           // - header
-//   { (>>>>>>[...])                                 // - arguments:
-//     { (>>>>>>[`gfn ,]) }                          //   - (arg)
-//     { (>>>>>>[...], policy: optimal-function-call-layout) // nested call:
-//       { (>>>>>>[$sformatf (]) }                           // - header
-//       { (>>>>>>>>>>[...])                                 // - arguments
-//         { (>>>>>>>>>>["%0d %0d\n" ,]) }                   //   - (arg)
-//         { (>>>>>>>>>>[cfg . num_pulses ,]) }              //   - (arg)
-//         { (>>>>>>>>>>[i ) ,]) }                           //   - (arg)
-//       }
-//     }
-//     { (>>>>>>[UVM_DEBUG )]) }                     //   - (arg)
-//   }
-// }
+// Handles formatting of `node` using Layout Optimizer.
 void OptimizeTokenPartitionTree(const BasicFormatStyle& style,
                                 TokenPartitionTree* node);
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -134,7 +134,16 @@ class LayoutItem {
     for (const auto& token : tokens_) {
       // TODO (mglb): support all possible break_decisions
       len += token.before.spaces_required;
-      len += token.Length();
+      if (const auto line_break_pos = token.Text().find('\n');
+          line_break_pos != std::string_view::npos) {
+        // Multiline tokens are not really supported.
+        // Use number of characters up to the first line break.
+        len += line_break_pos;
+        DVLOG(5) << __FUNCTION__ << ": WARNING: Token contains '\\n':\n"
+                 << *token.token;
+      } else {
+        len += token.Length();
+      }
     }
     len -= tokens_.front().before.spaces_required;
     return len;

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -722,7 +722,7 @@ class LayoutFunctionFactory {
 class TokenPartitionsLayoutOptimizer {
  public:
   explicit TokenPartitionsLayoutOptimizer(const BasicFormatStyle& style)
-      : style_(style), factory_(style) {}
+      : factory_(style) {}
 
   TokenPartitionsLayoutOptimizer(const TokenPartitionsLayoutOptimizer&) =
       delete;
@@ -737,7 +737,6 @@ class TokenPartitionsLayoutOptimizer {
   LayoutFunction CalculateOptimalLayout(const TokenPartitionTree& node) const;
 
  private:
-  const BasicFormatStyle& style_;
   const LayoutFunctionFactory factory_;
 };
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -634,15 +634,20 @@ class LayoutFunctionFactory {
 
   // Joins layouts horizontally and wraps them into multiple lines to stay under
   // column limit. Kind of like a words in a paragraph.
-  LayoutFunction Wrap(std::initializer_list<LayoutFunction> lfs) const {
-    return Wrap(lfs.begin(), lfs.end());
+  LayoutFunction Wrap(std::initializer_list<LayoutFunction> lfs,
+                      bool use_tokens_break_penalty = false,
+                      int hanging_indentation = 0) const {
+    return Wrap(lfs.begin(), lfs.end(), use_tokens_break_penalty,
+                hanging_indentation);
   }
 
   // See Wrap(std::initializer_list<LayoutFunction> lfs).
   //
   // Iterator: iterator type that dereferences to LayoutFunction.
   template <class Iterator>
-  LayoutFunction Wrap(const Iterator begin, const Iterator end) const {
+  LayoutFunction Wrap(const Iterator begin, const Iterator end,
+                      bool use_tokens_break_penalty = false,
+                      int hanging_indentation = 0) const {
     static_assert(IsIteratorDereferencingTo<Iterator, LayoutFunction>,
                   "Iterator's value type must be LayoutFunction.");
 
@@ -653,23 +658,41 @@ class LayoutFunctionFactory {
 
     absl::FixedArray<LayoutFunction> results(lfs.size());
 
-    int size = lfs.size();
+    const int size = lfs.size();
     for (int i = size - 1; i >= 0; --i) {
       absl::FixedArray<LayoutFunction> results_i(size - i);
       LayoutFunction incremental = lfs[i];
       for (int j = i; j < size - 1; ++j) {
         results_i[j - i] = Stack({
             incremental,
-            results[j + 1],
+            (i == 0) ? Indent(results[j + 1], hanging_indentation)
+                     : results[j + 1],
         });
 
         const auto& next_element = lfs[j + 1];
+        if (use_tokens_break_penalty) {
+          // Deprioritize token-level wrapping
+          // TODO(mglb): Find a better way to do this. This ratio has been
+          // chosen using only a few test cases.
+          const int wrapping_penalty = style_.over_column_limit_penalty;
+          const auto& second_layout = results[j + 1].front().layout;
+          const auto& first_line = second_layout.LeftmostDescendant()->Value();
+          const auto& first_token = first_line.TokensRange().front();
+          const int token_break_penalty = first_token.before.break_penalty;
 
-        const auto layout_functions = {std::move(incremental), next_element};
+          for (auto& segment : results_i[j - i])
+            segment.intercept += wrapping_penalty + token_break_penalty;
+        }
+
         if (next_element.MustWrap())
-          incremental = Stack(layout_functions);
+          incremental = Stack({
+              std::move(incremental),
+              Indent(next_element, hanging_indentation),
+          });
         else
-          incremental = Juxtaposition(layout_functions);
+          // TODO(mglb): use Stack for invervals where lfs[j] is multiline (i.e.
+          // has any stack sublayouts)
+          incremental = Juxtaposition({std::move(incremental), next_element});
       }
       results_i.back() = std::move(incremental);
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -516,8 +516,11 @@ class LayoutFunctionFactory {
   explicit LayoutFunctionFactory(const BasicFormatStyle& style)
       : style_(style) {}
 
-  // Creates CostFunction for a single line from UnwrappedLine 'uwline'.
+  // Creates LayoutFunction for a single line from UnwrappedLine 'uwline'.
   LayoutFunction Line(const UnwrappedLine& uwline) const;
+
+  // Creates LayoutFunction from a single line with tokens wrapped using Wrap().
+  LayoutFunction WrappedLine(const UnwrappedLine& uwline) const;
 
   // Combines two or more layouts vertically.
   // All combined layouts start at the same column. The first line of layout

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -2436,11 +2436,56 @@ TEST_F(TokenPartitionsLayoutOptimizerTest, CalculateOptimalLayout) {
   const auto optimizer = TokenPartitionsLayoutOptimizer(style_);
 
   {
+    const auto tree = TPT(4, PP::kAlwaysExpand,
+                          {
+                              TPT(4, {0, 1}),
+                              TPT(4, {1, 2}),
+                              TPT(4, {2, 3}),
+                          })
+                          .build(pre_format_tokens_);
+
+    const auto expected_layout = LT(LI(LayoutType::kStack, 0, true),     //
+                                    LT(LI(tree.Children()[0].Value())),  //
+                                    LT(LI(tree.Children()[1].Value())),  //
+                                    LT(LI(tree.Children()[2].Value())));
+    const auto expected_lf = LayoutFunction{
+        {0, expected_layout, 5, 4.0F, 0},
+        {35, expected_layout, 5, 4.0F, 100},
+        {37, expected_layout, 5, 204.0F, 300},
+    };
+
+    const LayoutFunction lf = optimizer.CalculateOptimalLayout(tree);
+    ExpectLayoutFunctionsEqual(lf, expected_lf, __LINE__);
+  }
+  {
     const auto tree = TPT(PP::kAlwaysExpand,
                           {
                               TPT(1, {0, 1}),
                               TPT(2, {1, 2}),
                               TPT(3, {2, 3}),
+                          })
+                          .build(pre_format_tokens_);
+
+    const auto expected_layout = LT(LI(LayoutType::kStack, 0, true),        //
+                                    LT(LI(tree.Children()[0].Value(), 1)),  //
+                                    LT(LI(tree.Children()[1].Value(), 2)),  //
+                                    LT(LI(tree.Children()[2].Value(), 3)));
+    const auto expected_lf = LayoutFunction{
+        {0, expected_layout, 8, 4.0F, 0},
+        {32, expected_layout, 8, 4.0F, 100},
+        {35, expected_layout, 8, 304.0F, 200},
+        {36, expected_layout, 8, 504.0F, 300},
+    };
+
+    const LayoutFunction lf = optimizer.CalculateOptimalLayout(tree);
+    ExpectLayoutFunctionsEqual(lf, expected_lf, __LINE__);
+  }
+  {
+    const auto tree = TPT(2, PP::kTabularAlignment,
+                          {
+                              TPT(2, {0, 1}, PP::kAlreadyFormatted),
+                              TPT(2, {1, 2}, PP::kAlreadyFormatted),
+                              TPT(2, {2, 3}, PP::kAlreadyFormatted),
                           })
                           .build(pre_format_tokens_);
 
@@ -2466,14 +2511,15 @@ TEST_F(TokenPartitionsLayoutOptimizerTest, CalculateOptimalLayout) {
                           })
                           .build(pre_format_tokens_);
 
-    const auto expected_layout = LT(LI(LayoutType::kStack, 0, true),     //
-                                    LT(LI(tree.Children()[0].Value())),  //
-                                    LT(LI(tree.Children()[1].Value())),  //
-                                    LT(LI(tree.Children()[2].Value())));
+    const auto expected_layout = LT(LI(LayoutType::kStack, 0, true),        //
+                                    LT(LI(tree.Children()[0].Value(), 1)),  //
+                                    LT(LI(tree.Children()[1].Value(), 2)),  //
+                                    LT(LI(tree.Children()[2].Value(), 3)));
     const auto expected_lf = LayoutFunction{
-        {0, expected_layout, 5, 4.0F, 0},
-        {35, expected_layout, 5, 4.0F, 100},
-        {37, expected_layout, 5, 204.0F, 300},
+        {0, expected_layout, 8, 4.0F, 0},
+        {32, expected_layout, 8, 4.0F, 100},
+        {35, expected_layout, 8, 304.0F, 200},
+        {36, expected_layout, 8, 504.0F, 300},
     };
 
     const LayoutFunction lf = optimizer.CalculateOptimalLayout(tree);

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -2331,42 +2331,6 @@ class OptimizeTokenPartitionTreeTest : public ::testing::Test,
   std::vector<TokenInfo> ftokens_;
 };
 
-TEST_F(OptimizeTokenPartitionTreeTest, OneLevelFunctionCall) {
-  using TPT = TokenPartitionTreeBuilder;
-
-  auto tree_under_test =
-      TPT(PartitionPolicyEnum::kOptimalFunctionCallLayout,
-          {
-              TPT({0, 1}, PartitionPolicyEnum::kFitOnLineElseExpand),
-              TPT(PartitionPolicyEnum::kFitOnLineElseExpand,
-                  {
-                      TPT({1, 2}, PartitionPolicyEnum::kFitOnLineElseExpand),
-                      TPT({2, 3}, PartitionPolicyEnum::kFitOnLineElseExpand),
-                      TPT({3, 4}, PartitionPolicyEnum::kFitOnLineElseExpand),
-                      TPT({4, 5}, PartitionPolicyEnum::kFitOnLineElseExpand),
-                      TPT({5, 6}, PartitionPolicyEnum::kFitOnLineElseExpand),
-                      TPT({6, 7}, PartitionPolicyEnum::kFitOnLineElseExpand),
-                  }),
-          })
-          .build(pre_format_tokens_);
-
-  const auto tree_expected =
-      TPT(PartitionPolicyEnum::kAlwaysExpand,
-          {
-              TPT(0, {0, 1}, PartitionPolicyEnum::kAlreadyFormatted),
-              TPT(4, {1, 3}, PartitionPolicyEnum::kAlreadyFormatted),
-              TPT(4, {3, 5}, PartitionPolicyEnum::kAlreadyFormatted),
-              TPT(4, {5, 7}, PartitionPolicyEnum::kAlreadyFormatted),
-          })
-          .build(pre_format_tokens_);
-
-  static const BasicFormatStyle style = CreateStyle();
-  OptimizeTokenPartitionTree(style, &tree_under_test);
-
-  EXPECT_PRED_FORMAT2(TokenPartitionTreesEqualPredFormat, tree_under_test,
-                      tree_expected);
-}
-
 TEST_F(OptimizeTokenPartitionTreeTest, AppendToLineWithInlinePartitions) {
   using TPT = TokenPartitionTreeBuilder;
   using PP = PartitionPolicyEnum;

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -1582,6 +1582,33 @@ TEST_F(LayoutFunctionFactoryTest, Wrap) {
     };
     ExpectLayoutFunctionsEqual(lf, expected_lf, __LINE__);
   }
+  {
+    const auto lf = factory_.Wrap(
+        {
+            factory_.Line(lines_.OneOver40Limit()),
+            factory_.Line(lines_.Short()),
+            factory_.Line(lines_.Indented()),
+        },
+        false, 7);
+    const auto expected_layout_vv =
+        LT(LI(LayoutType::kStack, 0, true),         //
+           LI(lines_.OneOver40Limit()),             //
+           LT(LI(LayoutType::kStack, 0, false, 7),  //
+              LI(lines_.Short(), 0),                //
+              LI(lines_.Indented(), 0)));
+    const auto expected_layout_vh =
+        LT(LI(LayoutType::kStack, 0, true),             //
+           LT(LI(LayoutType::kJuxtaposition, 0, true),  //
+              LI(lines_.OneOver40Limit(), 0),           //
+              LI(lines_.Short(), 0)),
+           LI(lines_.Indented(), 7));
+    const auto expected_lf = LayoutFunction{
+        {0, expected_layout_vv, 43, 404.0F, 200},
+        {14, expected_layout_vv, 43, 3204.0F, 300},
+        {33, expected_layout_vh, 43, 8902.0F, 200},
+    };
+    ExpectLayoutFunctionsEqual(lf, expected_lf, __LINE__);
+  }
 }
 
 TEST_F(LayoutFunctionFactoryTest, Indent) {

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -48,8 +48,6 @@ std::ostream& operator<<(std::ostream& stream, PartitionPolicyEnum p) {
       return stream << "inline";
     case PartitionPolicyEnum::kAppendFittingSubPartitions:
       return stream << "append-fitting-sub-partitions";
-    case PartitionPolicyEnum::kOptimalFunctionCallLayout:
-      return stream << "optimal-function-call-layout";
     case PartitionPolicyEnum::kJuxtaposition:
       return stream << "juxtaposition";
     case PartitionPolicyEnum::kStack:

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -50,6 +50,14 @@ std::ostream& operator<<(std::ostream& stream, PartitionPolicyEnum p) {
       return stream << "append-fitting-sub-partitions";
     case PartitionPolicyEnum::kOptimalFunctionCallLayout:
       return stream << "optimal-function-call-layout";
+    case PartitionPolicyEnum::kJuxtaposition:
+      return stream << "juxtaposition";
+    case PartitionPolicyEnum::kStack:
+      return stream << "stack";
+    case PartitionPolicyEnum::kWrap:
+      return stream << "wrap";
+    case PartitionPolicyEnum::kJuxtapositionOrIndentedStack:
+      return stream << "juxtaposition-or-indented-stack";
   }
   LOG(FATAL) << "Unknown partition policy " << int(p);
 }

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -56,11 +56,11 @@ enum class PartitionPolicyEnum {
   // do NOT bother to call SearchLineWraps or perform any other wrapping
   // optimization. Partitions with this policy can contain kInline
   // subpartitions.
-  // Reserved for policy-specific formatters, like Layout Optimizer and Tabular
+  // Reserved for policy-specific formatters, like LayoutOptimizer and Tabular
   // Aligner.
   //
   // Currently lines with this policy are generated in Tabular Aligner and
-  // Layout Optimizer. They are supported as an input in Layout Optimizer.
+  // LayoutOptimizer. They are supported as an input in LayoutOptimizer.
   kAlreadyFormatted,
 
   // Represents slice of kAlreadyFormatted line.
@@ -72,7 +72,7 @@ enum class PartitionPolicyEnum {
   //
   // The policy is intended to add non-permanent spacing between tokens in
   // situations where multiple token partition trees with different token
-  // spacings can coexist (e.g. in multiple layouts passed to Layout Optimizer).
+  // spacings can coexist (e.g. in multiple layouts passed to LayoutOptimizer).
   //
   // Invariants:
   // * Can exist only inside kAlreadyFormatted partition node.
@@ -85,7 +85,7 @@ enum class PartitionPolicyEnum {
   // tokens.
   //
   // Currently partitions with this policy are generated in Tabular Aligner and
-  // Layout Optimizer. They are supported as an input in Layout Optimizer.
+  // LayoutOptimizer. They are supported as an input in LayoutOptimizer.
   kInline,
 
   // Treats subpartitions as units, and appends them to the same line as
@@ -94,9 +94,9 @@ enum class PartitionPolicyEnum {
   // FormatStyle.wrap_spaces when wrapping.
   kAppendFittingSubPartitions,
 
-  // Layout Optimizer policies. See its implementation (layout_optimizer.cc)
+  // LayoutOptimizer policies. See its implementation (layout_optimizer.cc)
   // WARNING: when one of the following policies is assigned to a partition,
-  // it's whole subtree is handled by Layout Optimizer.
+  // its whole subtree is handled by LayoutOptimizer.
   kJuxtaposition,
   kStack,
   kWrap,

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -94,10 +94,6 @@ enum class PartitionPolicyEnum {
   // FormatStyle.wrap_spaces when wrapping.
   kAppendFittingSubPartitions,
 
-  // Does optimizations on partition tree and its subpartitions.
-  // Currently it used for reshaping function calls partitions.
-  kOptimalFunctionCallLayout,
-
   // Layout Optimizer policies. See its implementation (layout_optimizer.cc)
   // WARNING: when one of the following policies is assigned to a partition,
   // it's whole subtree is handled by Layout Optimizer.

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -97,6 +97,14 @@ enum class PartitionPolicyEnum {
   // Does optimizations on partition tree and its subpartitions.
   // Currently it used for reshaping function calls partitions.
   kOptimalFunctionCallLayout,
+
+  // Layout Optimizer policies. See its implementation (layout_optimizer.cc)
+  // WARNING: when one of the following policies is assigned to a partition,
+  // it's whole subtree is handled by Layout Optimizer.
+  kJuxtaposition,
+  kStack,
+  kWrap,
+  kJuxtapositionOrIndentedStack,
 };
 
 std::ostream& operator<<(std::ostream&, PartitionPolicyEnum);

--- a/common/formatting/unwrapped_line_test.cc
+++ b/common/formatting/unwrapped_line_test.cc
@@ -30,6 +30,11 @@ namespace {
 TEST(PartitionPolicyTest, Printing) {
   {
     std::ostringstream stream;
+    stream << PartitionPolicyEnum::kUninitialized;
+    EXPECT_EQ(stream.str(), "uninitialized");
+  }
+  {
+    std::ostringstream stream;
     stream << PartitionPolicyEnum::kAlwaysExpand;
     EXPECT_EQ(stream.str(), "always-expand");
   }
@@ -40,6 +45,11 @@ TEST(PartitionPolicyTest, Printing) {
   }
   {
     std::ostringstream stream;
+    stream << PartitionPolicyEnum::kTabularAlignment;
+    EXPECT_EQ(stream.str(), "tabular-alignment");
+  }
+  {
+    std::ostringstream stream;
     stream << PartitionPolicyEnum::kAlreadyFormatted;
     EXPECT_EQ(stream.str(), "already-formatted");
   }
@@ -47,6 +57,31 @@ TEST(PartitionPolicyTest, Printing) {
     std::ostringstream stream;
     stream << PartitionPolicyEnum::kInline;
     EXPECT_EQ(stream.str(), "inline");
+  }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kAppendFittingSubPartitions;
+    EXPECT_EQ(stream.str(), "append-fitting-sub-partitions");
+  }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kJuxtaposition;
+    EXPECT_EQ(stream.str(), "juxtaposition");
+  }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kStack;
+    EXPECT_EQ(stream.str(), "stack");
+  }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kWrap;
+    EXPECT_EQ(stream.str(), "wrap");
+  }
+  {
+    std::ostringstream stream;
+    stream << PartitionPolicyEnum::kJuxtapositionOrIndentedStack;
+    EXPECT_EQ(stream.str(), "juxtaposition-or-indented-stack");
   }
 }
 

--- a/common/util/iterator_range.h
+++ b/common/util/iterator_range.h
@@ -51,14 +51,19 @@ class iterator_range {
   iterator end_;
 };
 
+template <typename Iter>
+iterator_range(Iter, Iter) -> iterator_range<Iter>;
+
 // Helper function returning an iterator_range using template argument
 // deduction.
+// OBSOLETE: Use iterator_traits constructor directly.
 template <typename Iter>
 iterator_range<Iter> make_range(Iter begin, Iter end) {
   return iterator_range<Iter>(std::move(begin), std::move(end));
 }
 
 // Overload to operator on a std::pair of iterators.
+// OBSOLETE: Use iterator_traits constructor directly.
 template <typename Iter>
 iterator_range<Iter> make_range(std::pair<Iter, Iter> p) {
   return iterator_range<Iter>(std::move(p.first), std::move(p.second));

--- a/common/util/iterator_range.h
+++ b/common/util/iterator_range.h
@@ -38,6 +38,9 @@ class iterator_range {
   iterator_range(iterator b, iterator e)
       : begin_(std::move(b)), end_(std::move(e)) {}
 
+  explicit iterator_range(std::pair<Iter, Iter> p)
+      : begin_(std::move(p.first)), end_(std::move(p.second)) {}
+
   iterator_range(const iterator_range&) = default;
   iterator_range(iterator_range&&) noexcept = default;
   iterator_range& operator=(const iterator_range&) = default;
@@ -54,16 +57,19 @@ class iterator_range {
 template <typename Iter>
 iterator_range(Iter, Iter) -> iterator_range<Iter>;
 
+template <typename Iter>
+iterator_range(std::pair<Iter, Iter>) -> iterator_range<Iter>;
+
 // Helper function returning an iterator_range using template argument
 // deduction.
-// OBSOLETE: Use iterator_traits constructor directly.
+// OBSOLETE: Use iterator_range constructor directly.
 template <typename Iter>
 iterator_range<Iter> make_range(Iter begin, Iter end) {
   return iterator_range<Iter>(std::move(begin), std::move(end));
 }
 
 // Overload to operator on a std::pair of iterators.
-// OBSOLETE: Use iterator_traits constructor directly.
+// OBSOLETE: Use iterator_range constructor directly.
 template <typename Iter>
 iterator_range<Iter> make_range(std::pair<Iter, Iter> p) {
   return iterator_range<Iter>(std::move(p.first), std::move(p.second));

--- a/common/util/iterator_range_test.cc
+++ b/common/util/iterator_range_test.cc
@@ -32,91 +32,180 @@ using ::testing::ElementsAreArray;
 
 TEST(IteratorRangeTest, EmptyVector) {
   std::vector<int> v;
-  auto range = make_range(v.begin(), v.end());
-  EXPECT_EQ(range.begin(), range.end());
+  {
+    auto range = make_range(v.begin(), v.end());
+    EXPECT_EQ(range.begin(), range.end());
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    EXPECT_EQ(range.begin(), range.end());
+  }
 }
 
 TEST(IteratorRangeTest, EmptyVectorRangeComparison) {
   std::vector<int> v;
-  const auto range = make_range(v.begin(), v.end());
-  const auto range2 = make_range(v.begin(), v.end());
-  EXPECT_TRUE(BoundsEqual(range, range2));
-  EXPECT_TRUE(BoundsEqual(range2, range));
+  {
+    const auto range = make_range(v.begin(), v.end());
+    const auto range2 = make_range(v.begin(), v.end());
+    EXPECT_TRUE(BoundsEqual(range, range2));
+    EXPECT_TRUE(BoundsEqual(range2, range));
 
-  auto crange = make_range(v.cbegin(), v.cend());
-  EXPECT_TRUE(BoundsEqual(crange, crange));
-  // Testing mixed-iterator-constness
-  EXPECT_TRUE(BoundsEqual(range, crange));
-  EXPECT_TRUE(BoundsEqual(crange, range));
+    auto crange = make_range(v.cbegin(), v.cend());
+    EXPECT_TRUE(BoundsEqual(crange, crange));
+    // Testing mixed-iterator-constness
+    EXPECT_TRUE(BoundsEqual(range, crange));
+    EXPECT_TRUE(BoundsEqual(crange, range));
+  }
+  {
+    const auto range = iterator_range(v.begin(), v.end());
+    const auto range2 = iterator_range(v.begin(), v.end());
+    EXPECT_TRUE(BoundsEqual(range, range2));
+    EXPECT_TRUE(BoundsEqual(range2, range));
+
+    auto crange = iterator_range(v.cbegin(), v.cend());
+    EXPECT_TRUE(BoundsEqual(crange, crange));
+    // Testing mixed-iterator-constness
+    EXPECT_TRUE(BoundsEqual(range, crange));
+    EXPECT_TRUE(BoundsEqual(crange, range));
+  }
 }
 
 TEST(IteratorRangeTest, EmptyList) {
   std::list<int> v;
-  auto range = make_range(v.begin(), v.end());
-  EXPECT_EQ(range.begin(), range.end());
+  {
+    auto range = make_range(v.begin(), v.end());
+    EXPECT_EQ(range.begin(), range.end());
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    EXPECT_EQ(range.begin(), range.end());
+  }
 }
 
 TEST(IteratorRangeTest, EmptySet) {
   std::set<int> v;
-  auto range = make_range(v.begin(), v.end());
-  EXPECT_EQ(range.begin(), range.end());
+  {
+    auto range = make_range(v.begin(), v.end());
+    EXPECT_EQ(range.begin(), range.end());
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    EXPECT_EQ(range.begin(), range.end());
+  }
 }
 
 TEST(IteratorRangeTest, WholeVectorBeginEnd) {
   std::vector<int> v = {2, 3, 5, 7, 11, 13};
-  auto range = make_range(v.begin(), v.end());
-  EXPECT_THAT(range, ElementsAreArray(v));
+  {
+    auto range = make_range(v.begin(), v.end());
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
 }
 
 TEST(IteratorRangeTest, EqualNonemptyVectorRangeComparisons) {
   std::vector<int> v = {3, 5, 11};
-  auto range = make_range(v.begin(), v.end());
-  auto crange = make_range(v.cbegin(), v.cend());
-  EXPECT_TRUE(BoundsEqual(range, crange));
-  EXPECT_TRUE(BoundsEqual(crange, range));
+  {
+    auto range = make_range(v.begin(), v.end());
+    auto crange = make_range(v.cbegin(), v.cend());
+    EXPECT_TRUE(BoundsEqual(range, crange));
+    EXPECT_TRUE(BoundsEqual(crange, range));
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    auto crange = iterator_range(v.cbegin(), v.cend());
+    EXPECT_TRUE(BoundsEqual(range, crange));
+    EXPECT_TRUE(BoundsEqual(crange, range));
+  }
 }
 
 TEST(IteratorRangeTest, UnequalVectorRangeComparisons) {
   std::vector<int> v = {2, 3, 5, 7, 11, 13};
-  auto range = make_range(v.begin(), v.end());
-  auto range2 = make_range(range.begin() + 1, range.end());
-  auto range3 = make_range(range.begin(), range.end() - 1);
-  EXPECT_FALSE(BoundsEqual(range, range2));
-  EXPECT_FALSE(BoundsEqual(range, range3));
-  EXPECT_FALSE(BoundsEqual(range2, range));
-  EXPECT_FALSE(BoundsEqual(range2, range3));
-  EXPECT_FALSE(BoundsEqual(range3, range));
-  EXPECT_FALSE(BoundsEqual(range3, range2));
+  {
+    auto range = make_range(v.begin(), v.end());
+    auto range2 = make_range(range.begin() + 1, range.end());
+    auto range3 = make_range(range.begin(), range.end() - 1);
+    EXPECT_FALSE(BoundsEqual(range, range2));
+    EXPECT_FALSE(BoundsEqual(range, range3));
+    EXPECT_FALSE(BoundsEqual(range2, range));
+    EXPECT_FALSE(BoundsEqual(range2, range3));
+    EXPECT_FALSE(BoundsEqual(range3, range));
+    EXPECT_FALSE(BoundsEqual(range3, range2));
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    auto range2 = iterator_range(range.begin() + 1, range.end());
+    auto range3 = iterator_range(range.begin(), range.end() - 1);
+    EXPECT_FALSE(BoundsEqual(range, range2));
+    EXPECT_FALSE(BoundsEqual(range, range3));
+    EXPECT_FALSE(BoundsEqual(range2, range));
+    EXPECT_FALSE(BoundsEqual(range2, range3));
+    EXPECT_FALSE(BoundsEqual(range3, range));
+    EXPECT_FALSE(BoundsEqual(range3, range2));
+  }
 }
 
 TEST(IteratorRangeTest, WholeListBeginEnd) {
   std::list<int> v = {2, 3, 5, 7, 11, 13};
-  auto range = make_range(v.begin(), v.end());
-  EXPECT_THAT(range, ElementsAreArray(v));
+  {
+    auto range = make_range(v.begin(), v.end());
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
 }
 
 TEST(IteratorRangeTest, WholeSetBeginEnd) {
   std::set<int> v = {2, 3, 5, 7, 11, 13};
-  auto range = make_range(v.begin(), v.end());
-  EXPECT_THAT(range, ElementsAreArray(v));
+  {
+    auto range = make_range(v.begin(), v.end());
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
+  {
+    auto range = iterator_range(v.begin(), v.end());
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
 }
 
 TEST(IteratorRangeTest, WholeVectorMakePair) {
   std::vector<int> v = {2, 3, 5, 7, 11, 13};
-  auto range = make_range(std::make_pair(v.begin(), v.end()));
-  EXPECT_THAT(range, ElementsAreArray(v));
+  {
+    auto range = make_range(std::make_pair(v.begin(), v.end()));
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
+  {
+    auto range = iterator_range(std::pair(v.begin(), v.end()));
+    EXPECT_THAT(range, ElementsAreArray(v));
+  }
 }
 
 TEST(IteratorRangeTest, PartArray) {
   int v[] = {2, 3, 5, 7, 11, 13};
-  iterator_range<int*> range(&v[1], &v[4]);  // 3, 5, 7
-  EXPECT_THAT(range, ElementsAre(3, 5, 7));
+  {
+    iterator_range<int*> range(&v[1], &v[4]);  // 3, 5, 7
+    EXPECT_THAT(range, ElementsAre(3, 5, 7));
+  }
+  {
+    iterator_range range(&v[1], &v[4]);  // 3, 5, 7
+    EXPECT_THAT(range, ElementsAre(3, 5, 7));
+  }
 }
 
 TEST(IteratorRangeTest, ArrayMakeRange) {
   int v[] = {2, 3, 5, 7, 11, 13};
-  auto range = make_range(&v[1], &v[4]);
-  EXPECT_THAT(range, ElementsAre(3, 5, 7));
+  {
+    auto range = make_range(&v[1], &v[4]);
+    EXPECT_THAT(range, ElementsAre(3, 5, 7));
+  }
+  {
+    auto range = iterator_range(&v[1], &v[4]);
+    EXPECT_THAT(range, ElementsAre(3, 5, 7));
+  }
 }
 
 }  // namespace

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -533,6 +533,16 @@ static void DeterminePartitionExpansion(
         VLOG(3) << "Does not fit, expanding.";
         node_view.Expand();
       }
+      break;
+    }
+
+    case PartitionPolicyEnum::kJuxtapositionOrIndentedStack:
+    case PartitionPolicyEnum::kJuxtaposition:
+    case PartitionPolicyEnum::kStack:
+    case PartitionPolicyEnum::kWrap: {
+      // The policies are handled (and replaced) in Layout Optimizer.
+      LOG(FATAL) << "Unreachable. " << partition_policy;
+      break;
     }
   }
 }
@@ -841,6 +851,10 @@ Status Formatter::Format(const ExecutionControl& control) {
           // Reshape partition tree with kAppendFittingSubPartitions policy
           verible::ReshapeFittingSubpartitions(style_, &node);
           break;
+        case PartitionPolicyEnum::kJuxtaposition:
+        case PartitionPolicyEnum::kStack:
+        case PartitionPolicyEnum::kWrap:
+        case PartitionPolicyEnum::kJuxtapositionOrIndentedStack:
         case PartitionPolicyEnum::kOptimalFunctionCallLayout:
           verible::OptimizeTokenPartitionTree(style_, &node);
           break;

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -438,7 +438,6 @@ static void DeterminePartitionExpansion(
       LOG(FATAL) << "Got an uninitialized partition policy at: " << uwline;
       break;
     }
-    case PartitionPolicyEnum::kOptimalFunctionCallLayout:
     case PartitionPolicyEnum::kAlwaysExpand: {
       if (children.size() > 1) {
         node_view.Expand();
@@ -855,7 +854,6 @@ Status Formatter::Format(const ExecutionControl& control) {
         case PartitionPolicyEnum::kStack:
         case PartitionPolicyEnum::kWrap:
         case PartitionPolicyEnum::kJuxtapositionOrIndentedStack:
-        case PartitionPolicyEnum::kOptimalFunctionCallLayout:
           verible::OptimizeTokenPartitionTree(style_, &node);
           break;
         case PartitionPolicyEnum::kTabularAlignment:

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -8334,8 +8334,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  , second\n"
      "} e;\n",
      "typedef enum {\n"
-     "  first  /* c1 */,\n"
-     "  second\n"
+     "    first   /* c1 */\n"
+     "  , second\n"
      "} e;\n"},
     {"typedef enum {\n"
      "  first\n"
@@ -8343,8 +8343,9 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  , second\n"
      "} e;\n",
      "typedef enum {\n"
-     "            first\n"
-     "  /* c1 */, second\n"
+     "    first\n"
+     "  /* c1 */\n"
+     "  , second\n"
      "} e;\n"},
     {"typedef enum {\n"
      "  first /* c1 */\n"
@@ -8365,7 +8366,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "} e;\n",
      "typedef enum {\n"
      "  first\n"
-     "  /* c1 */,\n"
+     "  /* c1 */\n"
+     "  ,\n"
      "  /* c2 */\n"
      "  second\n"
      "} e;\n"},
@@ -8582,8 +8584,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar foobar (\n"
-     "      .first (1)  /* c1 */,\n"
-     "      .second(2)             /* c2 */\n"
+     "        .first (1)  /* c1 */\n"
+     "      , .second(2)  /* c2 */\n"
      "  );\n"
      "endmodule\n"},
     {"module foo;\n"
@@ -8606,8 +8608,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar foobar (\n"
-     "      .first (1)  /* c1 */,\n"
-     "      .second(2)             /* c2 */\n"
+     "        .first (1)  /* c1 */\n"
+     "      , .second(2)  /* c2 */\n"
      "  );\n"
      "endmodule\n"},
     {"module foo;\n"
@@ -8633,9 +8635,9 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar foobar (\n"
-     "      .first (1)\n"
-     "      /* c1 */,\n"
-     "      .second(2)\n"
+     "        .first (1)\n"
+     "      /* c1 */\n"
+     "      , .second(2)\n"
      "      /* c2 */\n"
      "  );\n"
      "endmodule\n"},
@@ -8649,8 +8651,9 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar foobar (\n"
-     "                .first (1)\n"
-     "      /* c1 */, .second(2)\n"
+     "        .first (1)\n"
+     "      /* c1 */\n"
+     "      , .second(2)\n"
      "      /* c2 */\n"
      "  );\n"
      "endmodule\n"},
@@ -8834,8 +8837,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar #(\n"
-     "      .first (1)  /* c1 */,\n"
-     "      .second(2)             /* c2 */\n"
+     "        .first (1)  /* c1 */\n"
+     "      , .second(2)  /* c2 */\n"
      "  ) baz ();\n"
      "endmodule\n"},
     {"module foo;\n"
@@ -8858,8 +8861,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar #(\n"
-     "      .first (1)  /* c1 */,\n"
-     "      .second(2)             /* c2 */\n"
+     "        .first (1)  /* c1 */\n"
+     "      , .second(2)  /* c2 */\n"
      "  ) baz ();\n"
      "endmodule\n"},
     {"module foo;\n"
@@ -8885,9 +8888,9 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar #(\n"
-     "      .first (1)\n"
-     "      /* c1 */,\n"
-     "      .second(2)\n"
+     "        .first (1)\n"
+     "      /* c1 */\n"
+     "      , .second(2)\n"
      "      /* c2 */\n"
      "  ) baz ();\n"
      "endmodule\n"},
@@ -8901,8 +8904,9 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n",
      "module foo;\n"
      "  bar #(\n"
-     "                .first (1)\n"
-     "      /* c1 */, .second(2)\n"
+     "        .first (1)\n"
+     "      /* c1 */\n"
+     "      , .second(2)\n"
      "      /* c2 */\n"
      "  ) baz ();\n"
      "endmodule\n"},

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -9788,6 +9788,5400 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule\n"},
 
     // -----------------------------------------------------------------
+    // Comments around and inside macro calls.
+
+    // between identifier and '(', no args
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */ /* c2 */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */ /* c2 */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */ // c2\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  // c2\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ // c2\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  // c2\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c1\n"
+     "// c2\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "/* c2 */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */ ();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "/* c2 */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "// c2\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    // c2\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "// c2\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    ();\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "// c2\n"
+     "// c3\n"
+     "();\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    ();\n"},
+
+    // between identifier and '(', with arg
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */ /* c2 */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */ /* c2 */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */ // c2\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  // c2\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ // c2\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  // c2\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c1\n"
+     "// c2\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "/* c2 */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */ (arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "/* c2 */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "// c2\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    // c2\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "// c2\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    (arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz // c1\n"
+     "// c2\n"
+     "// c3\n"
+     "(arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    (arg);\n"},
+
+    // after '(', no args
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    // c1\n"
+     "    // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */\n"
+     "/* c3 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c1\n"
+     "    // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "/* c3 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     ");\n"},
+
+    // after '(', with arg
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */ /* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */  /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */ /* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */  /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */ // c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */  // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */ /* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */  /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */ /* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */  /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "// c\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    // c\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */ // c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */  // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "// c1\n"
+     "// c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "/* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "/* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "// c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "// c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ // c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ // c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c1\n"
+     "// c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    /* c2 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    /* c2 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "// c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    arg);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    arg);\n"},
+
+    // after single arg
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "           /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "           /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "           // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "           /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg\n"
+     "           // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg// c1\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  // c1\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */\n"
+     "           /* c2 */\n"
+     "/* c3 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg// c1\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  // c1\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "           /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "           /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "           // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "           /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg\n"
+     "           // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg// c1\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  // c1\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */\n"
+     "           /* c2 */\n"
+     "/* c3 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg// c1\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  // c1\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     ");\n"},
+
+    // before colon
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */ /* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */  /* c2 */,\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */ /* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */  /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1// c\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  // c\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */ // c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */  // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "/* c */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           /* c */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "/* c1 */ /* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           /* c1 */  /* c2 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "/* c */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           /* c */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "/* c1 */ /* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           /* c1 */  /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "// c\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           // c\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "/* c1 */ // c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           /* c1 */  // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "// c1\n"
+     "// c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1\n"
+     "           // c1\n"
+     "           // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */\n"
+     "/* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */\n"
+     "           /* c2 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1// c1\n"
+     "/* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  // c1\n"
+     "           /* c2 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */\n"
+     "/* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */\n"
+     "           /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1// c1\n"
+     "/* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  // c1\n"
+     "           /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */\n"
+     "// c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */\n"
+     "           // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1// c1\n"
+     "// c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  // c1\n"
+     "           // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */ /* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */  /* c2 */,\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */ /* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */  /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1// c\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  // c\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */ // c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */  // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "/* c */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           /* c */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "/* c1 */ /* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           /* c1 */  /* c2 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "/* c */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           /* c */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "/* c1 */ /* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           /* c1 */  /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "// c\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           // c\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "/* c1 */ // c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           /* c1 */  // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "// c1\n"
+     "// c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1\n"
+     "           // c1\n"
+     "           // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */\n"
+     "/* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */\n"
+     "           /* c2 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1// c1\n"
+     "/* c2 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  // c1\n"
+     "           /* c2 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */, arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */, arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */\n"
+     "/* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */\n"
+     "           /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1// c1\n"
+     "/* c2 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  // c1\n"
+     "           /* c2 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */\n"
+     "// c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */\n"
+     "           // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1// c1\n"
+     "// c2\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  // c1\n"
+     "           // c2\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     "           , arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ", arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     "           , arg2);\n"},
+
+    // after colon
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */ /* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */  /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */ /* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */  /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,// c\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  // c\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */ // c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */  // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "/* c */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           /* c */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "/* c1 */ /* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           /* c1 */  /* c2 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "/* c */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           /* c */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "/* c1 */ /* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           /* c1 */  /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "// c\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           // c\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "/* c1 */ // c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           /* c1 */  // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "// c1\n"
+     "// c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,\n"
+     "           // c1\n"
+     "           // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */\n"
+     "/* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */\n"
+     "           /* c2 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,// c1\n"
+     "/* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  // c1\n"
+     "           /* c2 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */\n"
+     "/* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,// c1\n"
+     "/* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  // c1\n"
+     "           /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */\n"
+     "// c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */\n"
+     "           // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,// c1\n"
+     "// c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  // c1\n"
+     "           // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1,  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */ /* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */  /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */ /* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */  /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,// c\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  // c\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */ // c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */  // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "/* c */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           /* c */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "/* c1 */ /* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           /* c1 */  /* c2 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "/* c */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           /* c */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "/* c1 */ /* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           /* c1 */  /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "// c\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           // c\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "/* c1 */ // c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           /* c1 */  // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "// c1\n"
+     "// c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,\n"
+     "           // c1\n"
+     "           // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */\n"
+     "/* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */\n"
+     "           /* c2 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,// c1\n"
+     "/* c2 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  // c1\n"
+     "           /* c2 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */ arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */\n"
+     "/* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,// c1\n"
+     "/* c2 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  // c1\n"
+     "           /* c2 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */\n"
+     "// c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */\n"
+     "           // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,// c1\n"
+     "// c2\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  // c1\n"
+     "           // c2\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     "           arg2);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg2);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1,  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     "           arg2);\n"},
+
+    // after last arg
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2\n"
+     "           ,  /* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2\n"
+     "           ,  /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "           /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "           /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "           // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "           /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,\n"
+     "           // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c1 */\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,// c1\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  // c1\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c1 */\n"
+     "           /* c2 */\n"
+     "/* c3 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,// c1\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  // c1\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c1 */\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg1, arg2,  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2\n"
+     "           ,  /* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2\n"
+     "           ,  /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c1 */ /* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c1 */  /* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "           /* c */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c1 */ /* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "           /* c1 */  /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "// c\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "           // c\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c1 */ // c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "           /* c1 */  // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "           /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,\n"
+     "           // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c1 */\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,// c1\n"
+     "/* c2 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  // c1\n"
+     "/* c2 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */);\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c1 */\n"
+     "           /* c2 */\n"
+     "/* c3 */);\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c1 */\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,// c1\n"
+     "/* c2 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  // c1\n"
+     "           /* c2 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c1 */\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,// c1\n"
+     "// c2\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  // c1\n"
+     "           // c2\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  /* c1 */\n"
+     "           /* c2 */\n"
+     "           /* c3 */\n"
+     ");\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ");\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg1, arg2,  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     ");\n"},
+
+    // after ')', no args
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  // c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "// c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()// c1\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  // c1\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()// c1\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  // c1\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  // c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz()  // c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  // c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "// c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()// c1\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  // c1\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()// c1\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  // c1\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  // c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ()  // c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n"},
+
+    // after ')', with arg
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  // c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  // c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)// c1\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  // c1\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)// c1\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  // c1\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  // c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg)  // c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  // c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */ /* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */  /* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "// c\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "// c\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */ // c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */  // c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)// c1\n"
+     "/* c2 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  // c1\n"
+     "/* c2 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)// c1\n"
+     "/* c2 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  // c1\n"
+     "/* c2 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)// c1\n"
+     "// c2\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  // c1\n"
+     "// c2\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg)  // c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";\n"},
+
+    // after ';', no args
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();// c1 c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  // c1 c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  // c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz();  // c1\n"
+     "// c2\n"
+     "// c3\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  // c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ();  // c1\n"
+     "// c2\n"
+     "// c3\n"},
+
+    // after ';', with arg
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);// c1 c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  // c1 c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  // c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz(arg);  // c1\n"
+     "// c2\n"
+     "// c3\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  // c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(arg);  // c1\n"
+     "// c2\n"
+     "// c3\n"},
+
+    // everywhere, no args
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c */(/* c */)/* c */;/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */\n"
+     "    (  /* c */)  /* c */;  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */ /* c2 */(/* c1 */ /* c2 */)/* c1 */ /* c2 */;/* c1 */ "
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */\n"
+     "    (  /* c1 */  /* c2 */)  /* c1 */  /* c2 */;  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c */\n"
+     "(/* c */\n"
+     ")/* c */\n"
+     ";/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */\n"
+     "    (  /* c */\n"
+     "    )  /* c */\n"
+     ";  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */ /* c2 */\n"
+     "(/* c1 */ /* c2 */\n"
+     ")/* c1 */ /* c2 */\n"
+     ";/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */\n"
+     "    (  /* c1 */  /* c2 */\n"
+     "    )  /* c1 */  /* c2 */\n"
+     ";  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c\n"
+     "(// c\n"
+     ")// c\n"
+     ";// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c\n"
+     "    (  // c\n"
+     "    )  // c\n"
+     ";  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */ // c2\n"
+     "(/* c1 */ // c2\n"
+     ")/* c1 */ // c2\n"
+     ";/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  // c2\n"
+     "    (  /* c1 */  // c2\n"
+     "    )  /* c1 */  // c2\n"
+     ";  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */(\n"
+     "/* c */)\n"
+     "/* c */;\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */ (\n"
+     "    /* c */)\n"
+     "/* c */;\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */(\n"
+     "/* c1 */ /* c2 */)\n"
+     "/* c1 */ /* c2 */;\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */ (\n"
+     "    /* c1 */  /* c2 */)\n"
+     "/* c1 */  /* c2 */;\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */\n"
+     "(\n"
+     "/* c */\n"
+     ")\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */\n"
+     "    (\n"
+     "        /* c */\n"
+     "    )\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */\n"
+     "(\n"
+     "/* c1 */ /* c2 */\n"
+     ")\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */\n"
+     "    (\n"
+     "        /* c1 */  /* c2 */\n"
+     "    )\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c\n"
+     "(\n"
+     "// c\n"
+     ")\n"
+     "// c\n"
+     ";\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c\n"
+     "    (\n"
+     "        // c\n"
+     "    )\n"
+     "// c\n"
+     ";\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ // c2\n"
+     "(\n"
+     "/* c1 */ // c2\n"
+     ")\n"
+     "/* c1 */ // c2\n"
+     ";\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  // c2\n"
+     "    (\n"
+     "        /* c1 */  // c2\n"
+     "    )\n"
+     "/* c1 */  // c2\n"
+     ";\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ")\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    (\n"
+     "        /* c1 */\n"
+     "        /* c2 */\n"
+     "    )\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c1\n"
+     "// c2\n"
+     "(\n"
+     "// c1\n"
+     "// c2\n"
+     ")\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    (\n"
+     "        // c1\n"
+     "        // c2\n"
+     "    )\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */(/* c1 */\n"
+     "/* c2 */)/* c1 */\n"
+     "/* c2 */;/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */ (  /* c1 */\n"
+     "    /* c2 */)  /* c1 */\n"
+     "/* c2 */;  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "/* c2 */(// c1\n"
+     "/* c2 */)// c1\n"
+     "/* c2 */;// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */ (  // c1\n"
+     "    /* c2 */)  // c1\n"
+     "/* c2 */;  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ (  /* c1 */\n"
+     "        /* c2 */\n"
+     "    /* c3 */)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */\n"
+     "(/* c1 */\n"
+     "/* c2 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    (  /* c1 */\n"
+     "        /* c2 */\n"
+     "    )  /* c1 */\n"
+     "/* c2 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "/* c2 */\n"
+     "(// c1\n"
+     "/* c2 */\n"
+     ")// c1\n"
+     "/* c2 */\n"
+     ";// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */\n"
+     "    (  // c1\n"
+     "        /* c2 */\n"
+     "    )  // c1\n"
+     "/* c2 */\n"
+     ";  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "// c2\n"
+     "(/* c1 */\n"
+     "// c2\n"
+     ")/* c1 */\n"
+     "// c2\n"
+     ";/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    // c2\n"
+     "    (  /* c1 */\n"
+     "        // c2\n"
+     "    )  /* c1 */\n"
+     "// c2\n"
+     ";  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "// c2\n"
+     "(// c1\n"
+     "// c2\n"
+     ")// c1\n"
+     "// c2\n"
+     ";// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    (  // c1\n"
+     "       // c2\n"
+     "    )  // c1\n"
+     "       // c2\n"
+     ";  // c1\n"
+     "   // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    (  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */\n"
+     "    )  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ")// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    (  // c1\n"
+     "       // c2\n"
+     "       // c3\n"
+     "    )  // c1\n"
+     "       // c2\n"
+     "       // c3\n"
+     ";  // c1\n"
+     "   // c2\n"
+     "   // c3\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */)/* c */;/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */)  /* c */;  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */)/* c1 */ /* c2 */;/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */)  /* c1 */  /* c2 */;  /* c1 */  /* c2 "
+     "*/\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */\n"
+     ")/* c */\n"
+     ";/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */\n"
+     ")  /* c */\n"
+     ";  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */\n"
+     ")/* c1 */ /* c2 */\n"
+     ";/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */\n"
+     ")  /* c1 */  /* c2 */\n"
+     ";  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c\n"
+     ")// c\n"
+     ";// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c\n"
+     ")  // c\n"
+     ";  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ // c2\n"
+     ")/* c1 */ // c2\n"
+     ";/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  // c2\n"
+     ")  /* c1 */  // c2\n"
+     ";  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */)\n"
+     "/* c */;\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */)\n"
+     "/* c */;\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */)\n"
+     "/* c1 */ /* c2 */;\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */  /* c2 */)\n"
+     "/* c1 */  /* c2 */;\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */\n"
+     ")\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c */\n"
+     ")\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */\n"
+     ")\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  /* c2 */\n"
+     ")\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c\n"
+     ")\n"
+     "// c\n"
+     ";\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c\n"
+     ")\n"
+     "// c\n"
+     ";\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ // c2\n"
+     ")\n"
+     "/* c1 */ // c2\n"
+     ";\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  // c2\n"
+     ")\n"
+     "/* c1 */  // c2\n"
+     ";\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ")\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     ")\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c1\n"
+     "// c2\n"
+     ")\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c1\n"
+     "    // c2\n"
+     ")\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */)/* c1 */\n"
+     "/* c2 */;/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "/* c2 */)  /* c1 */\n"
+     "/* c2 */;  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */)// c1\n"
+     "/* c2 */;// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "/* c2 */)  // c1\n"
+     "/* c2 */;  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "/* c3 */)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     ")  /* c1 */\n"
+     "/* c2 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */\n"
+     ")// c1\n"
+     "/* c2 */\n"
+     ";// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    /* c2 */\n"
+     ")  // c1\n"
+     "/* c2 */\n"
+     ";  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "// c2\n"
+     ")/* c1 */\n"
+     "// c2\n"
+     ";/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    // c2\n"
+     ")  /* c1 */\n"
+     "// c2\n"
+     ";  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     ")// c1\n"
+     "// c2\n"
+     ";// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     ")  // c1\n"
+     "   // c2\n"
+     ";  // c1\n"
+     "   // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     ")  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ")// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     ")  // c1\n"
+     "   // c2\n"
+     "   // c3\n"
+     ";  // c1\n"
+     "   // c2\n"
+     "   // c3\n"},
+
+    // everywhere, with args
+
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c */(/* c */arg1/* c */,/* c */arg2/* c */)/* c */;/* c "
+     "*/\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */ (  /* c */\n"
+     "    arg1  /* c */,  /* c */\n"
+     "    arg2  /* c */)  /* c */;  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */ /* c2 */(/* c1 */ /* c2 */arg1/* c1 */ /* c2 */,/* c1 "
+     "*/ /* c2 */arg2/* c1 */ /* c2 */)/* c1 */ /* c2 */;/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */ (  /* c1 */  /* c2 */\n"
+     "    arg1  /* c1 */  /* c2 */,  /* c1 */  /* c2 */\n"
+     "    arg2  /* c1 */  /* c2 */)  /* c1 */  /* c2 */;  /* c1 */  /* c2 "
+     "*/\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c */\n"
+     "(/* c */\n"
+     "arg1/* c */\n"
+     ",/* c */\n"
+     "arg2/* c */\n"
+     ")/* c */\n"
+     ";/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c */\n"
+     "    (  /* c */\n"
+     "        arg1  /* c */\n"
+     "        ,  /* c */\n"
+     "        arg2  /* c */\n"
+     "    )  /* c */\n"
+     ";  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */ /* c2 */\n"
+     "(/* c1 */ /* c2 */\n"
+     "arg1/* c1 */ /* c2 */\n"
+     ",/* c1 */ /* c2 */\n"
+     "arg2/* c1 */ /* c2 */\n"
+     ")/* c1 */ /* c2 */\n"
+     ";/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  /* c2 */\n"
+     "    (  /* c1 */  /* c2 */\n"
+     "        arg1  /* c1 */  /* c2 */\n"
+     "        ,  /* c1 */  /* c2 */\n"
+     "        arg2  /* c1 */  /* c2 */\n"
+     "    )  /* c1 */  /* c2 */\n"
+     ";  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c\n"
+     "(// c\n"
+     "arg1// c\n"
+     ",// c\n"
+     "arg2// c\n"
+     ")// c\n"
+     ";// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c\n"
+     "    (  // c\n"
+     "        arg1  // c\n"
+     "        ,  // c\n"
+     "        arg2  // c\n"
+     "    )  // c\n"
+     ";  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */ // c2\n"
+     "(/* c1 */ // c2\n"
+     "arg1/* c1 */ // c2\n"
+     ",/* c1 */ // c2\n"
+     "arg2/* c1 */ // c2\n"
+     ")/* c1 */ // c2\n"
+     ";/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */  // c2\n"
+     "    (  /* c1 */  // c2\n"
+     "        arg1  /* c1 */  // c2\n"
+     "        ,  /* c1 */  // c2\n"
+     "        arg2  /* c1 */  // c2\n"
+     "    )  /* c1 */  // c2\n"
+     ";  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */(\n"
+     "/* c */arg1\n"
+     "/* c */,\n"
+     "/* c */arg2\n"
+     "/* c */)\n"
+     "/* c */;\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */ (\n"
+     "        /* c */ arg1\n"
+     "        /* c */,\n"
+     "        /* c */ arg2\n"
+     "    /* c */)\n"
+     "/* c */;\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */(\n"
+     "/* c1 */ /* c2 */arg1\n"
+     "/* c1 */ /* c2 */,\n"
+     "/* c1 */ /* c2 */arg2\n"
+     "/* c1 */ /* c2 */)\n"
+     "/* c1 */ /* c2 */;\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */ (\n"
+     "        /* c1 */  /* c2 */ arg1\n"
+     "        /* c1 */  /* c2 */,\n"
+     "        /* c1 */  /* c2 */ arg2\n"
+     "    /* c1 */  /* c2 */)\n"
+     "/* c1 */  /* c2 */;\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c */\n"
+     "(\n"
+     "/* c */\n"
+     "arg1\n"
+     "/* c */\n"
+     ",\n"
+     "/* c */\n"
+     "arg2\n"
+     "/* c */\n"
+     ")\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c */\n"
+     "    (\n"
+     "        /* c */\n"
+     "        arg1\n"
+     "        /* c */\n"
+     "        ,\n"
+     "        /* c */\n"
+     "        arg2\n"
+     "        /* c */\n"
+     "    )\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ /* c2 */\n"
+     "(\n"
+     "/* c1 */ /* c2 */\n"
+     "arg1\n"
+     "/* c1 */ /* c2 */\n"
+     ",\n"
+     "/* c1 */ /* c2 */\n"
+     "arg2\n"
+     "/* c1 */ /* c2 */\n"
+     ")\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  /* c2 */\n"
+     "    (\n"
+     "        /* c1 */  /* c2 */\n"
+     "        arg1\n"
+     "        /* c1 */  /* c2 */\n"
+     "        ,\n"
+     "        /* c1 */  /* c2 */\n"
+     "        arg2\n"
+     "        /* c1 */  /* c2 */\n"
+     "    )\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c\n"
+     "(\n"
+     "// c\n"
+     "arg1\n"
+     "// c\n"
+     ",\n"
+     "// c\n"
+     "arg2\n"
+     "// c\n"
+     ")\n"
+     "// c\n"
+     ";\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c\n"
+     "    (\n"
+     "        // c\n"
+     "        arg1\n"
+     "        // c\n"
+     "        ,\n"
+     "        // c\n"
+     "        arg2\n"
+     "        // c\n"
+     "    )\n"
+     "// c\n"
+     ";\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */ // c2\n"
+     "(\n"
+     "/* c1 */ // c2\n"
+     "arg1\n"
+     "/* c1 */ // c2\n"
+     ",\n"
+     "/* c1 */ // c2\n"
+     "arg2\n"
+     "/* c1 */ // c2\n"
+     ")\n"
+     "/* c1 */ // c2\n"
+     ";\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */  // c2\n"
+     "    (\n"
+     "        /* c1 */  // c2\n"
+     "        arg1\n"
+     "        /* c1 */  // c2\n"
+     "        ,\n"
+     "        /* c1 */  // c2\n"
+     "        arg2\n"
+     "        /* c1 */  // c2\n"
+     "    )\n"
+     "/* c1 */  // c2\n"
+     ";\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg1\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ",\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg2\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ")\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    (\n"
+     "        /* c1 */\n"
+     "        /* c2 */\n"
+     "        arg1\n"
+     "        /* c1 */\n"
+     "        /* c2 */\n"
+     "        ,\n"
+     "        /* c1 */\n"
+     "        /* c2 */\n"
+     "        arg2\n"
+     "        /* c1 */\n"
+     "        /* c2 */\n"
+     "    )\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "// c1\n"
+     "// c2\n"
+     "(\n"
+     "// c1\n"
+     "// c2\n"
+     "arg1\n"
+     "// c1\n"
+     "// c2\n"
+     ",\n"
+     "// c1\n"
+     "// c2\n"
+     "arg2\n"
+     "// c1\n"
+     "// c2\n"
+     ")\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    (\n"
+     "        // c1\n"
+     "        // c2\n"
+     "        arg1\n"
+     "        // c1\n"
+     "        // c2\n"
+     "        ,\n"
+     "        // c1\n"
+     "        // c2\n"
+     "        arg2\n"
+     "        // c1\n"
+     "        // c2\n"
+     "    )\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */(/* c1 */\n"
+     "/* c2 */arg1/* c1 */\n"
+     "/* c2 */,/* c1 */\n"
+     "/* c2 */arg2/* c1 */\n"
+     "/* c2 */)/* c1 */\n"
+     "/* c2 */;/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */ (  /* c1 */\n"
+     "        /* c2 */ arg1  /* c1 */\n"
+     "        /* c2 */,  /* c1 */\n"
+     "        /* c2 */ arg2  /* c1 */\n"
+     "    /* c2 */)  /* c1 */\n"
+     "/* c2 */;  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "/* c2 */(// c1\n"
+     "/* c2 */arg1// c1\n"
+     "/* c2 */,// c1\n"
+     "/* c2 */arg2// c1\n"
+     "/* c2 */)// c1\n"
+     "/* c2 */;// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */ (  // c1\n"
+     "        /* c2 */ arg1  // c1\n"
+     "        /* c2 */,  // c1\n"
+     "        /* c2 */ arg2  // c1\n"
+     "    /* c2 */)  // c1\n"
+     "/* c2 */;  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg2/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ (  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */ arg1  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */,  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */ arg2  /* c1 */\n"
+     "        /* c2 */\n"
+     "    /* c3 */)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */\n"
+     "(/* c1 */\n"
+     "/* c2 */\n"
+     "arg1/* c1 */\n"
+     "/* c2 */\n"
+     ",/* c1 */\n"
+     "/* c2 */\n"
+     "arg2/* c1 */\n"
+     "/* c2 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    (  /* c1 */\n"
+     "        /* c2 */\n"
+     "        arg1  /* c1 */\n"
+     "        /* c2 */\n"
+     "        ,  /* c1 */\n"
+     "        /* c2 */\n"
+     "        arg2  /* c1 */\n"
+     "        /* c2 */\n"
+     "    )  /* c1 */\n"
+     "/* c2 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "/* c2 */\n"
+     "(// c1\n"
+     "/* c2 */\n"
+     "arg1// c1\n"
+     "/* c2 */\n"
+     ",// c1\n"
+     "/* c2 */\n"
+     "arg2// c1\n"
+     "/* c2 */\n"
+     ")// c1\n"
+     "/* c2 */\n"
+     ";// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    /* c2 */\n"
+     "    (  // c1\n"
+     "        /* c2 */\n"
+     "        arg1  // c1\n"
+     "        /* c2 */\n"
+     "        ,  // c1\n"
+     "        /* c2 */\n"
+     "        arg2  // c1\n"
+     "        /* c2 */\n"
+     "    )  // c1\n"
+     "/* c2 */\n"
+     ";  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "// c2\n"
+     "(/* c1 */\n"
+     "// c2\n"
+     "arg1/* c1 */\n"
+     "// c2\n"
+     ",/* c1 */\n"
+     "// c2\n"
+     "arg2/* c1 */\n"
+     "// c2\n"
+     ")/* c1 */\n"
+     "// c2\n"
+     ";/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    // c2\n"
+     "    (  /* c1 */\n"
+     "        // c2\n"
+     "        arg1  /* c1 */\n"
+     "        // c2\n"
+     "        ,  /* c1 */\n"
+     "        // c2\n"
+     "        arg2  /* c1 */\n"
+     "        // c2\n"
+     "    )  /* c1 */\n"
+     "// c2\n"
+     ";  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "// c2\n"
+     "(// c1\n"
+     "// c2\n"
+     "arg1// c1\n"
+     "// c2\n"
+     ",// c1\n"
+     "// c2\n"
+     "arg2// c1\n"
+     "// c2\n"
+     ")// c1\n"
+     "// c2\n"
+     ";// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    (  // c1\n"
+     "       // c2\n"
+     "        arg1  // c1\n"
+     "        // c2\n"
+     "        ,  // c1\n"
+     "           // c2\n"
+     "        arg2  // c1\n"
+     "        // c2\n"
+     "    )  // c1\n"
+     "       // c2\n"
+     ";  // c1\n"
+     "   // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ",/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg2/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    (  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */\n"
+     "        arg1  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */\n"
+     "        ,  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */\n"
+     "        arg2  /* c1 */\n"
+     "        /* c2 */\n"
+     "        /* c3 */\n"
+     "    )  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg1// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ",// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg2// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ")// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "$foobarbaz  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    (  // c1\n"
+     "       // c2\n"
+     "       // c3\n"
+     "        arg1  // c1\n"
+     "        // c2\n"
+     "        // c3\n"
+     "        ,  // c1\n"
+     "           // c2\n"
+     "           // c3\n"
+     "        arg2  // c1\n"
+     "        // c2\n"
+     "        // c3\n"
+     "    )  // c1\n"
+     "       // c2\n"
+     "       // c3\n"
+     ";  // c1\n"
+     "   // c2\n"
+     "   // c3\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */arg1/* c */,/* c */arg2/* c */)/* c */;/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */\n"
+     "    arg1  /* c */,  /* c */\n"
+     "    arg2  /* c */)  /* c */;  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */arg1/* c1 */ /* c2 */,/* c1 */ /* c2 "
+     "*/arg2/* c1 */ /* c2 */)/* c1 */ /* c2 */;/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */\n"
+     "    arg1  /* c1 */  /* c2 */,  /* c1 */  /* c2 */\n"
+     "    arg2  /* c1 */  /* c2 */)  /* c1 */  /* c2 */;  /* c1 */  /* c2 "
+     "*/\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c */\n"
+     "arg1/* c */\n"
+     ",/* c */\n"
+     "arg2/* c */\n"
+     ")/* c */\n"
+     ";/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c */\n"
+     "    arg1  /* c */\n"
+     "    ,  /* c */\n"
+     "    arg2  /* c */\n"
+     ")  /* c */\n"
+     ";  /* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ /* c2 */\n"
+     "arg1/* c1 */ /* c2 */\n"
+     ",/* c1 */ /* c2 */\n"
+     "arg2/* c1 */ /* c2 */\n"
+     ")/* c1 */ /* c2 */\n"
+     ";/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  /* c2 */\n"
+     "    arg1  /* c1 */  /* c2 */\n"
+     "    ,  /* c1 */  /* c2 */\n"
+     "    arg2  /* c1 */  /* c2 */\n"
+     ")  /* c1 */  /* c2 */\n"
+     ";  /* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c\n"
+     "arg1// c\n"
+     ",// c\n"
+     "arg2// c\n"
+     ")// c\n"
+     ";// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c\n"
+     "    arg1  // c\n"
+     "    ,  // c\n"
+     "    arg2  // c\n"
+     ")  // c\n"
+     ";  // c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */ // c2\n"
+     "arg1/* c1 */ // c2\n"
+     ",/* c1 */ // c2\n"
+     "arg2/* c1 */ // c2\n"
+     ")/* c1 */ // c2\n"
+     ";/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */  // c2\n"
+     "    arg1  /* c1 */  // c2\n"
+     "    ,  /* c1 */  // c2\n"
+     "    arg2  /* c1 */  // c2\n"
+     ")  /* c1 */  // c2\n"
+     ";  /* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */arg1\n"
+     "/* c */,\n"
+     "/* c */arg2\n"
+     "/* c */)\n"
+     "/* c */;\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c */ arg1\n"
+     "    /* c */,\n"
+     "    /* c */ arg2\n"
+     "/* c */)\n"
+     "/* c */;\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */arg1\n"
+     "/* c1 */ /* c2 */,\n"
+     "/* c1 */ /* c2 */arg2\n"
+     "/* c1 */ /* c2 */)\n"
+     "/* c1 */ /* c2 */;\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  /* c2 */ arg1\n"
+     "    /* c1 */  /* c2 */,\n"
+     "    /* c1 */  /* c2 */ arg2\n"
+     "/* c1 */  /* c2 */)\n"
+     "/* c1 */  /* c2 */;\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c */\n"
+     "arg1\n"
+     "/* c */\n"
+     ",\n"
+     "/* c */\n"
+     "arg2\n"
+     "/* c */\n"
+     ")\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c */\n"
+     "    arg1\n"
+     "    /* c */\n"
+     "    ,\n"
+     "    /* c */\n"
+     "    arg2\n"
+     "    /* c */\n"
+     ")\n"
+     "/* c */\n"
+     ";\n"
+     "/* c */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ /* c2 */\n"
+     "arg1\n"
+     "/* c1 */ /* c2 */\n"
+     ",\n"
+     "/* c1 */ /* c2 */\n"
+     "arg2\n"
+     "/* c1 */ /* c2 */\n"
+     ")\n"
+     "/* c1 */ /* c2 */\n"
+     ";\n"
+     "/* c1 */ /* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  /* c2 */\n"
+     "    arg1\n"
+     "    /* c1 */  /* c2 */\n"
+     "    ,\n"
+     "    /* c1 */  /* c2 */\n"
+     "    arg2\n"
+     "    /* c1 */  /* c2 */\n"
+     ")\n"
+     "/* c1 */  /* c2 */\n"
+     ";\n"
+     "/* c1 */  /* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c\n"
+     "arg1\n"
+     "// c\n"
+     ",\n"
+     "// c\n"
+     "arg2\n"
+     "// c\n"
+     ")\n"
+     "// c\n"
+     ";\n"
+     "// c\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c\n"
+     "    arg1\n"
+     "    // c\n"
+     "    ,\n"
+     "    // c\n"
+     "    arg2\n"
+     "    // c\n"
+     ")\n"
+     "// c\n"
+     ";\n"
+     "// c\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */ // c2\n"
+     "arg1\n"
+     "/* c1 */ // c2\n"
+     ",\n"
+     "/* c1 */ // c2\n"
+     "arg2\n"
+     "/* c1 */ // c2\n"
+     ")\n"
+     "/* c1 */ // c2\n"
+     ";\n"
+     "/* c1 */ // c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */  // c2\n"
+     "    arg1\n"
+     "    /* c1 */  // c2\n"
+     "    ,\n"
+     "    /* c1 */  // c2\n"
+     "    arg2\n"
+     "    /* c1 */  // c2\n"
+     ")\n"
+     "/* c1 */  // c2\n"
+     ";\n"
+     "/* c1 */  // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg1\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ",\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     "arg2\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ")\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg1\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    ,\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg2\n"
+     "    /* c1 */\n"
+     "    /* c2 */\n"
+     ")\n"
+     "/* c1 */\n"
+     "/* c2 */\n"
+     ";\n"
+     "/* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "// c1\n"
+     "// c2\n"
+     "arg1\n"
+     "// c1\n"
+     "// c2\n"
+     ",\n"
+     "// c1\n"
+     "// c2\n"
+     "arg2\n"
+     "// c1\n"
+     "// c2\n"
+     ")\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    arg1\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    ,\n"
+     "    // c1\n"
+     "    // c2\n"
+     "    arg2\n"
+     "    // c1\n"
+     "    // c2\n"
+     ")\n"
+     "// c1\n"
+     "// c2\n"
+     ";\n"
+     "// c1\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */arg1/* c1 */\n"
+     "/* c2 */,/* c1 */\n"
+     "/* c2 */arg2/* c1 */\n"
+     "/* c2 */)/* c1 */\n"
+     "/* c2 */;/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */ arg1  /* c1 */\n"
+     "    /* c2 */,  /* c1 */\n"
+     "    /* c2 */ arg2  /* c1 */\n"
+     "/* c2 */)  /* c1 */\n"
+     "/* c2 */;  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */arg1// c1\n"
+     "/* c2 */,// c1\n"
+     "/* c2 */arg2// c1\n"
+     "/* c2 */)// c1\n"
+     "/* c2 */;// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    /* c2 */ arg1  // c1\n"
+     "    /* c2 */,  // c1\n"
+     "    /* c2 */ arg2  // c1\n"
+     "/* c2 */)  // c1\n"
+     "/* c2 */;  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */,/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */arg2/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */)/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ arg1  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */,  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */ arg2  /* c1 */\n"
+     "    /* c2 */\n"
+     "/* c3 */)  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */;  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "arg1/* c1 */\n"
+     "/* c2 */\n"
+     ",/* c1 */\n"
+     "/* c2 */\n"
+     "arg2/* c1 */\n"
+     "/* c2 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg1  /* c1 */\n"
+     "    /* c2 */\n"
+     "    ,  /* c1 */\n"
+     "    /* c2 */\n"
+     "    arg2  /* c1 */\n"
+     "    /* c2 */\n"
+     ")  /* c1 */\n"
+     "/* c2 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "/* c2 */\n"
+     "arg1// c1\n"
+     "/* c2 */\n"
+     ",// c1\n"
+     "/* c2 */\n"
+     "arg2// c1\n"
+     "/* c2 */\n"
+     ")// c1\n"
+     "/* c2 */\n"
+     ";// c1\n"
+     "/* c2 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    /* c2 */\n"
+     "    arg1  // c1\n"
+     "    /* c2 */\n"
+     "    ,  // c1\n"
+     "    /* c2 */\n"
+     "    arg2  // c1\n"
+     "    /* c2 */\n"
+     ")  // c1\n"
+     "/* c2 */\n"
+     ";  // c1\n"
+     "/* c2 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "// c2\n"
+     "arg1/* c1 */\n"
+     "// c2\n"
+     ",/* c1 */\n"
+     "// c2\n"
+     "arg2/* c1 */\n"
+     "// c2\n"
+     ")/* c1 */\n"
+     "// c2\n"
+     ";/* c1 */\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    // c2\n"
+     "    arg1  /* c1 */\n"
+     "    // c2\n"
+     "    ,  /* c1 */\n"
+     "    // c2\n"
+     "    arg2  /* c1 */\n"
+     "    // c2\n"
+     ")  /* c1 */\n"
+     "// c2\n"
+     ";  /* c1 */\n"
+     "// c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     "arg1// c1\n"
+     "// c2\n"
+     ",// c1\n"
+     "// c2\n"
+     "arg2// c1\n"
+     "// c2\n"
+     ")// c1\n"
+     "// c2\n"
+     ";// c1\n"
+     "// c2\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     "    arg1  // c1\n"
+     "    // c2\n"
+     "    ,  // c1\n"
+     "       // c2\n"
+     "    arg2  // c1\n"
+     "    // c2\n"
+     ")  // c1\n"
+     "   // c2\n"
+     ";  // c1\n"
+     "   // c2\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg1/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ",/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     "arg2/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ")/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";/* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    arg1  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    ,  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     "    arg2  /* c1 */\n"
+     "    /* c2 */\n"
+     "    /* c3 */\n"
+     ")  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"
+     ";  /* c1 */\n"
+     "/* c2 */\n"
+     "/* c3 */\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg1// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ",// c1\n"
+     "// c2\n"
+     "// c3\n"
+     "arg2// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ")// c1\n"
+     "// c2\n"
+     "// c3\n"
+     ";// c1\n"
+     "// c2\n"
+     "// c3\n",
+     "// verilog_syntax: parse-as-module-body\n"
+     "`FOOBARBAZ(  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    arg1  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     "    ,  // c1\n"
+     "       // c2\n"
+     "       // c3\n"
+     "    arg2  // c1\n"
+     "    // c2\n"
+     "    // c3\n"
+     ")  // c1\n"
+     "   // c2\n"
+     "   // c3\n"
+     ";  // c1\n"
+     "   // c2\n"
+     "   // c3\n"},
+
+    // -----------------------------------------------------------------
+
 };
 
 // Tests that formatter produces expected results, end-to-end.

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -368,8 +368,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "     dd)\n"},
     {// macro call with argument including EOL comment on own line
      "`FOOOO(aa, bb,\n//cc\ndd)\n",
-     "`FOOOO(aa, bb,  //cc\n"
-     // TODO(b/152324712): //cc comment should start its own line
+     "`FOOOO(aa, bb,\n"
+     "       //cc\n"
      "       dd)\n"},
     {"  // leading comment\n"
      "  `define   FOO    \\\n"  // multiline macro definition
@@ -389,15 +389,14 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
     {// long macro call breaking
      " `ASSERT_INIT(S, (D == 4 && K inside {0, 1}) ||"
      " (D == 3 && K== 4))\n",
-     "`ASSERT_INIT(S,\n"
-     "             (D == 4 && K inside {0, 1})\n"
-     "                 || (D == 3 && K == 4))\n"},
+     "`ASSERT_INIT(\n"
+     "    S, (D == 4 && K inside {0, 1}) ||\n"
+     "           (D == 3 && K == 4))\n"},
     {// long macro call breaking
      " `AINIT(S, (D == 4 && K inside {0, 1}) ||"
      " (D == 3 && K== 4))\n",
-     "`AINIT(S,\n"
-     "       (D == 4 && K inside {0, 1}) ||\n"
-     "           (D == 3 && K == 4))\n"},
+     "`AINIT(S, (D == 4 && K inside {0, 1}) ||\n"
+     "              (D == 3 && K == 4))\n"},
     {// long macro call breaking
      " `ASSERT_INIT(S, D == 4 && K inside {0, 1})\n",
      "`ASSERT_INIT(S,\n"
@@ -5499,8 +5498,7 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "      int count;\n"
         "      if (cfg.enable) begin\n"
         "        count = 1;\n"
-        "      end,\n"
-        "      utils_pkg::decrement())\n"
+        "      end, utils_pkg::decrement())\n"
         "endclass\n",
     },
 

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -795,6 +795,23 @@ static WithReason<SpacingOptions> BreakDecisionBetween(
     }
   }
 
+  if (left.format_token_enum == FTT::comment_block ||
+      right.format_token_enum == FTT::comment_block) {
+    auto preceding_whitespace = verible::make_string_view_range(
+        left.token->text().end(), right.token->text().begin());
+
+    auto pos = preceding_whitespace.find_first_of('\n', 0);
+    if (pos != absl::string_view::npos) {
+      // TODO(mglb): Preserve would be more suitable, but it doesn't work
+      // correctly yet.
+      // Add support for "Preserve" in Layout Optimizer.
+      // Correctly split partitions before tokens with "Preserve" decision in
+      // Tree Unwrapper.
+      return {SpacingOptions::MustWrap,
+              "Force-preserve line break around block comment"};
+    }
+  }
+
   // TODO(fangism): check for all token types in verilog.lex that
   // scan to an end-of-line, even if it returns the newline to scanning with
   // yyless().

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -2222,22 +2222,6 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
       },
       {
           DefaultStyle,
-          {TK_COMMENT_BLOCK, "/*comment*/"},
-          {verilog_tokentype::MacroCallId, "`uvm_foo_macro"},
-          {},  // any context
-          {},  // any context
-          {1, SpacingOptions::Undecided},
-      },
-      {
-          DefaultStyle,
-          {TK_COMMENT_BLOCK, "/*comment*/"},
-          {verilog_tokentype::MacroIdentifier, "`uvm_foo_id"},
-          {},  // any context
-          {},  // any context
-          {1, SpacingOptions::Undecided},
-      },
-      {
-          DefaultStyle,
           {PP_else, "`else"},
           {verilog_tokentype::MacroCallId, "`uvm_foo_macro"},
           {},  // any context
@@ -4598,14 +4582,6 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
       },
       {
           DefaultStyle,
-          {verilog_tokentype::TK_COMMENT_BLOCK, "/*comment*/"},
-          {verilog_tokentype::TK_LINE_CONT, "\\"},
-          {/* any context */},
-          {/* any context */},
-          {0, SpacingOptions::MustAppend},
-      },
-      {
-          DefaultStyle,
           {verilog_tokentype::SymbolIdentifier, "id"},
           {verilog_tokentype::TK_LINE_CONT, "\\"},
           {/* any context */},
@@ -4721,7 +4697,9 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
     right.format_token_enum =
         GetFormatTokenType(verilog_tokentype(right.TokenEnum()));
 
-    ASSERT_NE(right.format_token_enum, FormatTokenType::eol_comment)
+    ASSERT_TRUE(right.format_token_enum != FormatTokenType::eol_comment &&
+                left.format_token_enum != FormatTokenType::comment_block &&
+                right.format_token_enum != FormatTokenType::comment_block)
         << "This test does not support cases examining intertoken text. "
            "Move the test case to AnnotateBreakAroundComments instead.";
 
@@ -4774,6 +4752,39 @@ TEST(TokenAnnotatorTest, OriginalSpacingSensitiveTests) {
        {/* unspecified context */},
        {/* unspecified context */},
        {1, SpacingOptions::Undecided}},
+      {
+          DefaultStyle,
+          TK_COMMENT_BLOCK,
+          "/*comment*/",
+          "",
+          verilog_tokentype::MacroCallId,
+          "`uvm_foo_macro",
+          {},  // any context
+          {},  // any context
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          TK_COMMENT_BLOCK,
+          "/*comment*/",
+          "",
+          verilog_tokentype::MacroIdentifier,
+          "`uvm_foo_id",
+          {},  // any context
+          {},  // any context
+          {1, SpacingOptions::Undecided},
+      },
+      {
+          DefaultStyle,
+          verilog_tokentype::TK_COMMENT_BLOCK,
+          "/*comment*/",
+          "",
+          verilog_tokentype::TK_LINE_CONT,
+          "\\",
+          {/* any context */},
+          {/* any context */},
+          {0, SpacingOptions::MustAppend},
+      },
       {// //comment1
        // //comment2
        DefaultStyle,
@@ -4834,7 +4845,7 @@ TEST(TokenAnnotatorTest, OriginalSpacingSensitiveTests) {
        "// comment 2",
        {/* unspecified context */},
        {/* unspecified context */},
-       {2, SpacingOptions::Undecided}},
+       {2, SpacingOptions::MustWrap}},
       {// /* comment 1 */  // comment 2
        DefaultStyle,
        verilog_tokentype::TK_COMMENT_BLOCK,
@@ -5027,7 +5038,7 @@ TEST(TokenAnnotatorTest, OriginalSpacingSensitiveTests) {
           "/*comment*/",
           {/* unspecified context */},
           {/* unspecified context */},
-          {2, SpacingOptions::Undecided},
+          {2, SpacingOptions::MustWrap},
       },
       {
           DefaultStyle,

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -4701,7 +4701,7 @@ TEST(TokenAnnotatorTest, AnnotateFormattingWithContextTest) {
                 left.format_token_enum != FormatTokenType::comment_block &&
                 right.format_token_enum != FormatTokenType::comment_block)
         << "This test does not support cases examining intertoken text. "
-           "Move the test case to AnnotateBreakAroundComments instead.";
+           "Move the test case to OriginalSpacingSensitiveTests instead.";
 
     VLOG(1) << "left context: " << test_case.left_context;
     VLOG(1) << "right context: " << test_case.right_context;

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1757,7 +1757,7 @@ static const SyntaxTreeNode* GetAssignedExpressionFromDataDeclaration(
 // This phase is strictly concerned with reshaping token partitions,
 // and occurs on the return path of partition tree construction.
 void TreeUnwrapper::ReshapeTokenPartitions(
-    const SyntaxTreeNode& node, const verible::BasicFormatStyle& style,
+    const SyntaxTreeNode& node, const FormatStyle& style,
     TokenPartitionTree* recent_partition) {
   const auto tag = static_cast<NodeEnum>(node.Tag().tag);
   VLOG(3) << __FUNCTION__ << " node: " << tag;

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -96,7 +96,7 @@ class TreeUnwrapper : public verible::TreeUnwrapper {
   void SetIndentationsAndCreatePartitions(const verible::SyntaxTreeNode& node);
 
   void ReshapeTokenPartitions(const verible::SyntaxTreeNode& node,
-                              const verible::BasicFormatStyle& style,
+                              const FormatStyle& style,
                               verible::TokenPartitionTree* recent_partition);
 
   // Visits a node which requires a new UnwrappedLine, followed by

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -15,6 +15,7 @@
 #ifndef VERIBLE_VERILOG_FORMATTING_TREE_UNWRAPPER_H_
 #define VERIBLE_VERILOG_FORMATTING_TREE_UNWRAPPER_H_
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -47,6 +48,8 @@ struct UnwrapperData {
 
   explicit UnwrapperData(const verible::TokenSequence&);
 };
+
+enum class ContextHint;
 
 // Derived TreeUnwrapper for Verilog Formatting.
 // Contains all visitors and logic necessary for creating UnwrappedLines for
@@ -139,6 +142,16 @@ class TreeUnwrapper : public verible::TreeUnwrapper {
   // This determines placement of comments on unwrapped lines.
   // (Private-implementation idiom)
   std::unique_ptr<TokenScanner> inter_leaf_scanner_;
+
+  void PushContextHint(ContextHint hint) { context_hints_.push_back(hint); }
+  bool HasContextHint(ContextHint hint) const {
+    return std::find(context_hints_.rbegin(), context_hints_.rend(), hint) !=
+           context_hints_.rend();
+  }
+  const std::vector<ContextHint>& ContextHints() const {
+    return context_hints_;
+  }
+  std::vector<ContextHint> context_hints_;
 
   // For debug printing.
   verible::TokenInfo::Context token_context_;

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -1760,8 +1760,9 @@ const TreeUnwrapperTestData kUnwrapModuleTestCases[] = {
         ModuleDeclaration(
             0, L(0, {"module", "block_generate", ";"}),
             ModuleItemList(1,
-                           N(1,  //
-                             L(1, {"`ASSERT", "("}), L(3, {"blah", ")"})),
+                           N(1,                       //
+                             L(1, {"`ASSERT", "("}),  //
+                             L(3, {"blah", ")"})),
                            N(1,  //
                              L(1, {"generate"}), L(1, {"endgenerate"}))),
             L(0, {"endmodule"})),
@@ -3350,7 +3351,7 @@ const TreeUnwrapperTestData kClassTestCases[] = {
                 TaskDeclaration(
                     1, TaskHeader(1, {"task", "print", "(", ")", ";"}),
                     StatementList(2, L(2, {"begin"}),
-                                  N(3, L(3, {"$write", "("}),
+                                  N(3, N(3, L(3, {"$write"}), L(3, {"("})),
                                     L(5, {"\"Hello, world!\"", ")", ";"})),
                                   L(2, {"end"})),
                     L(1, {"endtask"}))),
@@ -3426,10 +3427,10 @@ const TreeUnwrapperTestData kClassTestCases[] = {
             0, L(0, {"class", "macro_unwrapping", ";"}),
             N(1, L(1, {"`MACRO_CALL", "("}),
               N(3, L(3, {"// verilog_syntax: parse-as-statements"}),
-                L(3, {"int", "count", ";"}),
-                FlowControl(3, L(3, {"if", "(", "cfg", ")", "begin"}),
-                            L(4, {"count", "=", "1", ";"}),
-                            L(3, {"end", ")"})))),
+                N(3, L(3, {"int", "count", ";"}),
+                  FlowControl(3, L(3, {"if", "(", "cfg", ")", "begin"}),
+                              L(4, {"count", "=", "1", ";"}),
+                              L(3, {"end", ")"}))))),
             L(0, {"endclass"})),
     },
     {
@@ -3447,11 +3448,11 @@ const TreeUnwrapperTestData kClassTestCases[] = {
             0, L(0, {"class", "macro_unwrapping_with_comment", ";"}),
             N(1, L(1, {"`MACRO_CALL", "("}),
               N(3, L(3, {"// verilog_syntax: parse-as-statements"}),
-                L(3, {"int", "count", ";"}),
-                FlowControl(3, L(3, {"if", "(", "cfg", ")", "begin"}),
-                            N(4, L(4, {"// parsed comment"}),
-                              L(4, {"count", "=", "1", ";"})),
-                            L(3, {"end", ")"})))),
+                N(3, L(3, {"int", "count", ";"}),
+                  FlowControl(3, L(3, {"if", "(", "cfg", ")", "begin"}),
+                              N(4, L(4, {"// parsed comment"}),
+                                L(4, {"count", "=", "1", ";"})),
+                              L(3, {"end", ")"}))))),
             L(0, {"endclass"})),
     },
 
@@ -5201,9 +5202,10 @@ const TreeUnwrapperTestData kUnwrapTaskTestCases[] = {
         "task foo;"
         "$makeitso(x);"
         "endtask",
-        TaskDeclaration(0, TaskHeader(0, {"task", "foo", ";"}),
-                        N(1, L(1, {"$makeitso", "("}), L(3, {"x", ")", ";"})),
-                        L(0, {"endtask"})),
+        TaskDeclaration(
+            0, TaskHeader(0, {"task", "foo", ";"}),
+            N(1, N(1, L(1, {"$makeitso"}), L(1, {"("})), L(3, {"x", ")", ";"})),
+            L(0, {"endtask"})),
     },
 
     {
@@ -5456,12 +5458,12 @@ const TreeUnwrapperTestData kUnwrapTaskTestCases[] = {
         "$makeitso(x);"
         "end "
         "endtask",
-        TaskDeclaration(
-            0, TaskHeader(0, {"task", "foo", ";"}),
-            FlowControl(1, L(1, {"while", "(", "1", ")", "begin"}),
-                        N(2, L(2, {"$makeitso", "("}), L(4, {"x", ")", ";"})),
-                        L(1, {"end"})),
-            L(0, {"endtask"})),
+        TaskDeclaration(0, TaskHeader(0, {"task", "foo", ";"}),
+                        FlowControl(1, L(1, {"while", "(", "1", ")", "begin"}),
+                                    N(2, N(2, L(2, {"$makeitso"}), L(2, {"("})),
+                                      L(4, {"x", ")", ";"})),
+                                    L(1, {"end"})),
+                        L(0, {"endtask"})),
     },
 
     {


### PR DESCRIPTION
Fixes: #1130 

Improved formatting of macro calls which takes into account many edge cases (like comments in various places of the call).

The new formatting is applied to:
* Standalone macro calls
* Macro calls nested inside standalone macro calls and other affected nested calls

Support for other cases (calls inside `if` conditions, in assignments, etc) will be done after implementing layout optimizer formatting for other structures.
Warning: the reshaping code is pretty messy, and does not work perfectly. However, it works better than current implementation. I'm going to revisit it after refactoring TokenPartitionTree and implementing kChoice partition policy. The choice operator should simplify things a lot.

There are also some other features:
* Partition policies for some Layout Optimizer combinators (juxtaposition, stack, wrap)
* Improvements in layout optimizer's wrapper: token-level wrapping, hanging indentation support
* Few fixes

Some new features in Layout Optimizer (mostly token-level wrapping and hanging indentation in Wrapper function) are not perfect. I''ll improve them when doing other tasks. They will be needed at some point in order to get ternary operator tabular alignment.

Sorry for a huge PR :) It can be safely reviewed commit after a commit.