### PR TITLE
Document a few readability TODOs and remove unnecessary lines.

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -15181,7 +15181,6 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "   // c3\n"},
 
     // -----------------------------------------------------------------
-
 };
 
 // Tests that formatter produces expected results, end-to-end.

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -59,7 +59,6 @@ namespace verilog {
 namespace formatter {
 
 using ::verible::iterator_range;
-using ::verible::LeafTag;
 using ::verible::NodeTag;
 using ::verible::PartitionPolicyEnum;
 using ::verible::PreFormatToken;
@@ -670,6 +669,8 @@ void TreeUnwrapper::Visit(const SyntaxTreeNode& node) {
 }
 
 // CST-descending phase that creates partitions with correct indentation.
+// TODO(mglb): This function is > 600 lines and should probably be split
+//             up into multiple.
 void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     const SyntaxTreeNode& node) {
   const auto tag = static_cast<NodeEnum>(node.Tag().tag);
@@ -1759,8 +1760,9 @@ static void ReshapeElseClause(const SyntaxTreeNode& node,
 
 static void HoistOnlyChildPartition(TokenPartitionTree* partition) {
   // kWrap uses relative child indentation as a hanging
-  if (partition->Value().PartitionPolicy() == PartitionPolicyEnum::kWrap) {
-  }
+  // if (partition->Value().PartitionPolicy() == PartitionPolicyEnum::kWrap) {
+  // TODO(mglb): implement or remove.
+  // }
   const auto* origin = partition->Value().Origin();
   if (partition->HoistOnlyChild()) {
     VLOG(4) << "reshape: hoisted, using child partition policy, parent origin";


### PR DESCRIPTION
 o There is an empty if() block which should either be filled,
   removed or documented.
 o Consider splitting up a very large function.
 o Remove unnecessary whitespace line and unused using-decl.

Signed-off-by: Henner Zeller <h.zeller@acm.org>