### PR TITLE
smoke test was expecting less failures

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -130,12 +130,12 @@ declare -A ExpectedFailCount
 
 ExpectedFailCount[syntax:ibex]=13
 ExpectedFailCount[lint:ibex]=13
-ExpectedFailCount[project:ibex]=172
+ExpectedFailCount[project:ibex]=173
 
-ExpectedFailCount[syntax:opentitan]=27
-ExpectedFailCount[lint:opentitan]=27
+ExpectedFailCount[syntax:opentitan]=28
+ExpectedFailCount[lint:opentitan]=28
 ExpectedFailCount[formatter:opentitan]=1
-ExpectedFailCount[project:opentitan]=648
+ExpectedFailCount[project:opentitan]=650
 
 ExpectedFailCount[project:Cores-SweRV]=21
 


### PR DESCRIPTION
Description:
Updates smoke test expected failures.

Changes:
- `project:ibex`: 173 instead of 172
- `syntax:opentitan`: 28 instead of 27
- `lint:opentitan`: 28 instead of 27
- `project:opentitan`: 650 instead of 648


Fixes: [#1308](https://github.com/chipsalliance/verible/issues/1308)

