### PR TITLE
Fix penalties in Layout Optimizer's Wrap combinator

### DIFF
--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -413,7 +413,7 @@ LayoutFunction LayoutFunctionFactory::Choice(
               return (a->CostAt(current_column) < b->CostAt(current_column));
             // Sort by gradient when cost is the same. Favor earlier
             // element when both gradients are equal.
-            return (a->gradient <= b->gradient);
+            return (a->gradient < b->gradient);
           });
 
       if (min_cost_segment != last_min_cost_segment) {

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -12647,11 +12647,10 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases80ColumnsLimit[] = {
      "cfg.convert2string()), UVM_LOW)\n"
      "endmodule",
      "module foo;\n"
-     "  `uvm_info(\n"
-     "      `gfn, $sformatf(\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE "
+     "  `uvm_info(`gfn, $sformatf(\n"
+     "                      \"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE "
      "|----\\n %s\",\n"
-     "                      cfg.convert2string()), UVM_LOW)\n"
-     "endmodule\n"},
+     "                      cfg.convert2string()), UVM_LOW)\nendmodule\n"},
     {"module x;"
      "`uvm_fatal(`gfn, $sformatf("
      "\"The data 0x%0h written to the signature address is formatted "
@@ -12703,10 +12702,9 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases100ColumnsLimit[] =
          "cfg.convert2string()), UVM_LOW)\n"
          "endmodule",
          "module foo;\n"
-         "  `uvm_info(\n"
-         "      `gfn, $sformatf(\"\\n\\n\\t ----| STARTING AES MAIN SEQUENCE "
-         "|----\\n %s\", cfg.convert2string()),\n"
-         "      UVM_LOW)\n"
+         "  `uvm_info(`gfn, $sformatf(\"\\n\\n\\t ----| STARTING AES MAIN "
+         "SEQUENCE |----\\n %s\",\n"
+         "                            cfg.convert2string()), UVM_LOW)\n"
          "endmodule\n"},
         {"module x;"
          "`uvm_fatal(`gfn, $sformatf("
@@ -12715,10 +12713,10 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases100ColumnsLimit[] =
          "signature_data))\n"
          "endmodule",
          "module x;\n"
-         "  `uvm_fatal(\n"
-         "      `gfn, $sformatf(\"The data 0x%0h written to the signature "
+         "  `uvm_fatal(`gfn, $sformatf(\n"
+         "                       \"The data 0x%0h written to the signature "
          "address is formatted incorrectly.\",\n"
-         "                      signature_data))\n"
+         "                       signature_data))\n"
          "endmodule\n"},
         {// nested modules, three-levels
          "module x; module y; module z;"
@@ -12730,11 +12728,11 @@ static constexpr FormatterTestCase kNestedFunctionsTestCases100ColumnsLimit[] =
          "module x;\n"
          "  module y;\n"
          "    module z;\n"
-         "      `uvm_fatal(\n"
-         "          `gfn,\n"
-         "          $sformatf(\"The data 0x%0h written to the signature "
+         "      `uvm_fatal(`gfn,\n"
+         "                 $sformatf(\n"
+         "                     \"The data 0x%0h written to the signature "
          "address is formatted incorrectly.\",\n"
-         "                    signature_data))\n"
+         "                     signature_data))\n"
          "    endmodule\n"
          "  endmodule\n"
          "endmodule\n"},


### PR DESCRIPTION
`style_.line_break_penalty` is already added in Stack combinator.

`kEarlierLinesFavoringPenalty` has been propagating to output layout function, which caused it to have slightly higher cost. Moreover, this penalty is not even needed - Choice operator already favors its earlier arguments when costs are the same.

The comparison function in Choice operator should return true only for lower costs, not lower or equal.