### PR TITLE
[LINT] Add rule explicit-begin

### DIFF
--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -23,8 +23,8 @@ cc_library(
         ":create_object_name_match_rule",
         ":disable_statement_rule",
         ":endif_comment_rule",
-        ":explicit_begin_rule",
         ":enum_name_style_rule",
+        ":explicit_begin_rule",
         ":explicit_function_lifetime_rule",
         ":explicit_function_task_parameter_type_rule",
         ":explicit_parameter_storage_type_rule",
@@ -601,23 +601,6 @@ cc_test(
         "//verilog/parser:verilog_token_enum",
         "@com_google_googletest//:gtest_main",
     ],
-)
-
-cc_library(
-    name = "explicit_begin_rule",
-    srcs = ["explicit_begin_rule.cc"],
-    hdrs = ["explicit_begin_rule.h"],
-    deps = [
-        "//common/analysis:lint_rule_status",
-        "//common/analysis:token_stream_lint_rule",
-        "//common/strings:comment_utils",
-        "//common/text:token_info",
-        "//verilog/analysis:descriptions",
-        "//verilog/analysis:lint_rule_registry",
-        "//verilog/parser:verilog_token_enum",
-        "@com_google_absl//absl/strings",
-    ],
-    alwayslink = 1,
 )
 
 cc_library(
@@ -1242,6 +1225,23 @@ cc_test(
         "//verilog/parser:verilog_token_enum",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+    name = "explicit_begin_rule",
+    srcs = ["explicit_begin_rule.cc"],
+    hdrs = ["explicit_begin_rule.h"],
+    deps = [
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:token_stream_lint_rule",
+        "//common/strings:comment_utils",
+        "//common/text:token_info",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -1244,6 +1244,20 @@ cc_library(
     alwayslink = 1,
 )
 
+cc_test(
+    name = "explicit_begin_rule_test",
+    srcs = ["explicit_begin_rule_test.cc"],
+    deps = [
+        ":explicit_begin_rule",
+        "//common/analysis:linter_test_utils",
+        "//common/analysis:token_stream_linter_test_utils",
+        "//common/text:symbol",
+        "//verilog/analysis:verilog_analyzer",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "explicit_function_lifetime_rule",
     srcs = ["explicit_function_lifetime_rule.cc"],

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -23,6 +23,7 @@ cc_library(
         ":create_object_name_match_rule",
         ":disable_statement_rule",
         ":endif_comment_rule",
+        ":explicit_begin_rule",
         ":enum_name_style_rule",
         ":explicit_function_lifetime_rule",
         ":explicit_function_task_parameter_type_rule",
@@ -600,6 +601,23 @@ cc_test(
         "//verilog/parser:verilog_token_enum",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+    name = "explicit_begin_rule",
+    srcs = ["explicit_begin_rule.cc"],
+    hdrs = ["explicit_begin_rule.h"],
+    deps = [
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:token_stream_lint_rule",
+        "//common/strings:comment_utils",
+        "//common/text:token_info",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
 )
 
 cc_library(

--- a/verilog/analysis/checkers/explicit_begin_rule.cc
+++ b/verilog/analysis/checkers/explicit_begin_rule.cc
@@ -141,11 +141,7 @@ void ExplicitBeginRule::HandleToken(const TokenInfo& token) {
 
   if (raise_violation) {
     violations_.insert(LintViolation(
-        token, absl::StrCat(kMessage, " Expected begin, got ", token.text()),
-        {AutoFix(
-            "Insert begin",
-            {end_of_condition_statement_,
-             absl::StrCat(end_of_condition_statement_.text(), " begin")})}));
+        last_condition_start_, absl::StrCat(kMessage, " Expected begin, got ", token.text())));
 
     // Once the violation is raised, we go back to a normal, default, state
     condition_expr_level_ = 0;

--- a/verilog/analysis/checkers/explicit_begin_rule.cc
+++ b/verilog/analysis/checkers/explicit_begin_rule.cc
@@ -1,0 +1,160 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/explicit_begin_rule.h"
+
+#include <deque>
+#include <set>
+#include <stack>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/token_stream_lint_rule.h"
+#include "common/strings/comment_utils.h"
+#include "common/text/token_info.h"
+#include "verilog/analysis/descriptions.h"
+#include "verilog/analysis/lint_rule_registry.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+
+using verible::AutoFix;
+using verible::LintRuleStatus;
+using verible::LintViolation;
+using verible::TokenInfo;
+using verible::TokenStreamLintRule;
+
+// Register the lint rule
+VERILOG_REGISTER_LINT_RULE(ExplicitBeginRule);
+
+static const char kMessage[] =
+    "All block construct shall explicitely use begin/end";
+
+const LintRuleDescriptor& ExplicitBeginRule::GetDescriptor() {
+  static const LintRuleDescriptor d{
+      .name = "explicit-begin",
+      .topic = "explicit-begin",
+      .desc =
+          "Checks that a Verilog ``begin`` directive follows all "
+          "if, else and for loops.",
+  };
+  return d;
+}
+
+void ExplicitBeginRule::HandleToken(const TokenInfo& token) {
+  // Responds to a token by updating the state of the analysis.
+  bool raise_violation = false;
+  switch (state_) {
+    case State::kNormal: {
+      // On if/else/for tokens;
+      // Also, skip all conditional statement after a for or a if
+      // Then, expect a `begin` token or record a violation.
+      switch (token.token_enum()) {
+        case TK_if:
+        case TK_for:
+          condition_expr_level_ = 0;
+          last_condition_start_ = token;
+          state_ = State::kInCondition;
+          break;
+        case TK_else:
+          last_condition_start_ = token;
+          end_of_condition_statement_ = token;
+          state_ = State::kInElse;
+          break;
+        default:
+          break;
+      }  // switch (token)
+      break;
+    }
+    case State::kInElse: {
+      // If we are in a else statement, we can either have a if (and need to
+      // skip cond. statement) Or directly wait for a begin. We make use of the
+      // boolean raise_violation in order to avoid code duplication.
+      switch (token.token_enum()) {
+        case TK_SPACE:  // stay in the same state
+          break;
+        case TK_COMMENT_BLOCK:
+        case TK_EOL_COMMENT:
+          break;
+        case TK_if:
+        case TK_for:
+          condition_expr_level_ = 0;
+          last_condition_start_ = token;
+          state_ = State::kInCondition;
+          break;
+        case TK_begin:
+          state_ = State::kNormal;
+          break;
+        default:
+          raise_violation = true;
+          break;
+      }  // switch (token)
+      break;
+    }
+    case State::kInCondition: {
+      if (token.text() == "(") {
+        condition_expr_level_++;
+      } else if (token.text() == ")") {
+        condition_expr_level_--;
+        if (condition_expr_level_ == 0) {
+          end_of_condition_statement_ = token;
+          state_ = State::kExpectBegin;
+        }
+      }
+      break;
+    }
+    case State::kExpectBegin: {
+      switch (token.token_enum()) {
+        case TK_SPACE:  // stay in the same state
+          break;
+        case TK_COMMENT_BLOCK:
+        case TK_EOL_COMMENT:
+          break;
+        case TK_begin:
+          // If we got our begin token, we go back to normal status
+          state_ = State::kNormal;
+          break;
+        default: {
+          raise_violation = true;
+          break;
+        }
+      }  // switch (token)
+      break;
+    }
+  }  // switch (state_)
+
+  if (raise_violation) {
+    violations_.insert(LintViolation(
+        last_condition_start_, absl::StrCat(kMessage),
+        {AutoFix(
+            "Insert begin",
+            {end_of_condition_statement_,
+             absl::StrCat(end_of_condition_statement_.text(), " begin")})}));
+
+    // Once the violation is raised, we go back to a normal, default, state
+    condition_expr_level_ = 0;
+    state_ = State::kNormal;
+    raise_violation = false;
+  }
+}
+
+LintRuleStatus ExplicitBeginRule::Report() const {
+  return LintRuleStatus(violations_, GetDescriptor());
+}
+
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/explicit_begin_rule.cc
+++ b/verilog/analysis/checkers/explicit_begin_rule.cc
@@ -42,7 +42,7 @@ using verible::TokenStreamLintRule;
 VERILOG_REGISTER_LINT_RULE(ExplicitBeginRule);
 
 static const char kMessage[] =
-    "All block construct shall explicitely use begin/end";
+    "All block construct shall explicitely use begin/end.";
 
 const LintRuleDescriptor& ExplicitBeginRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -89,6 +89,7 @@ void ExplicitBeginRule::HandleToken(const TokenInfo& token) {
           break;
         case TK_COMMENT_BLOCK:
         case TK_EOL_COMMENT:
+        case TK_NEWLINE:
           break;
         case TK_if:
         case TK_for:
@@ -123,6 +124,7 @@ void ExplicitBeginRule::HandleToken(const TokenInfo& token) {
           break;
         case TK_COMMENT_BLOCK:
         case TK_EOL_COMMENT:
+        case TK_NEWLINE:
           break;
         case TK_begin:
           // If we got our begin token, we go back to normal status
@@ -139,7 +141,7 @@ void ExplicitBeginRule::HandleToken(const TokenInfo& token) {
 
   if (raise_violation) {
     violations_.insert(LintViolation(
-        last_condition_start_, absl::StrCat(kMessage),
+        token, absl::StrCat(kMessage, " Expected begin, got ", token.text()),
         {AutoFix(
             "Insert begin",
             {end_of_condition_statement_,

--- a/verilog/analysis/checkers/explicit_begin_rule.h
+++ b/verilog/analysis/checkers/explicit_begin_rule.h
@@ -1,0 +1,88 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_EXPLICIT_BEGIN_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_EXPLICIT_BEGIN_RULE_H_
+
+#include <set>
+#include <stack>
+#include <string>
+
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/token_stream_lint_rule.h"
+#include "common/text/token_info.h"
+#include "verilog/analysis/descriptions.h"
+
+namespace verilog {
+namespace analysis {
+
+// Detects whether a Verilog `endif directive is followed by a comment that
+// matches the opening `ifdef or `ifndef.
+//
+// Accepted examples:
+//   `ifdef FOO
+//   `endif  // FOO
+//
+//   `ifndef BAR
+//   `endif  // BAR
+//
+// Rejected examples:
+//   `ifdef FOO
+//   `endif
+//
+//   `ifdef FOO
+//   `endif  // BAR
+//
+class ExplicitBeginRule : public verible::TokenStreamLintRule {
+ public:
+  using rule_type = verible::TokenStreamLintRule;
+
+  static const LintRuleDescriptor& GetDescriptor();
+
+  ExplicitBeginRule() : state_(State::kNormal), condition_expr_level_(0) {}
+
+  void HandleToken(const verible::TokenInfo& token) final;
+
+  verible::LintRuleStatus Report() const final;
+
+ private:
+  // States of the internal token-based analysis.
+  enum class State {
+    kNormal,
+    kInCondition,
+    kInElse,
+    kExpectBegin
+  };
+
+  // Internal lexical analysis state.
+  State state_;
+
+  // Level of nested parenthesis when analizing conditional expressions.
+  int condition_expr_level_;
+
+  // Token information for the last seen block opening (for/if/else).
+  verible::TokenInfo last_condition_start_ = verible::TokenInfo::EOFToken();
+  verible::TokenInfo end_of_condition_statement_ = verible::TokenInfo::EOFToken();
+
+
+  // Collection of found violations.
+  std::set<verible::LintViolation> violations_;
+
+  void trigger_violation_();
+};
+
+}  // namespace analysis
+}  // namespace verilog
+
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_ENDIF_COMMENT_RULE_H_

--- a/verilog/analysis/checkers/explicit_begin_rule.h
+++ b/verilog/analysis/checkers/explicit_begin_rule.h
@@ -31,18 +31,27 @@ namespace analysis {
 // matches the opening `ifdef or `ifndef.
 //
 // Accepted examples:
-//   `ifdef FOO
-//   `endif  // FOO
+//   if (FOO) begin
 //
-//   `ifndef BAR
-//   `endif  // BAR
+//   else begin
+//
+//   else if (FOO) begin
+//
+//   for (FOO) begin
 //
 // Rejected examples:
-//   `ifdef FOO
-//   `endif
+//   if (FOO)
+//       BAR
 //
-//   `ifdef FOO
-//   `endif  // BAR
+//   else
+//       BAR
+//
+//   else if (FOO)
+//       BAR
+//
+//   for (FOO) begin
+//       BAR
+//
 //
 class ExplicitBeginRule : public verible::TokenStreamLintRule {
  public:
@@ -58,12 +67,7 @@ class ExplicitBeginRule : public verible::TokenStreamLintRule {
 
  private:
   // States of the internal token-based analysis.
-  enum class State {
-    kNormal,
-    kInCondition,
-    kInElse,
-    kExpectBegin
-  };
+  enum class State { kNormal, kInCondition, kInElse, kExpectBegin };
 
   // Internal lexical analysis state.
   State state_;
@@ -73,8 +77,8 @@ class ExplicitBeginRule : public verible::TokenStreamLintRule {
 
   // Token information for the last seen block opening (for/if/else).
   verible::TokenInfo last_condition_start_ = verible::TokenInfo::EOFToken();
-  verible::TokenInfo end_of_condition_statement_ = verible::TokenInfo::EOFToken();
-
+  verible::TokenInfo end_of_condition_statement_ =
+      verible::TokenInfo::EOFToken();
 
   // Collection of found violations.
   std::set<verible::LintViolation> violations_;

--- a/verilog/analysis/checkers/explicit_begin_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_begin_rule_test.cc
@@ -1,0 +1,101 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/explicit_begin_rule.h"
+
+#include <initializer_list>
+
+#include "common/analysis/linter_test_utils.h"
+#include "common/analysis/token_stream_linter_test_utils.h"
+#include "common/text/symbol.h"
+#include "gtest/gtest.h"
+#include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+namespace {
+
+using verible::LintTestCase;
+using verible::RunApplyFixCases;
+using verible::RunLintTestCases;
+
+// Tests that space-only text passes.
+TEST(ExplicitBeginRuleTest, AcceptsBlank) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {""},
+      {" "},
+      {"\n"},
+      {" \n\n"},
+  };
+  RunLintTestCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases);
+}
+
+// Tests that properly matched if/begin passes.
+TEST(ExplicitBeginRuleTest, AcceptsEndifWithComment) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+    {"if (FOO) begin"},
+    {"if (FOO)\n begin"},
+    {"if (FOO) //Comment\n begin"},
+    {"else begin \n FOO"},
+    {"else \nbegin \n FOO"},
+    {"else //Comment\n begin \n FOO"},
+    {"else \n //Comment\n begin \n FOO"},
+    {"else if (FOO) begin"},
+    {"else if (FOO)\n begin"},
+    {"else if (FOO) //Comment\n begin"},
+    {"else if (FOO)\n //Comment\n begin"},
+  };
+  RunLintTestCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases);
+}
+
+// Tests that unmatched block/begin fails is detected.
+TEST(ExplicitBeginRuleTest, RejectsEndifWithoutComment) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+     {"if (FOO) BAR"},
+    {"if (FOO)\n BAR"},
+    {"if (FOO) //Comment\n BAR"},
+    {"else \n FOO"},
+    {"else \n \n FOO"},
+    {"else //Comment\n  FOO"},
+    {"else \n //Comment\n FOO"},
+    {"else if (FOO) BAR"},
+    {"else if (FOO)\n BAR"},
+    {"else if (FOO) //Comment\n BAR"},
+    {"else if (FOO)\n //Comment\n BAR"},
+  };
+  RunLintTestCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases);
+}
+
+TEST(ExplicitBeginRuleTest, ApplyAutoFix) {
+  // Alternatives the auto fix offers
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+    {"if (FOO) BAR","if (FOO) begin BAR"},
+    {"if (FOO)\n BAR","if (FOO) begin\n BAR"},
+    {"if (FOO) //Comment\n BAR","if (FOO) begin //Comment\n BAR"},
+    {"else \n FOO","else  begin \n FOO"},
+    {"else \n \n FOO","else begin  \n \n FOO"},
+    {"else //Comment\n  FOO","else begin //Comment\n  FOO"},
+    {"else \n //Comment\n FOO","else begin \n //Comment\n FOO"},
+    {"else if (FOO) BAR","else if (FOO) begin BAR"},
+    {"else if (FOO)\n BAR","else if (FOO) begin\n BAR"},
+    {"else if (FOO) //Comment\n BAR","else if (FOO) begin //Comment\n BAR"},
+    {"else if (FOO)\n //Comment\n BAR","else if (FOO) begin\n //Comment\n BAR"},
+  };
+  RunApplyFixCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases, "");
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/explicit_begin_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_begin_rule_test.cc
@@ -43,57 +43,39 @@ TEST(ExplicitBeginRuleTest, AcceptsBlank) {
 }
 
 // Tests that properly matched if/begin passes.
-TEST(ExplicitBeginRuleTest, AcceptsEndifWithComment) {
+TEST(ExplicitBeginRuleTest, AcceptsBlocksWithBegin) {
   const std::initializer_list<LintTestCase> kTestCases = {
-    {"if (FOO) begin"},
-    {"if (FOO)\n begin"},
-    {"if (FOO) //Comment\n begin"},
-    {"else begin \n FOO"},
-    {"else \nbegin \n FOO"},
-    {"else //Comment\n begin \n FOO"},
-    {"else \n //Comment\n begin \n FOO"},
-    {"else if (FOO) begin"},
-    {"else if (FOO)\n begin"},
-    {"else if (FOO) //Comment\n begin"},
-    {"else if (FOO)\n //Comment\n begin"},
+      {"if (FOO) begin"},
+      {"if (FOO)\n begin"},
+      {"if (FOO) //Comment\n begin"},
+      {"else begin \n FOO"},
+      {"else \nbegin \n FOO"},
+      {"else //Comment\n begin \n FOO"},
+      {"else \n //Comment\n begin \n FOO"},
+      {"else if (FOO) begin"},
+      {"else if (FOO)\n begin"},
+      {"else if (FOO) //Comment\n begin"},
+      {"else if (FOO)\n //Comment\n begin"},
   };
   RunLintTestCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases);
 }
 
 // Tests that unmatched block/begin fails is detected.
-TEST(ExplicitBeginRuleTest, RejectsEndifWithoutComment) {
+TEST(ExplicitBeginRuleTest, RejectBlocksWithoutBegin) {
   const std::initializer_list<LintTestCase> kTestCases = {
-     {"if (FOO) BAR"},
-    {"if (FOO)\n BAR"},
-    {"if (FOO) //Comment\n BAR"},
-    {"else \n FOO"},
-    {"else \n \n FOO"},
-    {"else //Comment\n  FOO"},
-    {"else \n //Comment\n FOO"},
-    {"else if (FOO) BAR"},
-    {"else if (FOO)\n BAR"},
-    {"else if (FOO) //Comment\n BAR"},
-    {"else if (FOO)\n //Comment\n BAR"},
+      {{TK_if, "if"}, " (FOO) BAR"},
+      {{TK_if, "if"}, " (FOO)\n BAR"},
+      {{TK_if, "if"}, " (FOO) //Comment\n BAR"},
+      {{TK_else, "else"}, " \n FOO"},
+      {{TK_else, "else"}, " \n \n FOO"},
+      {{TK_else, "else"}, " //Comment\n  FOO"},
+      {{TK_else, "else"}, " \n //Comment\n FOO"},
+      {"else ", {TK_if, "if"}, " (FOO) BAR"},
+      {"else ", {TK_if, "if"}, " (FOO)\n BAR"},
+      {"else ", {TK_if, "if"}, " (FOO) //Comment\n BAR"},
+      {"else ", {TK_if, "if"}, " (FOO)\n //Comment\n BAR"},
   };
   RunLintTestCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases);
-}
-
-TEST(ExplicitBeginRuleTest, ApplyAutoFix) {
-  // Alternatives the auto fix offers
-  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
-    {"if (FOO) BAR","if (FOO) begin BAR"},
-    {"if (FOO)\n BAR","if (FOO) begin\n BAR"},
-    {"if (FOO) //Comment\n BAR","if (FOO) begin //Comment\n BAR"},
-    {"else \n FOO","else  begin \n FOO"},
-    {"else \n \n FOO","else begin  \n \n FOO"},
-    {"else //Comment\n  FOO","else begin //Comment\n  FOO"},
-    {"else \n //Comment\n FOO","else begin \n //Comment\n FOO"},
-    {"else if (FOO) BAR","else if (FOO) begin BAR"},
-    {"else if (FOO)\n BAR","else if (FOO) begin\n BAR"},
-    {"else if (FOO) //Comment\n BAR","else if (FOO) begin //Comment\n BAR"},
-    {"else if (FOO)\n //Comment\n BAR","else if (FOO) begin\n //Comment\n BAR"},
-  };
-  RunApplyFixCases<VerilogAnalyzer, ExplicitBeginRule>(kTestCases, "");
 }
 
 }  // namespace


### PR DESCRIPTION
Add rule to check if the begin keyword always follows a if/else/for.
Related to #1321