### PR TITLE
[symbol-table] Reserve for named call parameters

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -119,10 +119,10 @@ KnownIssue[project:$BASE_TEST_DIR/ivtest/ivltests/wreal.v]=1017
 
 #--- Too many to mention manually, so here we do the 'waive all' approach
 declare -A KnownProjectToolIssue
-KnownProjectToolIssue[project:basejump_stl]="#1002 #1003"
-KnownProjectToolIssue[project:ibex]="#1002 #1003"
-KnownProjectToolIssue[project:uvm]="#1002 #1003"
-KnownProjectToolIssue[project:opentitan]="#1002 #1003"
+KnownProjectToolIssue[project:basejump_stl]="#1003"
+KnownProjectToolIssue[project:ibex]="#1003"
+KnownProjectToolIssue[project:uvm]="#1003"
+KnownProjectToolIssue[project:opentitan]="#1003"
 
 # Run smoke test on provided files for project.
 # Returns 0 if all tools finished without crashing.


### PR DESCRIPTION
Reserve number of reference branches for calls using named parameters.

Fixes #1002
