### PR TITLE
Provide a automatic analyze with preprocess branch filter fallback.

### DIFF
--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -205,6 +205,19 @@ std::unique_ptr<VerilogAnalyzer> VerilogAnalyzer::AnalyzeAutomaticMode(
   return analyzer;
 }
 
+std::unique_ptr<VerilogAnalyzer>
+VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(absl::string_view text,
+                                                    absl::string_view name) {
+  std::unique_ptr<verilog::VerilogAnalyzer> parser;
+  for (bool preprocess_filter_branches : {false, true}) {
+    parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
+        text, name, {.filter_branches = preprocess_filter_branches});
+    if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) break;
+    VLOG(1) << "Retry parsing with filter branches enabled";
+  }
+  return parser;
+}
+
 void VerilogAnalyzer::FilterTokensForSyntaxTree() {
   data_.FilterTokens(&VerilogLexer::KeepSyntaxTreeTokens);
 }

--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -68,6 +68,13 @@ class VerilogAnalyzer : public verible::FileAnalyzer {
       absl::string_view text, absl::string_view name,
       const VerilogPreprocess::Config& preprocess_config);
 
+  // Automatically analyze with correct parsing mode like AnalyzeAutomaticMode()
+  // but attempt first with preprocessor disabled to get as complete as
+  // possible parse tree; if this yields to syntax errors, fall back to
+  // enabling preprocess branches.
+  static std::unique_ptr<VerilogAnalyzer> AnalyzeAutomaticPreprocessFallback(
+      absl::string_view text, absl::string_view name);
+
   const VerilogPreprocessData& PreprocessorData() const {
     return preprocessor_data_;
   }


### PR DESCRIPTION
The new AnalyzeAutomaticPreprocessFallback() is attempting to

  1) Parse fully with all preprocess branches enabled. If that
     results into a syntax error, possibly due to incomplete
     resulting SystemVerilog statements, proceed to
  2) Parse, but filter out preprocessing branches.

Doing (1) first allows to retain as much as possible information
in the parse tree (useful in many contexts from linting to
language server), but the fallback to (2) allows to cover more
cases.

This then can be used in #1290 #1293 and #1294

Signed-off-by: Henner Zeller <h.zeller@acm.org>