### PR TITLE
Add support for custom UnwrappedLine's Origin printer

### DIFF
--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -134,7 +134,7 @@ std::ostream& TokenPartitionTreePrinter::PrintTree(std::ostream& stream,
   stream << Spacer(indent) << "{ ";
   if (children.empty()) {
     stream << '(';
-    value.AsCode(&stream, verbose);
+    value.AsCode(&stream, verbose, origin_printer);
     stream << ") }";
   } else {
     stream << '('
@@ -145,15 +145,15 @@ std::ostream& TokenPartitionTreePrinter::PrintTree(std::ostream& stream,
            << "[<auto>], policy: " << value.PartitionPolicy() << ") @"
            << NodePath(node);
     if (value.Origin() != nullptr) {
-      static constexpr int kContextLimit = 25;
-      stream << ", (origin: \""
-             << AutoTruncate{StringSpanOfSymbol(*value.Origin()), kContextLimit}
-             << "\")";
+      stream << ", (origin: ";
+      origin_printer(stream, value.Origin());
+      stream << ")";
     }
     stream << '\n';
     // token range spans all of children nodes
     for (const auto& child : children) {
-      TokenPartitionTreePrinter(child, verbose).PrintTree(stream, indent + 2)
+      TokenPartitionTreePrinter(child, verbose, origin_printer)
+              .PrintTree(stream, indent + 2)
           << '\n';
     }
     stream << Spacer(indent) << '}';

--- a/common/formatting/token_partition_tree.h
+++ b/common/formatting/token_partition_tree.h
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <iosfwd>
+#include <utility>
 #include <vector>
 
 #include "common/formatting/basic_format_style.h"
@@ -74,9 +75,11 @@ std::vector<std::vector<int>> FlushLeftSpacingDifferences(
 // that of all of its children.
 // Usage: stream << TokenPartitionTreePrinter(tree) << std::endl;
 struct TokenPartitionTreePrinter {
-  explicit TokenPartitionTreePrinter(const TokenPartitionTree& n,
-                                     bool verbose = false)
-      : node(n), verbose(verbose) {}
+  explicit TokenPartitionTreePrinter(
+      const TokenPartitionTree& n, bool verbose = false,
+      UnwrappedLine::OriginPrinterFunction origin_printer =
+          UnwrappedLine::DefaultOriginPrinter)
+      : node(n), verbose(verbose), origin_printer(std::move(origin_printer)) {}
 
   std::ostream& PrintTree(std::ostream& stream, int indent = 0) const;
 
@@ -84,6 +87,8 @@ struct TokenPartitionTreePrinter {
   const TokenPartitionTree& node;
   // If true, display inter-token information.
   bool verbose;
+
+  UnwrappedLine::OriginPrinterFunction origin_printer;
 };
 
 std::ostream& operator<<(std::ostream& stream,

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -15,6 +15,7 @@
 #ifndef VERIBLE_COMMON_FORMATTING_UNWRAPPED_LINE_H_
 #define VERIBLE_COMMON_FORMATTING_UNWRAPPED_LINE_H_
 
+#include <functional>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -163,8 +164,17 @@ class UnwrappedLine {
   // Returns true if the UnwrappedLine is empty, if it has no tokens
   bool IsEmpty() const { return tokens_.empty(); }
 
+  // Used by AsCode() and other code using it
+  using OriginPrinterFunction =
+      std::function<void(std::ostream&, const verible::Symbol*)>;
+
+  // Default origin printing function used by AsCode()
+  static void DefaultOriginPrinter(std::ostream&, const verible::Symbol*);
+
   // Currently for debugging, prints the UnwrappedLine as Code
-  std::ostream* AsCode(std::ostream*, bool verbose = false) const;
+  std::ostream* AsCode(
+      std::ostream*, bool verbose = false,
+      const OriginPrinterFunction& origin_printer = DefaultOriginPrinter) const;
 
  private:
   // Data members:

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -15,6 +15,7 @@
 #ifndef VERIBLE_VERILOG_FORMATTING_TREE_UNWRAPPER_H_
 #define VERIBLE_VERILOG_FORMATTING_TREE_UNWRAPPER_H_
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -94,10 +95,9 @@ class TreeUnwrapper : public verible::TreeUnwrapper {
 
   void SetIndentationsAndCreatePartitions(const verible::SyntaxTreeNode& node);
 
-  static void ReshapeTokenPartitions(
-      const verible::SyntaxTreeNode& node,
-      const verible::BasicFormatStyle& style,
-      verible::TokenPartitionTree* recent_partition);
+  void ReshapeTokenPartitions(const verible::SyntaxTreeNode& node,
+                              const verible::BasicFormatStyle& style,
+                              verible::TokenPartitionTree* recent_partition);
 
   // Visits a node which requires a new UnwrappedLine, followed by
   // traversing all children
@@ -125,6 +125,10 @@ class TreeUnwrapper : public verible::TreeUnwrapper {
 
   // For print debugging.
   verible::TokenWithContext VerboseToken(const verible::TokenInfo&) const;
+
+  // For print debugging.
+  verible::TokenPartitionTreePrinter VerilogPartitionPrinter(
+      const verible::TokenPartitionTree& partition) const;
 
   // Data members:
 


### PR DESCRIPTION
before:
```
{ (>>>>>>>>>>[<auto>], policy: wrap) @{3,1,0,1,1}, (origin: "`gfn, $sfor..., UVM_DEBUG")
  { (>>>>>>>>>>[`gfn ,], policy: fit-else-expand, (origin: "`gfn")) }
  { (>>>>>>>>>>[<auto>], policy: juxtaposition-or-indented-stack) @{3,1,0,1,1,1}, (origin: "$sformatf("..._pulses, i)")
    { (>>>>>>>>>>[<auto>], policy: wrap) @{3,1,0,1,1,1,0}
      { (>>>>>>>>>>[$sformatf], policy: fit-else-expand, (origin: "$sformatf")) }
      { (>>>>>>>>>>[(], policy: fit-else-expand, (origin: "(")) }
    }
    { (>>>>>>>>>>>>>>[<auto>], policy: wrap) @{3,1,0,1,1,1,1}, (origin: ""a %0d b %0...m_pulses, i")
      { (>>>>>>>>>>>>>>["a %0d b %0d" ,], policy: fit-else-expand, (origin: ""a %0d b %0d"")) }
      { (>>>>>>>>>>>>>>[cfg . num_pulses ,], policy: fit-else-expand, (origin: "cfg.num_pulses")) }
      { (>>>>>>>>>>>>>>[i ) ,], policy: fit-else-expand, (origin: "i")) }
    }
  }
  { (>>>>>>>>>>[UVM_DEBUG], policy: fit-else-expand, (origin: "UVM_DEBUG")) }
}
```

after:
```
{ (>>>>>>>>>>[<auto>], policy: wrap) @{3,1,0,1,1}, (origin: kMacroArgList@204-264 "`gfn, $sfor..., UVM_DEBUG")
  { (>>>>>>>>>>[`gfn ,], policy: fit-else-expand, (origin: kExpression@204-208 "`gfn")) }
  { (>>>>>>>>>>[<auto>], policy: juxtaposition-or-indented-stack) @{3,1,0,1,1,1}, (origin: kSystemTFCall@210-253 "$sformatf("..._pulses, i)")
    { (>>>>>>>>>>[<auto>], policy: wrap) @{3,1,0,1,1,1,0}
      { (>>>>>>>>>>[$sformatf], policy: fit-else-expand, (origin: #SystemTFIdentifier@210-219 "$sformatf")) }
      { (>>>>>>>>>>[(], policy: fit-else-expand, (origin: #'('@219-220 "(")) }
    }
    { (>>>>>>>>>>>>>>[<auto>], policy: wrap) @{3,1,0,1,1,1,1}, (origin: kArgumentList@220-252 ""a %0d b %0...m_pulses, i")
      { (>>>>>>>>>>>>>>["a %0d b %0d" ,], policy: fit-else-expand, (origin: kExpression@220-233 ""a %0d b %0d"")) }
      { (>>>>>>>>>>>>>>[cfg . num_pulses ,], policy: fit-else-expand, (origin: kExpression@235-249 "cfg.num_pulses")) }
      { (>>>>>>>>>>>>>>[i ) ,], policy: fit-else-expand, (origin: kExpression@251-252 "i")) }
    }
  }
  { (>>>>>>>>>>[UVM_DEBUG], policy: fit-else-expand, (origin: kExpression@255-264 "UVM_DEBUG")) }
}
```