### PR TITLE
Obfuscator: Make sure to not accidentally generating keywords for identifier

### DIFF
--- a/common/strings/obfuscator.h
+++ b/common/strings/obfuscator.h
@@ -21,7 +21,6 @@
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "common/strings/compare.h"
-#include "common/strings/random.h"
 #include "common/util/bijective_map.h"
 
 namespace verible {
@@ -90,7 +89,9 @@ class IdentifierObfuscator : public Obfuscator {
   typedef Obfuscator parent_type;
 
  public:
-  IdentifierObfuscator() : Obfuscator(RandomEqualLengthIdentifier) {}
+  // Tip for users of this: use something like RandomEqualLengthIdentifier,
+  // but also make sure to not accidentally generate any of your keywords.
+  IdentifierObfuscator(const generator_type& g) : Obfuscator(g) {}
 
   // Same as inherited method, but verifies that key and value are equal length.
   bool encode(absl::string_view key, absl::string_view value);

--- a/common/strings/obfuscator.h
+++ b/common/strings/obfuscator.h
@@ -91,7 +91,7 @@ class IdentifierObfuscator : public Obfuscator {
  public:
   // Tip for users of this: use something like RandomEqualLengthIdentifier,
   // but also make sure to not accidentally generate any of your keywords.
-  IdentifierObfuscator(const generator_type& g) : Obfuscator(g) {}
+  explicit IdentifierObfuscator(const generator_type& g) : Obfuscator(g) {}
 
   // Same as inherited method, but verifies that key and value are equal length.
   bool encode(absl::string_view key, absl::string_view value);

--- a/common/strings/obfuscator_test.cc
+++ b/common/strings/obfuscator_test.cc
@@ -14,9 +14,9 @@
 
 #include "common/strings/obfuscator.h"
 
+#include "common/strings/random.h"
 #include "common/util/bijective_map.h"
 #include "common/util/logging.h"
-#include "common/strings/random.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/common/strings/obfuscator_test.cc
+++ b/common/strings/obfuscator_test.cc
@@ -16,6 +16,7 @@
 
 #include "common/util/bijective_map.h"
 #include "common/util/logging.h"
+#include "common/strings/random.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -159,7 +160,7 @@ TEST(ObfuscatorTest, LoadMap) {
 }
 
 TEST(IdentifierObfuscatorTest, Transform) {
-  IdentifierObfuscator ob;
+  IdentifierObfuscator ob(RandomEqualLengthIdentifier);
   const auto& tran = ob.GetTranslator();
   // repeat same string
   for (int i = 0; i < 2; ++i) {
@@ -183,12 +184,12 @@ TEST(IdentifierObfuscatorTest, Transform) {
 }
 
 TEST(IdentifierObfuscatorTest, EncodeInvalid) {
-  IdentifierObfuscator ob;
+  IdentifierObfuscator ob(RandomEqualLengthIdentifier);
   EXPECT_DEATH(ob.encode("cat", "sheep"), "");  // mismatch length
 }
 
 TEST(IdentifierObfuscatorTest, EncodeValidTransform) {
-  IdentifierObfuscator ob;
+  IdentifierObfuscator ob(RandomEqualLengthIdentifier);
   ob.encode("cat", "cow");
   const auto& tran = ob.GetTranslator();
   // repeat same string

--- a/verilog/tools/obfuscator/verilog_obfuscate.cc
+++ b/verilog/tools/obfuscator/verilog_obfuscate.cc
@@ -69,7 +69,8 @@ Output is written to stdout.
 )");
   const auto args = verible::InitCommandLine(usage, &argc, &argv);
 
-  IdentifierObfuscator subst;  // initially empty identifier map
+  // initially empty identifier map
+  IdentifierObfuscator subst(verilog::RandomEqualLengthSymbolIdentifier);
 
   // Set mode to encode or decode.
   const bool decode = absl::GetFlag(FLAGS_decode);

--- a/verilog/transform/obfuscate.cc
+++ b/verilog/transform/obfuscate.cc
@@ -21,6 +21,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "common/strings/obfuscator.h"
+#include "common/strings/random.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"
 #include "verilog/analysis/verilog_equivalence.h"
@@ -99,7 +100,7 @@ static absl::Status VerifyDecoding(absl::string_view original,
   // Skip if original transformation was already decoding.
   if (subst.is_decoding()) return absl::OkStatus();
 
-  IdentifierObfuscator reverse_subst;
+  IdentifierObfuscator reverse_subst(verible::RandomEqualLengthIdentifier);
   reverse_subst.set_decode_mode(true);
 
   // Copy over mappings.  Verify map reconstruction.

--- a/verilog/transform/obfuscate.cc
+++ b/verilog/transform/obfuscate.cc
@@ -32,6 +32,17 @@ namespace verilog {
 
 using verible::IdentifierObfuscator;
 
+std::string RandomEqualLengthSymbolIdentifier(absl::string_view in) {
+  verilog::VerilogLexer lexer("");  // Oracle to check identifier-ness.
+  // In rare case we accidentally generate a keyword, try again.
+  for (;;) {
+    std::string candidate = verible::RandomEqualLengthIdentifier(in);
+    lexer.Restart(candidate);
+    if (lexer.DoNextToken().token_enum() == verilog_tokentype::SymbolIdentifier)
+      return candidate;
+  }
+}
+
 // TODO(fangism): single-char identifiers don't need to be obfuscated.
 // or use a shuffle/permutation to guarantee collision-free reversibility.
 
@@ -100,7 +111,7 @@ static absl::Status VerifyDecoding(absl::string_view original,
   // Skip if original transformation was already decoding.
   if (subst.is_decoding()) return absl::OkStatus();
 
-  IdentifierObfuscator reverse_subst(verible::RandomEqualLengthIdentifier);
+  IdentifierObfuscator reverse_subst(RandomEqualLengthSymbolIdentifier);
   reverse_subst.set_decode_mode(true);
 
   // Copy over mappings.  Verify map reconstruction.

--- a/verilog/transform/obfuscate.h
+++ b/verilog/transform/obfuscate.h
@@ -23,6 +23,10 @@
 
 namespace verilog {
 
+// Returns an identifier ([alpha][alnum]*) of equal length to input, and
+// makes sure that it is a valid symbol identifier, not another Verilog keyword.
+std::string RandomEqualLengthSymbolIdentifier(absl::string_view in);
+
 // Obfuscates Verilog code.  Identifiers are randomized as equal length
 // replacements, and transformations are recorded (in subst) and re-applied
 // to the same strings seen.  Input code only needs to be lexically valid,

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -17,6 +17,7 @@
 #include <sstream>
 
 #include "common/strings/obfuscator.h"
+#include "common/strings/random.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -27,7 +28,7 @@ using verible::IdentifierObfuscator;
 
 // To make these tests deterministic, obfuscation maps are pre-populated.
 TEST(ObfuscateVerilogCodeTest, PreloadedSubstitutions) {
-  IdentifierObfuscator ob;
+  IdentifierObfuscator ob(verible::RandomEqualLengthIdentifier);
   const std::pair<std::string, std::string> subs[] = {
       {"aaa", "AAA"},
       {"bbb", "BBB"},
@@ -106,7 +107,7 @@ TEST(ObfuscateVerilogCodeTest, InputLexicalError) {
       "`FOO(`)\n",
   };
   for (const auto& test : kTestCases) {
-    IdentifierObfuscator ob;
+    IdentifierObfuscator ob(verible::RandomEqualLengthIdentifier);
     std::ostringstream output;
     const auto status = ObfuscateVerilogCode(test, &output, &ob);
     EXPECT_FALSE(status.ok());

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -17,7 +17,6 @@
 #include <sstream>
 
 #include "common/strings/obfuscator.h"
-#include "common/strings/random.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -26,9 +25,14 @@ namespace {
 
 using verible::IdentifierObfuscator;
 
+static std::string ExpectNeverToBeCalled(absl::string_view) {
+  EXPECT_FALSE("This identifier generator should've never been called");
+  return "";
+}
+
 // To make these tests deterministic, obfuscation maps are pre-populated.
 TEST(ObfuscateVerilogCodeTest, PreloadedSubstitutions) {
-  IdentifierObfuscator ob(verible::RandomEqualLengthIdentifier);
+  IdentifierObfuscator ob(ExpectNeverToBeCalled);
   const std::pair<std::string, std::string> subs[] = {
       {"aaa", "AAA"},
       {"bbb", "BBB"},
@@ -107,7 +111,7 @@ TEST(ObfuscateVerilogCodeTest, InputLexicalError) {
       "`FOO(`)\n",
   };
   for (const auto& test : kTestCases) {
-    IdentifierObfuscator ob(verible::RandomEqualLengthIdentifier);
+    IdentifierObfuscator ob(RandomEqualLengthSymbolIdentifier);
     std::ostringstream output;
     const auto status = ObfuscateVerilogCode(test, &output, &ob);
     EXPECT_FALSE(status.ok());


### PR DESCRIPTION
Since we can't easily ask the lexer for a definitive list of keywords
that are not SymbolIdentififier's, we simply use it as an oracle while
generating a random name.
    
Fixes #1072
