### PR TITLE
Use fully qualified name for Py import.

### DIFF
--- a/verilog/tools/kythe/filelist_parser_test.py
+++ b/verilog/tools/kythe/filelist_parser_test.py
@@ -17,7 +17,7 @@
 import sys
 import unittest
 
-import filelist_parser
+from verilog.tools.kythe import filelist_parser
 
 
 class FilelistParserTest(unittest.TestCase):


### PR DESCRIPTION
Signed-off-by: Henner Zeller <hzeller@google.com>