### PR TITLE
Use the single element in ScopedMemberItem directly.

### DIFF
--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -1208,7 +1208,7 @@ void KytheFactsExtractor::ReferenceIncludeFile(
   // Create child of edge between the parent and the member of the included
   // file.
   for (const auto& [_, member] : included_file_scope->Members()) {
-    CreateEdge(member.vname, kEdgeChildOf, vnames_context_.top());
+    CreateEdge(member, kEdgeChildOf, vnames_context_.top());
   }
 
   // Append the scope of the included file to the current scope.

--- a/verilog/tools/kythe/scope_resolver.cc
+++ b/verilog/tools/kythe/scope_resolver.cc
@@ -22,7 +22,7 @@ namespace verilog {
 namespace kythe {
 
 void Scope::AddMemberItem(const ScopeMemberItem& member_item) {
-  members_.insert({member_item.vname.signature.Names().back(), member_item});
+  members_.insert({member_item.signature.Names().back(), member_item});
 }
 
 void Scope::AppendScope(const Scope& scope) {
@@ -33,11 +33,11 @@ void Scope::AppendScope(const Scope& scope) {
 
 const VName* Scope::SearchForDefinition(absl::string_view name) const {
   const auto& found = members_.find(name);
-  return found == members_.end() ? nullptr : &found->second.vname;
+  return found == members_.end() ? nullptr : &found->second;
 }
 
 void Scope::RemoveMember(const ScopeMemberItem& member) {
-  members_.erase(member.vname.signature.Names().back());
+  members_.erase(member.signature.Names().back());
 }
 
 const VName* ScopeContext::SearchForDefinition(absl::string_view name) const {

--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -30,13 +30,8 @@ namespace verilog {
 namespace kythe {
 
 // Used to wrap whatever needs to be recorded in a scope item.
-// TODO(hzeller): should be plain VName, no need to copy for one member.
-struct ScopeMemberItem {
-  /*implicit*/ ScopeMemberItem(const VName& vname) : vname(vname) {}  // NOLINT
-
-  // VName of this member.
-  VName vname;
-};
+// Right now, this is just a VName, if it will be more, make this a struct.
+using ScopeMemberItem = VName;
 
 // Represents some scope in SystemVerilog code like class or module.
 class Scope {


### PR DESCRIPTION
The ScopedMemberItem struct only contains a single element,
a VName, so let's use that directly. Left the typename, so
that it will be possible to convert back to a struct if need be.

Signed-off-by: Henner Zeller <h.zeller@acm.org>