### PR TITLE
Make it simpler to create coverage for a particular target.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -77,20 +77,25 @@ else
   BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wstring-conversion"
 fi
 
+# If parameter given and the MODE allows choosing, we build the target
+# as provided, otherwise all. This allows manual invocation of interesting
+# targets.
+CHOSEN_TARGET=${1:-//...}
+
 case "$MODE" in
   test|test-clang)
-    bazel test --keep_going --cache_test_results=no --test_output=errors $BAZEL_OPTS //...
+    bazel test --keep_going --cache_test_results=no --test_output=errors $BAZEL_OPTS "$CHOSEN_TARGET"
     ;;
 
   asan|asan-clang)
-    bazel test --config=asan --cache_test_results=no --test_output=errors $BAZEL_OPTS -c fastbuild //...
+    bazel test --config=asan --cache_test_results=no --test_output=errors $BAZEL_OPTS -c fastbuild "$CHOSEN_TARGET"
     ;;
 
   coverage)
     bazel coverage \
           --combined_report=lcov \
           --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main \
-          //...
+          "$CHOSEN_TARGET"
     # output will be in bazel-out/_coverage/_coverage_report.dat
     ;;
 

--- a/.github/bin/generate-coverage-html.sh
+++ b/.github/bin/generate-coverage-html.sh
@@ -37,7 +37,10 @@ COVERAGE_DATA=bazel-out/_coverage/_coverage_report.dat
 cd $PROJECT_ROOT
 if [ ! -r "${COVERAGE_DATA}" ]; then
   echo "First, run coverage tests; invoke"
-  echo "MODE=coverage .github/bin/build-and-test.sh"
+  echo "  MODE=coverage .github/bin/build-and-test.sh"
+  echo
+  echo ".. or with a specific target"
+  echo "  MODE=coverage .github/bin/build-and-test.sh //foo/bar:baz_test"
   exit
 fi
 

--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,8 @@ pkgs.mkShell {
       gcc
       git
       glibc
-      jdk
+      jdk11
+      lcov
       python3
     ];
 


### PR DESCRIPTION
Thus it is possible to test if a particular unit test provides all the
necessary coverage, not other tests that accidentally cover that code
path.

Update dependencies to run coverage in development environment.