### PR TITLE
LSP Range: allow empty range overlap predicate.

### DIFF
--- a/common/lsp/lsp-protocol-operators.h
+++ b/common/lsp/lsp-protocol-operators.h
@@ -31,8 +31,16 @@ inline constexpr bool operator<(const Position &a, const Position &b) {
 inline constexpr bool operator>=(const Position &a, const Position &b) {
   return !(a < b);
 }
+inline constexpr bool operator==(const Position &a, const Position &b) {
+  return a.line == b.line && a.character == b.character;
+}
+
+// Ranges overlap if some part of one is inside the other range.
+// Also empty ranges are considered overlapping if their start point is within
+// the other range.
+// rangerOverlap() is commutative.
 inline constexpr bool rangeOverlap(const Range &a, const Range &b) {
-  return !(a.start >= b.end || b.start >= a.end);
+  return !(a.start >= b.end || b.start >= a.end) || (a.start == b.start);
 }
 }  // namespace lsp
 }  // namespace verible

--- a/common/lsp/lsp-protocol-operators_test.cc
+++ b/common/lsp/lsp-protocol-operators_test.cc
@@ -30,6 +30,61 @@ TEST(LspPositionTest, BasicOperatorsLessThanGreaterEqual) {
   EXPECT_GE(higherChar, lowerChar);
 }
 
+TEST(LspPositionTest, RangeSelfOverlap) {
+  constexpr Range range = {
+      // Range of one character wide.
+      .start = {.line = 10, .character = 2},
+      .end = {.line = 10, .character = 3},
+  };
+  EXPECT_TRUE(rangeOverlap(range, range));
+}
+
+TEST(LspPositionTest, RangeSelfOverlapEmptyRange) {
+  // Special case: empty range overlaps with itself.
+  constexpr Range empty = {
+      // Zero wide range.
+      .start = {.line = 10, .character = 2},
+      .end = {.line = 10, .character = 2},
+  };
+  EXPECT_TRUE(rangeOverlap(empty, empty));
+}
+
+TEST(LspPositionTest, EmptyRangeWithinOther) {
+  constexpr Range outer = {
+      // [2..4)
+      .start = {.line = 10, .character = 2},
+      .end = {.line = 10, .character = 4},
+  };
+
+  {
+    constexpr Range empty = {
+        .start = {.line = 10, .character = 2},
+        .end = {.line = 10, .character = 2},
+    };
+    EXPECT_TRUE(rangeOverlap(empty, outer));
+    EXPECT_TRUE(rangeOverlap(outer, empty));
+  }
+
+  {
+    constexpr Range empty = {
+        .start = {.line = 10, .character = 3},
+        .end = {.line = 10, .character = 3},
+    };
+    EXPECT_TRUE(rangeOverlap(empty, outer));
+    EXPECT_TRUE(rangeOverlap(outer, empty));
+  }
+
+  // Just outside the range.
+  {
+    constexpr Range empty = {
+        .start = {.line = 10, .character = 4},
+        .end = {.line = 10, .character = 4},
+    };
+    EXPECT_FALSE(rangeOverlap(empty, outer));
+    EXPECT_FALSE(rangeOverlap(outer, empty));
+  }
+}
+
 TEST(LspPositionTest, InsideRangeNested) {
   constexpr Range large_range = {
       .start = {.line = 10, .character = 1},

--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -35,8 +35,8 @@ Position:
   character: integer  # Zero based column
 
 Range:
-  start: Position
-  end: Position
+  start: Position     # inclusive.
+  end: Position       # exclusive.
 
 TextDocumentIdentifier:
   uri: string

--- a/verilog/tools/ls/verible-verilog-ls_test.sh
+++ b/verilog/tools/ls/verible-verilog-ls_test.sh
@@ -48,7 +48,11 @@ awk '/^{/ { printf("Content-Length: %d\r\n\r\n%s", length($0), $0)}' > ${TMP_IN}
 
 # A file with a lint error (no newline at EOF). Then editing it and watching diagnostic go away.
 {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://mini.sv","text":"module mini();\nendmodule"}}}
-{"jsonrpc":"2.0", "id":10, "method":"textDocument/codeAction","params":{"textDocument":{"uri":"file://mini.sv"},"range":{"start":{"line":0,"character":0},"end":{"line":2,"character":0}}}}
+
+# Requesting a code-action exactly at the position the EOF message is reported.
+# This is an interesting special case, as the missing EOF-newline is an empty
+# range, yet it should be detected as overlapping with that diagnostic message.
+{"jsonrpc":"2.0", "id":10, "method":"textDocument/codeAction","params":{"textDocument":{"uri":"file://mini.sv"},"range":{"start":{"line":1,"character":9},"end":{"line":1,"character":9}}}}
 {"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file://mini.sv"},"contentChanges":[{"range":{"start":{"character":9,"line":1},"end":{"character":9,"line":1}},"text":"\n"}]}}
 {"jsonrpc":"2.0", "id":11, "method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file://mini.sv"}}}
 {"jsonrpc":"2.0","method":"textDocument/didClose","params":{"textDocument":{"uri":"file://mini.sv"}}}
@@ -101,7 +105,7 @@ cat > "${JSON_EXPECTED}" <<EOF
        "method":"textDocument/publishDiagnostics",
        "params": {
           "uri": "file://mini.sv",
-          "diagnostics":[{"message":"File must end with a newline."}]
+          "diagnostics":[{"message":"File must end with a newline.","range":{"start":{"line":1,"character":9}}}]
        }
     }
   },


### PR DESCRIPTION
codeAction requests often just include the cursor position in the
request which is an empty range. If the diagnostic in question is
a one-character range, make sure we recognize that as overlap.

Signed-off-by: Henner Zeller <h.zeller@acm.org>