### PR TITLE
Unroll OR expression on initializer list in MatchesTagAnyOf()

### DIFF
--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -156,16 +156,16 @@ class SyntaxTreeNode : public Symbol {
     switch (enums.size()) {
       case 4:
         if (*it++ == EnumType(tag_)) return true;
-        [[fallthrough]];
+        ABSL_FALLTHROUGH_INTENDED;
       case 3:
         if (*it++ == EnumType(tag_)) return true;
-        [[fallthrough]];
+        ABSL_FALLTHROUGH_INTENDED;
       case 2:
         if (*it++ == EnumType(tag_)) return true;
-        [[fallthrough]];
+        ABSL_FALLTHROUGH_INTENDED;
       case 1:
         if (*it++ == EnumType(tag_)) return true;
-        [[fallthrough]];
+        ABSL_FALLTHROUGH_INTENDED;
       case 0:
         return false;
       default:

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -149,12 +149,29 @@ class SyntaxTreeNode : public Symbol {
     return tag_ == static_cast<int>(e);
   }
 
-  // TODO(fangism): when performance is needed, use a flat_set.
   template <typename EnumType>
   bool MatchesTagAnyOf(std::initializer_list<EnumType> enums) const {
-    // Linear search.
-    auto iter = std::find(enums.begin(), enums.end(), EnumType(tag_));
-    return iter != enums.end();
+    auto it = enums.begin();
+    // Unroll OR expression. Right now, we never have more than 4.
+    switch (enums.size()) {
+      case 4:
+        if (*it++ == EnumType(tag_)) return true;
+        [[fallthrough]];
+      case 3:
+        if (*it++ == EnumType(tag_)) return true;
+        [[fallthrough]];
+      case 2:
+        if (*it++ == EnumType(tag_)) return true;
+        [[fallthrough]];
+      case 1:
+        if (*it++ == EnumType(tag_)) return true;
+        [[fallthrough]];
+      case 0:
+        return false;
+      default:
+        // TODO(hzeller): with constexpr magic, can we static_assert() this ?
+        LOG(FATAL) << "need more choice " << enums.size();
+    }
   }
 
  private:


### PR DESCRIPTION
In a particularly large file, this sped up the formatting by
a factor of > 2x (34sec -> 16sec).

Signed-off-by: Henner Zeller <h.zeller@acm.org>