### PR TITLE
Make InitCommandLine() return vector of string_view instead of char*

### DIFF
--- a/common/tools/jcxxgen.cc
+++ b/common/tools/jcxxgen.cc
@@ -360,7 +360,7 @@ int main(int argc, char *argv[]) {
     std::cerr << "Need filename";
     return 1;
   }
-  const std::string &schema_filename = file_args[1];
+  const std::string schema_filename{file_args[1].begin(), file_args[1].end()};
   auto objects = LoadObjectTypes(schema_filename);
   if (!objects) {
     fprintf(stderr, "Couldn't parse spec\n");

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -36,7 +36,7 @@ static absl::Status ChangedLines(const SubcommandArgsRange& args,
     return absl::InvalidArgumentError(
         "Missing patchfile argument.  Use '-' for stdin.");
   }
-  const char* patchfile = args[0];
+  const absl::string_view patchfile = args[0];
   std::string patch_contents;
   if (auto status = verible::file::GetContents(patchfile, &patch_contents);
       !status.ok()) {
@@ -64,7 +64,7 @@ static absl::Status ApplyPick(const SubcommandArgsRange& args,
   if (args.empty()) {
     return absl::InvalidArgumentError("Missing patchfile argument.");
   }
-  const char* patchfile = args[0];
+  const absl::string_view patchfile = args[0];
   std::string patch_contents;
   if (auto status = verible::file::GetContents(patchfile, &patch_contents);
       !status.ok()) {

--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -46,7 +46,7 @@ static std::string GetBuildVersion() {
 }
 
 // We might want to have argc edited in the future, hence non-const param.
-std::vector<char*> InitCommandLine(
+std::vector<absl::string_view> InitCommandLine(
     absl::string_view usage,
     int* argc,  // NOLINT(readability-non-const-parameter)
     char*** argv) {
@@ -62,7 +62,8 @@ std::vector<char*> InitCommandLine(
   google::InstallFailureSignalHandler();
 #endif
 
-  return absl::ParseCommandLine(*argc, *argv);
+  const auto positional_parameters = absl::ParseCommandLine(*argc, *argv);
+  return {positional_parameters.cbegin(), positional_parameters.cend()};
 }
 
 }  // namespace verible

--- a/common/util/init_command_line.h
+++ b/common/util/init_command_line.h
@@ -22,9 +22,13 @@
 namespace verible {
 
 // Initializes command-line tool, including parsing flags.
+// The recognized flags are initialized and their text removed from the
+// input command line, returning the remaining positional parameters.
+// Positional parameters after `--` are returned as-is and not interpreted
+// as flags.
 // Returns positional arguments, where element[0] is the program name.
-std::vector<char*> InitCommandLine(absl::string_view usage, int* argc,
-                                   char*** argv);
+std::vector<absl::string_view> InitCommandLine(absl::string_view usage,
+                                               int* argc, char*** argv);
 
 }  // namespace verible
 

--- a/common/util/subcommand.h
+++ b/common/util/subcommand.h
@@ -30,7 +30,7 @@ namespace verible {
 
 // This should be the same type returned by InitCommandLine in
 // common/util/init_command_line.h
-using SubcommandArgs = std::vector<char*>;
+using SubcommandArgs = std::vector<absl::string_view>;
 using SubcommandArgsIterator = SubcommandArgs::const_iterator;
 using SubcommandArgsRange =
     verible::container_iterator_range<SubcommandArgsIterator>;

--- a/common/util/subcommand_test.cc
+++ b/common/util/subcommand_test.cc
@@ -40,7 +40,7 @@ TEST(SubcommandRegistryTest, HelpNoArgsTest) {
   const SubcommandEntry& help(registry.GetSubcommandEntry("help"));
   std::istringstream ins;
   std::ostringstream outs, errs;
-  std::vector<char*> args;
+  std::vector<absl::string_view> args;
   const SubcommandArgsRange range(args.begin(), args.end());
   const auto status = help.main(range, ins, outs, errs);
   EXPECT_TRUE(status.ok()) << "Unexpected error:\n" << status.message();
@@ -54,8 +54,7 @@ TEST(SubcommandRegistryTest, HelpHelpCommand) {
   const SubcommandEntry& help(registry.GetSubcommandEntry("help"));
   std::istringstream ins;
   std::ostringstream outs, errs;
-  char arg[] = "help";
-  std::vector<char*> args{arg};
+  std::vector<absl::string_view> args{"help"};
   const SubcommandArgsRange range(args.begin(), args.end());
 
   const auto status = help.main(range, ins, outs, errs);
@@ -82,7 +81,7 @@ TEST(SubcommandRegistryTest, RegisterCommandPublicOk) {
     EXPECT_TRUE(absl::StrContains(registry.ListCommands(), "fizz"));
   }
 
-  std::vector<char*> args;
+  std::vector<absl::string_view> args;
   const SubcommandArgsRange range(args.begin(), args.end());
   const SubcommandEntry& fizz_entry(registry.GetSubcommandEntry("fizz"));
 
@@ -111,7 +110,7 @@ TEST(SubcommandRegistryTest, RegisterCommandHiddenOk) {
     EXPECT_FALSE(absl::StrContains(registry.ListCommands(), "buzz"));
   }
 
-  std::vector<char*> args;
+  std::vector<absl::string_view> args;
   const SubcommandArgsRange range(args.begin(), args.end());
   const SubcommandEntry& buzz_entry(registry.GetSubcommandEntry("buzz"));
 
@@ -148,7 +147,7 @@ TEST(SubcommandRegistryTest, RegisterCommandMultipleCommands) {
   }
 
   // Run each subcommand once.
-  std::vector<char*> args;
+  std::vector<absl::string_view> args;
   const SubcommandArgsRange range(args.begin(), args.end());
   {
     const SubcommandEntry& fizz_entry(registry.GetSubcommandEntry("fizz"));

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -44,7 +44,7 @@ static absl::Status StripComments(const SubcommandArgsRange& args,
     return absl::InvalidArgumentError(
         "Missing file argument.  Use '-' for stdin.");
   }
-  const char* source_file = args[0];
+  const absl::string_view source_file = args[0];
   std::string source_contents;
   if (auto status = verible::file::GetContents(source_file, &source_contents);
       !status.ok()) {
@@ -113,7 +113,7 @@ static absl::Status MultipleCU(const SubcommandArgsRange& args, std::istream&,
   if (args.empty()) {
     return absl::InvalidArgumentError("Missing file arguments.");
   }
-  for (const char* source_file : args) {
+  for (absl::string_view source_file : args) {
     message_stream << source_file << ":\n";
     auto status = PreprocessSingleFile(source_file, outs, message_stream);
     if (!status.ok()) return status;
@@ -130,7 +130,7 @@ static absl::Status GenerateVariants(const SubcommandArgsRange& args,
     return absl::InvalidArgumentError(
         "ERROR: generate-variants only works on one file.");
   }
-  const char* source_file = args[0];
+  const absl::string_view source_file = args[0];
   std::string source_contents;
   if (auto status = verible::file::GetContents(source_file, &source_contents);
       !status.ok()) {

--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -290,7 +290,7 @@ int main(int argc, char** argv) {
 
   int exit_status = 0;
   // All positional arguments are file names.  Exclude program name.
-  for (const char* filename :
+  for (absl::string_view filename :
        verible::make_range(args.begin() + 1, args.end())) {
     std::string content;
     if (!verible::file::GetContents(filename, &content).ok()) {
@@ -308,7 +308,8 @@ int main(int argc, char** argv) {
         AnalyzeOneFile(content, filename, preprocess_config, &file_json);
     exit_status = std::max(exit_status, file_status);
     if (absl::GetFlag(FLAGS_export_json)) {
-      json_out[filename] = std::move(file_json);
+      json_out[std::string{filename.begin(), filename.end()}] =
+          std::move(file_json);
     }
   }
 


### PR DESCRIPTION
For all intendt and purposes, we're only interested in string_view
for the positional parameters and in particular do not want to encourage
modifying them (in particular since all kind of split operations can
cheaply and easily be done in the string_view domain).

The `char*` was just a leaked implementation detail of the
underlying main() entry point which happens to return a writable
buffer.

Signed-off-by: Henner Zeller <hzeller@google.com>