### PR TITLE
With all uses of std::set gone, operator< not needed anymore.

### DIFF
--- a/verilog/tools/kythe/kythe_facts.cc
+++ b/verilog/tools/kythe/kythe_facts.cc
@@ -27,11 +27,6 @@
 namespace verilog {
 namespace kythe {
 
-bool Signature::operator<(const Signature& other) const {
-  return std::lexicographical_compare(names_.begin(), names_.end(),
-                                      other.names_.begin(), other.names_.end());
-}
-
 std::string Signature::ToString() const {
   std::string signature;
   for (absl::string_view name : names_) {
@@ -48,12 +43,6 @@ std::string Signature::ToBase64() const {
 bool VName::operator==(const VName& other) const {
   return path == other.path && root == other.root && corpus == other.corpus &&
          signature == other.signature && language == other.language;
-}
-
-bool VName::operator<(const VName& other) const {
-  return std::tie(signature, path, language, root, corpus) <
-         std::tie(other.signature, other.path, other.language, other.root,
-                  other.corpus);
 }
 
 std::ostream& VName::FormatJSON(std::ostream& stream, bool debug,
@@ -79,11 +68,6 @@ std::ostream& operator<<(std::ostream& stream, const VName& vname) {
 bool Fact::operator==(const Fact& other) const {
   return fact_value == other.fact_value && fact_name == other.fact_name &&
          node_vname == other.node_vname;
-}
-
-bool Fact::operator<(const Fact& other) const {
-  return std::tie(node_vname, fact_name, fact_value) <
-         std::tie(other.node_vname, other.fact_name, other.fact_value);
 }
 
 std::ostream& Fact::FormatJSON(std::ostream& stream, bool debug,
@@ -113,11 +97,6 @@ std::ostream& operator<<(std::ostream& stream, const Fact& fact) {
 bool Edge::operator==(const Edge& other) const {
   return edge_name == other.edge_name && source_node == other.source_node &&
          target_node == other.target_node;
-}
-
-bool Edge::operator<(const Edge& other) const {
-  return std::tie(source_node, edge_name, target_node) <
-         std::tie(other.source_node, other.edge_name, other.target_node);
 }
 
 std::ostream& Edge::FormatJSON(std::ostream& stream, bool debug,

--- a/verilog/tools/kythe/kythe_facts.h
+++ b/verilog/tools/kythe/kythe_facts.h
@@ -42,9 +42,6 @@ class Signature {
   }
   bool operator!=(const Signature& other) const { return !(*this == other); }
 
-  // TODO(hzeller): remove other uses of std::set, then operator< can go
-  bool operator<(const Signature& other) const;
-
   // Returns the signature concatenated as a string.
   std::string ToString() const;
 
@@ -74,7 +71,6 @@ H AbslHashValue(H state, const Signature& v) {
 // Node vector name for kythe facts.
 struct VName {
   bool operator==(const VName& other) const;
-  bool operator<(const VName& other) const;
 
   std::ostream& FormatJSON(std::ostream&, bool debug,
                            int indentation = 0) const;
@@ -110,7 +106,6 @@ struct Fact {
 
   bool operator==(const Fact& other) const;
   bool operator!=(const Fact& other) const { return !(*this == other); }
-  bool operator<(const Fact& other) const;
 
   std::ostream& FormatJSON(std::ostream&, bool debug,
                            int indentation = 0) const;
@@ -140,7 +135,6 @@ struct Edge {
 
   bool operator==(const Edge& other) const;
   bool operator!=(const Edge& other) const { return !(*this == other); }
-  bool operator<(const Edge& other) const;
 
   std::ostream& FormatJSON(std::ostream&, bool debug,
                            int indentation = 0) const;

--- a/verilog/tools/kythe/kythe_facts_test.cc
+++ b/verilog/tools/kythe/kythe_facts_test.cc
@@ -60,13 +60,6 @@ TEST(SignatureTest, Equality) {
   }
 }
 
-TEST(SignatureTest, LessThen) {
-  const Signature s1("aaa");
-  const Signature s2("bbb");
-  EXPECT_LT(s1, s2);
-  EXPECT_FALSE(s2 < s1);
-}
-
 TEST(VNameTest, DefaultCtor) {
   const VName vname;
   std::ostringstream stream;
@@ -103,8 +96,6 @@ TEST(VNameTest, FilledCtor) {
     const VName vname2;
     EXPECT_FALSE(vname == vname2);
     EXPECT_FALSE(vname2 == vname);
-    EXPECT_LT(vname2, vname);
-    EXPECT_FALSE(vname < vname2);
   }
 }
 
@@ -136,7 +127,6 @@ TEST(FactTest, Equality) {
   EXPECT_EQ(fact2, fact2);
   EXPECT_NE(fact1, fact2);
   EXPECT_NE(fact2, fact1);
-  EXPECT_LT(fact1, fact2);
 }
 
 TEST(EdgeTest, FormatJSON) {
@@ -175,8 +165,6 @@ TEST(EdgeTest, Equality) {
   EXPECT_EQ(edge2, edge2);
   EXPECT_NE(edge1, edge2);
   EXPECT_NE(edge2, edge1);
-  EXPECT_LT(edge1, edge2);
-  EXPECT_FALSE(edge2 < edge1);
 }
 
 }  // namespace


### PR DESCRIPTION
Remove this dead code.

Signed-off-by: Henner Zeller <h.zeller@acm.org>