### PR TITLE
Add .envrc and .direnv to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ tags
 releasing/out
 compile_commands.json
 
+# Local user config
+.envrc
+.direnv


### PR DESCRIPTION
These files are typically user configurations never meant to
be submitted.

Signed-off-by: Henner Zeller <h.zeller@acm.org>