### PR TITLE
Re-enable bazel caching action for Windows.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -282,8 +282,6 @@ jobs:
 
     - name: Mount bazel cache
       uses: actions/cache@v2
-      # Currently, this is using >3GiB, bringing us well beyond 5GiB per repo
-      if: false
       with:
         path: "c:/users/runneradmin/_bazel_runneradmin"
         key: bazelcache_windows2_${{ steps.cache_timestamp.outputs.time }}


### PR DESCRIPTION
According to this blog post, cache size was
increased from 5GiB to 10GiB.
https://github.blog/changelog/2021-11-23-github-actions-cache-size-is-now-increased-to-10gb-per-repository/

Signed-off-by: Henner Zeller <h.zeller@acm.org>