### PR TITLE
Fix accidental use of std::string_view instead lf absl::string_view.

### DIFF
--- a/common/analysis/violation_handler.cc
+++ b/common/analysis/violation_handler.cc
@@ -123,7 +123,7 @@ void ViolationFixer::HandleViolation(
     return;
   }
 
-  static std::string_view previous_fix_conflict =
+  static absl::string_view previous_fix_conflict =
       "The fix conflicts with "
       "previously applied fixes, rejecting.\n";
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -136,7 +136,7 @@ class LayoutItem {
       // TODO (mglb): support all possible break_decisions
       len += token.before.spaces_required;
       if (const auto line_break_pos = token.Text().find('\n');
-          line_break_pos != std::string_view::npos) {
+          line_break_pos != absl::string_view::npos) {
         // Multiline tokens are not really supported.
         // Use number of characters up to the first line break.
         len += line_break_pos;


### PR DESCRIPTION
We're using absl::string_view as a compatibility guarantee for
different platforms, so let's use it throughout.

Signed-off-by: Henner Zeller <hzeller@google.com>