### PR TITLE
Simplify style guide citations: just have one topic.

### DIFF
--- a/common/analysis/citation.cc
+++ b/common/analysis/citation.cc
@@ -20,10 +20,4 @@ namespace verible {
 std::string GetStyleGuideCitation(absl::string_view topic) {
   return absl::StrCat("[Style: ", topic, "]");
 }
-
-// Return a reference to some verification style citation for the given topic.
-std::string GetVerificationCitation(absl::string_view topic) {
-  return absl::StrCat("[Verification-Style: ", topic, "]");
-}
-
 }  // namespace verible

--- a/common/analysis/citation.h
+++ b/common/analysis/citation.h
@@ -23,10 +23,6 @@ namespace verible {
 // Given a styleguide topic, return a reference to some styleguide
 // citation for the given topic (e.g. just the topic-name or an URL).
 std::string GetStyleGuideCitation(absl::string_view topic);
-
-// Given a verification styleguide topic, return a reference to
-// a citation (e.g. just the topic-name or an URL).
-std::string GetVerificationCitation(absl::string_view topic);
 }  // namespace verible
 
 #endif  // VERIBLE_COMMON_ANALYSIS_CITATION_H_

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -157,9 +157,7 @@ struct LintRuleStatus {
   LintRuleStatus(const std::set<LintViolation>& vs,
                  const Descriptor& descriptor)
       : lint_rule_name(descriptor.name),
-        url(!descriptor.dv_topic.empty()
-                ? GetVerificationCitation(descriptor.dv_topic)
-                : GetStyleGuideCitation(descriptor.topic)),
+        url(GetStyleGuideCitation(descriptor.topic)),
         violations(vs) {}
 
   explicit LintRuleStatus(const std::set<LintViolation>& vs) : violations(vs) {}

--- a/verilog/analysis/checkers/create_object_name_match_rule.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule.cc
@@ -56,7 +56,7 @@ VERILOG_REGISTER_LINT_RULE(CreateObjectNameMatchRule);
 const LintRuleDescriptor& CreateObjectNameMatchRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "create-object-name-match",
-      .dv_topic = "naming",
+      .topic = "uvm-naming",
       .desc =
           "Checks that the 'name' argument of `type_id::create()` "
           "matches the name of the variable to which it is assigned.",

--- a/verilog/analysis/checkers/forbidden_macro_rule.cc
+++ b/verilog/analysis/checkers/forbidden_macro_rule.cc
@@ -36,7 +36,7 @@
 namespace verilog {
 namespace analysis {
 
-using verible::GetVerificationCitation;
+using verible::GetStyleGuideCitation;
 using verible::container::FindWithDefault;
 using verible::matcher::Matcher;
 
@@ -47,7 +47,7 @@ VERILOG_REGISTER_LINT_RULE(ForbiddenMacroRule);
 const LintRuleDescriptor& ForbiddenMacroRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "forbidden-macro",
-      .dv_topic = "logging",
+      .topic = "uvm-logging",
       .desc = "Checks that no forbidden macro calls are used.",
   };
   return d;
@@ -62,9 +62,9 @@ static const Matcher& MacroCallMatcher() {
 // Set of invalid macros and URLs
 const std::map<std::string, std::string>&
 ForbiddenMacroRule::InvalidMacrosMap() {
-  // TODO(hzeller): don't use GetVerificationCitation here, more downstream.
+  // TODO(hzeller): don't use GetStyleGuideCitation here, more downstream.
   static const auto* invalid_symbols = new std::map<std::string, std::string>({
-      {"`uvm_warning", GetVerificationCitation("logging")},
+      {"`uvm_warning", GetStyleGuideCitation("uvm-logging")},
   });
   return *invalid_symbols;
 }

--- a/verilog/analysis/checkers/forbidden_symbol_rule.cc
+++ b/verilog/analysis/checkers/forbidden_symbol_rule.cc
@@ -44,7 +44,7 @@ VERILOG_REGISTER_LINT_RULE(ForbiddenSystemTaskFunctionRule);
 const LintRuleDescriptor& ForbiddenSystemTaskFunctionRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "invalid-system-task-function",
-      .dv_topic = "forbidden-system-functions",
+      .topic = "forbidden-system-functions",
       .desc =
           "Checks that no forbidden system tasks or functions are used. These "
           "consist of the following functions: `$psprintf`, `$random`, and "

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule.cc
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule.cc
@@ -40,9 +40,8 @@ VERILOG_REGISTER_LINT_RULE(UvmMacroSemicolonRule);
 const LintRuleDescriptor& UvmMacroSemicolonRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "uvm-macro-semicolon",
-      .dv_topic =
-          "uvm-macro-semicolon-convention",  // TODO(b/155128436): verify
-                                             // style guide anchor name
+      .topic = "uvm-macro-semicolon-convention",  // TODO(b/155128436): verify
+                                                  // style guide anchor name
       .desc = "Checks that no `uvm_* macro calls end with ';'.",
   };
   return d;

--- a/verilog/analysis/checkers/void_cast_rule.cc
+++ b/verilog/analysis/checkers/void_cast_rule.cc
@@ -49,7 +49,7 @@ VERILOG_REGISTER_LINT_RULE(VoidCastRule);
 const LintRuleDescriptor& VoidCastRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "void-cast",
-      .dv_topic = "void-casts",
+      .topic = "void-casts",
       .desc =
           "Checks that void casts do not contain certain function/method "
           "calls. ",

--- a/verilog/analysis/descriptions.h
+++ b/verilog/analysis/descriptions.h
@@ -36,10 +36,9 @@ struct LintConfigParameterDescriptor {
 };
 
 struct LintRuleDescriptor {
-  LintRuleId name;             // ID/name of the rule.
-  absl::string_view topic;     // section in style-guide
-  absl::string_view dv_topic;  // section in design verification style-guide
-  std::string desc;            // Detailed description.
+  LintRuleId name;          // ID/name of the rule.
+  absl::string_view topic;  // section in style-guide
+  std::string desc;         // Detailed description.
   std::vector<LintConfigParameterDescriptor> param;
 };
 

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -400,10 +400,7 @@ void GetLintRuleDescriptionsMarkdown(std::ostream* os) {
     const auto& d = rule.second.descriptor;
     *os << "### " << rule.first << "\n";
     *os << d.desc;
-    *os << " See "
-        << (d.dv_topic.empty() ? verible::GetStyleGuideCitation(d.topic)
-                               : verible::GetVerificationCitation(d.dv_topic))
-        << ".\n\n";
+    *os << " See " << verible::GetStyleGuideCitation(d.topic) << ".\n\n";
 
     if (!d.param.empty()) {
       *os << "##### Parameter" << (d.param.size() > 1 ? "s" : "") << "\n";


### PR DESCRIPTION
Distinguishing between dv-style and regular style seems unnecessarily
complictaed.

Signed-off-by: Henner Zeller <h.zeller@acm.org>
Co-authored-by: Sergey Sokolov <snsokolov@users.noreply.github.com>