### PR TITLE
Make "slew" a simple SymbolIdentifier.

### DIFF
--- a/verilog/formatting/verilog_token.cc
+++ b/verilog/formatting/verilog_token.cc
@@ -387,7 +387,6 @@ static const absl::node_hash_map<verilog_tokentype, FTT>& FormatTokenTypeMap() {
       {verilog_tokentype::TK_resolveto, FTT::keyword},
       {verilog_tokentype::TK_sin, FTT::keyword},
       {verilog_tokentype::TK_sinh, FTT::keyword},
-      {verilog_tokentype::TK_slew, FTT::keyword},
       {verilog_tokentype::TK_sqrt, FTT::keyword},
       {verilog_tokentype::TK_tan, FTT::keyword},
       {verilog_tokentype::TK_tanh, FTT::keyword},

--- a/verilog/parser/verilog.lex
+++ b/verilog/parser/verilog.lex
@@ -782,7 +782,7 @@ pow { UpdateLocation(); return TK_pow; }
 resolveto { UpdateLocation(); return TK_resolveto; }
 sin { UpdateLocation(); return TK_sin; }
 sinh { UpdateLocation(); return TK_sinh; }
-slew { UpdateLocation(); return TK_slew; }   /* Verilog-AMS */
+slew { UpdateLocation(); return SymbolIdentifier; }   /* Verilog-AMS; currently not used */
 split { UpdateLocation(); return SymbolIdentifier; } /* Verilog-AMS; currently not used */
 sqrt { UpdateLocation(); return TK_sqrt; }
 tan { UpdateLocation(); return TK_tan; }

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -577,7 +577,6 @@ is not locally defined, so the grammar here uses only generic identifiers.
 %token TK_resolveto "resolveto"
 %token TK_sin "sin"
 %token TK_sinh "sinh"
-%token TK_slew "slew"
 %token TK_sqrt "sqrt"
 %token TK_tan "tan"
 %token TK_tanh "tanh"

--- a/verilog/parser/verilog_lexer_unittest.cc
+++ b/verilog/parser/verilog_lexer_unittest.cc
@@ -1198,7 +1198,6 @@ static std::initializer_list<LexerTestData> kKeywordTests = {
     {{TK_resolveto, "resolveto"}},
     {{TK_sin, "sin"}},
     {{TK_sinh, "sinh"}},
-    {{TK_slew, "slew"}},
     {{TK_sqrt, "sqrt"}},
     {{TK_tan, "tan"}},
     {{TK_tanh, "tanh"}},

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -1800,6 +1800,7 @@ static const ParserTestCaseArray kModuleTests = {
     "module m; wire p_pkg::foo_t [2:0] foo [0:1]; endmodule\n",
     "module m(wire p_pkg::foo_t [2:0] foo [0:2]); endmodule\n",
     "module m; wire infinite; endmodule\n",  // infinite also a keyword
+    "module m; wire slew; endmodule\n",      // Regression #753
     "interface _if; wire p_pkg::foo_t foo; endinterface\n",
     "interface _if; wire p_pkg::foo_t [1:0] foo [0:1]; endinterface\n",
     // system task calls


### PR DESCRIPTION
Right now, it is not used as a keyword anywhere, so not even
a need to make it a KeywordIdentifier.

Fixes #753

Signed-off-by: Henner Zeller <hzeller@google.com>