### PR TITLE
Don't use flat_hash_map where pointer stability is needed.

### DIFF
--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -50,7 +50,7 @@ cc_library(
         "//common/util:auto_pop_stack",
         "//common/util:iterator_range",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:node_hash_map",
     ],
 )
 

--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"
+#include "absl/container/node_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "common/util/auto_pop_stack.h"
 #include "common/util/iterator_range.h"
@@ -246,7 +246,9 @@ class ScopeResolver {
   //   "pkg1": ["my_fun", "my_class"],
   //   "pkg2": ["my_fun", "my_class"]
   // }
-  absl::flat_hash_map<Signature, Scope> scopes_;
+  // NB: we internally work with pointers of scopes stored in the
+  // value, so we can't use flat_hash_map that moves around Scope.
+  absl::node_hash_map<Signature, Scope> scopes_;
 
   // Pointer to the previous file's discovered scopes (if a previous file
   // exists). This is used for definition finding in cross-file referencing.


### PR DESCRIPTION
Use node_hash_map instead.

Signed-off-by: Henner Zeller <h.zeller@acm.org>