### PR TITLE
Report name of redefined macro, not body.

### DIFF
--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -79,6 +79,7 @@ class MacroDefinition {
       : header_(header), name_(name), is_callable_(false) {}
 
   absl::string_view Name() const { return name_.text(); }
+  const TokenInfo& NameToken() const { return name_; }
 
   const TokenInfo& DefinitionText() const { return definition_text_; }
 

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -199,9 +199,9 @@ VerilogPreprocess::RegisterMacroDefinition(const MacroDefinition& definition) {
   const bool inserted = InsertOrUpdate(&preprocess_data_.macro_definitions,
                                        definition.Name(), definition);
   if (inserted) return nullptr;
-  return std::make_unique<VerilogPreprocessError>(
-      definition.DefinitionText(),
-      absl::StrCat("Re-defining macro '", definition.Name(), "'"));
+  return std::make_unique<VerilogPreprocessError>(definition.NameToken(),
+                                                  "Re-defining macro");
+  // TODO(hzeller): multiline warning with 'previously defined here' location
 }
 
 // Responds to `define directives.  Macro definitions are parsed and saved


### PR DESCRIPTION
Use the token that represents the name.

Signed-off-by: Henner Zeller <hzeller@google.com>