### PR TITLE
LanguageServer: Use parse fallback with preprocessing.

### DIFF
--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -33,22 +33,12 @@ static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
   return VerilogLintTextStructure(filename, config, text_structure);
 }
 
-static std::unique_ptr<verilog::VerilogAnalyzer> ParseWithPreprocessFallback(
-    absl::string_view content, absl::string_view file) {
-  std::unique_ptr<verilog::VerilogAnalyzer> parser;
-  for (bool preprocess_filter_branches : {false, true}) {
-    parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
-        content, file, {.filter_branches = preprocess_filter_branches});
-    if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) break;
-  }
-  return parser;
-}
-
 ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
                            absl::string_view content)
     : version_(version),
       uri_(uri),
-      parser_(ParseWithPreprocessFallback(content, uri)) {
+      parser_(verilog::VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(
+          content, uri)) {
   LOG(INFO) << "Analyzed " << uri << " lex:" << parser_->LexStatus()
             << "; parser:" << parser_->ParseStatus() << std::endl;
   // TODO(hzeller): we should use a filename not URI; strip prefix.

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -54,7 +54,7 @@ class ParsedBuffer {
  private:
   const int64_t version_;
   const std::string uri_;
-  std::unique_ptr<verilog::VerilogAnalyzer> parser_;
+  const std::unique_ptr<verilog::VerilogAnalyzer> parser_;
   std::vector<verible::LintRuleStatus> lint_statuses_;
 };
 


### PR DESCRIPTION
First attempt to parse without preprocessing to be able to
lint all preprocessing branches. However, if that fails (because
it sometimes might result in incomplete parse issues), attempt
to do the same parsing with preprocess branch filtering enabled.

Signed-off-by: Henner Zeller <hzeller@google.com>