### PR TITLE
SymbolTable: provide more detailed information about re-defined symbols.

### DIFF
--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -132,8 +132,21 @@ LineColumnRange TextStructureView::GetRangeForToken(
     const LineColumn eofPos = GetLineColAtOffset(Contents().length());
     return {eofPos, eofPos};
   }
+  // TODO(hzeller): This should simply be GetRangeForText(token.text()),
+  // but the more thorough error checking in GetRangeForText()
+  // exposes a token overrun in verilog_analyzer_test.cc
+  // Defer to fix in separate change.
   return {GetLineColAtOffset(token.left(Contents())),
           GetLineColAtOffset(token.right(Contents()))};
+}
+
+LineColumnRange TextStructureView::GetRangeForText(
+    absl::string_view text) const {
+  const int from = std::distance(Contents().begin(), text.begin());
+  const int to = std::distance(Contents().begin(), text.end());
+  CHECK_GE(from, 0) << '"' << text << '"';
+  CHECK_LT(to, Contents().length()) << '"' << text << '"';
+  return {GetLineColAtOffset(from), GetLineColAtOffset(to)};
 }
 
 TokenRange TextStructureView::TokenRangeOnLine(size_t lineno) const {

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -145,7 +145,7 @@ LineColumnRange TextStructureView::GetRangeForText(
   const int from = std::distance(Contents().begin(), text.begin());
   const int to = std::distance(Contents().begin(), text.end());
   CHECK_GE(from, 0) << '"' << text << '"';
-  CHECK_LT(to, Contents().length()) << '"' << text << '"';
+  CHECK_LE(to, Contents().length()) << '"' << text << '"';
   return {GetLineColAtOffset(from), GetLineColAtOffset(to)};
 }
 

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -107,6 +107,10 @@ class TextStructureView {
   // Convenience function: Given the token, return the range it covers.
   LineColumnRange GetRangeForToken(const TokenInfo& token) const;
 
+  // Convenience function: Given a text snippet, that needs to be a substring
+  // of Contents(), return the range it covers.
+  LineColumnRange GetRangeForText(absl::string_view text) const;
+
   const std::vector<TokenSequence::const_iterator>& GetLineTokenMap() const {
     return line_token_map_;
   }

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -226,13 +226,24 @@ TEST_F(TokenRangeTest, GetRangeOfTokenEofTokenAcceptedUniversally) {
 TEST_F(TokenRangeTest, GetRangeForTokenOrText) {
   const TokenInfo& token = data_.FindTokenAt({0, 7});
   EXPECT_EQ(token.text(), "world");
-  const LineColumnRange token_range = data_.GetRangeForToken(token);
-  EXPECT_EQ(token_range.start.line, 0);
-  EXPECT_EQ(token_range.start.column, 7);
+  {  // Extract from token
+    const LineColumnRange range = data_.GetRangeForToken(token);
+    EXPECT_EQ(range.start.line, 0);
+    EXPECT_EQ(range.start.column, 7);
+  }
+  {  // Extract from token text
+    const LineColumnRange range = data_.GetRangeForText(token.text());
+    EXPECT_EQ(range.start.line, 0);
+    EXPECT_EQ(range.start.column, 7);
+  }
 
-  const LineColumnRange text_range = data_.GetRangeForText(token.text());
-  EXPECT_EQ(text_range.start.line, 0);
-  EXPECT_EQ(text_range.start.column, 7);
+  {  // Entire text range
+    const LineColumnRange range = data_.GetRangeForText(data_.Contents());
+    EXPECT_EQ(range.start.line, 0);
+    EXPECT_EQ(range.start.column, 0);
+    EXPECT_EQ(range.end.line, data_.Lines().size() - 1);
+    EXPECT_EQ(range.end.column, data_.Lines().back().length());
+  }
 }
 
 TEST_F(TokenRangeTest, FindTokenAtPosition) {

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -216,6 +216,25 @@ TEST_F(TokenRangeTest, GetRangeOfTokenVerifyAllRangesExclusive) {
   }
 }
 
+TEST_F(TokenRangeTest, GetRangeOfTokenEofTokenAcceptedUniversally) {
+  // For the EOF token, the returned range should automatically be relative
+  // to the TextView no matter where it comes from.
+  EXPECT_EQ(data_.GetRangeForToken(data_.EOFToken()),
+            data_.GetRangeForToken(TokenInfo::EOFToken()));
+}
+
+TEST_F(TokenRangeTest, GetRangeForTokenOrText) {
+  const TokenInfo& token = data_.FindTokenAt({0, 7});
+  EXPECT_EQ(token.text(), "world");
+  const LineColumnRange token_range = data_.GetRangeForToken(token);
+  EXPECT_EQ(token_range.start.line, 0);
+  EXPECT_EQ(token_range.start.column, 7);
+
+  const LineColumnRange text_range = data_.GetRangeForText(token.text());
+  EXPECT_EQ(text_range.start.line, 0);
+  EXPECT_EQ(text_range.start.column, 7);
+}
+
 TEST_F(TokenRangeTest, FindTokenAtPosition) {
   EXPECT_EQ(data_.FindTokenAt({0, 0}).text(), "hello");
   EXPECT_EQ(data_.FindTokenAt({0, 4}).text(), "hello");
@@ -229,13 +248,6 @@ TEST_F(TokenRangeTest, FindTokenAtPosition) {
   // Graceful handling of values out of range: EOF
   EXPECT_TRUE(data_.FindTokenAt({-1, -1}).isEOF());
   EXPECT_TRUE(data_.FindTokenAt({42, 7}).isEOF());
-}
-
-TEST_F(TokenRangeTest, GetRangeOfTokenEofTokenAcceptedUniversally) {
-  // For the EOF token, the returned range should automatically be relative
-  // to the TextView no matter where it comes from.
-  EXPECT_EQ(data_.GetRangeForToken(data_.EOFToken()),
-            data_.GetRangeForToken(TokenInfo::EOFToken()));
 }
 
 // Checks that when lower == upper, returned range is empty.

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -2575,9 +2575,9 @@ TEST(BuildSymbolTableTest, ModuleExplicitAndImplicitDeclarations) {
 
 TEST(BuildSymbolTableTest, ModuleImplicitRedeclared) {
   TestVerilogSourceFile src("foo.sv",
-                            "module m;"
-                            "assign a = 1'b0;"
-                            "wire a;"
+                            "module m;\n"
+                            "assign a = 1'b0;\n"
+                            "wire a;\n"
                             "endmodule\n");
   const auto status = src.Parse();
   ASSERT_TRUE(status.ok()) << status.message();
@@ -2587,7 +2587,8 @@ TEST(BuildSymbolTableTest, ModuleImplicitRedeclared) {
   EXPECT_EQ(build_diagnostics.size(), 1);
   EXPECT_FALSE(build_diagnostics.front().ok());
   EXPECT_EQ(build_diagnostics.front().message(),
-            "Symbol \"a\" is already defined in the $root::m scope.");
+            "foo.sv:3:6: Symbol \"a\" is already defined in the $root::m scope "
+            "at 2:8:");
 }
 
 TEST(BuildSymbolTableTest, ClassDeclarationSingle) {


### PR DESCRIPTION
Provide location of new and previous definition of a symbol that
is found out to be re-defined.

Signed-off-by: Henner Zeller <hzeller@google.com>