### PR TITLE
Don't limit the diagnostic messages for textDocument/diagnostics

### DIFF
--- a/verilog/tools/ls/verible-lsp-adapter.h
+++ b/verilog/tools/ls/verible-lsp-adapter.h
@@ -28,7 +28,8 @@ namespace verilog {
 
 // Given the output of the parser and a lint status, create a diagnostic
 // output to be sent in textDocument/publishDiagnostics notification.
-std::vector<verible::lsp::Diagnostic> CreateDiagnostics(const BufferTracker &);
+std::vector<verible::lsp::Diagnostic> CreateDiagnostics(const BufferTracker &,
+                                                        int message_limit);
 
 // Generate code actions from autofixes provided by the linter.
 std::vector<verible::lsp::CodeAction> GenerateLinterCodeActions(

--- a/verilog/tools/ls/verilog_ls.cc
+++ b/verilog/tools/ls/verilog_ls.cc
@@ -84,8 +84,15 @@ static void SendDiagnostics(const std::string &uri,
   // This should not send anything if the diagnostics we're about to
   // send would be exactly the same as last time.
   verible::lsp::PublishDiagnosticsParams params;
+
+  // For the diagnostic notification (that we send somewhat unsolicited), we
+  // limit the number of diagnostic messages. In the
+  // textDocument/diagnostic RPC request, we send all of them.
+  // Arbitrary limit here. Maybe set with flag ?
+  static constexpr int kDiagnosticLimit = 500;
   params.uri = uri;
-  params.diagnostics = verilog::CreateDiagnostics(buffer_tracker);
+  params.diagnostics =
+      verilog::CreateDiagnostics(buffer_tracker, kDiagnosticLimit);
   dispatcher->SendNotification("textDocument/publishDiagnostics", params);
 }
 


### PR DESCRIPTION
While we limit the number of diagnostic messages we send in the
unsolicted notification to the editor, don't do that if explicitly
requested in the textDocument/diagnostics RPC request.

Signed-off-by: Henner Zeller <h.zeller@acm.org>