### PR TITLE
Format syntax errors always with column range.

### DIFF
--- a/common/analysis/file_analyzer.cc
+++ b/common/analysis/file_analyzer.cc
@@ -118,21 +118,8 @@ std::string FileAnalyzer::TokenErrorMessage(
   // TODO(fangism): accept a RejectedToken to get an explanation message.
   std::ostringstream output_stream;
   if (!error_token.isEOF()) {
-    // TODO(hzeller): simply print LineColumnRange ?
-    LineColumnRange range = Data().GetRangeForToken(error_token);
-    --range.end.column;  // Point to last character, not one-past-the-end.
-    output_stream << "token: \"" << error_token.text() << "\" at "
-                  << range.start;
-    if (range.start.line == range.end.line) {
-      // Only print upper bound if it differs by > 1 character.
-      if (range.start.column + 1 < range.end.column) {
-        // .column is 0-based index, so +1 to get 1-based index.
-        output_stream << '-' << range.end.column + 1;
-      }
-    } else {
-      // Already prints 1-based index.
-      output_stream << '-' << range.end;
-    }
+    const LineColumnRange range = Data().GetRangeForToken(error_token);
+    output_stream << "token: \"" << error_token.text() << "\" at " << range;
   } else {
     const auto end = Data().GetLineColAtOffset(Data().Contents().length());
     output_stream << "token: <<EOF>> at " << end;
@@ -174,10 +161,7 @@ std::string FileAnalyzer::LinterTokenErrorMessage(
           ErrorSeverity severity, AnalysisPhase phase,
           absl::string_view token_text, absl::string_view context_line,
           const std::string& message) {
-        // TODO(hzeller): switch to printing range, but make sure that
-        // potential users are not running into trouble.
-        out << filename_ << ':' << range.start << ": " << phase << " "
-            << severity;
+        out << filename_ << ':' << range << " " << phase << " " << severity;
         if (error_token.token_info.isEOF()) {
           out << " (unexpected EOF)";
         } else {

--- a/common/analysis/file_analyzer_test.cc
+++ b/common/analysis/file_analyzer_test.cc
@@ -60,14 +60,14 @@ TEST(FileAnalyzerTest, TokenErrorMessageSameLine) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(17, 5));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \"w0rld\" at 2:5-9");
+    EXPECT_EQ(message, "token: \"w0rld\" at 2:5:2:9:");
   }
   {
     constexpr bool with_diagnostic_context = false;
     const auto message = analyzer.LinterTokenErrorMessage(
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(absl::StrContains(
-        message, "hello.txt:2:5: syntax error at token \"w0rld\""))
+        message, "hello.txt:2:5:2:9: syntax error at token \"w0rld\""))
         << message;
   }
   {
@@ -95,7 +95,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageSameLineWithContext) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(17, 5));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \"w0rld\" at 2:5-9");
+    EXPECT_EQ(message, "token: \"w0rld\" at 2:5:2:9:");
   }
   {
     constexpr bool with_diagnostic_context = true;
@@ -103,7 +103,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageSameLineWithContext) {
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(
         absl::StrContains(message,
-                          "hello.txt:2:5: syntax error at token \"w0rld\"\n"
+                          "hello.txt:2:5:2:9: syntax error at token \"w0rld\"\n"
                           "bye w0rld\n"
                           "    ^"))
         << message;
@@ -135,7 +135,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageOneChar) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(5, 1));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \",\" at 1:6");
+    EXPECT_EQ(message, "token: \",\" at 1:6:");
   }
   {
     constexpr bool with_diagnostic_context = false;
@@ -170,7 +170,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageOneCharWithContext) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(5, 1));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \",\" at 1:6");
+    EXPECT_EQ(message, "token: \",\" at 1:6:");
   }
   {
     constexpr bool with_diagnostic_context = true;
@@ -191,14 +191,14 @@ TEST(FileAnalyzerTest, TokenErrorMessageDifferentLine) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(7, 9));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \"world\nbye\" at 1:8-2:3");
+    EXPECT_EQ(message, "token: \"world\nbye\" at 1:8:2:3:");
   }
   {
     constexpr bool with_diagnostic_context = false;
     const auto message = analyzer.LinterTokenErrorMessage(
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(absl::StrContains(
-        message, "hello.txt:1:8: syntax error at token \"world\nbye\""));
+        message, "hello.txt:1:8:2:3: syntax error at token \"world\nbye\""));
   }
   {
     analyzer.ExtractLinterTokenErrorDetail(
@@ -226,7 +226,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageDifferentLineWithContext) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(7, 9));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \"world\nbye\" at 1:8-2:3");
+    EXPECT_EQ(message, "token: \"world\nbye\" at 1:8:2:3:");
   }
   {
     constexpr bool with_diagnostic_context = true;
@@ -234,7 +234,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageDifferentLineWithContext) {
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(absl::StrContains(
         message,
-        "hello.txt:1:8: syntax error at token \"world\nbye\"\n"
+        "hello.txt:1:8:2:3: syntax error at token \"world\nbye\"\n"
         "hello, world\n"
         "       ^"))
         << message;
@@ -249,7 +249,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageEOF) {
   FakeFileAnalyzer analyzer(text, "unbalanced.txt");
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: <<EOF>> at 3:1");
+    EXPECT_EQ(message, "token: <<EOF>> at 3:1:");
   }
   {
     constexpr bool with_diagnostic_context = false;
@@ -268,14 +268,15 @@ TEST(FileAnalyzerTest, TokenErrorMessageEOFWithContext) {
   FakeFileAnalyzer analyzer(text, "unbalanced.txt");
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: <<EOF>> at 3:8");
+    EXPECT_EQ(message, "token: <<EOF>> at 3:8:");
   }
   {
     constexpr bool with_diagnostic_context = true;
     const auto message = analyzer.LinterTokenErrorMessage(
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(absl::StrContains(
-        message, "unbalanced.txt:3:8: syntax error (unexpected EOF)"));
+        message, "unbalanced.txt:3:8: syntax error (unexpected EOF)"))
+        << message;
   }
   {
     analyzer.ExtractLinterTokenErrorDetail(

--- a/common/analysis/file_analyzer_test.cc
+++ b/common/analysis/file_analyzer_test.cc
@@ -60,14 +60,14 @@ TEST(FileAnalyzerTest, TokenErrorMessageSameLine) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(17, 5));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \"w0rld\" at 2:5:2:9:");
+    EXPECT_EQ(message, "token: \"w0rld\" at 2:5-9:");
   }
   {
     constexpr bool with_diagnostic_context = false;
     const auto message = analyzer.LinterTokenErrorMessage(
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(absl::StrContains(
-        message, "hello.txt:2:5:2:9: syntax error at token \"w0rld\""))
+        message, "hello.txt:2:5-9: syntax error at token \"w0rld\""))
         << message;
   }
   {
@@ -95,7 +95,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageSameLineWithContext) {
   const TokenInfo error_token(1, analyzer.Data().Contents().substr(17, 5));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \"w0rld\" at 2:5:2:9:");
+    EXPECT_EQ(message, "token: \"w0rld\" at 2:5-9:");
   }
   {
     constexpr bool with_diagnostic_context = true;
@@ -103,7 +103,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageSameLineWithContext) {
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
     EXPECT_TRUE(
         absl::StrContains(message,
-                          "hello.txt:2:5:2:9: syntax error at token \"w0rld\"\n"
+                          "hello.txt:2:5-9: syntax error at token \"w0rld\"\n"
                           "bye w0rld\n"
                           "    ^"))
         << message;
@@ -249,7 +249,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageEOF) {
   FakeFileAnalyzer analyzer(text, "unbalanced.txt");
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: <<EOF>> at 3:1:");
+    EXPECT_EQ(message, "token: <<EOF>> at 3:1");
   }
   {
     constexpr bool with_diagnostic_context = false;
@@ -268,7 +268,7 @@ TEST(FileAnalyzerTest, TokenErrorMessageEOFWithContext) {
   FakeFileAnalyzer analyzer(text, "unbalanced.txt");
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: <<EOF>> at 3:8:");
+    EXPECT_EQ(message, "token: <<EOF>> at 3:8");
   }
   {
     constexpr bool with_diagnostic_context = true;

--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -134,7 +134,7 @@ void LintStatusFormatter::FormatViolation(std::ostream* stream,
   (*stream) << path << ':'
             << line_column_map_.GetLineColAtOffset(base,
                                                    violation.token.left(base))
-            << ": " << violation.reason << ' ' << url << " [" << rule_name
+            << ' ' << violation.reason << ' ' << url << " [" << rule_name
             << ']';
 }
 

--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -131,11 +131,12 @@ void LintStatusFormatter::FormatViolation(std::ostream* stream,
                                           absl::string_view rule_name) const {
   // TODO(fangism): Use the context member to print which named construct or
   // design element the violation appears in (or full stack thereof).
-  (*stream) << path << ':'
-            << line_column_map_.GetLineColAtOffset(base,
-                                                   violation.token.left(base))
-            << ' ' << violation.reason << ' ' << url << " [" << rule_name
-            << ']';
+  const verible::LineColumnRange range{
+      line_column_map_.GetLineColAtOffset(base, violation.token.left(base)),
+      line_column_map_.GetLineColAtOffset(base, violation.token.right(base))};
+
+  (*stream) << path << ':' << range << ' ' << violation.reason << ' ' << url
+            << " [" << rule_name << ']';
 }
 
 void LintRuleStatus::WaiveViolations(

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -123,9 +123,10 @@ TEST(LintRuleStatusFormatterTest, SimpleOutput) {
       "some/path/to/somewhere.fvg",
       text,
       {{"reason1", TokenInfo(dont_care_tag, text.substr(0, 5)),
-        "some/path/to/somewhere.fvg:1:1: reason1 http://foobar [test-rule]"},
+        "some/path/to/somewhere.fvg:1:1-5: reason1 http://foobar [test-rule]"},
        {"reason2", TokenInfo(dont_care_tag, text.substr(21, 4)),
-        "some/path/to/somewhere.fvg:2:4: reason2 http://foobar [test-rule]"}}};
+        "some/path/to/somewhere.fvg:2:4-7: reason2 http://foobar "
+        "[test-rule]"}}};
 
   RunLintStatusTest(test);
 }
@@ -209,9 +210,10 @@ TEST(LintRuleStatusFormatterTest, MultipleStatusesSimpleOutput) {
       "some/path/to/somewhere.fvg",
       text,
       {{"reason1", TokenInfo(dont_care_tag, text.substr(0, 5)),
-        "some/path/to/somewhere.fvg:1:1: reason1 http://foobar [test-rule]"},
+        "some/path/to/somewhere.fvg:1:1-5: reason1 http://foobar [test-rule]"},
        {"reason2", TokenInfo(dont_care_tag, text.substr(21, 4)),
-        "some/path/to/somewhere.fvg:2:4: reason2 http://foobar [test-rule]"}}};
+        "some/path/to/somewhere.fvg:2:4-7: reason2 http://foobar "
+        "[test-rule]"}}};
 
   RunLintStatusesTest(test, false);
 }
@@ -230,10 +232,10 @@ TEST(LintRuleStatusFormatterTestWithContext, MultipleStatusesSimpleOutput) {
       "some/path/to/somewhere.fvg",
       text,
       {{"reason1", TokenInfo(dont_care_tag, text.substr(0, 5)),
-        "some/path/to/somewhere.fvg:1:1: reason1 http://foobar "
+        "some/path/to/somewhere.fvg:1:1-5: reason1 http://foobar "
         "[test-rule]\nThis is some code\n"},
        {"reason2", TokenInfo(dont_care_tag, text.substr(21, 4)),
-        "some/path/to/somewhere.fvg:2:4: reason2 http://foobar "
+        "some/path/to/somewhere.fvg:2:4-7: reason2 http://foobar "
         "[test-rule]\nThat you are looking at right now\n   "}}};
   RunLintStatusesTest(test, true);
 }

--- a/common/strings/line_column_map.cc
+++ b/common/strings/line_column_map.cc
@@ -29,7 +29,7 @@ namespace verible {
 // Print to the user as 1-based index because that is how lines
 // and columns are indexed in every file diagnostic tool.
 std::ostream& operator<<(std::ostream& out, const LineColumn& line_column) {
-  return out << line_column.line + 1 << ':' << line_column.column + 1 << ':';
+  return out << line_column.line + 1 << ':' << line_column.column + 1;
 }
 
 std::ostream& operator<<(std::ostream& out, const LineColumnRange& r) {
@@ -40,7 +40,14 @@ std::ostream& operator<<(std::ostream& out, const LineColumnRange& r) {
   right.column--;
   out << r.start;
   // Only if we cover more than a single character, print range of columns.
-  if (r.start < right) out << right;
+  if (r.start.line == right.line) {
+    if (right.column > r.start.column) out << '-' << right.column + 1;
+  } else {
+    // TODO(hzeller): what is a good format to mark a range of multiple lines
+    // that is understood by common editors ?
+    out << ':' << right;
+  }
+  out << ':';
   return out;
 }
 

--- a/common/strings/line_column_map.cc
+++ b/common/strings/line_column_map.cc
@@ -28,11 +28,8 @@ namespace verible {
 
 // Print to the user as 1-based index because that is how lines
 // and columns are indexed in every file diagnostic tool.
-// TODO(hzeller): this should have a ':' at the end, but the current expectation
-// in TokenErrorMessage() is that it ends with the column. Consider printing
-// a range there in the first place.
 std::ostream& operator<<(std::ostream& out, const LineColumn& line_column) {
-  return out << line_column.line + 1 << ':' << line_column.column + 1;
+  return out << line_column.line + 1 << ':' << line_column.column + 1 << ':';
 }
 
 std::ostream& operator<<(std::ostream& out, const LineColumnRange& r) {
@@ -41,8 +38,10 @@ std::ostream& operator<<(std::ostream& out, const LineColumnRange& r) {
   // character.
   LineColumn right = r.end;
   right.column--;
-  // That center colon should come from LineColumn already; see comment above.
-  return out << r.start << ':' << right << ':';
+  out << r.start;
+  // Only if we cover more than a single character, print range of columns.
+  if (r.start < right) out << right;
+  return out;
 }
 
 // Records locations of line breaks, which can then be used to translate

--- a/common/strings/line_column_map_test.cc
+++ b/common/strings/line_column_map_test.cc
@@ -72,10 +72,10 @@ const LineColumnMapTestData map_test_data[] = {
 // Test test verifies that line-column offset appear to the user correctly.
 TEST(LineColumnTextTest, PrintLineColumn) {
   static constexpr LineColumnTestData text_test_data[] = {
-      {{0, 0}, "1:1"},
-      {{0, 1}, "1:2"},
-      {{1, 0}, "2:1"},
-      {{10, 8}, "11:9"},
+      {{0, 0}, "1:1:"},
+      {{0, 1}, "1:2:"},
+      {{1, 0}, "2:1:"},
+      {{10, 8}, "11:9:"},
   };
   for (const auto& test_case : text_test_data) {
     std::ostringstream oss;
@@ -86,10 +86,10 @@ TEST(LineColumnTextTest, PrintLineColumn) {
 
 TEST(LineColumnTextTest, PrintLineColumnRange) {
   static constexpr LineColumnRangeTestData text_test_data[] = {
-      {{{0, 0}, {0, 7}}, "1:1:1:7:"},
-      {{{0, 1}, {0, 3}}, "1:2:1:3:"},
-      {{{1, 0}, {2, 14}}, "2:1:3:14:"},
-      {{{10, 8}, {11, 2}}, "11:9:12:2:"},
+      {{{0, 0}, {0, 7}}, "1:1:1:7:"},   {{{0, 1}, {0, 3}}, "1:2:1:3:"},
+      {{{1, 0}, {2, 14}}, "2:1:3:14:"}, {{{10, 8}, {11, 2}}, "11:9:12:2:"},
+      {{{10, 8}, {10, 9}}, "11:9:"},  // Single character range
+      {{{10, 8}, {10, 8}}, "11:9:"},  // Empty range.
   };
   for (const auto& test_case : text_test_data) {
     std::ostringstream oss;

--- a/common/strings/line_column_map_test.cc
+++ b/common/strings/line_column_map_test.cc
@@ -72,10 +72,10 @@ const LineColumnMapTestData map_test_data[] = {
 // Test test verifies that line-column offset appear to the user correctly.
 TEST(LineColumnTextTest, PrintLineColumn) {
   static constexpr LineColumnTestData text_test_data[] = {
-      {{0, 0}, "1:1:"},
-      {{0, 1}, "1:2:"},
-      {{1, 0}, "2:1:"},
-      {{10, 8}, "11:9:"},
+      {{0, 0}, "1:1"},
+      {{0, 1}, "1:2"},
+      {{1, 0}, "2:1"},
+      {{10, 8}, "11:9"},
   };
   for (const auto& test_case : text_test_data) {
     std::ostringstream oss;
@@ -86,8 +86,10 @@ TEST(LineColumnTextTest, PrintLineColumn) {
 
 TEST(LineColumnTextTest, PrintLineColumnRange) {
   static constexpr LineColumnRangeTestData text_test_data[] = {
-      {{{0, 0}, {0, 7}}, "1:1:1:7:"},   {{{0, 1}, {0, 3}}, "1:2:1:3:"},
-      {{{1, 0}, {2, 14}}, "2:1:3:14:"}, {{{10, 8}, {11, 2}}, "11:9:12:2:"},
+      {{{0, 0}, {0, 7}}, "1:1-7:"},  // Same line, multiple columns
+      {{{0, 1}, {0, 3}}, "1:2-3:"},
+      {{{1, 0}, {2, 14}}, "2:1:3:14:"},  // start/end different lines
+      {{{10, 8}, {11, 2}}, "11:9:12:2:"},
       {{{10, 8}, {10, 9}}, "11:9:"},  // Single character range
       {{{10, 8}, {10, 8}}, "11:9:"},  // Empty range.
   };

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -261,7 +261,7 @@ TEST_F(VerilogLinterTest, KnownTreeLintViolation) {
                                            "endtask\n");
   EXPECT_TRUE(diagnostics.first.ok());
   const auto expected =
-      "bad.sv:2:3: $psprintf is a forbidden system function "
+      "bad.sv:2:3-11: $psprintf is a forbidden system function "
       "or task, please use $sformatf instead";
   EXPECT_THAT(diagnostics.second, StartsWith(expected));
   EXPECT_THAT(diagnostics.second, EndsWith("[invalid-system-task-function]\n"));
@@ -355,7 +355,7 @@ TEST_F(VerilogLinterTest, KnownTextStructureLintViolation) {
       "endmodule\n");
   EXPECT_TRUE(diagnostics.first.ok());
   EXPECT_THAT(diagnostics.second,
-              StartsWith("long.sv:2:101: Line length exceeds "
+              StartsWith("long.sv:2:101-114: Line length exceeds "
                          "max: 100; is: 114"));
   EXPECT_THAT(diagnostics.second, EndsWith("[line-length]\n"));
 }
@@ -384,8 +384,9 @@ TEST_F(VerilogLinterTest, ModuleBodyLineLength) {
       "initial xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = "
       "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[777777777777];\n");
   EXPECT_TRUE(diagnostics.first.ok());
-  EXPECT_THAT(diagnostics.second,
-              StartsWith("module-body.sv:3:101: Line length exceeds max: "));
+  EXPECT_THAT(
+      diagnostics.second,
+      StartsWith("module-body.sv:3:101-114: Line length exceeds max: "));
   EXPECT_THAT(diagnostics.second, EndsWith("[line-length]\n"));
 }
 

--- a/verilog/tools/lint/lint_tool_test.sh
+++ b/verilog/tools/lint/lint_tool_test.sh
@@ -107,7 +107,7 @@ status="$?"
 
 DIAGNOSTIC_OUTPUT="${TEST_TMPDIR}/expected-diagnostic.out"
 cat > "${DIAGNOSTIC_OUTPUT}" <<EOF
-${TEST_TMPDIR}/syntax-error.sv:2:1:2:8: syntax error at token "endclass"
+${TEST_TMPDIR}/syntax-error.sv:2:1-8: syntax error at token "endclass"
 endclass
 ^
 EOF
@@ -122,7 +122,7 @@ status="$?"
 }
 
 cat > "${DIAGNOSTIC_OUTPUT}" <<EOF
-${TEST_TMPDIR}/syntax-error.sv:2:1:2:8: syntax error at token "endclass"
+${TEST_TMPDIR}/syntax-error.sv:2:1-8: syntax error at token "endclass"
 EOF
 
 "$lint_tool" "$TEST_FILE" > "${MY_OUTPUT_FILE}.out"

--- a/verilog/tools/lint/lint_tool_test.sh
+++ b/verilog/tools/lint/lint_tool_test.sh
@@ -107,7 +107,7 @@ status="$?"
 
 DIAGNOSTIC_OUTPUT="${TEST_TMPDIR}/expected-diagnostic.out"
 cat > "${DIAGNOSTIC_OUTPUT}" <<EOF
-${TEST_TMPDIR}/syntax-error.sv:2:1: syntax error at token "endclass"
+${TEST_TMPDIR}/syntax-error.sv:2:1:2:8: syntax error at token "endclass"
 endclass
 ^
 EOF
@@ -122,7 +122,7 @@ status="$?"
 }
 
 cat > "${DIAGNOSTIC_OUTPUT}" <<EOF
-${TEST_TMPDIR}/syntax-error.sv:2:1: syntax error at token "endclass"
+${TEST_TMPDIR}/syntax-error.sv:2:1:2:8: syntax error at token "endclass"
 EOF
 
 "$lint_tool" "$TEST_FILE" > "${MY_OUTPUT_FILE}.out"

--- a/verilog/tools/syntax/verilog_syntax_test.sh
+++ b/verilog/tools/syntax/verilog_syntax_test.sh
@@ -115,8 +115,8 @@ strip_error < "$MY_OUTPUT_FILE" > "$MY_OUTPUT_FILE".filtered
 
 cat > "$MY_EXPECT_FILE" <<EOF
 -:1:8: syntax error at token "1"
--:2:1:2:9: syntax error at token "endmodule"
--:4:1:4:9: syntax error at token "endmodule"
+-:2:1-9: syntax error at token "endmodule"
+-:4:1-9: syntax error at token "endmodule"
 EOF
 
 diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE".filtered || \

--- a/verilog/tools/syntax/verilog_syntax_test.sh
+++ b/verilog/tools/syntax/verilog_syntax_test.sh
@@ -115,8 +115,8 @@ strip_error < "$MY_OUTPUT_FILE" > "$MY_OUTPUT_FILE".filtered
 
 cat > "$MY_EXPECT_FILE" <<EOF
 -:1:8: syntax error at token "1"
--:2:1: syntax error at token "endmodule"
--:4:1: syntax error at token "endmodule"
+-:2:1:2:9: syntax error at token "endmodule"
+-:4:1:4:9: syntax error at token "endmodule"
 EOF
 
 diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE".filtered || \


### PR DESCRIPTION
If the token mentioned in a syntax error covers more than one character,
print syntax error with the full column range.