### PR TITLE
Project: If we have specific parse error messages, provide these.

### DIFF
--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -72,6 +72,9 @@ class VerilogSourceFile {
   // Returns the first non-Ok status if there is one, else OkStatus().
   absl::Status Status() const { return status_; }
 
+  // Return human readable error messages if available.
+  std::vector<std::string> ErrorMessages() const;
+
   // Returns the name used to reference the file.
   absl::string_view ReferencedPath() const { return referenced_path_; }
 


### PR DESCRIPTION
If we can generate detailed parse error messages, output these
instead of a generic error status. This will improve Kythe logging.

Signed-off-by: Henner Zeller <hzeller@google.com>