### PR TITLE
Always stream the final Kythe result.

### DIFF
--- a/verilog/tools/kythe/kythe_facts_extractor.h
+++ b/verilog/tools/kythe/kythe_facts_extractor.h
@@ -57,13 +57,13 @@ class KytheFactsPrinter {
 
 std::ostream& operator<<(std::ostream&, const KytheFactsPrinter&);
 
-// Extracted Kythe indexing facts and edges.
-struct KytheIndexingData {
-  // Extracted Kythe indexing facts.
-  std::set<Fact> facts;
-
-  // Extracted Kythe edges.
-  std::set<Edge> edges;
+// Output sink interface for producing the Kythe output.
+class KytheOutput {
+ public:
+  // Output all Kythe facts from the indexing data.
+  virtual void Emit(const Fact& fact) = 0;
+  virtual void Emit(const Edge& edge) = 0;
+  virtual ~KytheOutput() {}
 };
 
 // Extract facts across an entire project.
@@ -72,18 +72,6 @@ struct KytheIndexingData {
 // Currently, the file_list must be dependency-ordered for best results, that
 // is, definitions of symbols should be encountered earlier in the file list
 // than references to those symbols.
-KytheIndexingData ExtractKytheFacts(const IndexingFactNode& file_list,
-                                    const VerilogProject& project);
-
-// Interface for producing the Kythe output.
-class KytheOutput {
- public:
-  // Output all Kythe facts from the indexing data.
-  virtual void Emit(const KytheIndexingData& indexing_data) = 0;
-  virtual ~KytheOutput() {}
-};
-
-// Populate the Kythe output stream with Kythe facts.
 void StreamKytheFactsEntries(KytheOutput* kythe_output,
                              const IndexingFactNode& file_list_facts_tree,
                              const VerilogProject& project);

--- a/verilog/tools/kythe/kythe_proto_output.cc
+++ b/verilog/tools/kythe/kythe_proto_output.cc
@@ -14,13 +14,6 @@
 
 #include "verilog/tools/kythe/kythe_proto_output.h"
 
-#ifndef _WIN32
-#include <unistd.h>  // for STDOUT_FILENO
-#else
-#include <stdio.h>
-#define STDOUT_FILENO _fileno(stdout)
-#endif
-
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "third_party/proto/kythe/storage.pb.h"
@@ -74,16 +67,14 @@ void OutputProto(const Entry& entry, FileOutputStream* stream) {
 
 }  // namespace
 
-void KytheProtoOutput::Emit(const KytheIndexingData& indexing_data) {
-  FileOutputStream file_output(STDOUT_FILENO);
-  file_output.SetCloseOnDelete(true);
+KytheProtoOutput::KytheProtoOutput(int fd) : out_(fd) {}
+KytheProtoOutput::~KytheProtoOutput() { out_.Close(); }
 
-  for (const Fact& fact : indexing_data.facts) {
-    OutputProto(ConvertFactToEntry(fact), &file_output);
-  }
-  for (const Edge& edge : indexing_data.edges) {
-    OutputProto(ConvertEdgeToEntry(edge), &file_output);
-  }
+void KytheProtoOutput::Emit(const Fact& fact) {
+  OutputProto(ConvertFactToEntry(fact), &out_);
+}
+void KytheProtoOutput::Emit(const Edge& edge) {
+  OutputProto(ConvertEdgeToEntry(edge), &out_);
 }
 
 }  // namespace kythe

--- a/verilog/tools/kythe/kythe_proto_output.h
+++ b/verilog/tools/kythe/kythe_proto_output.h
@@ -15,16 +15,24 @@
 #ifndef VERIBLE_VERILOG_TOOLS_KYTHE_KYTHE_PROTO_OUTPUT_H_
 #define VERIBLE_VERILOG_TOOLS_KYTHE_KYTHE_PROTO_OUTPUT_H_
 
+#include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "verilog/tools/kythe/kythe_facts.h"
 #include "verilog/tools/kythe/kythe_facts_extractor.h"
 
 namespace verilog {
 namespace kythe {
 
-class KytheProtoOutput : public KytheOutput {
+class KytheProtoOutput final : public KytheOutput {
  public:
-  // Output all Kythe facts from the indexing data in proto format.
-  void Emit(const KytheIndexingData& indexing_data);
+  KytheProtoOutput(int output_fd);
+  ~KytheProtoOutput() final;
+
+  // Output Kythe facts from the indexing data in proto format.
+  void Emit(const Fact& fact) final;
+  void Emit(const Edge& edge) final;
+
+ private:
+  ::google::protobuf::io::FileOutputStream out_;
 };
 
 }  // namespace kythe

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -32,6 +32,13 @@
 #include "verilog/tools/kythe/kythe_facts_extractor.h"
 #include "verilog/tools/kythe/kythe_proto_output.h"
 
+#ifndef _WIN32
+#include <unistd.h>  // for STDOUT_FILENO
+#else
+#include <stdio.h>
+#define STDOUT_FILENO _fileno(stdout)
+#endif
+
 // for --print_kythe_facts flag
 enum class PrintMode {
   kJSON,
@@ -100,9 +107,9 @@ namespace kythe {
 
 // Prints Kythe facts in proto format to stdout.
 static void PrintKytheFactsProtoEntries(
-    const IndexingFactNode& file_list_facts_tree,
-    const VerilogProject& project) {
-  KytheProtoOutput proto_output;
+    const IndexingFactNode& file_list_facts_tree, const VerilogProject& project,
+    int fd) {
+  KytheProtoOutput proto_output(fd);
   StreamKytheFactsEntries(&proto_output, file_list_facts_tree, project);
 }
 
@@ -132,7 +139,8 @@ static std::vector<absl::Status> ExtractTranslationUnits(
       break;
     }
     case PrintMode::kProto: {
-      PrintKytheFactsProtoEntries(file_list_facts_tree, *project);
+      PrintKytheFactsProtoEntries(file_list_facts_tree, *project,
+                                  STDOUT_FILENO);
       break;
     }
   }


### PR DESCRIPTION
Instead of collecting the final result in an ever-growing set
before printing, write them out as they are received to
minimize memory use.

This _could_ result in the same facts be emitted multiple times
if there are duplicates (can there ?), but this is benign.

Make StreamKytheFactsEntries() the main toplevel function.
Remove the ExtractKytheFacts() that accumulates everything in
sets first.

Signed-off-by: Henner Zeller <hzeller@google.com>