### PR TITLE
Fixing syntax error on wire delay value 

### DIFF
--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5453,7 +5453,7 @@ net_declaration
                           MakePackedDimensionsNode($3),
                           $4, $5, $6); }
   | net_type delay3 net_variable_or_decl_assigns ';'
-  { $$ = MakeTaggedNode(N::kNetDeclaration, $1, $2, $3, $4); }
+  { $$ = MakeTaggedNode(N::kNetDeclaration, $1, nullptr, nullptr, $2, $3, $4); }
   /* TODO(fangism): net_type_identifer [ delay_control ] list_of_net_decl_assignments */
   /* TODO(fangism): TK_interconnect ... */
   ;

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5452,6 +5452,8 @@ net_declaration
     { $$ = MakeTaggedNode(N::kNetDeclaration, $1, $2,
                           MakePackedDimensionsNode($3),
                           $4, $5, $6); }
+  | net_type delay3 net_variable_or_decl_assigns ';'
+  { $$ = MakeTaggedNode(N::kNetDeclaration, $1, $2, $3, $4); }
   /* TODO(fangism): net_type_identifer [ delay_control ] list_of_net_decl_assignments */
   /* TODO(fangism): TK_interconnect ... */
   ;

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -1786,6 +1786,7 @@ static const ParserTestCaseArray kModuleTests = {
     "swimming bool;  // bool is an Icarus Verilog extension\n"
     "endmodule",
     // net declarations
+    "module m; wire #(100) x = y,z=k,foo; endmodule\n",
     "module m; wire signed foo; endmodule\n",
     "module m; wire signed [7:0] foo; endmodule\n",
     "module m; wire unsigned foo; endmodule\n",

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -1787,6 +1787,9 @@ static const ParserTestCaseArray kModuleTests = {
     "endmodule",
     // net declarations
     "module m; wire #(100) x = y,z=k,foo; endmodule\n",
+    "module m; wire #1.5 x = y; endmodule;\n"
+    "module m; wire #(100) x = y; endmodule;\n"
+    "module m; wire [1:0] #1 x = y; endmodule;\n"
     "module m; wire signed foo; endmodule\n",
     "module m; wire signed [7:0] foo; endmodule\n",
     "module m; wire unsigned foo; endmodule\n",


### PR DESCRIPTION
This PR introduces a fix for declaring a net with delay, which is allowed by LRM (A.2.1.3) as:
`net_declaration ::= net_type [...] data_type_or_implicit [delay3] list_of_net_decl_assignments ;`

Added test: 
```verilog
module m; 
wire #(100) x = y,z=k,foo; 
endmodule
```
Proposed modification to 'verilog.y' grammer:

- 'net_declaration' rule now accepts:
` net_type delay3 net_variable_or_decl_assigns ';'`

Explanation:
'net_declaration' rule accepts  ` net_type data_type_or_implicit net_variable_or_decl_assigns ';'`
Which pares this line correctly
```verilog
wire  [12:0] #(100) x = y; 
```
Because 'data_type_or_implicit' accepts `decl_dimensions delay3_or_drive_opt`
Notice 'decl_dimensions' is not optional here, so removing it causes a problem.
An easy workaround would be to add a new rule for 'net_declaration' that works for this line only.

Issues fixed: [271](https://github.com/chipsalliance/verible/issues/271)

