### PR TITLE
Update zlib package from 1.2.11 to 1.2.12

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,9 +125,9 @@ http_archive(
 http_archive(
     name = "net_zlib",
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    strip_prefix = "zlib-1.2.11",
-    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+    sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+    strip_prefix = "zlib-1.2.12",
+    urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
 )
 
 http_archive(


### PR DESCRIPTION
The previous version is no longer available for download and breaks builds.