### PR TITLE
Use ContainerProxy for VectorTree's children list

### DIFF
--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -231,6 +231,7 @@ cc_library(
     srcs = ["vector_tree.cc"],
     hdrs = ["vector_tree.h"],
     deps = [
+        ":container_proxy",
         ":iterator_range",
         ":logging",
         ":spacer",

--- a/common/util/vector_tree.h
+++ b/common/util/vector_tree.h
@@ -403,6 +403,10 @@ class VectorTree : private _VectorTreeImpl {
   typedef _VectorTreeImpl impl_type;
 
  public:
+  using VectorTreeChildrenList =
+      vector_tree_internal::VectorTreeChildrenList<std::vector<this_type>>;
+  friend VectorTreeChildrenList;
+
   // Self-recursive type that represents children in an expanded view.
   typedef std::vector<this_type> subnodes_type;
   typedef T value_type;
@@ -523,9 +527,9 @@ class VectorTree : private _VectorTreeImpl {
 
   const this_type* Parent() const { return parent_; }
 
-  auto& Children() { return children_; }
+  VectorTreeChildrenList& Children() { return children_; }
 
-  const auto& Children() const { return children_; }
+  const VectorTreeChildrenList& Children() const { return children_; }
 
   bool is_leaf() const { return children_.empty(); }
 
@@ -960,10 +964,6 @@ class VectorTree : private _VectorTreeImpl {
   // This value is managed by VectorTreeChildrenList, constructors, and
   // operator=(). There should be no need to set it manually in other places.
   this_type* parent_ = nullptr;
-
-  using VectorTreeChildrenList =
-      vector_tree_internal::VectorTreeChildrenList<std::vector<this_type>>;
-  friend VectorTreeChildrenList;
 
   // Array of nodes/subtrees.
   VectorTreeChildrenList children_;

--- a/common/util/vector_tree.h
+++ b/common/util/vector_tree.h
@@ -291,9 +291,7 @@ class VectorTreeChildrenList
   const container_type& underlying_container() const { return container_; }
 
   void ElementsInserted(iterator first, iterator last) {
-    for (auto& child : iterator_range(first, last)) {
-      child.parent_ = &node_;
-    }
+    LinkChildrenToParent(iterator_range(first, last));
   }
 
   // Unused:
@@ -302,13 +300,17 @@ class VectorTreeChildrenList
   // Unused:
   // void ElementsBeingReplaced()
 
-  void ElementsWereReplaced() {
-    for (auto& child : container_) {
+  void ElementsWereReplaced() { LinkChildrenToParent(container_); }
+
+ private:
+  // Sets parent pointer of nodes from `children` range to address of `node_`.
+  template <class Range>
+  void LinkChildrenToParent(Range&& children) {
+    for (auto& child : children) {
       child.parent_ = &node_;
     }
   }
 
- private:
   // Hide constructors and assignments from the world. This object is created
   // and assigned-to only in VectorTree.
 
@@ -320,16 +322,12 @@ class VectorTreeChildrenList
   VectorTreeChildrenList(VectorTreeType& node,
                          const VectorTreeChildrenList& other)
       : node_(node), container_(other.container_) {
-    for (auto& child : container_) {
-      child.parent_ = &node;
-    }
+    LinkChildrenToParent(container_);
   }
 
   VectorTreeChildrenList& operator=(const VectorTreeChildrenList& other) {
     container_ = other.container_;
-    for (auto& child : container_) {
-      child.parent_ = &node_;
-    }
+    LinkChildrenToParent(container_);
     return *this;
   }
 
@@ -341,18 +339,14 @@ class VectorTreeChildrenList
       : node_(node), container_(std::move(other.container_)) {
     // Note: `other` is not notified about the change because it ends up in
     // undefined state as a result of the move.
-    for (auto& child : container_) {
-      child.parent_ = &node;
-    }
+    LinkChildrenToParent(container_);
   }
 
   VectorTreeChildrenList& operator=(VectorTreeChildrenList&& other) noexcept {
     // Note: `other` is not notified about the change because it ends up in
     // undefined state as a result of the move.
     container_ = std::move(other.container_);
-    for (auto& child : container_) {
-      child.parent_ = &node_;
-    }
+    LinkChildrenToParent(container_);
     return *this;
   }
 

--- a/common/util/vector_tree_test.cc
+++ b/common/util/vector_tree_test.cc
@@ -2055,5 +2055,87 @@ TEST(VectorTreeTest, PrintTreeCustom) {
 })");
 }
 
+TEST(VectorTreeTest, ChildrenManipulation) {
+  VectorTreeTestType tree(verible::testing::MakeExampleFamilyTree());
+
+  auto& children_gp = tree.Children();
+
+  children_gp.push_back(VectorTreeTestType(NamedInterval(4, 6, "parent3")));
+
+  EXPECT_EQ(tree.Children().size(), 3);
+  EXPECT_EQ(tree.Children().back().Value(), NamedInterval(4, 6, "parent3"));
+  EXPECT_EQ(tree.Children().back().Parent(), &tree);
+
+  auto& p3 = tree.Children().back();
+  auto& children_p3 = p3.Children();
+
+  children_p3.push_back(VectorTreeTestType(NamedInterval(4, 5, "child5")));
+  children_p3.emplace_back(NamedInterval(5, 6, "child6"));
+
+  EXPECT_EQ(p3.Children().size(), 2);
+
+  EXPECT_EQ(p3.Children().at(0).Value(), NamedInterval(4, 5, "child5"));
+  EXPECT_EQ(p3.Children().at(0).Parent(), &p3);
+
+  EXPECT_EQ(p3.Children().at(1).Value(), NamedInterval(5, 6, "child6"));
+  EXPECT_EQ(p3.Children().at(1).Parent(), &p3);
+
+  auto& p2 = tree.Children().at(1);
+
+  const NamedInterval original_p2_children[] = {
+      p2.Children().at(0).Value(),
+      p2.Children().at(1).Value(),
+  };
+
+  children_p3.insert(children_p3.begin(), p2.Children().begin(),
+                     p2.Children().end());
+
+  EXPECT_EQ(p3.Children().size(), 4);
+
+  EXPECT_EQ(p3.Children().at(0).Value(), original_p2_children[0]);
+  EXPECT_EQ(p3.Children().at(0).Parent(), &p3);
+
+  EXPECT_EQ(p3.Children().at(1).Value(), original_p2_children[1]);
+  EXPECT_EQ(p3.Children().at(1).Parent(), &p3);
+
+  EXPECT_EQ(p3.Children().at(2).Value(), NamedInterval(4, 5, "child5"));
+  EXPECT_EQ(p3.Children().at(2).Parent(), &p3);
+
+  EXPECT_EQ(p3.Children().at(3).Value(), NamedInterval(5, 6, "child6"));
+  EXPECT_EQ(p3.Children().at(3).Parent(), &p3);
+
+  EXPECT_EQ(p2.Children().size(), 2);
+
+  EXPECT_EQ(p2.Children().at(0).Value(), original_p2_children[0]);
+  EXPECT_EQ(p2.Children().at(0).Parent(), &p2);
+
+  EXPECT_EQ(p2.Children().at(1).Value(), original_p2_children[1]);
+  EXPECT_EQ(p2.Children().at(1).Parent(), &p2);
+
+  p2.Children().clear();
+
+  EXPECT_EQ(p2.Children().size(), 0);
+
+  p2.Children().assign({
+      VectorTreeTestType(NamedInterval(0, 1, "foo")),
+      VectorTreeTestType(NamedInterval(1, 2, "bar")),
+      VectorTreeTestType(NamedInterval(2, 3, "baz")),
+  });
+
+  EXPECT_EQ(p2.Children().size(), 3);
+
+  EXPECT_EQ(p2.Children().at(0).Value(), NamedInterval(0, 1, "foo"));
+  EXPECT_EQ(p2.Children().at(0).Parent(), &p2);
+
+  EXPECT_EQ(p2.Children().at(1).Value(), NamedInterval(1, 2, "bar"));
+  EXPECT_EQ(p2.Children().at(1).Parent(), &p2);
+
+  EXPECT_EQ(p2.Children().at(2).Value(), NamedInterval(2, 3, "baz"));
+  EXPECT_EQ(p2.Children().at(2).Parent(), &p2);
+
+  tree.Children().clear();
+  EXPECT_TRUE(tree.Children().empty());
+}
+
 }  // namespace
 }  // namespace verible


### PR DESCRIPTION
This PR implements `VectorTreeChildrenList` class, which extends `ContainerProxyBase` to create a wrapper for `std::vector` containing VectorTree nodes. The class automatically sets correct `parent_` pointer in each inserted node, where the "correct" pointer is passed in a constructor.
The class is used in VectorTree as a child nodes storage (`children_` member), and as a public interface for children list access and manipulation (retured as a reference from `Children()` method).
As a result VectorTree's `parent_` member is only set/modified either in VectorTree's constructor or assignment, or inside VectorTreeChildrenList.

Only VectorTree methods were modified to take advantage of this new class. Other code still uses methods like `NewChild()` for inserting nodes. I'll update the codebase to use the new interface in near future, after finishing one more VectorTree refactoring.