### PR TITLE
Flatten whole subtree in argumentless kMacroCalls.

### DIFF
--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -179,6 +179,7 @@ cc_test(
         ":format_style",
         ":formatter",
         "//common/formatting:align",
+        "//common/strings:display_utils",
         "//common/strings:position",
         "//common/text:text_structure",
         "//common/util:logging",

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -18380,19 +18380,24 @@ TEST(FormatterEndToEndTest, FuzzingRegression_UseAfterFree_1384) {
 }
 #endif
 
-#if 0
 // https://github.com/chipsalliance/verible/issues/1386
 TEST(FormatterEndToEndTest, FuzzingRegressionHierachyInvariant) {
-  TestForNonCrash(string_view_from_literal("`c(`c()\0;);"));
-}
-#endif
-
 #if 0
+  // Original sample input from fuzzer
+  TestForNonCrash(string_view_from_literal("`c(`c()\0;);"));
+#endif
+#if 0
+  // Lexically correct variant (`\0` -> `\n`)
+  TestForNonCrash(string_view_from_literal("`c(`c()\n;);"));
+#endif
+  // Lexically correct variant (`\0` removed)
+  TestForNonCrash(string_view_from_literal("`c(`c(););"));
+}
+
 // Possibly same ? https://github.com/chipsalliance/verible/issues/1386
 TEST(FormatterEndToEndTest, FuzzingRegression_outofmemory) {
-  TestForNonCrash({"`f(1'O`f())\n", 12});
+  TestForNonCrash(string_view_from_literal("`f(1'O`f())\n"));
 }
-#endif
 
 }  // namespace
 }  // namespace formatter

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -29,6 +29,7 @@
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include "common/formatting/align.h"
+#include "common/strings/display_utils.h"
 #include "common/strings/position.h"
 #include "common/text/text_structure.h"
 #include "common/util/logging.h"
@@ -18346,14 +18347,23 @@ foobar, input    bit [4] foobaz,
   }
 }
 
+// Creates a string_view spanning a whole string literal.
+// Works correctly with strings containing null bytes.
+template <std::size_t N>
+constexpr absl::string_view string_view_from_literal(const char (&s)[N]) {
+  return absl::string_view(s, N - 1);
+}
+
 // The following regressions have been found by a fuzzer, so the input might
 // look a bit 'funny'. Nevertheless, they expose real bugs in the code.
 
 [[maybe_unused]] void TestForNonCrash(absl::string_view input) {
+  using verible::EscapeString;
   FormatStyle style;
   std::ostringstream stream;
   const auto status = FormatVerilog(input, "<filename>", style, stream);
-  EXPECT_OK(status);
+  EXPECT_OK(status) << "Reason: " << status.message() << "\nEscaped input: \""
+                    << EscapeString(input) << "\"";
 }
 
 #if 0
@@ -18373,7 +18383,7 @@ TEST(FormatterEndToEndTest, FuzzingRegression_UseAfterFree_1384) {
 #if 0
 // https://github.com/chipsalliance/verible/issues/1386
 TEST(FormatterEndToEndTest, FuzzingRegressionHierachyInvariant) {
-  TestForNonCrash({"`c(`c()\0;);", 12});
+  TestForNonCrash(string_view_from_literal("`c(`c()\0;);"));
 }
 #endif
 

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -2680,11 +2680,9 @@ void TreeUnwrapper::ReshapeTokenPartitions(
         MacroCallReshaper(style, &partition).Reshape();
         break;
       }
-      // If there are no call args, join the '(' and ')' together.
       if (MacroCallArgsIsEmpty(*GetMacroCallArgs(node))) {
-        // FIXME (mglb): Do more checks: EOL comments can be inside.
-        FlattenOnce(partition);
-        VLOG(4) << "NODE: kMacroCall (flattened):\n" << partition;
+        // If there are no call args, join the name, '(' and ')' together.
+        partition.Children().clear();
       } else {
         // Merge closing parenthesis into last argument partition
         // Test for ')' and MacroCallCloseToEndLine because macros


### PR DESCRIPTION
Partial fix of #1386.

The tests that remain commented-out fail with status message:
```
Formatted output is lexically different from the input.    Please file a bug.  Details:
Mismatched token enums.  got: (MacroCallCloseToEndLine) (#711: ")") vs. (')') (#41: ")")
First mismatched token [2]: (MacroCallCloseToEndLine) (#711: ")") vs. (')') (#41: ")")
First mismatched token [2]: (MacroArg) (#710: "`c()\0;") vs. (MacroArg) (#710: "`c();")
```
The first mismatch is caused by existence of two `)` tokens (real `)` and `MacroCallCloseToEndLine`), which are detected differently due to changed formatting.
The second mismatch is caused by removal of `\0` (`\n` in the other test case).