### PR TITLE
ExpandableTreeView: Add support for tree types other than VectorTree.

### DIFF
--- a/common/util/expandable_tree_view_test.cc
+++ b/common/util/expandable_tree_view_test.cc
@@ -31,7 +31,8 @@ using ::testing::ElementsAre;
 using verible::testing::NamedInterval;
 using verible::testing::VectorTreeTestType;
 
-using ExpandableTreeViewTestType = ExpandableTreeView<NamedInterval>;
+using ExpandableTreeViewTestType =
+    ExpandableTreeView<VectorTree<NamedInterval>>;
 
 // Test that basic Tree View operations work on a singleton node.
 TEST(ExpandableTreeViewTest, RootOnly) {
@@ -250,7 +251,8 @@ TEST(ExpandableTreeViewTest, FamilyTreeApplyPreOrder) {
 
   std::vector<absl::string_view> visit_order;
   tree_view.ApplyPreOrder(
-      [=, &visit_order](VectorTree<TreeViewNodeInfo<NamedInterval>>& node) {
+      [=, &visit_order](
+          VectorTree<TreeViewNodeInfo<VectorTree<NamedInterval>>>& node) {
         const absl::string_view name = node.Value().Value().name;
         visit_order.push_back(name);
         if (name[0] == 'p') {
@@ -282,7 +284,8 @@ TEST(ExpandableTreeViewTest, FamilyTreeApplyPostOrder) {
 
   std::vector<absl::string_view> visit_order;
   tree_view.ApplyPostOrder(
-      [=, &visit_order](VectorTree<TreeViewNodeInfo<NamedInterval>>& node) {
+      [=, &visit_order](
+          VectorTree<TreeViewNodeInfo<VectorTree<NamedInterval>>>& node) {
         const absl::string_view name = node.Value().Value().name;
         visit_order.push_back(name);
         if (name[0] == 'p' && name.back() == '1') {

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -71,7 +71,7 @@ using verible::UnwrappedLine;
 using verible::VectorTree;
 using verible::VectorTreeLeavesIterator;
 
-typedef VectorTree<TreeViewNodeInfo<UnwrappedLine>> partition_node_type;
+typedef VectorTree<TreeViewNodeInfo<TokenPartitionTree>> partition_node_type;
 
 // Takes a TextStructureView and FormatStyle, and formats UnwrappedLines.
 class Formatter {
@@ -556,7 +556,7 @@ static std::vector<UnwrappedLine> MakeUnwrappedLinesWorklist(
     const TokenPartitionTree& format_tokens_partitions,
     std::vector<verible::PreFormatToken>* preformatted_tokens) {
   // Initialize a tree view that treats partitions as fully-expanded.
-  ExpandableTreeView<UnwrappedLine> format_tokens_partition_view(
+  ExpandableTreeView<TokenPartitionTree> format_tokens_partition_view(
       format_tokens_partitions);
 
   // For unwrapped lines that fit, don't bother expanding their partitions.


### PR DESCRIPTION
Since tree methods are now generic, there's no reason to limit `ExpandableTreeView` to `VectorTree` class.