### PR TITLE
Always use branching preprocessing with the syntax checker.

### DIFF
--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -298,8 +298,11 @@ int main(int argc, char** argv) {
       continue;
     }
 
-    // TODO(hzeller): make preprocessing configurable with flags.
-    const verilog::VerilogPreprocess::Config preprocess_config;
+    // TODO(hzeller): is there ever a situation in which we do not want
+    // to use the preprocessor ?
+    const verilog::VerilogPreprocess::Config preprocess_config{
+        .filter_branches = true,
+    };
     json file_json;
     int file_status =
         AnalyzeOneFile(content, filename, preprocess_config, &file_json);


### PR DESCRIPTION
I was considering making this configurable via flags, but this is
a strong case of 'this should just do the right thing'.

We _might_ need to start allowing `+define+` command line options,
but that is on my short-list of things to implement.
