### PR TITLE
Get bash from /usr/bin/env instead of hard-coded path /bin/bash

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/generate-coverage-html.sh
+++ b/.github/bin/generate-coverage-html.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/github-pages-setup.sh
+++ b/.github/bin/github-pages-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/github-releases-setup.sh
+++ b/.github/bin/github-releases-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/install-bazel.sh
+++ b/.github/bin/install-bazel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/install-kythe.sh
+++ b/.github/bin/install-kythe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/install-python.sh
+++ b/.github/bin/install-python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/make-compilation-db.sh
+++ b/.github/bin/make-compilation-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/run-clang-format.sh
+++ b/.github/bin/run-clang-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/run-kythe.sh
+++ b/.github/bin/run-kythe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/set-compiler.sh
+++ b/.github/bin/set-compiler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- mode: sh; sh-basic-offset: 2; indent-tabs-mode: nil; -*-
 # Copyright 2021 The Verible Authors.
 #

--- a/.github/bin/verify-kythe-extraction.sh
+++ b/.github/bin/verify-kythe-extraction.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/settings.sh
+++ b/.github/settings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bazel/sh_test_with_runfiles_lib.sh
+++ b/bazel/sh_test_with_runfiles_lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/lsp/dummy-ls_test.sh
+++ b/common/lsp/dummy-ls_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/parser/move_yacc_stack_symbols.sh
+++ b/common/parser/move_yacc_stack_symbols.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/parser/record_syntax_error.sh
+++ b/common/parser/record_syntax_error.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/tools/patch_tool_test.sh
+++ b/common/tools/patch_tool_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/tools/verible-transform-interactive-test.sh
+++ b/common/tools/verible-transform-interactive-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/tools/verible-transform-interactive.sh
+++ b/common/tools/verible-transform-interactive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # verible-transform-interactive.sh
 #
 # Copyright 2020 The Verible Authors.

--- a/common/util/create_version_header.sh
+++ b/common/util/create_version_header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/kythe-browse.sh
+++ b/kythe-browse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/diff/diff_format_lex_error_test.sh
+++ b/verilog/tools/diff/diff_format_lex_error_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/diff/diff_format_match_test.sh
+++ b/verilog/tools/diff/diff_format_match_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/diff/diff_format_mismatch_test.sh
+++ b/verilog/tools/diff/diff_format_mismatch_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/diff/diff_obfuscate_match_test.sh
+++ b/verilog/tools/diff/diff_obfuscate_match_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/diff/diff_obfuscate_mismatch_test.sh
+++ b/verilog/tools/diff/diff_obfuscate_mismatch_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/diff/diff_user_errors_test.sh
+++ b/verilog/tools/diff/diff_user_errors_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/diff_formatter.sh
+++ b/verilog/tools/formatter/diff_formatter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_file_badlines_test.sh
+++ b/verilog/tools/formatter/format_file_badlines_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_file_lex_error_test.sh
+++ b/verilog/tools/formatter/format_file_lex_error_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_file_lines_test.sh
+++ b/verilog/tools/formatter/format_file_lines_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_file_syntax_error_test.sh
+++ b/verilog/tools/formatter/format_file_syntax_error_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_file_test.sh
+++ b/verilog/tools/formatter/format_file_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_inplace_test.sh
+++ b/verilog/tools/formatter/format_inplace_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_stdin_inplace_test.sh
+++ b/verilog/tools/formatter/format_stdin_inplace_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/format_stdin_test.sh
+++ b/verilog/tools/formatter/format_stdin_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/git-verible-verilog-format.sh
+++ b/verilog/tools/formatter/git-verible-verilog-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # git-verible-verilog-format.sh
 #
 # Copyright 2020 The Verible Authors.

--- a/verilog/tools/formatter/triage_formatter.sh
+++ b/verilog/tools/formatter/triage_formatter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/formatter/verible-verilog-format-changed-lines-interactive.sh
+++ b/verilog/tools/formatter/verible-verilog-format-changed-lines-interactive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # verible-verilog-format-changed-lines-interactive.sh.
 
 # Copyright 2020 The Verible Authors.

--- a/verilog/tools/kythe/verification_test.sh
+++ b/verilog/tools/kythe/verification_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Google LLC.
 # SPDX-License-Identifier: Apache-2.0

--- a/verilog/tools/kythe/verilog_kythe_extractor_test.sh
+++ b/verilog/tools/kythe/verilog_kythe_extractor_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/lint/lint_tool_test.sh
+++ b/verilog/tools/lint/lint_tool_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/lint/show_line_col.sh
+++ b/verilog/tools/lint/show_line_col.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/ls/verible-verilog-ls_test.sh
+++ b/verilog/tools/ls/verible-verilog-ls_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2021 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/obfuscator/obfuscate_test.sh
+++ b/verilog/tools/obfuscator/obfuscate_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/preprocessor/verilog_preprocessor_test.sh
+++ b/verilog/tools/preprocessor/verilog_preprocessor_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/project/project_tool_test.sh
+++ b/verilog/tools/project/project_tool_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/syntax/triage_parser.sh
+++ b/verilog/tools/syntax/triage_parser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # Copyright 2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/verilog/tools/syntax/verilog_syntax_test.sh
+++ b/verilog/tools/syntax/verilog_syntax_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In Posix-compliant systems, bash is not guaranteed to be installed
in /bin/bash; but if it is installed, it can be queried with
/usr/bin/env

Signed-off-by: Henner Zeller <h.zeller@acm.org>