### PR TITLE
Allow keyword 'continuous' also to be used in an identifier context.

### DIFF
--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -803,6 +803,8 @@ KeywordIdentifier
     { $$ = move($1); }
   | TK_infinite
     { $$ = move($1); }
+  | TK_continuous
+    { $$ = move($1); }
   ;
 
 /* TODO(fangism): phase this out:

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -1799,8 +1799,9 @@ static const ParserTestCaseArray kModuleTests = {
     "module m(wire p_pkg::foo_t foo); endmodule\n",
     "module m; wire p_pkg::foo_t [2:0] foo [0:1]; endmodule\n",
     "module m(wire p_pkg::foo_t [2:0] foo [0:2]); endmodule\n",
-    "module m; wire infinite; endmodule\n",  // infinite also a keyword
-    "module m; wire slew; endmodule\n",      // Regression #753
+    "module m; wire continuous; endmodule\n",  // Regression #672
+    "module m; wire infinite; endmodule\n",    // infinite also a keyword
+    "module m; wire slew; endmodule\n",        // Regression #753
     "interface _if; wire p_pkg::foo_t foo; endinterface\n",
     "interface _if; wire p_pkg::foo_t [1:0] foo [0:1]; endinterface\n",
     // system task calls

--- a/verilog/parser/verilog_token_classifications.cc
+++ b/verilog/parser/verilog_token_classifications.cc
@@ -169,6 +169,7 @@ bool IsIdentifierLike(verilog_tokentype token_type) {
     case verilog_tokentype::TK_discrete:
     case verilog_tokentype::TK_sample:
     case verilog_tokentype::TK_infinite:
+    case verilog_tokentype::TK_continuous:
       return true;
     default:
       break;


### PR DESCRIPTION
Fixes #672

Signed-off-by: Henner Zeller <hzeller@google.com>