### PR TITLE
Unbutu releases: also link libstc++ statically for newer distributions.

### DIFF
--- a/releasing/ubuntu/common/compiler.dockerstage
+++ b/releasing/ubuntu/common/compiler.dockerstage
@@ -3,3 +3,7 @@ RUN apt-get install -y  \
     build-essential     \
     g++                 \
     gcc
+
+# Link libstdc++ statically: more resilience against library version mismatch
+ENV BAZEL_LINKOPTS "-static-libstdc++:-lm"
+ENV BAZEL_LINKLIBS "-l%:libstdc++.a"


### PR DESCRIPTION
Similar to the xenial and bionic distributions (that require a different
g++), also use the static libstdc++ linking for releases of the newer
ubuntus. That way we are slighly more resilient to library version
mismatch in case the download is attempted to run in
Debian distributions/releases.

Downside: larger release tar to download.

Signed-off-by: Henner Zeller <h.zeller@acm.org>