### PR TITLE
Use flat_hash_map instead of std::map in ScopeResolver.

### DIFF
--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -50,6 +50,7 @@ cc_library(
         "//common/util:auto_pop_stack",
         "//common/util:iterator_range",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 

--- a/verilog/tools/kythe/kythe_facts.cc
+++ b/verilog/tools/kythe/kythe_facts.cc
@@ -27,11 +27,6 @@
 namespace verilog {
 namespace kythe {
 
-bool Signature::operator==(const Signature& other) const {
-  return names_.size() == other.names_.size() &&
-         std::equal(names_.begin(), names_.end(), other.names_.begin());
-}
-
 bool Signature::operator<(const Signature& other) const {
   return std::lexicographical_compare(names_.begin(), names_.end(),
                                       other.names_.begin(), other.names_.end());

--- a/verilog/tools/kythe/kythe_facts.h
+++ b/verilog/tools/kythe/kythe_facts.h
@@ -38,8 +38,12 @@ class Signature {
     names_.push_back(std::string(name));
   }
 
-  bool operator==(const Signature& other) const;
+  bool operator==(const Signature& other) const {
+    return names_ == other.names_;
+  }
   bool operator!=(const Signature& other) const { return !(*this == other); }
+
+  // TODO(hzeller): remove other uses of std::set, then operator< can go
   bool operator<(const Signature& other) const;
 
   // Returns the signature concatenated as a string.
@@ -67,6 +71,10 @@ class Signature {
   // for "x" ==> ["m", "x"]
   std::vector<std::string> names_;
 };
+template <typename H>
+H AbslHashValue(H state, const Signature& v) {
+  return H::combine(std::move(state), v.Names());
+}
 
 // Node vector name for kythe facts.
 struct VName {

--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "common/util/auto_pop_stack.h"
 #include "common/util/iterator_range.h"
@@ -245,7 +246,7 @@ class ScopeResolver {
   //   "pkg1": ["my_fun", "my_class"],
   //   "pkg2": ["my_fun", "my_class"]
   // }
-  std::map<Signature, Scope> scopes_;
+  absl::flat_hash_map<Signature, Scope> scopes_;
 
   // Pointer to the previous file's discovered scopes (if a previous file
   // exists). This is used for definition finding in cross-file referencing.


### PR DESCRIPTION
This sped up indexing of earlgray about 3x (3:30min -> 1:10min)

Signed-off-by: Henner Zeller <h.zeller@acm.org>