### PR TITLE
Show an example implementation of using project policies.

### DIFF
--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -332,6 +332,14 @@ cc_test(
 )
 
 cc_library(
+    name = "project_policies",
+    srcs = ["project_policies.cc"],
+    deps = [
+        ":verilog_linter_configuration",
+    ],
+)
+
+cc_library(
     name = "verilog_project",
     srcs = ["verilog_project.cc"],
     hdrs = ["verilog_project.h"],

--- a/verilog/analysis/project_policies.cc
+++ b/verilog/analysis/project_policies.cc
@@ -1,0 +1,49 @@
+// Copyright 2017-2022 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "verilog/analysis/verilog_linter_configuration.h"
+
+namespace verilog {
+// This is an empty stub-implementation of how a built-in policy could
+// look like.
+// See declaration in verilog_linter_configuration.h
+const std::vector<ProjectPolicy>& GetBuiltinProjectPolicies() {
+  static const std::vector<ProjectPolicy> kBuiltin{
+      /*  Example
+      {
+        // name of policy
+        "pocket_calculator",
+
+        // paths affected (substring matched)
+        {"src/pocket_calculator"},
+
+        // paths excluded (substring matched)
+        {"generated/stuff"},
+
+        // policy reviewers
+        {"trustyreviewer1", "trustyreviewer2"},
+
+        // disabled rules
+        {"undesirable-rule", "really-undesirable-rule"},
+
+        // enabled rules
+        {"opt-in-rule1", "opt-in-rule2"},
+      },
+      */
+  };
+  return kBuiltin;
+}
+}  // namespace verilog

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -87,11 +87,16 @@ std::string AbslUnparseFlag(const RuleBundle& bundle);
 bool AbslParseFlag(absl::string_view text, RuleBundle* bundle,
                    std::string* error);
 
-// ProjectPolicy is needed in a transitional period when new rules are
-// becoming enabled while pre-existing code is still following their
-// respective project conventions and guidelines.  These blanket waivers
-// are intended to minimize agony on current projects, while allowing
-// the full set of rules to take effect on new projects.
+// ProjectPolicy provides a way to compile-in lint policies depending on
+// filenames right into verible in case reading from the configuration
+// file is not feasible.
+//
+// Usually, using the --rules_config configuration file or the
+// .rules.verible_lint file found in the root directory of the project
+// (if --rules_config_search is set) is a better choice.
+//
+// This feature is here for legacy reasons and might change or go away.
+// Please consult the verible mailing list in case you need it.
 struct ProjectPolicy {
   // A short name for policy, for diagnostic purposes.
   absl::string_view name;
@@ -130,6 +135,10 @@ struct ProjectPolicy {
   // Returns a glob pattern for shell case statement: "*path1* | *path2* | ..."
   std::string ListPathGlobs() const;
 };
+
+// Return a list of compiled-in project policies.
+// See project_policies.cc for an implementation.
+const std::vector<ProjectPolicy>& GetBuiltinProjectPolicies();
 
 struct LinterOptions {
   // strings, ints, bools, and unprocessed values from flags, no other derived

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -231,6 +231,7 @@ cc_binary(
         "//common/util:file_util",
         "//common/util:init_command_line",
         "//common/util:logging",
+        "//verilog/analysis:project_policies",
         "//verilog/analysis:verilog_linter",
         "//verilog/analysis:verilog_linter_configuration",
         "@com_google_absl//absl/flags:flag",

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2022 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -198,8 +198,11 @@ int main(int argc, char** argv) {
       exit_status = 1;
       continue;
     }
-    const LinterConfiguration& config = *config_status;
-
+    LinterConfiguration& config = *config_status;
+    // Apply built-in policies if available.
+    for (const auto& policy : verilog::GetBuiltinProjectPolicies()) {
+      config.UseProjectPolicy(policy, filename);
+    }
     const int lint_status = verilog::LintOneFile(
         &std::cout, filename, config, violation_handler.get(),
         absl::GetFlag(FLAGS_check_syntax), absl::GetFlag(FLAGS_parse_fatal),

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -19,8 +19,10 @@ cc_library(
     deps = [
         "//common/lsp:lsp-text-buffer",
         "//common/util:logging",
+        "//verilog/analysis:project_policies",
         "//verilog/analysis:verilog_analyzer",
         "//verilog/analysis:verilog_linter",
+        "//verilog/analysis:verilog_linter_configuration",
         "@com_google_absl//absl/status",
     ],
 )
@@ -37,9 +39,9 @@ cc_library(
         "//common/text:text_structure",
         "//verilog/analysis:verilog_analyzer",
         "//verilog/analysis:verilog_linter",
-        "//verilog/parser:verilog_token_enum",
-        "//verilog/formatting:formatter",
         "//verilog/formatting:format_style_init",
+        "//verilog/formatting:formatter",
+        "//verilog/parser:verilog_token_enum",
         "@jsonhpp",
     ],
 )

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -17,6 +17,7 @@
 
 #include "absl/status/status.h"
 #include "common/util/logging.h"
+#include "verilog/analysis/verilog_linter_configuration.h"
 
 namespace verilog {
 static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
@@ -28,6 +29,11 @@ static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
     config = *from_flags;
   } else {
     LOG(ERROR) << from_flags.status().message() << std::endl;
+  }
+
+  // Apply built-in policies if available.
+  for (const auto &policy : verilog::GetBuiltinProjectPolicies()) {
+    config.UseProjectPolicy(policy, filename);
   }
 
   return VerilogLintTextStructure(filename, config, text_structure);


### PR DESCRIPTION
This just provides an empty GetBuiltinProjectPolicies()
in project_policies.cc file that shows how built-in policies
can be added to verible.

Better document the ProjectPolicy struct.

Use the these built-in policies in verble-verilog-lint and
verible-verilog-ls.

Signed-off-by: Henner Zeller <hzeller@google.com>