### PR TITLE
Use TokenPartitionTree instead of VectorTree<UnwrappedLine>

### DIFF
--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -188,7 +188,7 @@ struct TreeUnwrapperTestData {
 // Iterates through UnwrappedLines and expected lines and verifies that they
 // are equal
 bool VerifyUnwrappedLines(std::ostream* stream,
-                          const verible::VectorTree<UnwrappedLine>& uwlines,
+                          const verible::TokenPartitionTree& uwlines,
                           const TreeUnwrapperTestData& test_case) {
   std::ostringstream first_diff_stream;
   const auto diff = verible::DeepEqual(


### PR DESCRIPTION
`TokenPartitionTree` is currently an alias to `VectorTree<UnwrappedLine>`, but it will be promoted to a class soon.