### PR TITLE
Make sure error message context arrow is aligned with code in case of…

### DIFF
--- a/common/analysis/file_analyzer.cc
+++ b/common/analysis/file_analyzer.cc
@@ -16,6 +16,7 @@
 
 #include "common/analysis/file_analyzer.h"
 
+#include <algorithm>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
 #include <vector>
@@ -171,7 +172,10 @@ std::string FileAnalyzer::LinterTokenErrorMessage(
           out << " : " << message;
         }
         if (diagnostic_context && !context_line.empty()) {
-          out << "\n" << context_line << std::endl;
+          // Need to get rid of all tabs so that spacing
+          std::string no_tab_line(context_line.begin(), context_line.end());
+          std::replace(no_tab_line.begin(), no_tab_line.end(), '\t', ' ');
+          out << "\n" << no_tab_line << std::endl;
           out << verible::Spacer(range.start.column) << "^";
         }
       });

--- a/common/analysis/file_analyzer_test.cc
+++ b/common/analysis/file_analyzer_test.cc
@@ -165,21 +165,22 @@ TEST(FileAnalyzerTest, TokenErrorMessageOneChar) {
 
 // Verify that an error token on one character is reported correctly.
 TEST(FileAnalyzerTest, TokenErrorMessageOneCharWithContext) {
-  const std::string text("hello, world\nbye w0rld\n");
+  const std::string text("\thello, world\nbye w0rld\n");
   FakeFileAnalyzer analyzer(text, "hello.txt");
-  const TokenInfo error_token(1, analyzer.Data().Contents().substr(5, 1));
+  const TokenInfo error_token(1, analyzer.Data().Contents().substr(6, 1));
   {
     const auto message = analyzer.TokenErrorMessage(error_token);
-    EXPECT_EQ(message, "token: \",\" at 1:6:");
+    EXPECT_EQ(message, "token: \",\" at 1:7:");
   }
   {
     constexpr bool with_diagnostic_context = true;
     const auto message = analyzer.LinterTokenErrorMessage(
         {error_token, AnalysisPhase::kParsePhase}, with_diagnostic_context);
+    // The tab character is replaced with a space for the arrow to align
     EXPECT_TRUE(absl::StrContains(message,
-                                  "hello.txt:1:6: syntax error at token \",\"\n"
-                                  "hello, world\n"
-                                  "     ^"))
+                                  "hello.txt:1:7: syntax error at token \",\"\n"
+                                  " hello, world\n"
+                                  "      ^"))
         << message;
   }
 }


### PR DESCRIPTION
… tab.

In case there is a tab character in the error reporting line, the
ascii-art arrow pointing to the error is off as the terminal does not
print it as single-character width. Fix it by replacing all tabs with
spaces.

Signed-off-by: Henner Zeller <hzeller@google.com>