### PR TITLE
Update the install rules to latest.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,9 +68,9 @@ http_archive(
 # 'make install' equivalent rule
 http_archive(
     name = "com_github_google_rules_install",
-    sha256 = "9147455f1c234fba7922731fb32842f6b3ad01dcafe344be5292f80f82b25dad",
-    strip_prefix = "bazel_rules_install-4cd8ab0b5d8a0117bb5b8c89a0024508d5d4d5ed",
-    urls = ["https://github.com/google/bazel_rules_install/archive/4cd8ab0b5d8a0117bb5b8c89a0024508d5d4d5ed.zip"],
+    sha256 = "880217b21dbd40928bbe3bca3d97bd4de7d70d5383665ec007d7e1aac41d9739",
+    strip_prefix = "bazel_rules_install-5ae7c2a8d22de2558098e3872fc7f3f7edc61fb4",
+    urls = ["https://github.com/google/bazel_rules_install/archive/5ae7c2a8d22de2558098e3872fc7f3f7edc61fb4.zip"],
 )
 
 load("@com_github_google_rules_install//:deps.bzl", "install_rules_dependencies")


### PR DESCRIPTION
They have fixes that should work on freeBSD, i.e. they
might start working on MacOS.

Signed-off-by: Henner Zeller <h.zeller@acm.org>