### PR TITLE
Store string_view in Signature() array, not std::string.

### DIFF
--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -49,8 +49,8 @@ cc_library(
         ":kythe_facts",
         "//common/util:auto_pop_stack",
         "//common/util:iterator_range",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/container:node_hash_map",
+        "@com_google_absl//absl/strings",
     ],
 )
 
@@ -94,6 +94,7 @@ cc_library(
         "//verilog/analysis:verilog_project",
         "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
     ],

--- a/verilog/tools/kythe/kythe_facts.h
+++ b/verilog/tools/kythe/kythe_facts.h
@@ -30,12 +30,11 @@ inline constexpr absl::string_view kEmptyKytheLanguage = "";
 // Unique identifier for Kythe facts.
 class Signature {
  public:
-  explicit Signature(absl::string_view name = "")
-      : names_({std::string(name)}) {}
+  explicit Signature(absl::string_view name = "") : names_({name}) {}
 
   Signature(const Signature& parent, absl::string_view name)
       : names_(parent.Names()) {
-    names_.push_back(std::string(name));
+    names_.push_back(name);
   }
 
   bool operator==(const Signature& other) const {
@@ -52,7 +51,7 @@ class Signature {
   // Returns the signature concatenated as a string in base 64.
   std::string ToBase64() const;
 
-  const std::vector<std::string>& Names() const { return names_; }
+  const std::vector<absl::string_view>& Names() const { return names_; }
 
  private:
   // List that uniquely determines this signature and differentiates it from any
@@ -65,7 +64,7 @@ class Signature {
   //
   // for "m" ==> ["m"]
   // for "x" ==> ["m", "x"]
-  std::vector<std::string> names_;
+  std::vector<absl::string_view> names_;
 };
 template <typename H>
 H AbslHashValue(H state, const Signature& v) {

--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -54,7 +54,7 @@ class Scope {
   // Appends the member of the given scope to the current scope.
   void AppendScope(const Scope& scope);
 
-  using MemberMap = absl::node_hash_map<std::string, ScopeMemberItem>;
+  using MemberMap = absl::node_hash_map<absl::string_view, ScopeMemberItem>;
   const MemberMap& Members() const { return members_; }
   const Signature& GetSignature() const { return signature_; }
 


### PR DESCRIPTION
All strings are backed by the text structure ultimately.
There is one string that is generated ad-hoc, which is the
assembled location string "@123:456"; this is now kept in
a stable backing store.

In a test with a particular large file, this resulted in
some significant improvement:
311s -> 232s (25% improvement).

TODO: storing these vectors of strings seems like a waste
of space; couldn't we just have a string-view and a pointer to
the parent signature ?

Signed-off-by: Henner Zeller <h.zeller@acm.org>