### PR TITLE
Explicitly set stdout to binary for Windows.

### DIFF
--- a/verilog/tools/ls/verilog_ls.cc
+++ b/verilog/tools/ls/verilog_ls.cc
@@ -101,6 +101,7 @@ int main(int argc, char *argv[]) {
 
 #ifdef _WIN32
   _setmode(_fileno(stdin), _O_BINARY);
+  _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
   std::cerr << "Verible Alpha Language Server " << GetVersionNumber()


### PR DESCRIPTION
Suspect it messes with the line-endings otherwise.

Issues: #1343
