### PR TITLE
Don't rely on implicit const char* -> bool conversion.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -70,6 +70,7 @@ else
   # -- only recognized by clang
   # Don't rely on implicit template type deduction
   BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wctad-maybe-unsupported"
+  BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wstring-conversion"
 fi
 
 case "$MODE" in

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -94,7 +94,6 @@ cc_library(
     hdrs = ["obfuscator.h"],
     deps = [
         ":compare",
-        ":random",
         "//common/util:bijective_map",
         "//common/util:logging",
         "@com_google_absl//absl/status",
@@ -107,6 +106,7 @@ cc_test(
     srcs = ["obfuscator_test.cc"],
     deps = [
         ":obfuscator",
+        ":random",
         "//common/util:bijective_map",
         "//common/util:logging",
         "@com_google_googletest//:gtest_main",

--- a/verilog/transform/BUILD
+++ b/verilog/transform/BUILD
@@ -17,6 +17,7 @@ cc_library(
     hdrs = ["obfuscate.h"],
     deps = [
         "//common/strings:obfuscator",
+        "//common/strings:random",
         "//common/text:token_info",
         "//common/util:logging",
         "//verilog/analysis:verilog_equivalence",

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -26,7 +26,7 @@ namespace {
 using verible::IdentifierObfuscator;
 
 static std::string ExpectNeverToBeCalled(absl::string_view) {
-  EXPECT_FALSE("This identifier generator should've never been called");
+  EXPECT_TRUE(false) << "This identifier generator should've never been called";
   return "";
 }
 

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -26,7 +26,7 @@ namespace {
 using verible::IdentifierObfuscator;
 
 static std::string ExpectNeverToBeCalled(absl::string_view) {
-  EXPECT_TRUE(false) << "This identifier generator should've never been called";
+  ADD_FAILURE() << "This identifier generator should've never been called";
   return "";
 }
 


### PR DESCRIPTION
While here only used in a test, this is an error-prone pattern.

Also fix slightly changed dependencies needed with the recent move
of using random identifier generation closer to the specific
verilog tool.

Signed-off-by: Henner Zeller <hzeller@google.com>