### PR TITLE
Don't force a particular bazel version.

### DIFF
--- a/.github/settings.sh
+++ b/.github/settings.sh
@@ -31,10 +31,8 @@ export BAZEL_CXXOPTS="-std=c++17"
 # Reduce the verbosity of progress output on CI
 export BAZEL_OPTS="-c opt --show_progress_rate_limit=10.0"
 
+# Used to fetch the BAZEL version where needed.
 export BAZEL_VERSION=4.0.0
-# Without following environment variable set, Bazel updates itself to the
-# latest version
-export USE_BAZEL_VERSION=$BAZEL_VERSION
 
 # TODO(b/171989992): revert to using release version after upgrading system
 #   libraries/image (need: GLIBCXX_3.4.26, CXXABI_1.3.11, GLIBC_2.29).


### PR DESCRIPTION
The USE_BAZEL_VERSION appears to be unnecessarily strict enforcement
of a particular bazel version when anything > 3.x.x should typically
work.

Signed-off-by: Henner Zeller <h.zeller@acm.org>