### PR TITLE
Surface the verilog preprocessor config up one level.

### DIFF
--- a/common/analysis/linter_test_utils.h
+++ b/common/analysis/linter_test_utils.h
@@ -70,6 +70,8 @@ void RunLintTestCase(const LintTestCase& test,
                      const LintRuleGenerator<RuleType>& make_rule,
                      absl::string_view filename) {
   // All linters start by parsing to yield a TextStructure.
+  // TODO(hzeller): make preprocessor configurable. Right now, preprocessor
+  // is specific in verilog, no such concept in common.
   AnalyzerType analyzer(test.code, filename);
   absl::Status unused_parser_status = analyzer.Analyze();
 

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -32,6 +32,8 @@
 namespace verilog {
 namespace {
 
+static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+
 using verible::SyntaxTreeSearchTestCase;
 using verible::TextStructureView;
 using verible::TreeSearchMatch;
@@ -49,7 +51,8 @@ TEST(IsZeroTest, NonZero) {
       "(0)",
   };
   for (auto code : kTestCases) {
-    const auto analyzer_ptr = AnalyzeVerilogExpression(code, "<file>");
+    const auto analyzer_ptr =
+        AnalyzeVerilogExpression(code, "<file>", kDefaultPreprocess);
     const auto& node = ABSL_DIE_IF_NULL(analyzer_ptr)->SyntaxTree();
     const auto tag = node->Tag();
     EXPECT_EQ(tag.kind, verible::SymbolKind::kNode);
@@ -66,7 +69,8 @@ TEST(IsZeroTest, Zero) {
       "'0",
   };
   for (auto code : kTestCases) {
-    const auto analyzer_ptr = AnalyzeVerilogExpression(code, "<file>");
+    const auto analyzer_ptr =
+        AnalyzeVerilogExpression(code, "<file>", kDefaultPreprocess);
     const auto& node = ABSL_DIE_IF_NULL(analyzer_ptr)->SyntaxTree();
     const auto tag = node->Tag();
     EXPECT_EQ(tag.kind, verible::SymbolKind::kNode);
@@ -82,7 +86,8 @@ TEST(ConstantIntegerValueTest, NotInteger) {
       "(2)",
   };
   for (auto code : kTestCases) {
-    const auto analyzer_ptr = AnalyzeVerilogExpression(code, "<file>");
+    const auto analyzer_ptr =
+        AnalyzeVerilogExpression(code, "<file>", kDefaultPreprocess);
     const auto& node = ABSL_DIE_IF_NULL(analyzer_ptr)->SyntaxTree();
     const auto tag = node->Tag();
     EXPECT_EQ(tag.kind, verible::SymbolKind::kNode);
@@ -99,7 +104,8 @@ TEST(ConstantIntegerValueTest, IsInteger) {
       {"666", 666},
   };
   for (auto test : kTestCases) {
-    const auto analyzer_ptr = AnalyzeVerilogExpression(test.first, "<file>");
+    const auto analyzer_ptr =
+        AnalyzeVerilogExpression(test.first, "<file>", kDefaultPreprocess);
     const auto& node = ABSL_DIE_IF_NULL(analyzer_ptr)->SyntaxTree();
     const auto tag = node->Tag();
     EXPECT_EQ(tag.kind, verible::SymbolKind::kNode);
@@ -582,7 +588,8 @@ TEST(ReferenceIsSimpleTest, Simple) {
       "_y",
   };
   for (auto code : kTestCases) {
-    const auto analyzer_ptr = AnalyzeVerilogExpression(code, "<file>");
+    const auto analyzer_ptr =
+        AnalyzeVerilogExpression(code, "<file>", kDefaultPreprocess);
     const auto& node = ABSL_DIE_IF_NULL(analyzer_ptr)->SyntaxTree();
     {
       const auto status = analyzer_ptr->LexStatus();
@@ -609,7 +616,8 @@ TEST(ReferenceIsSimpleTest, NotSimple) {
   };
   for (auto code : kTestCases) {
     VLOG(1) << __FUNCTION__ << " test: " << code;
-    const auto analyzer_ptr = AnalyzeVerilogExpression(code, "<file>");
+    const auto analyzer_ptr =
+        AnalyzeVerilogExpression(code, "<file>", kDefaultPreprocess);
     const auto& node = ABSL_DIE_IF_NULL(analyzer_ptr)->SyntaxTree();
     {
       const auto status = analyzer_ptr->LexStatus();

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -45,6 +45,7 @@ cc_library(
         "//verilog/CST:identifier",
         "//verilog/CST:module",
         "//verilog/analysis:verilog_analyzer",
+        "//verilog/preprocessor:verilog_preprocess",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
     ],

--- a/verilog/analysis/extractors.cc
+++ b/verilog/analysis/extractors.cc
@@ -24,12 +24,13 @@ namespace verilog {
 namespace analysis {
 
 // Find all modules and collect interface names
-absl::Status CollectInterfaceNames(absl::string_view content,
-                                   std::set<std::string>* if_names) {
+absl::Status CollectInterfaceNames(
+    absl::string_view content, std::set<std::string>* if_names,
+    const VerilogPreprocess::Config& preprocess_config) {
   VLOG(1) << __FUNCTION__;
 
-  const auto analyzer =
-      verilog::VerilogAnalyzer::AnalyzeAutomaticMode(content, "<file>");
+  const auto analyzer = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
+      content, "<file>", preprocess_config);
   auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();
   auto parse_status = analyzer->ParseStatus();
 

--- a/verilog/analysis/extractors.h
+++ b/verilog/analysis/extractors.h
@@ -24,6 +24,7 @@
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
+#include "verilog/preprocessor/verilog_preprocess.h"
 
 namespace verilog {
 namespace analysis {
@@ -31,8 +32,9 @@ namespace analysis {
 // Collect all identifiers under module header subtree in the CTS.
 // This could be useful when interface names are required to be
 // preserved.
-absl::Status CollectInterfaceNames(absl::string_view content,
-                                   std::set<std::string>* if_names);
+absl::Status CollectInterfaceNames(
+    absl::string_view content, std::set<std::string>* if_names,
+    const verilog::VerilogPreprocess::Config& preprocess_config);
 
 }  // namespace analysis
 }  // namespace verilog

--- a/verilog/analysis/extractors_test.cc
+++ b/verilog/analysis/extractors_test.cc
@@ -26,6 +26,7 @@
 namespace verilog {
 namespace analysis {
 namespace {
+static constexpr VerilogPreprocess::Config kDefaultPreprocess;
 
 TEST(CollectInterfaceNamesTest, NonModuleTests) {
   const std::pair<absl::string_view, std::set<std::string>> kTestCases[] = {
@@ -36,7 +37,8 @@ TEST(CollectInterfaceNamesTest, NonModuleTests) {
   };
   for (const auto& test : kTestCases) {
     std::set<std::string> preserved;
-    EXPECT_OK(CollectInterfaceNames(test.first, &preserved));
+    EXPECT_OK(
+        CollectInterfaceNames(test.first, &preserved, kDefaultPreprocess));
     EXPECT_EQ(preserved, test.second);
   }
 }
@@ -52,7 +54,8 @@ TEST(CollectInterfaceNamesTest, MinimalistModuleTests) {
   };
   for (const auto& test : kTestCases) {
     std::set<std::string> preserved;
-    EXPECT_OK(CollectInterfaceNames(test.first, &preserved));
+    EXPECT_OK(
+        CollectInterfaceNames(test.first, &preserved, kDefaultPreprocess));
     EXPECT_EQ(preserved, test.second);
   }
 }
@@ -88,7 +91,8 @@ TEST(CollectInterfaceNamesTest, BiggerModuleTests) {
   };
   for (const auto& test : kTestCases) {
     std::set<std::string> preserved;
-    EXPECT_OK(CollectInterfaceNames(test.first, &preserved));
+    EXPECT_OK(
+        CollectInterfaceNames(test.first, &preserved, kDefaultPreprocess));
     EXPECT_EQ(preserved, test.second);
   }
 }

--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -65,7 +65,8 @@ class VerilogAnalyzer : public verible::FileAnalyzer {
   // Automatically analyze with the correct parsing mode, as detected
   // by parser directive comments.
   static std::unique_ptr<VerilogAnalyzer> AnalyzeAutomaticMode(
-      absl::string_view text, absl::string_view name);
+      absl::string_view text, absl::string_view name,
+      const VerilogPreprocess::Config& preprocess_config);
 
   const VerilogPreprocessData& PreprocessorData() const {
     return preprocessor_data_;

--- a/verilog/analysis/verilog_excerpt_parse.cc
+++ b/verilog/analysis/verilog_excerpt_parse.cc
@@ -40,7 +40,8 @@ using verible::container::FindOrNull;
 // about the prolog and epilog, leaving only the substructure of interest.
 static std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogConstruct(
     absl::string_view prolog, absl::string_view text, absl::string_view epilog,
-    absl::string_view filename) {
+    absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   VLOG(2) << __FUNCTION__;
   CHECK(epilog.empty() || absl::ascii_isspace(epilog[0]))
       << "epilog text must begin with a whitespace to prevent unintentional "
@@ -48,8 +49,8 @@ static std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogConstruct(
   const std::string analyze_text = absl::StrCat(prolog, text, epilog);
   // Disable parser directive comments because a specific parser
   // is already being selected.
-  auto analyzer_ptr =
-      absl::make_unique<VerilogAnalyzer>(analyze_text, filename);
+  auto analyzer_ptr = absl::make_unique<VerilogAnalyzer>(analyze_text, filename,
+                                                         preprocess_config);
 
   if (!ABSL_DIE_IF_NULL(analyzer_ptr)->Analyze().ok()) {
     VLOG(2) << __FUNCTION__ << ": Analyze() failed.  code:\n" << analyze_text;
@@ -69,21 +70,26 @@ static std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogConstruct(
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogPropertySpec(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   return AnalyzeVerilogConstruct("module foo;\nproperty p;\n", text,
-                                 "\nendproperty;\nendmodule;\n", filename);
+                                 "\nendproperty;\nendmodule;\n", filename,
+                                 preprocess_config);
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogStatements(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   return AnalyzeVerilogConstruct("function foo();\n", text, "\nendfunction\n",
-                                 filename);
+                                 filename, preprocess_config);
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogExpression(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   return AnalyzeVerilogConstruct("module foo;\nif (", text,
-                                 " ) $error;\nendmodule\n", filename);
+                                 " ) $error;\nendmodule\n", filename,
+                                 preprocess_config);
   // $error in this context is an elaboration system task
   // The space before the ) is critical to accommodate escaped identifiers.
   // Without the space, lexing an escaped identifier would consume part
@@ -91,41 +97,46 @@ std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogExpression(
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogModuleBody(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   return AnalyzeVerilogConstruct("module foo;\n", text, "\nendmodule\n",
-                                 filename);
+                                 filename, preprocess_config);
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogClassBody(
-    absl::string_view text, absl::string_view filename) {
-  return AnalyzeVerilogConstruct("class foo;\n", text, "\nendclass\n",
-                                 filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
+  return AnalyzeVerilogConstruct("class foo;\n", text, "\nendclass\n", filename,
+                                 preprocess_config);
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogPackageBody(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   return AnalyzeVerilogConstruct("package foo;\n", text, "\nendpackage\n",
-                                 filename);
+                                 filename, preprocess_config);
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogLibraryMap(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config) {
   // The prolog/epilog strings come from verilog.lex as token enums:
   // PD_LIBRARY_SYNTAX_BEGIN and PD_LIBRARY_SYNTAX_END.
   // These are used in verilog.y to enclose the complete library_description
   // grammar rule.
   return AnalyzeVerilogConstruct(
       "`____verible_verilog_library_begin____\n", text,
-      "\n`____verible_verilog_library_end____\n", filename);
+      "\n`____verible_verilog_library_end____\n", filename, preprocess_config);
 }
 
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogWithMode(
-    absl::string_view text, absl::string_view filename,
-    absl::string_view mode) {
+    absl::string_view text, absl::string_view filename, absl::string_view mode,
+    const VerilogPreprocess::Config& preprocess_config) {
   static const auto* func_map =
       new std::map<absl::string_view,
                    std::function<std::unique_ptr<VerilogAnalyzer>(
-                       absl::string_view, absl::string_view)>>{
+                       absl::string_view, absl::string_view,
+                       const VerilogPreprocess::Config&)>>{
           {"parse-as-statements", &AnalyzeVerilogStatements},
           {"parse-as-expression", &AnalyzeVerilogExpression},
           {"parse-as-module-body", &AnalyzeVerilogModuleBody},
@@ -136,7 +147,7 @@ std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogWithMode(
       };
   const auto* func_ptr = FindOrNull(*func_map, mode);
   if (!func_ptr) return nullptr;
-  return (*func_ptr)(text, filename);
+  return (*func_ptr)(text, filename, preprocess_config);
 }
 
 }  // namespace verilog

--- a/verilog/analysis/verilog_excerpt_parse.h
+++ b/verilog/analysis/verilog_excerpt_parse.h
@@ -24,45 +24,57 @@
 
 #include "absl/strings/string_view.h"
 #include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/preprocessor/verilog_preprocess.h"
 
 namespace verilog {
 
 // The interface for these functions should all be:
-//   std::unique_ptr<VerilogAnalyzer> (const string& text);
+//   std::unique_ptr<VerilogAnalyzer> (absl::string_view text,
+//                                     absl::string_view filename,
+//                                     const VerilogPreprocess::Config& config);
+// );
 
 // Analyzes test as Verilog property_spec
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogPropertySpec(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // Analyzes text as Verilog statements.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogStatements(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // Analyzes text as any Verilog expression.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogExpression(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // Analyzes text as any Verilog module body.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogModuleBody(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // Analyzes text as any Verilog class body.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogClassBody(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // Analyzes text as any Verilog package body.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogPackageBody(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // TODO(fangism): analogous functions for: function, task, ...
 
 // Analyzes text as any Verilog library map.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogLibraryMap(
-    absl::string_view text, absl::string_view filename);
+    absl::string_view text, absl::string_view filename,
+    const VerilogPreprocess::Config& preprocess_config);
 
 // Analyzes text in the selected parsing `mode`.
 std::unique_ptr<VerilogAnalyzer> AnalyzeVerilogWithMode(
-    absl::string_view text, absl::string_view filename, absl::string_view mode);
+    absl::string_view text, absl::string_view filename, absl::string_view mode,
+    const VerilogPreprocess::Config& preprocess_config);
 
 }  // namespace verilog
 

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -111,8 +111,12 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
   }
 
   // Lex and parse the contents of the file.
-  const auto analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(content, filename);
+  // TODO(hzeller): Chose preprocessing option. Maybe start with default
+  // to include as much as possible, but fall back to process `ifdef branches
+  // on syntax issues. For now: just the default.
+  static constexpr verilog::VerilogPreprocess::Config preprocess_config;
+  const auto analyzer = VerilogAnalyzer::AnalyzeAutomaticMode(
+      content, filename, preprocess_config);
   if (check_syntax) {
     const auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();
     const auto parse_status = analyzer->ParseStatus();

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -53,6 +53,7 @@
 #include "verilog/formatting/token_annotator.h"
 #include "verilog/formatting/tree_unwrapper.h"
 #include "verilog/parser/verilog_token_enum.h"
+#include "verilog/preprocessor/verilog_preprocess.h"
 
 namespace verilog {
 namespace formatter {
@@ -114,8 +115,8 @@ Status VerifyFormatting(const verible::TextStructureView& text_structure,
   // Note: We cannot just Tokenize() and compare because Analyze()
   // performs additional transformations like expanding MacroArgs to
   // expression subtrees.
-  const auto reanalyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(formatted_output, filename);
+  const auto reanalyzer = VerilogAnalyzer::AnalyzeAutomaticMode(
+      formatted_output, filename, verilog::VerilogPreprocess::Config());
   const auto relex_status = ABSL_DIE_IF_NULL(reanalyzer)->LexStatus();
   const auto reparse_status = reanalyzer->ParseStatus();
 
@@ -200,7 +201,8 @@ static Status ReformatVerilog(absl::string_view original_text,
 static absl::StatusOr<std::unique_ptr<VerilogAnalyzer>> ParseWithStatus(
     absl::string_view text, absl::string_view filename) {
   std::unique_ptr<VerilogAnalyzer> analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(text, filename);
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          text, filename, verilog::VerilogPreprocess::Config());
   {
     // Lex and parse code.  Exit on failure.
     const auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -53,6 +53,8 @@ absl::Status VerifyFormatting(const verible::TextStructureView& text_structure,
 
 namespace {
 
+static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+
 using absl::StatusCode;
 using testing::HasSubstr;
 using verible::AlignmentPolicy;
@@ -63,7 +65,7 @@ using verible::LineNumberSet;
 TEST(VerifyFormattingTest, NoError) {
   const absl::string_view code("class c;endclass\n");
   const std::unique_ptr<VerilogAnalyzer> analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<filename>");
+      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const auto status = VerifyFormatting(text_structure, code, "<filename>");
   EXPECT_OK(status);
@@ -73,7 +75,7 @@ TEST(VerifyFormattingTest, NoError) {
 TEST(VerifyFormattingTest, LexError) {
   const absl::string_view code("class c;endclass\n");
   const std::unique_ptr<VerilogAnalyzer> analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<filename>");
+      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const absl::string_view bad_code("1class c;endclass\n");  // lexical error
   const auto status = VerifyFormatting(text_structure, bad_code, "<filename>");
@@ -85,7 +87,7 @@ TEST(VerifyFormattingTest, LexError) {
 TEST(VerifyFormattingTest, ParseError) {
   const absl::string_view code("class c;endclass\n");
   const std::unique_ptr<VerilogAnalyzer> analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<filename>");
+      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const absl::string_view bad_code("classc;endclass\n");  // syntax error
   const auto status = VerifyFormatting(text_structure, bad_code, "<filename>");
@@ -97,7 +99,7 @@ TEST(VerifyFormattingTest, ParseError) {
 TEST(VerifyFormattingTest, LexicalDifference) {
   const absl::string_view code("class c;endclass\n");
   const std::unique_ptr<VerilogAnalyzer> analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<filename>");
+      VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const absl::string_view bad_code("class c;;endclass\n");  // different tokens
   const auto status = VerifyFormatting(text_structure, bad_code, "<filename>");

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -39,6 +39,8 @@ using ParserTestData = verible::TokenInfoTestData;
 
 using ParserTestCaseArray = std::initializer_list<const char*>;
 
+static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+
 // No syntax tree expected from these inputs.
 static const ParserTestCaseArray kEmptyTests = {
     "", "    ", "\t\t\t", "\n\n", "// comment\n", "/* comment */\n",
@@ -6240,7 +6242,8 @@ static void TestVerilogLibraryParser(const ParserTestCaseArray& data) {
   for (const auto& code : data) {
     VLOG(1) << "test_data[" << i << "] = '" << code << "'\n";
     // TODO(fangism): refactor TestParserAcceptValid to accept a lambda
-    const auto analyzer = AnalyzeVerilogLibraryMap(code, "<<inline-test>>");
+    const auto analyzer =
+        AnalyzeVerilogLibraryMap(code, "<<inline-test>>", kDefaultPreprocess);
     const absl::Status status = ABSL_DIE_IF_NULL(analyzer)->ParseStatus();
     if (!status.ok()) {
       // Print more detailed error message.
@@ -6294,7 +6297,8 @@ static void TestVerilogLibraryParserMatchAll(const ParserTestCaseArray& data) {
     VLOG(1) << "test_data[" << i << "] = '" << code << "'\n";
 
     // TODO(fangism): refactor TestParserAllMatched to accept a lambda
-    const auto analyzer = AnalyzeVerilogLibraryMap(code, "<<inline-test>>");
+    const auto analyzer =
+        AnalyzeVerilogLibraryMap(code, "<<inline-test>>", kDefaultPreprocess);
     const absl::Status status = ABSL_DIE_IF_NULL(analyzer)->ParseStatus();
     EXPECT_TRUE(status.ok())
         << status.message()

--- a/verilog/preprocessor/BUILD
+++ b/verilog/preprocessor/BUILD
@@ -4,7 +4,7 @@ licenses(["notice"])
 
 package(
     default_visibility = [
-        "//verilog/analysis:__subpackages__",
+        "//verilog:__subpackages__",
         # TODO(b/130113490): standalone preprocessor tool
     ],
 )

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -18,6 +18,10 @@
 #include "absl/status/status.h"
 #include "common/util/logging.h"
 
+static constexpr verilog::VerilogPreprocess::Config kPreprocessConfig{
+    .filter_branches = false,  // TODO(hzeller): switch on.
+};
+
 namespace verilog {
 static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
     absl::string_view filename, const verilog::VerilogAnalyzer &parser) {
@@ -37,7 +41,8 @@ ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
                            absl::string_view content)
     : version_(version),
       uri_(uri),
-      parser_(verilog::VerilogAnalyzer::AnalyzeAutomaticMode(content, uri)) {
+      parser_(verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
+          content, uri, kPreprocessConfig)) {
   LOG(INFO) << "Analyzed " << uri << " lex:" << parser_->LexStatus()
             << "; parser:" << parser_->ParseStatus() << std::endl;
   // TODO(hzeller): we should use a filename not URI; strip prefix.

--- a/verilog/tools/obfuscator/verilog_obfuscate.cc
+++ b/verilog/tools/obfuscator/verilog_obfuscate.cc
@@ -119,8 +119,8 @@ Output is written to stdout.
   const bool preserve_interface = absl::GetFlag(FLAGS_preserve_interface);
   if (preserve_interface) {
     std::set<std::string> preserved;
-    const auto status =
-        verilog::analysis::CollectInterfaceNames(content, &preserved);
+    const auto status = verilog::analysis::CollectInterfaceNames(
+        content, &preserved, verilog::VerilogPreprocess::Config());
     if (!status.ok()) {
       std::cerr << status.message();
       return 1;


### PR DESCRIPTION
Add VerilogPreprocess::Config to all analyzer convenience
methods, such as AnalyzeAutomaticMode() but as well as all
the excerpt parse methods, such as AnalyzeVerilogExpression(...).

Wire this up all the way to the tools where they are used (and tests),
but choose the safe preprocessor choice defaults for now, to be
changed later.

So no functional change right now, just preparation to make it
possible to choose configuration.

Signed-off-by: Henner Zeller <h.zeller@acm.org>