### PR TITLE
Fix to make 'infinite' usable as symbol.

### DIFF
--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -802,6 +802,8 @@ KeywordIdentifier
   /* TK_sample is in SystemVerilog coverage_event */
   | TK_sample
     { $$ = move($1); }
+  | TK_infinite
+    { $$ = move($1); }
   ;
 
 /* TODO(fangism): phase this out:

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -1799,6 +1799,7 @@ static const ParserTestCaseArray kModuleTests = {
     "module m(wire p_pkg::foo_t foo); endmodule\n",
     "module m; wire p_pkg::foo_t [2:0] foo [0:1]; endmodule\n",
     "module m(wire p_pkg::foo_t [2:0] foo [0:2]); endmodule\n",
+    "module m; wire infinite; endmodule\n",  // infinite also a keyword
     "interface _if; wire p_pkg::foo_t foo; endinterface\n",
     "interface _if; wire p_pkg::foo_t [1:0] foo [0:1]; endinterface\n",
     // system task calls

--- a/verilog/parser/verilog_token_classifications.cc
+++ b/verilog/parser/verilog_token_classifications.cc
@@ -168,6 +168,7 @@ bool IsIdentifierLike(verilog_tokentype token_type) {
     case verilog_tokentype::TK_from:
     case verilog_tokentype::TK_discrete:
     case verilog_tokentype::TK_sample:
+    case verilog_tokentype::TK_infinite:
       return true;
     default:
       break;


### PR DESCRIPTION
Fixes #399

Signed-off-by: Henner Zeller <h.zeller@acm.org>