### PR TITLE
Use newer rules for m4, fixing the glibc 2.34 compile issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,13 @@ syntax checker will be at
 `bazel-bin/verilog/tools/syntax/verible-verilog-syntax` (corresponding to the
 target name `//verilog/tools/syntax:verible-verilog-syntax`).
 
-### Building on systems with glibc >= 2.34
+### Optionally using local flex/bison for build
 
-To build Verible on systems with glibc >= 2.34, you need to use install flex and bison. Then, build Verible with
+Flex and Bison, that are needed for the parser generation, are compiled as part
+of the build process. But if for any reason you want or need local tools (e.g.
+if you encounter a compile problem with them - please file a bug then)
+can choose so by adding `--//bazel:use_local_flex_bison` to your bazel
+command line:
 
 ```bash
 # Also append the option '--//bazel:use_local_flex_bison' to test/install commands

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,9 +94,8 @@ win_flex_configure(
 
 http_archive(
     name = "rules_m4",
-    sha256 = "c67fa9891bb19e9e6c1050003ba648d35383b8cb3c9572f397ad24040fb7f0eb",
-    # m4 1.4.18
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2/rules_m4-v0.2.tar.xz"],
+    sha256 = "b0309baacfd1b736ed82dc2bb27b0ec38455a31a3d5d20f8d05e831ebeef1a8e",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.2/rules_m4-v0.2.2.tar.xz"],
 )
 
 load("@rules_m4//m4:m4.bzl", "m4_register_toolchains")
@@ -116,9 +115,8 @@ flex_register_toolchains()
 
 http_archive(
     name = "rules_bison",
-    sha256 = "6ee9b396f450ca9753c3283944f9a6015b61227f8386893fb59d593455141481",
-    # bison 3.3.2
-    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2/rules_bison-v0.2.tar.xz"],
+    sha256 = "9577455967bfcf52f9167274063ebb74696cb0fd576e4226e14ed23c5d67a693",
+    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.2.1/rules_bison-v0.2.1.tar.xz"],
 )
 
 load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")


### PR DESCRIPTION
So now this should compile cleanly there as well.

Fixing #957

Signed-off-by: Henner Zeller <h.zeller@acm.org>