### PR TITLE
Prepare users of VectorTree to be more agnostic about the internal co…

### DIFF
--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -1489,7 +1489,7 @@ class FormatUsingOriginalSpacingTest : public ::testing::Test,
  protected:
   void RunTestCase(TokenPartitionTree actual,
                    const TokenPartitionTree expected) {
-    std::vector<TokenPartitionTree> nodes;
+    TokenPartitionTree::subnodes_type nodes;
     nodes.push_back(std::move(actual));
     FormatUsingOriginalSpacing(TokenPartitionRange(nodes.begin(), nodes.end()));
     EXPECT_PRED_FORMAT2(TokenPartitionTreesEqualPredFormat, nodes[0], expected);

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -64,8 +64,8 @@ void AdoptLayoutAndFlattenIfSameType(const LayoutTree& source,
     const auto& first_subitem = source.Children().front().Value();
     CHECK(src_item.MustWrap() == first_subitem.MustWrap());
     CHECK(src_item.SpacesBefore() == first_subitem.SpacesBefore());
-    destination->Children().reserve(destination->Children().size() +
-                                    source.Children().size());
+    destination->SetExpectedChildrenUpperBound(destination->Children().size() +
+                                               source.Children().size());
     for (const auto& sublayout : source.Children())
       destination->AdoptSubtree(sublayout);
   } else {

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -606,7 +606,7 @@ class TokenPartitionTreeWrapper {
   std::unique_ptr<UnwrappedLine> unwrapped_line_;
 };
 
-using partition_iterator = std::vector<TokenPartitionTree>::const_iterator;
+using partition_iterator = TokenPartitionTree::subnodes_type::const_iterator;
 using partition_range = verible::container_iterator_range<partition_iterator>;
 
 struct AppendFittingSubpartitionsResult {

--- a/common/formatting/token_partition_tree.h
+++ b/common/formatting/token_partition_tree.h
@@ -38,7 +38,7 @@ namespace verible {
 // TODO(fangism): Promote this to a class that privately inherits the base.
 // Methods on this class will preserve invariants.
 using TokenPartitionTree = VectorTree<UnwrappedLine>;
-using TokenPartitionIterator = std::vector<TokenPartitionTree>::iterator;
+using TokenPartitionIterator = TokenPartitionTree::subnodes_type::iterator;
 using TokenPartitionRange = container_iterator_range<TokenPartitionIterator>;
 
 // Analyses (non-modifying):

--- a/common/formatting/token_partition_tree_test_utils.cc
+++ b/common/formatting/token_partition_tree_test_utils.cc
@@ -38,14 +38,14 @@ TokenPartitionTree TokenPartitionTreeBuilder::build(
     const std::vector<verible::PreFormatToken>& tokens) const {
   TokenPartitionTree node;
 
-  auto& child_nodes = node.Children();
-  child_nodes.reserve(children_.size());
+  node.SetExpectedChildrenUpperBound(children_.size());
   for (const auto& child : children_) {
     node.NewChild(child.build(tokens));
   }
 
   FormatTokenRange node_tokens;
   if (token_indexes_range_.first < 0) {
+    const auto& child_nodes = node.Children();
     CHECK(!child_nodes.empty());
     CHECK_LT(token_indexes_range_.second, 0);
     node_tokens.set_begin(child_nodes.front().Value().TokensRange().begin());

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -426,7 +426,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
       const size_t num_params = FindAllNamedParams(node).size();
       // +1 to accommodate the slot needed for a nested type reference
       // e.g. for "B" in "A#(.X(), .Y(), ...)::B"
-      reference_branch_point_->Children().reserve(num_params + 1);
+      reference_branch_point_->SetExpectedChildrenUpperBound(num_params + 1);
     }
     Descend(node);
   }
@@ -437,7 +437,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
       // FindAll* will also catch actual port connections inside preprocessing
       // conditionals.
       const size_t num_ports = FindAllActualNamedPort(node).size();
-      reference_branch_point_->Children().reserve(num_ports);
+      reference_branch_point_->SetExpectedChildrenUpperBound(num_ports);
     }
     Descend(node);
   }

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -364,7 +364,7 @@ IndexingFactNode ExtractFiles(absl::string_view file_list_path,
   VerilogExtractionState project_extraction_state{project};
 
   // pre-allocate file nodes with the number of translation units
-  file_list_facts_tree.Children().reserve(translation_units.size());
+  file_list_facts_tree.SetExpectedChildrenUpperBound(translation_units.size());
   for (auto* translation_unit : translation_units) {
     if (translation_unit == nullptr) continue;
     const auto parse_status = translation_unit->Parse();


### PR DESCRIPTION
…ntainer.

This will make it simpler to change the container later. In particular,
not all containers might have reserve(), so pull that operation into a
method that can be implemented according to the containers' needs.

Also, make the `subnodes_type` typedef in VectorTree public for users
to properly define their iterator types.

This is a preparation for other changes to be simpler, so
no functional or container type change in this PR.

Signed-off-by: Henner Zeller <h.zeller@acm.org>