### PR TITLE
Add more stable URL to zlib sources.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,7 +127,10 @@ http_archive(
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
     sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
     strip_prefix = "zlib-1.2.12",
-    urls = ["https://zlib.net/zlib-1.2.12.tar.gz"],
+    urls = [
+        "https://zlib.net/zlib-1.2.12.tar.gz",
+        "https://zlib.net/fossils/zlib-1.2.12.tar.gz",
+    ],
 )
 
 http_archive(


### PR DESCRIPTION
The main URL to zlib sources from zlib.net
(https://zlib.net/zlib-1.2.12.tar.gz) will probably stop working after
new release. This is what happened with the URL to version 1.2.11.

https://zlib.net/fossils/ contains packages for versions released since
1995, so I assume the link to a package in this directory will be more
stable.