### PR TITLE
Document UseAfterFree bug

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -18214,17 +18214,6 @@ TEST(FormatterEndToEndTest, FunctionCallsWithComments) {
   }
 }
 
-#if 0
-// https://github.com/chipsalliance/verible/issues/1381
-TEST(FormatterEndToEndTest, FuzzingRegressions) {
-  FormatStyle style;
-  std::ostringstream stream;
-  absl::string_view input("P#(\0\0//\0//\0,);", 14);
-  const auto status = FormatVerilog(input, "<filename>", style, stream);
-  EXPECT_OK(status);
-}
-#endif
-
 // Extracts the first non-whitespace token and prepends it with number of
 // of newlines seen in front of it. So "\n \n\n  foo" -> "3foo"
 std::string NLCountAndfirstWord(absl::string_view str) {
@@ -18356,6 +18345,27 @@ foobar, input    bit [4] foobaz,
     }
   }
 }
+
+#if 0
+// https://github.com/chipsalliance/verible/issues/1381
+TEST(FormatterEndToEndTest, FuzzingRegression_1381) {
+  FormatStyle style;
+  std::ostringstream stream;
+  absl::string_view input("P#(\0\0//\0//\0,);", 14);
+  const auto status = FormatVerilog(input, "<filename>", style, stream);
+  EXPECT_OK(status);
+}
+#endif
+
+#if 0
+TEST(FormatterEndToEndTest, FuzzingRegression_UseAfterFree) {
+  FormatStyle style;
+  std::ostringstream stream;
+  absl::string_view input("`c(`c(//););", 12);
+  const auto status = FormatVerilog(input, "<filename>", style, stream);
+  EXPECT_OK(status);
+}
+#endif
 
 }  // namespace
 }  // namespace formatter


### PR DESCRIPTION
... found with a fuzzer, so the input looks a bit random :)

Signed-off-by: Henner Zeller <h.zeller@acm.org>