### PR TITLE
Linter: if needed, make two parse attempts with and w/o pp-branches.

### DIFF
--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -111,12 +111,14 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
   }
 
   // Lex and parse the contents of the file.
-  // TODO(hzeller): Chose preprocessing option. Maybe start with default
-  // to include as much as possible, but fall back to process `ifdef branches
-  // on syntax issues. For now: just the default.
-  static constexpr verilog::VerilogPreprocess::Config preprocess_config;
-  const auto analyzer = VerilogAnalyzer::AnalyzeAutomaticMode(
-      content, filename, preprocess_config);
+  // Attempt first to run without preprocessing to capture more information,
+  // but if that results in parse issues, filter out preprocessing branches
+  // as that is often the reason.
+  // TODO(hzeller): this behavior could be configurable, but then again this
+  //   is something the user is expecting to work as best as possible (which
+  //   is also why we use automatic mode).
+  const auto analyzer =
+      VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(content, filename);
   if (check_syntax) {
     const auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();
     const auto parse_status = analyzer->ParseStatus();

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -54,6 +54,10 @@ std::set<verible::LintViolationWithStatus> GetSortedViolations(
 // If 'lint_fatal' is true, exit nonzero on finding lint violations.
 // Returns an exit_code like status where 0 means success, 1 means some
 // errors were found (syntax, lint), and anything else is a fatal error.
+//
+// TODO(hzeller): the options to this function are a lot and many of them
+//   the same type does not help. Make at least the bool options a struct with
+//   names parameters.
 int LintOneFile(std::ostream* stream, absl::string_view filename,
                 const LinterConfiguration& config,
                 verible::ViolationHandler* violation_handler, bool check_syntax,


### PR DESCRIPTION
Parsing without filtering the preprocessing branches will work
most of the time and provide more 'material' for the linter to look
over. But if parsing fails in that case (because it can result
in invalid syntactic constructs), retry with preprocessing
branches enabled.

Signed-off-by: Henner Zeller <hzeller@google.com>