### PR TITLE
Expand the classification of what is consider an Identifier.

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -118,10 +118,10 @@ KnownIssue[project:$BASE_TEST_DIR/ivtest/ivltests/wreal.v]=1017
 
 #--- Too many to mention manually, so here we do the 'waive all' approach
 declare -A KnownProjectToolIssue
-KnownProjectToolIssue[project:basejump_stl]="#917 #1002 #1003"
-KnownProjectToolIssue[project:ibex]="#917 #1002 #1003"
-KnownProjectToolIssue[project:uvm]="#917 #1002 #1003"
-KnownProjectToolIssue[project:opentitan]="#917 #1002 #1003"
+KnownProjectToolIssue[project:basejump_stl]="#1002 #1003"
+KnownProjectToolIssue[project:ibex]="#1002 #1003"
+KnownProjectToolIssue[project:uvm]="#1002 #1003"
+KnownProjectToolIssue[project:opentitan]="#1002 #1003"
 
 # Run smoke test on provided files for project.
 # Returns 0 if all tools finished without crashing.
@@ -184,7 +184,7 @@ function run_smoke_test() {
         else
           # This is an so far unknown issue
           echo "::error:: 😱 ${single_file}: crash exit code $EXIT_CODE for $tool"
-          head -10 ${TOOL_OUT}   # Might be useful in this case
+          head -15 ${TOOL_OUT}   # Might be useful in this case
           result=$((${result} + 1))
         fi
       fi

--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: sh; sh-basic-offset: 2; indent-tabs-mode: nil; -*-
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,6 +134,7 @@ function run_smoke_test() {
   local TOOL_OUT=${TMPDIR}/tool.$$.out
   local PROJECT_NAME=$1
   local FILELIST=$2
+  local GIT_URL=$3
   local result=0
 
   echo "::group::== Running verible on ${TERM_BOLD}${PROJECT_NAME}${TERM_RESET} with $(wc -l < ${FILELIST}) files =="
@@ -184,6 +186,7 @@ function run_smoke_test() {
         else
           # This is an so far unknown issue
           echo "::error:: 😱 ${single_file}: crash exit code $EXIT_CODE for $tool"
+          echo "Input File URL: ${GIT_URL}/blob/master/$(echo $single_file | cut -d/ -f6-)"
           head -15 ${TOOL_OUT}   # Might be useful in this case
           result=$((${result} + 1))
         fi
@@ -209,7 +212,7 @@ for git_project in ${TEST_GIT_PROJECTS} ; do
   FILELIST=${PROJECT_DIR}/verible.filelist
   find ${PROJECT_DIR} -name "*.sv" -o -name "*.svh" -o -name "*.v" | sort > ${FILELIST}
 
-  run_smoke_test ${PROJECT_NAME} ${FILELIST}
+  run_smoke_test ${PROJECT_NAME} ${FILELIST} ${git_project}
   status_sum=$((${status_sum} + $?))
   echo
 done

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -48,6 +48,7 @@
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/verilog_project.h"
 #include "verilog/parser/verilog_parser.h"
+#include "verilog/parser/verilog_token_classifications.h"
 #include "verilog/parser/verilog_token_enum.h"
 
 namespace verilog {
@@ -724,16 +725,15 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const auto tag = leaf.Tag().tag;
     VLOG(1) << __FUNCTION__ << " [leaf]: " << VerboseToken(leaf.get());
     switch (tag) {
-      case verilog_tokentype::SymbolIdentifier:
-        HandleIdentifier(leaf);
-        break;
-
       case verilog_tokentype::TK_SCOPE_RES:  // "::"
       case '.':
         last_hierarchy_operator_ = &leaf.get();
         break;
 
       default:
+        if (verilog::IsIdentifierLike(static_cast<verilog_tokentype>(tag))) {
+          HandleIdentifier(leaf);
+        }
         break;
     }
     VLOG(1) << "end " << __FUNCTION__ << " [leaf]:" << VerboseToken(leaf.get());

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -1469,6 +1469,23 @@ TEST(BuildSymbolTableTest, ModuleInstanceNamedParameterAssignment) {
   }
 }
 
+TEST(BuildSymbolTableTest, KeywordAsIdentifierRegressionIssue917) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module foo;\n"
+                            " timer #(.N(1)) t;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode& root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(foo_node, root_symbol, "foo");
+  MUST_ASSIGN_LOOKUP_SYMBOL(timer_instance_node, foo_node, "t");
+}
+
 TEST(BuildSymbolTableTest, ModuleInstanceNamedPortIsParameter) {
   TestVerilogSourceFile src("foobar.sv",
                             "module m #(\n"

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -800,6 +800,7 @@ KeywordIdentifier
  * For now, allow these to be used as identifiers until we actually find
  * examples that use the dialects, and will require additional context.
  */
+  // If these change: modify verilog_token_classifications.cc:IsIdentifierLike()
   /* Verilog-AMS: */
   : TK_branch
     { $$ = move($1); }

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -135,6 +135,11 @@ static SymbolPtr MakeUnpackedDimensionsNode(SymbolPtr& arg) {
   return MakeTaggedNode(N::kUnpackedDimensions, arg);
 }
 
+static SymbolPtr &RetagTokenAs(SymbolPtr& arg, verilog_tokentype new_type) {
+  auto& leaf = down_cast<verible::SyntaxTreeLeaf&>(*arg);
+  leaf.get_mutable()->set_token_enum(new_type);
+  return arg;
+}
 %}
 
 %debug
@@ -799,56 +804,56 @@ KeywordIdentifier
 /* The following are keywords in certain dialects of Verilog.
  * For now, allow these to be used as identifiers until we actually find
  * examples that use the dialects, and will require additional context.
+ * So for now, they are just treated as SymbolIdentifier
  */
-  // If these change: modify verilog_token_classifications.cc:IsIdentifierLike()
   /* Verilog-AMS: */
   : TK_branch
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_access
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_exclude
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_flow
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_from
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_ground
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_connect
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   /* Verilog-A derivative operators */
   | TK_ddx
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_ddt
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_idt
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_idtmod
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   /* Verilog-AMS connect keywords: */
   | TK_split
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_merged
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   /* Verilog-AMS event statements: */
   | TK_timer
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   /* | TK_cross is used in SystemVerilog covergroups */
   | TK_above
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_discrete
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_initial_step
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   | TK_final_step
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   /* TK_sample is in SystemVerilog coverage_event */
   | TK_sample
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   /* TODO(fangism): 'bool' is not a SystemVerilog keyword, but we may
    *   still want to discourage it (style-guide).  */
   | TK_bool
-    { $$ = move($1); }
+    { $$ = move(RetagTokenAs($1, SymbolIdentifier)); }
   ;
 
 /* TODO(fangism): phase this out:

--- a/verilog/parser/verilog_token_classifications.cc
+++ b/verilog/parser/verilog_token_classifications.cc
@@ -161,6 +161,29 @@ bool IsIdentifierLike(verilog_tokentype token_type) {
     case verilog_tokentype::TK_Sskew:
     case verilog_tokentype::TK_Stimeskew:
     case verilog_tokentype::TK_Swidth:
+
+      // These are from KeywordIdentifier (verilog.y)
+      // TODO(hzeller): there needs to be an automatic classification.
+    case verilog_tokentype::TK_branch:
+    case verilog_tokentype::TK_access:
+    case verilog_tokentype::TK_exclude:
+    case verilog_tokentype::TK_flow:
+    case verilog_tokentype::TK_from:
+    case verilog_tokentype::TK_ground:
+    case verilog_tokentype::TK_connect:
+    case verilog_tokentype::TK_ddx:
+    case verilog_tokentype::TK_ddt:
+    case verilog_tokentype::TK_idt:
+    case verilog_tokentype::TK_idtmod:
+    case verilog_tokentype::TK_split:
+    case verilog_tokentype::TK_merged:
+    case verilog_tokentype::TK_timer:
+    case verilog_tokentype::TK_above:
+    case verilog_tokentype::TK_discrete:
+    case verilog_tokentype::TK_initial_step:
+    case verilog_tokentype::TK_final_step:
+    case verilog_tokentype::TK_sample:
+    case verilog_tokentype::TK_bool:
       return true;
     default:
       break;

--- a/verilog/parser/verilog_token_classifications.cc
+++ b/verilog/parser/verilog_token_classifications.cc
@@ -161,29 +161,6 @@ bool IsIdentifierLike(verilog_tokentype token_type) {
     case verilog_tokentype::TK_Sskew:
     case verilog_tokentype::TK_Stimeskew:
     case verilog_tokentype::TK_Swidth:
-
-      // These are from KeywordIdentifier (verilog.y)
-      // TODO(hzeller): there needs to be an automatic classification.
-    case verilog_tokentype::TK_branch:
-    case verilog_tokentype::TK_access:
-    case verilog_tokentype::TK_exclude:
-    case verilog_tokentype::TK_flow:
-    case verilog_tokentype::TK_from:
-    case verilog_tokentype::TK_ground:
-    case verilog_tokentype::TK_connect:
-    case verilog_tokentype::TK_ddx:
-    case verilog_tokentype::TK_ddt:
-    case verilog_tokentype::TK_idt:
-    case verilog_tokentype::TK_idtmod:
-    case verilog_tokentype::TK_split:
-    case verilog_tokentype::TK_merged:
-    case verilog_tokentype::TK_timer:
-    case verilog_tokentype::TK_above:
-    case verilog_tokentype::TK_discrete:
-    case verilog_tokentype::TK_initial_step:
-    case verilog_tokentype::TK_final_step:
-    case verilog_tokentype::TK_sample:
-    case verilog_tokentype::TK_bool:
       return true;
     default:
       break;


### PR DESCRIPTION
Use the IsIdentifierLike() classifier. And fix the classifier
to contain the KeywordIdentifier class of tokens (as the
bug in question was actually triggered due to one of these,
TK_timer).

Fixes #917

Signed-off-by: Henner Zeller <h.zeller@acm.org>