### PR TITLE
Treat wreal like any other primitive data type.

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -110,7 +110,6 @@ KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/sv_default_port_value1.v]=10
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/sv_default_port_value3.v]=1010
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/pr2202846c.v]=1015
 KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/packed_dims_invalid_class.v]=1146
-KnownIssue[project:$BASE_TEST_DIR/ivtest/ivltests/wreal.v]=1017
 
 #--- Basejump
 # These mostly crash for all the same reason except the first.

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -2788,6 +2788,8 @@ non_integer_type
     { $$ = move($1); }
   | TK_shortreal
     { $$ = move($1); }
+ | TK_wreal /* Verilog-AMS */
+    { $$ = move($1); }
   ;
 
 macro_digits
@@ -5207,8 +5209,6 @@ port_declaration_noattr
     trailing_assign_opt
     { $$ = MakeTaggedNode(N::kPortDeclaration, nullptr, $1,
                           ForwardChildren($2), $3); }
-  | port_direction TK_wreal GenericIdentifier trailing_assign_opt
-    { $$ = MakeTaggedNode(N::kPortDeclaration, $1, nullptr, $2, $3, nullptr, $4); }
   | data_type_primitive GenericIdentifier decl_dimensions_opt trailing_assign_opt
     { $$ = MakeTaggedNode(N::kPortDeclaration, nullptr, nullptr,
                           // just expand without ForwardChildren:
@@ -5461,14 +5461,7 @@ module_port_declaration
   /* In the LRM, this is ansi_port_declaration.
    * Any of these could be prefixed with attribute_list_opt.
    */
-  : TK_wreal delay3_opt net_variable_or_decl_assigns ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3, $4); }
-  | port_direction TK_wreal list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3, $4); }
-  // | TK_wreal delay3 net_variable_list ';'
-  // | TK_wreal net_variable_list ';'
-  // | TK_wreal net_decl_assigns ';'
-  | port_direction signed_unsigned_opt qualified_id decl_dimensions_opt
+  : port_direction signed_unsigned_opt qualified_id decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
     { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3,
                           MakePackedDimensionsNode($4),

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -1642,7 +1642,7 @@ static const ParserTestCaseArray kModuleTests = {
     "  wire bar = 1);\n"  // wire port, no direction, with trailing assign
     "endmodule",
     "module foo (\n"
-    "  input real bar);\n"  // wreal port
+    "  input real bar);\n"  // real port
     "endmodule",
     "module foo (\n"
     "  input var i,\n"  // var keyword
@@ -2744,6 +2744,10 @@ static const ParserTestCaseArray kModuleTests = {
     "module type_reffer;\n"
     "real a = 4.76;\n"
     "var type(a) c;\n"
+    "endmodule\n",
+    "module type_reffer;\n"
+    "wreal a;\n"
+    "wreal b = 4.76;\n"
     "endmodule\n",
     "module type_reffer;\n"
     "real a = 4.76;\n"


### PR DESCRIPTION
Simplify the grammar without making a special case for wreal.

Fixes #1017
