### PR TITLE
[WIP] implementing ExpandMacro method in the preprocessor

### DIFF
--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -105,6 +105,8 @@ class MacroDefinition {
   // Create a text substitution map to be used for macro expansion.
   absl::Status PopulateSubstitutionMap(const std::vector<TokenInfo>&,
                                        substitution_map_type*) const;
+  absl::Status PopulateSubstitutionMap(const std::vector<DefaultTokenInfo>&,
+                                       substitution_map_type*) const;
 
   // Replace formal parameter references with actuals.
   static const TokenInfo& SubstituteText(const substitution_map_type&,

--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -86,9 +86,13 @@ class MacroDefinition {
   void SetDefinitionText(const TokenInfo& t) { definition_text_ = t; }
 
   // Lexes the definition_text_ and store it in lexed_macro_body
-  void SetLexedDefinitionText(const std::vector<TokenInfo> l) {lexed_macro_body = l ;} 
+  void SetLexedDefinitionTokens(const std::vector<TokenInfo>& l) {
+    lexed_definition_tokens_ = l;
+  }
 
-  const std::vector<TokenInfo>& GetLexedDefinitionText() const { return lexed_macro_body; }
+  const std::vector<TokenInfo>& GetLexedDefinitionText() const {
+    return lexed_definition_tokens_;
+  }
 
   // Macro definitions with empty () should call this.
   void SetCallable() { is_callable_ = true; }
@@ -132,8 +136,7 @@ class MacroDefinition {
 
   // un-tokenized text
   DefaultTokenInfo definition_text_;
-  std::vector<TokenInfo> lexed_macro_body;
-
+  std::vector<TokenInfo> lexed_definition_tokens_;
 };
 
 }  // namespace verible

--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -85,6 +85,11 @@ class MacroDefinition {
 
   void SetDefinitionText(const TokenInfo& t) { definition_text_ = t; }
 
+  // Lexes the definition_text_ and store it in lexed_macro_body
+  void SetLexedDefinitionText(const std::vector<TokenInfo> l) {lexed_macro_body = l ;} 
+
+  const std::vector<TokenInfo>& GetLexedDefinitionText() const { return lexed_macro_body; }
+
   // Macro definitions with empty () should call this.
   void SetCallable() { is_callable_ = true; }
 
@@ -127,6 +132,8 @@ class MacroDefinition {
 
   // un-tokenized text
   DefaultTokenInfo definition_text_;
+  std::vector<TokenInfo> lexed_macro_body;
+
 };
 
 }  // namespace verible

--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -85,15 +85,6 @@ class MacroDefinition {
 
   void SetDefinitionText(const TokenInfo& t) { definition_text_ = t; }
 
-  // Lexes the definition_text_ and store it in lexed_macro_body
-  void SetLexedDefinitionTokens(const std::vector<TokenInfo>& l) {
-    lexed_definition_tokens_ = l;
-  }
-
-  const std::vector<TokenInfo>& GetLexedDefinitionText() const {
-    return lexed_definition_tokens_;
-  }
-
   // Macro definitions with empty () should call this.
   void SetCallable() { is_callable_ = true; }
 
@@ -136,7 +127,6 @@ class MacroDefinition {
 
   // un-tokenized text
   DefaultTokenInfo definition_text_;
-  std::vector<TokenInfo> lexed_definition_tokens_;
 };
 
 }  // namespace verible

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -209,11 +209,17 @@ std::unique_ptr<VerilogAnalyzer>
 VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(absl::string_view text,
                                                     absl::string_view name) {
   std::unique_ptr<verilog::VerilogAnalyzer> parser;
-  for (bool preprocess_filter_branches : {false, true}) {
-    parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
-        text, name, {.filter_branches = preprocess_filter_branches});
-    if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) break;
-    VLOG(1) << "Retry parsing with filter branches enabled";
+  for(bool preprocess_expand_macros : {true, false}){
+    bool expand_macro_status=0;
+    for (bool preprocess_filter_branches : {false, true}) {
+      parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
+          text, name, {.filter_branches = preprocess_filter_branches,.expand_macros=preprocess_expand_macros});
+      if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) {expand_macro_status=1; break;}
+      VLOG(1) << "Retry parsing with filter branches enabled";
+    }
+    if(expand_macro_status) break;
+    VLOG(1) << "Retry parsing with macro expanding disabled";
+    
   }
   return parser;
 }

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -209,17 +209,21 @@ std::unique_ptr<VerilogAnalyzer>
 VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(absl::string_view text,
                                                     absl::string_view name) {
   std::unique_ptr<verilog::VerilogAnalyzer> parser;
-  for(bool preprocess_expand_macros : {true, false}){
-    bool expand_macro_status=0;
+  for (bool preprocess_expand_macros : {true, false}) {
+    bool expand_macro_status = 0;
     for (bool preprocess_filter_branches : {false, true}) {
       parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
-          text, name, {.filter_branches = preprocess_filter_branches,.expand_macros=preprocess_expand_macros});
-      if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) {expand_macro_status=1; break;}
+          text, name,
+          {.filter_branches = preprocess_filter_branches,
+           .expand_macros = preprocess_expand_macros});
+      if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) {
+        expand_macro_status = 1;
+        break;
+      }
       VLOG(1) << "Retry parsing with filter branches enabled";
     }
-    if(expand_macro_status) break;
+    if (expand_macro_status) break;
     VLOG(1) << "Retry parsing with macro expanding disabled";
-    
   }
   return parser;
 }

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -209,7 +209,7 @@ std::unique_ptr<VerilogAnalyzer>
 VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(absl::string_view text,
                                                     absl::string_view name) {
   std::unique_ptr<verilog::VerilogAnalyzer> parser;
-  for (bool preprocess_expand_macros : {true, false}) {
+  for (bool preprocess_expand_macros : {false, true}) {
     bool expand_macro_status = 0;
     for (bool preprocess_filter_branches : {false, true}) {
       parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
@@ -223,7 +223,7 @@ VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(absl::string_view text,
       VLOG(1) << "Retry parsing with filter branches enabled";
     }
     if (expand_macro_status) break;
-    VLOG(1) << "Retry parsing with macro expanding disabled";
+    VLOG(1) << "Retry parsing with macro expanding enabled";
   }
   return parser;
 }

--- a/verilog/preprocessor/BUILD
+++ b/verilog/preprocessor/BUILD
@@ -23,6 +23,7 @@ cc_library(
         "//common/util:logging",
         "//verilog/parser:verilog_parser",
         "//verilog/parser:verilog_token_enum",
+        "//verilog/parser:verilog_lexer",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -246,9 +246,9 @@ absl::Status VerilogPreprocess::ExpandMacro(MacroDefinition* definition) {
        lexer.DoNextToken()) {
     // handle lexical error
     const verible::TokenInfo& subtoken(lexer.GetLastToken());
-    myseq.push_back(std::move(subtoken));
+    myseq.push_back(subtoken);
   }
-  definition->SetLexedDefinitionTokens(std::move(myseq));
+  definition->SetLexedDefinitionTokens(myseq);
   return absl::OkStatus();
 }
 

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -136,8 +136,8 @@ class VerilogPreprocess {
   absl::Status HandleTokenIterator(TokenStreamView::const_iterator,
                                    const StreamIteratorGenerator&);
   absl::Status HandleMacroIdentifier(TokenStreamView::const_iterator,
-                                     const StreamIteratorGenerator&);
-  absl::Status HandleMacroIdentifier(verible::TokenInfo);
+                                     const StreamIteratorGenerator&,
+                                     bool forward);
 
   absl::Status HandleDefine(TokenStreamView::const_iterator,
                             const StreamIteratorGenerator&);

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -101,6 +101,8 @@ class VerilogPreprocess {
     // want to emit all tokens.
     bool filter_branches = false;
 
+    // Expand macro definition bodies, this will relexes the macro body.
+    bool expand_macros = false;
     // TODO(hzeller): Provide a map of command-line provided +define+'s
   };
 
@@ -154,7 +156,7 @@ class VerilogPreprocess {
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
   void RegisterMacroDefinition(const MacroDefinition&);
-  absl::Status ExpandMacro(MacroDefinition&);
+  absl::Status ExpandMacro(MacroDefinition*);
 
   const Config config_;
 

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -68,9 +68,11 @@ struct VerilogPreprocessError {
 struct VerilogPreprocessData {
   using MacroDefinition = verible::MacroDefinition;
   using MacroDefinitionRegistry = std::map<absl::string_view, MacroDefinition>;
+  using TokenSequence = std::vector<verible::TokenInfo>;
 
   // Resulting token stream after preprocessing
   verible::TokenStreamView preprocessed_token_stream;
+  std::vector<TokenSequence> lexed_macros_backup;
 
   // Map of defined macros.
   MacroDefinitionRegistry macro_definitions;
@@ -134,6 +136,7 @@ class VerilogPreprocess {
   absl::Status HandleTokenIterator(TokenStreamView::const_iterator,
                                    const StreamIteratorGenerator&);
   absl::Status HandleMacroIdentifier(TokenStreamView::const_iterator);
+  absl::Status HandleMacroIdentifier(verible::TokenInfo);
 
   absl::Status HandleDefine(TokenStreamView::const_iterator,
                             const StreamIteratorGenerator&);
@@ -156,7 +159,7 @@ class VerilogPreprocess {
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
   void RegisterMacroDefinition(const MacroDefinition&);
-  static absl::Status ExpandMacro(MacroDefinition*);
+  absl::Status ExpandMacro(const MacroDefinition&);
 
   const Config config_;
 

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -135,7 +135,8 @@ class VerilogPreprocess {
 
   absl::Status HandleTokenIterator(TokenStreamView::const_iterator,
                                    const StreamIteratorGenerator&);
-  absl::Status HandleMacroIdentifier(TokenStreamView::const_iterator);
+  absl::Status HandleMacroIdentifier(TokenStreamView::const_iterator,
+                                     const StreamIteratorGenerator&);
   absl::Status HandleMacroIdentifier(verible::TokenInfo);
 
   absl::Status HandleDefine(TokenStreamView::const_iterator,
@@ -148,6 +149,10 @@ class VerilogPreprocess {
   absl::Status HandleElse(TokenStreamView::const_iterator else_pos);
   absl::Status HandleEndif(TokenStreamView::const_iterator endif_pos);
 
+  static absl::Status ParseMacroCall(const StreamIteratorGenerator&,
+                                     verible::MacroCall*,
+                                     const verible::MacroDefinition&);
+
   // The following functions return nullptr when there is no error:
   absl::Status ConsumeMacroDefinition(const StreamIteratorGenerator&,
                                       TokenStreamView*);
@@ -159,7 +164,9 @@ class VerilogPreprocess {
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
   void RegisterMacroDefinition(const MacroDefinition&);
-  absl::Status ExpandMacro(const MacroDefinition&);
+  absl::Status ExpandMacro(const absl::string_view&);
+  absl::Status ExpandCallableMacro(const verible::MacroCall&,
+                                   const verible::MacroDefinition*);
 
   const Config config_;
 

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -149,9 +149,10 @@ class VerilogPreprocess {
   absl::Status HandleElse(TokenStreamView::const_iterator else_pos);
   absl::Status HandleEndif(TokenStreamView::const_iterator endif_pos);
 
-  static absl::Status ParseMacroCall(const StreamIteratorGenerator&,
-                                     verible::MacroCall*,
-                                     const verible::MacroDefinition&);
+  static absl::Status ConsumeAndParseMacroCall(TokenStreamView::const_iterator,
+                                               const StreamIteratorGenerator&,
+                                               verible::MacroCall*,
+                                               const verible::MacroDefinition&);
 
   // The following functions return nullptr when there is no error:
   absl::Status ConsumeMacroDefinition(const StreamIteratorGenerator&,
@@ -164,9 +165,9 @@ class VerilogPreprocess {
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
   void RegisterMacroDefinition(const MacroDefinition&);
-  absl::Status ExpandMacro(const absl::string_view&);
-  absl::Status ExpandCallableMacro(const verible::MacroCall&,
-                                   const verible::MacroDefinition*);
+  absl::Status ExpandText(const absl::string_view&);
+  absl::Status ExpandMacro(const verible::MacroCall&,
+                           const verible::MacroDefinition*);
 
   const Config config_;
 

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -131,6 +131,7 @@ class VerilogPreprocess {
 
   absl::Status HandleTokenIterator(TokenStreamView::const_iterator,
                                    const StreamIteratorGenerator&);
+  absl::Status HandleMacroIdentifier(TokenStreamView::const_iterator);
 
   absl::Status HandleDefine(TokenStreamView::const_iterator,
                             const StreamIteratorGenerator&);
@@ -153,6 +154,7 @@ class VerilogPreprocess {
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
   void RegisterMacroDefinition(const MacroDefinition&);
+  absl::Status ExpandMacro(MacroDefinition&);
 
   const Config config_;
 

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -156,7 +156,7 @@ class VerilogPreprocess {
       TokenStreamView::const_iterator*, MacroParameterInfo*);
 
   void RegisterMacroDefinition(const MacroDefinition&);
-  absl::Status ExpandMacro(MacroDefinition*);
+  static absl::Status ExpandMacro(MacroDefinition*);
 
   const Config config_;
 

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -566,5 +566,209 @@ module baz(); endmodule
   }
 }
 
+TEST(VerilogPreprocessTest, MacroExpansion) {
+  const RawAndFiltered test_cases[] = {
+      {"[** Multi-tokens macros being correctly parsed **]",
+       R"(
+`define ASSIGN1 =1
+`define ASSIGN0 =0
+module foo;
+wire x`ASSIGN1;
+wire y `ASSIGN0;
+endmodule)",
+       // ...equivalent to
+       R"(
+`define ASSIGN1 =1
+`define ASSIGN0 =0
+module foo;
+wire x =1;
+wire y =0;
+endmodule)"},
+
+      {"[** Multi-tokens macros not empty after undefing **]",
+       R"(
+`define XWIRE wire x
+`define YWIRE wire y
+module foo;
+`XWIRE = 1;
+`YWIRE = 0;
+endmodule
+`undef XWIRE
+`undef YWIRE)",
+       // ...equivalent to
+       R"(
+`define XWIRE wire x
+`define YWIRE wire y
+module foo;
+wire x = 1;
+wire y = 0;
+endmodule
+`undef XWIRE
+`undef YWIRE)"},
+
+      {"[** Macros that contain other macro calls, redefining the inner macro "
+       "**]",
+       R"(
+`define XWIRE wire x
+`define YWIRE wire y
+`define ASSIGN1XWIRE `XWIRE = 1;
+`define ASSIGN0YWIRE `YWIRE = 0;
+module foo;
+`ASSIGN1XWIRE
+`ASSIGN0YWIRE
+`define XWIRE wire new_x_wire
+`ASSIGN1XWIRE
+endmodule)",
+       // ...equivalent to
+       R"(
+`define XWIRE wire x
+`define YWIRE wire y
+`define ASSIGN1XWIRE `XWIRE = 1;
+`define ASSIGN0YWIRE `YWIRE = 0;
+module foo;
+wire x = 1;
+wire y = 0;
+`define XWIRE wire new_x_wire
+wire new_x_wire = 1;
+endmodule)"},
+
+      {"[** Macros contatining back to back macro calls **]",
+       R"(
+`define XWIRE wire x
+`define YWIRE wire y
+`define ASSIGN1 = 1
+`define ASSIGN0 = 0
+`define ASSIGN1XWIRE `XWIRE `ASSIGN1;
+`define ASSIGN0YWIRE `YWIRE `ASSIGN0;
+module foo;
+`ASSIGN1XWIRE
+`ASSIGN0YWIRE
+`define XWIRE wire new_x_wire
+`ASSIGN1XWIRE
+endmodule)",
+       // ...equivalent to
+       R"(
+`define XWIRE wire x
+`define YWIRE wire y
+`define ASSIGN1 = 1
+`define ASSIGN0 = 0
+`define ASSIGN1XWIRE `XWIRE `ASSIGN1;
+`define ASSIGN0YWIRE `YWIRE `ASSIGN0;
+module foo;
+wire x = 1;
+wire y = 0;
+`define XWIRE wire new_x_wire
+wire new_x_wire = 1;
+endmodule)"},
+
+      {"[** Macros with formal parameters, expanded with both default value, "
+       "and actual passed value **]",
+       R"(
+`define LSb(n=2) [n-1:0]
+module testcase_ppMacro;
+localparam int A = 123;
+wire a = A`LSb();
+wire b = A`LSb(5);
+wire c = A[5-1:0]; 
+endmodule)",
+       // ...equivalent to
+       R"(
+`define LSb(n=2) [n-1:0]
+module testcase_ppMacro;
+localparam int A = 123;
+wire a = A[2-1:0];
+wire b = A[5-1:0];
+wire c = A[5-1:0]; 
+endmodule)"},
+
+      {"[** Actual parameter is another macro call **]",
+       R"(
+`define FOO a
+`define A(n) n
+`define B(n=x) n ,y
+module m;
+wire `A(xyz);
+wire `B(`FOO);
+endmodule
+`undef B
+`undef A
+`undef FOO)",
+       // ...equivalent to
+       R"(
+`define FOO a
+`define A(n) n
+`define B(n=x) n ,y
+module m;
+wire xyz;
+wire a ,y;
+endmodule
+`undef B
+`undef A
+`undef FOO)"},
+
+      {"[** Multiple parameter macros (From 2017 SV-LRM) **]",
+       R"(
+`define MACRO1(a=5,b="B",c) $display(a,,b,,c);
+`define MACRO2(a=5, b, c="C") $display(a,,b,,c);
+`define MACRO3(a=5, b=0, c="C") $display(a,,b,,c);
+module m;
+`MACRO1 ( , 2, 3 )
+`MACRO1 ( 1 , , 3 ) 
+`MACRO1 ( , 2, )
+`MACRO2 (1, , 3)
+`MACRO2 (, 2, )
+`MACRO2 (, 2)
+`MACRO3 ( 1 )
+`MACRO3 ()
+endmodule
+`undef MACRO)",
+       // ...equivalent to
+       R"(
+`define MACRO1(a=5,b="B",c) $display(a,,b,,c);
+`define MACRO2(a=5, b, c="C") $display(a,,b,,c);
+`define MACRO3(a=5, b=0, c="C") $display(a,,b,,c);
+module m;
+$display(5,,2,,3);
+$display(1,,"B",,3);
+$display(5,,2,,);
+$display(1,,,,3);
+$display(5,,2,,"C");
+$display(5,,2,,"C");
+$display(1,,0,,"C");
+$display(5,,0,,"C");
+endmodule
+`undef MACRO)"}
+
+  };
+
+  for (const auto& test_case : test_cases) {
+    PreprocessorTester expanded(
+        test_case.pp_input, VerilogPreprocess::Config({.expand_macros = true}));
+    EXPECT_TRUE(expanded.Status().ok())
+        << expanded.Status() << " " << test_case.description;
+    PreprocessorTester equivalent(
+        test_case.equivalent,
+        VerilogPreprocess::Config({.expand_macros = false}));
+    EXPECT_TRUE(equivalent.Status().ok())
+        << equivalent.Status() << " " << test_case.description;
+    const auto& expanded_stream = expanded.Data().GetTokenStreamView();
+    const auto& equivalent_stream = equivalent.Data().GetTokenStreamView();
+    EXPECT_GT(expanded_stream.size(), 0) << test_case.description;
+    EXPECT_EQ(expanded_stream.size(), equivalent_stream.size())
+        << test_case.description;
+    auto expanded_it = expanded_stream.begin();
+    auto equivalent_it = equivalent_stream.begin();
+    while (expanded_it != expanded_stream.end() &&
+           equivalent_it != equivalent_stream.end()) {
+      EXPECT_EQ((*expanded_it)->text(), (*equivalent_it)->text())
+          << test_case.description;
+      EXPECT_EQ((*expanded_it)->token_enum(), (*equivalent_it)->token_enum())
+          << test_case.description;
+      ++expanded_it;
+      ++equivalent_it;
+    }
+  }
+}
+
 }  // namespace
 }  // namespace verilog

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -737,7 +737,28 @@ $display(5,,2,,"C");
 $display(1,,0,,"C");
 $display(5,,0,,"C");
 endmodule
-`undef MACRO)"}
+`undef MACRO)"},
+
+      {"[** Nested callable macros **]",
+       R"(
+`define MACRO1(n) real x=n;
+`define MACRO2(m) real y=m; `MACRO1(1)
+module foo;
+`MACRO1(2)
+`MACRO2(3)
+endmodule
+`undef MACRO1
+`undef MACRO2)",
+       // ...equivalent to
+       R"(
+`define MACRO1(n) real x=n;
+`define MACRO2(m) real y=m; `MACRO1(1)
+module foo;
+real x=2;
+real y=3; real x=1;
+endmodule
+`undef MACRO1
+`undef MACRO2)"}
 
   };
 


### PR DESCRIPTION
**Description:**
This PR introduces a way to handle macro calls, instead of substituting the macro identifier with the definition text (`PP_define_body` token), the preprocessor re-lexes the definition text, and feed the new lexed tokens to the next stage (parser by default).

**Example:**
```verilog
`define DELAY #100
module m;
     wire `DELAY x=y;
endmodule
````
Old behavior:
`DELAY` is substituted with a ``PP_define_body`` token, then parser matches it to a  `GenericIdentifier`.

New behavior:
`DELAY` is substituted with 2 token describing `#` and `100`


**Changes:**

- `MacroDefinition`:
  - Added a field to save the lexed macro definitions as a vector of tokens
  - Added two methods to set/ get this field.
- `VerilogPreprocess`:
  - Added `HandleMacroIdentifier` method which searches for the macro definition, and if found, it will add the lexed body to the preprocessor stream view.
  - Added `ExpandMacro` method which lexes the macro body, and then sets the `MacroDefinition`'s `lexed_macro_body`.
  - `HandleTokenIterator`:
    - if a token is `MacroIdentifier` or `MacroIdItem` then call `HandleMacroIdentifier`.
  - `HandleDefine`:
    - if the macro is callable (contains parameters) then `ExpandMacro` is not ready for it.

**To-Do list:**

- [x] Apply clang-format.
- [x] Add new testcases (I am currently testing by building, then using the lint tool)
- [x] These changes introduced many errors in the test suite, still investigating these errors.
- [x] In case there is an \`undef to an expanded macro, it is deleted too from the preprocessor stream view, because it is just pointing to its address as saved in `MacroDefinition`.
- [x] For now, only use this new approach when a macro is expanded directly into the SV main code, not inside another macro, or preprocessor directive (I think these are most of the cases that fail in the test suite).
- [x] I think it is not totally correct to expand the macro once it's defined, but it should be expanded (and lexed) on calls, e.g.
```verilog
`define FIRST 1
`define SECOND `FIRST
`define FIRST 2
````
Calling `SECOND` should be expanded to `2`, not `1`.

**Future Work:**
- [x] Handle the callable macros.
- [x] Handle the nested macros.

**Fixes:** 
Issue [#1208](https://github.com/chipsalliance/verible/issues/1208)
