### PR TITLE
Use proper logging instead of std::cerr.

### DIFF
--- a/common/lsp/json-rpc-dispatcher.cc
+++ b/common/lsp/json-rpc-dispatcher.cc
@@ -40,7 +40,7 @@ void JsonRpcDispatcher::DispatchMessage(absl::string_view data) {
   // Direct dispatch, later maybe send to an executor that returns futures ?
   const bool is_notification = (request.find("id") == request.end());
   VLOG(1) << "Got " << (is_notification ? "notification" : "method call")
-          << " '" << method << "'";
+          << " '" << method << "'; req-size: " << data.size();
   bool handled = false;
   if (is_notification) {
     handled = CallNotification(request, method);

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -18,6 +18,7 @@ cc_library(
     hdrs = ["lsp-parse-buffer.h"],
     deps = [
         "//common/lsp:lsp-text-buffer",
+        "//common/util:logging",
         "//verilog/analysis:verilog_analyzer",
         "//verilog/analysis:verilog_linter",
         "@com_google_absl//absl/status",

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -16,6 +16,7 @@
 #include "verilog/tools/ls/lsp-parse-buffer.h"
 
 #include "absl/status/status.h"
+#include "common/util/logging.h"
 
 namespace verilog {
 static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
@@ -26,7 +27,7 @@ static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
   if (auto from_flags = LinterConfigurationFromFlags(); from_flags.ok()) {
     config = *from_flags;
   } else {
-    std::cerr << from_flags.status().message() << std::endl;
+    LOG(ERROR) << from_flags.status().message() << std::endl;
   }
 
   return VerilogLintTextStructure(filename, config, text_structure);
@@ -37,7 +38,7 @@ ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
     : version_(version),
       uri_(uri),
       parser_(verilog::VerilogAnalyzer::AnalyzeAutomaticMode(content, uri)) {
-  std::cerr << "Analyzed " << uri << " lex:" << parser_->LexStatus()
+  LOG(INFO) << "Analyzed " << uri << " lex:" << parser_->LexStatus()
             << "; parser:" << parser_->ParseStatus() << std::endl;
   // TODO(hzeller): we should use a filename not URI; strip prefix.
   if (auto lint_result = RunLinter(uri, *parser_); lint_result.ok()) {

--- a/verilog/tools/ls/verilog_ls.cc
+++ b/verilog/tools/ls/verilog_ls.cc
@@ -102,10 +102,7 @@ int main(int argc, char *argv[]) {
     std::cout << reply << std::flush;
   };
 
-  // We want the buffer size to be the largest message we could
-  // receive. It typically would be in the order of largest file to
-  // be opened (as it is sent verbatim in didOpen).
-  // Should be chosen accordingly.
+  // Stream splitter splits the input stream into messages (header/body).
   MessageStreamSplitter stream_splitter;
   JsonRpcDispatcher dispatcher(write_fun);
 


### PR DESCRIPTION
While at it: also log size of JSON RPC requests. And fix
outdated comment for the stream splitter (buffer sizes are
dynamically adapted these days).

Signed-off-by: Henner Zeller <hzeller@google.com>