### PR TITLE
Move include of vlog_is_on.h into generic logging.h

### DIFF
--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -130,6 +130,7 @@ cc_library(
         ":unwrapped_line",
         "//common/util:container_iterator_range",
         "//common/util:value_saver",
+        "//common/util:logging",
         "//common/util:vector_tree",
         "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/strings",

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -30,8 +30,8 @@
 #include "common/formatting/token_partition_tree.h"
 #include "common/formatting/unwrapped_line.h"
 #include "common/util/container_iterator_range.h"
+#include "common/util/logging.h"
 #include "common/util/value_saver.h"
-#include "glog/vlog_is_on.h"
 
 namespace verible {
 

--- a/common/util/logging.h
+++ b/common/util/logging.h
@@ -24,6 +24,7 @@
 // Quiet fatal logging does not exist in glog; work around here
 #define COMPACT_GOOGLE_LOG_QFATAL COMPACT_GOOGLE_LOG_FATAL
 #include "glog/logging.h"
+#include "glog/vlog_is_on.h"
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This allows us a simpler change once logging is available in
absl directly.

Signed-off-by: Henner Zeller <hzeller@google.com>