### PR TITLE
Replace linear search in Scope::SearchForDefinition() with map lookup.

### DIFF
--- a/verilog/tools/kythe/kythe_facts.cc
+++ b/verilog/tools/kythe/kythe_facts.cc
@@ -32,10 +32,6 @@ bool Signature::operator<(const Signature& other) const {
                                       other.names_.begin(), other.names_.end());
 }
 
-bool Signature::IsNameEqual(absl::string_view name) const {
-  return names_.back() == name;
-}
-
 std::string Signature::ToString() const {
   std::string signature;
   for (absl::string_view name : names_) {

--- a/verilog/tools/kythe/kythe_facts.h
+++ b/verilog/tools/kythe/kythe_facts.h
@@ -52,10 +52,6 @@ class Signature {
   // Returns the signature concatenated as a string in base 64.
   std::string ToBase64() const;
 
-  // Checks whether this signature represents the same given variable in its
-  // scope.
-  bool IsNameEqual(absl::string_view) const;
-
   const std::vector<std::string>& Names() const { return names_; }
 
  private:

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -1197,7 +1197,7 @@ void KytheFactsExtractor::ReferenceIncludeFile(
 
   // Create child of edge between the parent and the member of the included
   // file.
-  for (const ScopeMemberItem& member : included_file_scope->Members()) {
+  for (const auto& [_, member] : included_file_scope->Members()) {
     CreateEdge(member.vname, kEdgeChildOf, vnames_context_.top());
   }
 

--- a/verilog/tools/kythe/kythe_facts_test.cc
+++ b/verilog/tools/kythe/kythe_facts_test.cc
@@ -29,15 +29,12 @@ TEST(SignatureTest, EmptyToString) {
   const Signature s;
   EXPECT_EQ(s.ToString(), "");
   EXPECT_THAT(s.Names(), ElementsAre(""));
-  EXPECT_TRUE(s.IsNameEqual(""));
 }
 
 TEST(SignatureTest, ToString) {
   const Signature s("foobar");
   EXPECT_EQ(s.ToString(), "foobar#");
   EXPECT_THAT(s.Names(), ElementsAre("foobar"));
-  EXPECT_TRUE(s.IsNameEqual("foobar"));
-  EXPECT_FALSE(s.IsNameEqual("barfoo"));
 }
 
 TEST(SignatureTest, WithParentToString) {
@@ -45,9 +42,6 @@ TEST(SignatureTest, WithParentToString) {
   const Signature s2(s1, "baz");
   EXPECT_EQ(s2.ToString(), "foobar#baz#");
   EXPECT_THAT(s2.Names(), ElementsAre("foobar", "baz"));
-  EXPECT_TRUE(s2.IsNameEqual("baz"));
-  EXPECT_FALSE(s2.IsNameEqual("bar"));
-  EXPECT_FALSE(s2.IsNameEqual("foobar"));
 }
 
 TEST(SignatureTest, Equality) {

--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -33,8 +33,6 @@ namespace kythe {
 struct ScopeMemberItem {
   ScopeMemberItem(const VName& vname) : vname(vname) {}
 
-  bool operator<(const ScopeMemberItem& other) const;
-
   // VName of this member.
   VName vname;
 };
@@ -56,7 +54,8 @@ class Scope {
   // Appends the member of the given scope to the current scope.
   void AppendScope(const Scope& scope);
 
-  const std::set<ScopeMemberItem>& Members() const { return members_; }
+  using MemberMap = absl::node_hash_map<std::string, ScopeMemberItem>;
+  const MemberMap& Members() const { return members_; }
   const Signature& GetSignature() const { return signature_; }
 
   // Searches for the given reference_name in the current scope and returns its
@@ -71,7 +70,7 @@ class Scope {
   Signature signature_;
 
   // list of the members inside this scope.
-  std::set<ScopeMemberItem> members_;
+  MemberMap members_;
 };
 
 // Container with a stack of Scopes to hold the accessible scopes during


### PR DESCRIPTION
In a particular sample file, that reduced the processing time
from 48min to 8 seconds.

Signed-off-by: Henner Zeller <hzeller@google.com>