### PR TITLE
Parsing/Preprocessing: add the concept of 'warning'.

### DIFF
--- a/common/analysis/file_analyzer.h
+++ b/common/analysis/file_analyzer.h
@@ -61,13 +61,24 @@ enum class AnalysisPhase {
 };
 
 // String representation of phase (needed for CHECK).
+const char* AnalysisPhaseName(const AnalysisPhase& phase);
 std::ostream& operator<<(std::ostream&, const AnalysisPhase&);
 
-// RejectedToken is a categorized error token.
+enum class ErrorSeverity {
+  kError,
+  kWarning,
+};
+const char* ErrorSeverityDescription(const ErrorSeverity& severity);
+std::ostream& operator<<(std::ostream&, const ErrorSeverity&);
+
+// RejectedToken is a categorized warning/error token.
+// TODO(hzeller): In the presence of warnings, this probably needs to be
+// renamed, as a token is not rejected per-se.
 struct RejectedToken {
   TokenInfo token_info;
   AnalysisPhase phase;
   std::string explanation;
+  ErrorSeverity severity = ErrorSeverity::kError;
 };
 
 std::ostream& operator<<(std::ostream&, const RejectedToken&);
@@ -105,10 +116,11 @@ class FileAnalyzer : public TextStructure {
   // "token_text" is the exact text of the token.
   // The "context_line" is the line in which the corresponding error happened.
   // The "message" finally is a human-readable error message
+  // TODO(hzeller): these are a lot of parameters, maybe a struct would be good.
   using ReportLinterErrorFunction = std::function<void(
-      const std::string& filename, LineColumnRange range, AnalysisPhase phase,
-      absl::string_view token_text, absl::string_view context_line,
-      const std::string& message)>;
+      const std::string& filename, LineColumnRange range,
+      ErrorSeverity severity, AnalysisPhase phase, absl::string_view token_text,
+      absl::string_view context_line, const std::string& message)>;
 
   // Extract detailed diagnostic information for rejected token.
   void ExtractLinterTokenErrorDetail(

--- a/verilog/analysis/json_diagnostics.cc
+++ b/verilog/analysis/json_diagnostics.cc
@@ -24,6 +24,7 @@
 
 using nlohmann::json;
 using verible::AnalysisPhase;
+using verible::ErrorSeverity;
 using verible::LineColumnRange;
 
 namespace verilog {
@@ -56,8 +57,10 @@ json GetLinterTokenErrorsAsJson(const verilog::VerilogAnalyzer* analyzer,
     analyzer->ExtractLinterTokenErrorDetail(
         rejected_token,
         [&error](const std::string& filename, LineColumnRange range,
-                 AnalysisPhase phase, absl::string_view token_text,
-                 absl::string_view context_line, const std::string& message) {
+                 ErrorSeverity severity, AnalysisPhase phase,
+                 absl::string_view token_text, absl::string_view context_line,
+                 const std::string& message) {
+          // TODO: should this do something different for severity = kWarning ?
           error["line"] = range.start.line;  // NB: zero based index
           error["column"] = range.start.column;
           error["text"] = std::string(token_text);

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -239,6 +239,25 @@ absl::Status VerilogAnalyzer::Analyze() {
       parse_status_ = absl::InvalidArgumentError("Preprocessor error.");
       return parse_status_;
     }
+
+    for (const auto& warning : preprocessor_data_.warnings) {
+      const verible::RejectedToken warn_token{
+          warning.token_info, verible::AnalysisPhase::kPreprocessPhase,
+          warning.error_message, verible::ErrorSeverity::kWarning};
+#if 0
+      // For now, don't surface macro warnings yet in the output, as the
+      // preprocessor does not yet work with `ifdef branches and thus would
+      // report redifinitions in common situations such as these
+      // `ifdef FOO
+      //   `define BAR "x"
+      // `else
+      //   `define BAR "y"
+      // `endif
+      rejected_tokens_.push_back(warn_token);
+#else
+      LOG(INFO) << LinterTokenErrorMessage(warn_token, false);
+#endif
+    }
     MutableData().MutableTokenStreamView() =
         preprocessor_data_.preprocessed_token_stream;  // copy
     // TODO(fangism): could we just move, swap, or directly reference?

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -52,6 +52,7 @@ namespace verilog {
 // TODO(fangism): configuration policy enums.
 
 // VerilogPreprocessError contains preprocessor error information.
+// TODO(hzeller): should we just use verible::RejectedToken here ?
 struct VerilogPreprocessError {
   verible::TokenInfo token_info;  // offending token
   std::string error_message;
@@ -73,7 +74,10 @@ struct VerilogPreprocessData {
   MacroDefinitionRegistry macro_definitions;
 
   // Sequence of tokens rejected by preprocessing.
+  // TODO(hzeller): Until we have a severity in VerilogPreprocessError, these
+  // are two separate vectors.
   std::vector<VerilogPreprocessError> errors;
+  std::vector<VerilogPreprocessError> warnings;
 };
 
 // VerilogPreprocess transforms a TokenStreamView.
@@ -114,7 +118,8 @@ class VerilogPreprocess {
   static std::unique_ptr<VerilogPreprocessError> ParseMacroParameter(
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
-  void RegisterMacroDefinition(const MacroDefinition&);
+  std::unique_ptr<VerilogPreprocessError> RegisterMacroDefinition(
+      const MacroDefinition&);
 
   // Results of preprocessing
   VerilogPreprocessData preprocess_data_;

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -240,7 +240,7 @@ cc_binary(
 )
 
 sh_test_with_runfiles_lib(
-    name = "tool_test",
+    name = "lint_tool_test",
     size = "small",
     srcs = ["lint_tool_test.sh"],
     args = ["$(location :verible-verilog-lint)"],

--- a/verilog/tools/lint/lint_tool_test.sh
+++ b/verilog/tools/lint/lint_tool_test.sh
@@ -107,7 +107,7 @@ status="$?"
 
 DIAGNOSTIC_OUTPUT="${TEST_TMPDIR}/expected-diagnostic.out"
 cat > "${DIAGNOSTIC_OUTPUT}" <<EOF
-${TEST_TMPDIR}/syntax-error.sv:2:1: syntax error, rejected "endclass" (syntax-error).
+${TEST_TMPDIR}/syntax-error.sv:2:1: syntax error at token "endclass"
 endclass
 ^
 EOF
@@ -122,7 +122,7 @@ status="$?"
 }
 
 cat > "${DIAGNOSTIC_OUTPUT}" <<EOF
-${TEST_TMPDIR}/syntax-error.sv:2:1: syntax error, rejected "endclass" (syntax-error).
+${TEST_TMPDIR}/syntax-error.sv:2:1: syntax error at token "endclass"
 EOF
 
 "$lint_tool" "$TEST_FILE" > "${MY_OUTPUT_FILE}.out"

--- a/verilog/tools/syntax/verilog_syntax_test.sh
+++ b/verilog/tools/syntax/verilog_syntax_test.sh
@@ -114,9 +114,9 @@ status="$?"
 strip_error < "$MY_OUTPUT_FILE" > "$MY_OUTPUT_FILE".filtered
 
 cat > "$MY_EXPECT_FILE" <<EOF
--:1:8: syntax error, rejected "1"
--:2:1: syntax error, rejected "endmodule"
--:4:1: syntax error, rejected "endmodule"
+-:1:8: syntax error at token "1"
+-:2:1: syntax error at token "endmodule"
+-:4:1: syntax error at token "endmodule"
 EOF
 
 diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE".filtered || \
@@ -170,7 +170,7 @@ status="$?"
 strip_error < "$MY_OUTPUT_FILE" > "$MY_OUTPUT_FILE".filtered
 
 cat > "$MY_EXPECT_FILE" <<EOF
--:1:8: syntax error, rejected "1"
+-:1:8: syntax error at token "1"
 EOF
 
 diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE".filtered || \


### PR DESCRIPTION
So far, all messages in the lex/preprocessing/parse phase have been
of 'error severity'. However, there are issues whose severity can
be lower e.g. warning about re-definition of a macro.

In this change
  * Make RejectedToken contain a severity (name of that object
    is still the same, might need some re-name later)
  * Change printing of rejected tokens to include the severity
    and don't talk about a 'rejected token', but just the token
    a hand; that does sound more user-friendly (the 'rejected'
    sounds more like an artifact of parsing).
    CAVE: this might trip up scripts of users that grep for
    messages.
  * Surface preprocessing re-definition as warning message.
  * Do _not_ include the preprocessing warning yet in the output
    of the parser; merely LOG(INFO) it at this point.
    (Reason: might be too noisy as the preprocessor has limited
    understanding of `ifdef branches).
    At least, this provides a properly formatted filename + line-number
    info in the log.

Added a few TODOs for further cleanups.

Signed-off-by: Henner Zeller <hzeller@google.com>