### PR TITLE
[VeriblePreProcessor][1]: multiple-cu mode

### DIFF
--- a/verilog/tools/preprocessor/BUILD
+++ b/verilog/tools/preprocessor/BUILD
@@ -14,6 +14,8 @@ cc_binary(
         "//common/util:init_command_line",
         "//common/util:subcommand",
         "//verilog/transform:strip_comments",
+        "//verilog/preprocessor:verilog_preprocess",
+        "//verilog/parser:verilog_lexer",
         "@com_google_absl//absl/flags:usage",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",


### PR DESCRIPTION
### NOTE: This is a part of the sequentially splitted PRs from PR #1360.

**Description:**
In case of `--multiple-cu` is true, and multiple files are passed to the tool, each one of them will be compiled in a separate compilation unit, thus declarations scopes will end by the end of each file (this is the default behavior).

