### PR TITLE
Include the BAZEL_OPTS when runing :install for the release

### DIFF
--- a/.github/bin/github-releases-setup.sh
+++ b/.github/bin/github-releases-setup.sh
@@ -32,7 +32,7 @@ mkdir -p $PREFIX_DOC
 mkdir -p $PREFIX_MAN
 
 # Binaries
-bazel run :install -c opt -- $PREFIX_BIN
+bazel run :install ${BAZEL_OPTS} -c opt -- $PREFIX_BIN
 for BIN in $PREFIX_BIN/*; do
     ls -l $BIN
     file $BIN


### PR DESCRIPTION
On jammy, we need the additional --//bazel:use_local_flex_bison
option that was not passed to the bazel run :install failing
to produce install binaries for Ubuntu jammy.

Fixes #1369