### PR TITLE
Flatten associative binary operations.

### DIFF
--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -296,6 +296,7 @@ cc_library(
         "//common/text:tree_utils",
         "//common/util:casts",
         "//common/util:logging",
+        "//verilog/parser:verilog_token_classifications",
         "//verilog/parser:verilog_token_enum",
         "@com_google_absl//absl/strings",
     ],

--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -98,6 +98,11 @@ const verible::Symbol* GetConditionExpressionFalseCase(
   return GetSubtreeAsSymbol(condition_expr, NodeEnum::kConditionExpression, 4);
 }
 
+std::vector<verible::TreeSearchMatch> FindAllBinaryOperations(
+    const verible::Symbol& root) {
+  return verible::SearchSyntaxTree(root, NodekBinaryExpression());
+}
+
 std::vector<TreeSearchMatch> FindAllConditionExpressions(
     const verible::Symbol& root) {
   return verible::SearchSyntaxTree(root, NodekConditionExpression());

--- a/verilog/parser/verilog_token_classifications.cc
+++ b/verilog/parser/verilog_token_classifications.cc
@@ -51,6 +51,24 @@ bool IsUnaryOperator(verilog_tokentype token_type) {
   }
 }
 
+bool IsAssociativeOperator(verilog_tokentype op) {
+  switch (static_cast<int>(op)) {
+    case verilog_tokentype::TK_or:
+    case verilog_tokentype::TK_and:
+    case verilog_tokentype::TK_LAND:
+    case verilog_tokentype::TK_LOR:
+    case verilog_tokentype::TK_NXOR:
+    case '+':
+    case '*':
+    case '^':
+    case '|':
+    case '&':
+      return true;
+    default:
+      return false;
+  }
+}
+
 bool IsTernaryOperator(verilog_tokentype token_type) {
   switch (static_cast<int>(token_type)) {
     case '?':

--- a/verilog/parser/verilog_token_classifications.h
+++ b/verilog/parser/verilog_token_classifications.h
@@ -28,6 +28,9 @@ bool IsComment(verilog_tokentype token_type);
 // Returns true if token enum *can* be a unary operator.
 bool IsUnaryOperator(verilog_tokentype);
 
+// Returns true if operator is an associative binary operator.
+bool IsAssociativeOperator(verilog_tokentype);
+
 // Returns true if token enum *can* be a ternary operator.
 bool IsTernaryOperator(verilog_tokentype);
 

--- a/verilog/parser/verilog_token_classifications_test.cc
+++ b/verilog/parser/verilog_token_classifications_test.cc
@@ -58,6 +58,32 @@ TEST(VerilogTokenTest, IsUnaryOperatorTest) {
   EXPECT_FALSE(IsUnaryOperator(verilog_tokentype('#')));
 }
 
+TEST(VerilogTokenTest, IsAssociativeOperatorTest) {
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype('*')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('/')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('%')));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype('+')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('-')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('~')));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype('&')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('!')));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype('|')));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype('^')));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype::TK_LAND));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype::TK_LOR));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype::TK_NAND));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype::TK_NOR));
+  EXPECT_TRUE(IsAssociativeOperator(verilog_tokentype::TK_NXOR));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype::TK_INCR));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype::TK_DECR));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype(':')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('?')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype(',')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('.')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype(';')));
+  EXPECT_FALSE(IsAssociativeOperator(verilog_tokentype('#')));
+}
+
 TEST(VerilogTokenTest, IsTernaryOperatorTest) {
   EXPECT_FALSE(IsTernaryOperator(verilog_tokentype('*')));
   EXPECT_FALSE(IsTernaryOperator(verilog_tokentype('/')));


### PR DESCRIPTION
This reduces stack depth for long chained expressions.

Fixes #1236
