### PR TITLE
Use unversioned clang/clang++ if versioned binaries don't exist.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -19,6 +19,10 @@ set -e
 source ./.github/settings.sh
 
 if [[ "${MODE}" == *-clang ]]; then
+  # Baseline in case we don't find a specific version below
+  export CXX=clang++
+  export CC=clang
+
   # clang versions supported. Starting with 13, we
   # get some warnings in absl, so let's not go beyond
   # 12 for now.


### PR DESCRIPTION
Depending on the platform, there might not be a versioned binary
such as clang-12 available. Fall back to simply clang then.

Signed-off-by: Henner Zeller <h.zeller@acm.org>