### PR TITLE
Adding support of +define+ in FileList.

### DIFF
--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -368,7 +368,6 @@ absl::StatusOr<FileList> ParseSourceFileListFromCommandline(
     }
     absl::string_view plus_argument_type = argument_plus_splitted[0];
     if (plus_argument_type == "define") {
-      // define argument.
       for (const absl::string_view define_argument :
            verible::make_range(argument_plus_splitted.begin() + 1,
                                argument_plus_splitted.end())) {
@@ -386,7 +385,6 @@ absl::StatusOr<FileList> ParseSourceFileListFromCommandline(
         result.defines.emplace_back(macro_pair.first, macro_pair.second);
       }
     } else if (plus_argument_type == "incdir") {
-      // incdir argument.
       for (const absl::string_view incdir_argument :
            verible::make_range(argument_plus_splitted.begin() + 1,
                                argument_plus_splitted.end())) {

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -350,8 +350,7 @@ absl::StatusOr<FileList> ParseSourceFileListFromCommandline(
     const std::vector<absl::string_view>& cmdline) {
   FileList file_list_out;
   for (absl::string_view argument :
-       verible::make_range(cmdline.begin() + 1, cmdline.end())) {
-    // cmdline[0] is the tool's name, which can be skipped.
+       verible::make_range(cmdline.begin(), cmdline.end())) {
     if (argument.empty()) continue;
     if (argument[0] != '+') {
       // Then "argument" is a SV file name.

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -350,8 +350,7 @@ absl::StatusOr<FileList> ParseSourceFileListFromFile(
 absl::StatusOr<FileList> ParseSourceFileListFromCommandline(
     const std::vector<absl::string_view>& cmdline) {
   FileList result;
-  for (absl::string_view argument :
-       verible::make_range(cmdline.begin(), cmdline.end())) {
+  for (absl::string_view argument : cmdline) {
     if (argument.empty()) continue;
     if (argument[0] != '+') {
       // Then "argument" is a SV file name.

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -321,6 +321,8 @@ class VerilogProject {
 
 // TODO(karimtera): Using "MacroDefiniton" struct might be better.
 struct TextMacroDefinition {
+  TextMacroDefinition(std::string name, std::string value)
+      : name(std::move(name)), value(std::move(value)){};
   std::string name;
   std::string value;
   bool operator==(const TextMacroDefinition& macro_definition) const {

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -319,6 +319,15 @@ class VerilogProject {
       buffer_to_analyzer_map_;
 };
 
+// TODO(karimtera): Using "MacroDefiniton" struct might be better.
+struct TextMacroDefinition {
+  std::string name;
+  std::string value;
+  bool operator==(const TextMacroDefinition& macro_definition) const {
+    return name == macro_definition.name && value == macro_definition.value;
+  }
+};
+
 // File list for compiling a System Verilog project.
 struct FileList {
   // Ordered list of files to compile.
@@ -327,6 +336,8 @@ struct FileList {
   std::vector<std::string> include_dirs;
   // Path to the file list.
   std::string file_list_path;
+  // Defined macros.
+  std::vector<TextMacroDefinition> defines;
 };
 
 // Reads in a list of files line-by-line from 'file_list_file'. The include
@@ -338,6 +349,11 @@ absl::StatusOr<FileList> ParseSourceFileListFromFile(
 // directories are prefixed by "+incdir+"
 FileList ParseSourceFileList(absl::string_view file_list_path,
                              const std::string& file_list_content);
+
+// Parse positional parameters from command line and extract files, +incdir+ and
+// +define+.
+absl::StatusOr<FileList> ParseSourceFileListFromCommandline(
+    const std::vector<absl::string_view>& cmdline);
 
 }  // namespace verilog
 

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -597,7 +597,7 @@ TEST(VerilogProjectTest, ParseInvalidSourceFileListFromCommandline) {
       {"+define+macro1="}, {"+define+"}, {"+not_valid_define+"}};
   for (const auto& cmdline : test_cases) {
     auto parsed_file_list = ParseSourceFileListFromCommandline(cmdline);
-    ASSERT_FALSE(parsed_file_list.ok());
+    EXPECT_FALSE(parsed_file_list.ok());
   }
 }
 
@@ -611,6 +611,7 @@ TEST(VerilogProjectTest, ParseSourceFileListFromCommandline) {
       "+incdir+./path/to/file3",
       "+define+macro5",
       "file3",
+      "+define+macro6=a=b",
       "+incdir+../path/to/file4+./path/to/file5"};
   auto parsed_file_list = ParseSourceFileListFromCommandline(cmdline);
   ASSERT_TRUE(parsed_file_list.ok());
@@ -620,14 +621,12 @@ TEST(VerilogProjectTest, ParseSourceFileListFromCommandline) {
   EXPECT_THAT(parsed_file_list->include_dirs,
               ElementsAre("~/path/to/file1", "path/to/file2", "./path/to/file3",
                           "../path/to/file4", "./path/to/file5"));
-  std::vector<TextMacroDefinition> macros = {{"macro1", "text1"},
-                                             {"macro2", ""},
-                                             {"macro3", "text3"},
-                                             {"macro4", ""},
-                                             {"macro5", ""}};
-  EXPECT_THAT(
-      parsed_file_list->defines,
-      ElementsAre(macros[0], macros[1], macros[2], macros[3], macros[4]));
+  std::vector<TextMacroDefinition> macros = {
+      {"macro1", "text1"}, {"macro2", ""}, {"macro3", "text3"},
+      {"macro4", ""},      {"macro5", ""}, {"macro6", "a=b"}};
+  EXPECT_THAT(parsed_file_list->defines,
+              ElementsAre(macros[0], macros[1], macros[2], macros[3], macros[4],
+                          macros[5]));
 }
 
 }  // namespace

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -594,8 +594,6 @@ TEST(VerilogProjectTest, ParseSourceFileList) {
 
 TEST(VerilogProjectTest, ParseSourceFileListFromCommandline) {
   std::vector<absl::string_view> cmdline;
-  // The first argument will be discarded.
-  cmdline.push_back("the_tool_name");
   cmdline.push_back("+define+macro1=text1+macro2+macro3=text3");
   cmdline.push_back("file1");
   cmdline.push_back("+define+macro4");

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -592,17 +592,26 @@ TEST(VerilogProjectTest, ParseSourceFileList) {
               ElementsAre(".", "/an/include_dir1", "/an/include_dir2"));
 }
 
+TEST(VerilogProjectTest, ParseInvalidSourceFileListFromCommandline) {
+  std::vector<std::vector<absl::string_view>> test_cases = {
+      {"+define+macro1="}, {"+define+"}, {"+not_valid_define+"}};
+  for (const auto& cmdline : test_cases) {
+    auto parsed_file_list = ParseSourceFileListFromCommandline(cmdline);
+    ASSERT_FALSE(parsed_file_list.ok());
+  }
+}
+
 TEST(VerilogProjectTest, ParseSourceFileListFromCommandline) {
-  std::vector<absl::string_view> cmdline;
-  cmdline.push_back("+define+macro1=text1+macro2+macro3=text3");
-  cmdline.push_back("file1");
-  cmdline.push_back("+define+macro4");
-  cmdline.push_back("file2");
-  cmdline.push_back("+incdir+~/path/to/file1+path/to/file2");
-  cmdline.push_back("+incdir+./path/to/file3");
-  cmdline.push_back("+define+macro5");
-  cmdline.push_back("file3");
-  cmdline.push_back("+incdir+../path/to/file4+./path/to/file5");
+  std::vector<absl::string_view> cmdline = {
+      "+define+macro1=text1+macro2+macro3=text3",
+      "file1",
+      "+define+macro4",
+      "file2",
+      "+incdir+~/path/to/file1+path/to/file2",
+      "+incdir+./path/to/file3",
+      "+define+macro5",
+      "file3",
+      "+incdir+../path/to/file4+./path/to/file5"};
   auto parsed_file_list = ParseSourceFileListFromCommandline(cmdline);
   ASSERT_TRUE(parsed_file_list.ok());
 
@@ -611,12 +620,11 @@ TEST(VerilogProjectTest, ParseSourceFileListFromCommandline) {
   EXPECT_THAT(parsed_file_list->include_dirs,
               ElementsAre("~/path/to/file1", "path/to/file2", "./path/to/file3",
                           "../path/to/file4", "./path/to/file5"));
-  std::vector<TextMacroDefinition> macros;
-  macros.push_back(TextMacroDefinition{"macro1", "text1"});
-  macros.push_back(TextMacroDefinition{"macro2", ""});
-  macros.push_back(TextMacroDefinition{"macro3", "text3"});
-  macros.push_back(TextMacroDefinition{"macro4", ""});
-  macros.push_back(TextMacroDefinition{"macro5", ""});
+  std::vector<TextMacroDefinition> macros = {{"macro1", "text1"},
+                                             {"macro2", ""},
+                                             {"macro3", "text3"},
+                                             {"macro4", ""},
+                                             {"macro5", ""}};
   EXPECT_THAT(
       parsed_file_list->defines,
       ElementsAre(macros[0], macros[1], macros[2], macros[3], macros[4]));

--- a/verilog/tools/preprocessor/BUILD
+++ b/verilog/tools/preprocessor/BUILD
@@ -17,6 +17,7 @@ cc_binary(
         "//verilog/preprocessor:verilog_preprocess",
         "//verilog/parser:verilog_lexer",
         "//verilog/analysis:verilog_analyzer",
+        "//verilog/analysis:verilog_project",
         "//verilog/analysis:flow_tree",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:usage",

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -153,6 +153,8 @@ static absl::Status GenerateVariants(const SubcommandArgsRange& args,
     return parsed_file_list.status();
   }
   const auto& files = parsed_file_list->file_paths;
+  // TODO(karimtera): Pass the +define's to the preprocessor, and only
+  // generate variants with theses defines fixed.
 
   const int limit_variants = absl::GetFlag(FLAGS_limit_variants);
 

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -41,8 +41,9 @@ static absl::Status StripComments(const SubcommandArgsRange& args,
                                   std::istream&, std::ostream& outs,
                                   std::ostream&) {
   // Parse the arguments into a FileList.
-  std::vector<absl::string_view> cmdline_args(args.begin(),args.end());
-  auto parsed_file_list = verilog::ParseSourceFileListFromCommandline(cmdline_args);
+  std::vector<absl::string_view> cmdline_args(args.begin(), args.end());
+  auto parsed_file_list =
+      verilog::ParseSourceFileListFromCommandline(cmdline_args);
   if (!parsed_file_list.ok()) {
     return parsed_file_list.status();
   }
@@ -120,17 +121,17 @@ static absl::Status MultipleCU(const SubcommandArgsRange& args, std::istream&,
                                std::ostream& outs,
                                std::ostream& message_stream) {
   // Parse the arguments into a FileList.
-  std::vector<absl::string_view> cmdline_args(args.begin(),args.end());
-  auto parsed_file_list = verilog::ParseSourceFileListFromCommandline(cmdline_args);
+  std::vector<absl::string_view> cmdline_args(args.begin(), args.end());
+  auto parsed_file_list =
+      verilog::ParseSourceFileListFromCommandline(cmdline_args);
   if (!parsed_file_list.ok()) {
     return parsed_file_list.status();
   }
   const auto& files = parsed_file_list->file_paths;
-  //TODO(karimtera): Pass defines and incdirs to "PreprocessSingleFile()".
+  // TODO(karimtera): Pass defines and incdirs to "PreprocessSingleFile()".
 
   if (files.empty()) {
-    return absl::InvalidArgumentError(
-        "ERROR: Missing file argument.");
+    return absl::InvalidArgumentError("ERROR: Missing file argument.");
   }
   for (const absl::string_view source_file : files) {
     message_stream << source_file << ":\n";
@@ -145,8 +146,9 @@ static absl::Status GenerateVariants(const SubcommandArgsRange& args,
                                      std::istream&, std::ostream& outs,
                                      std::ostream& message_stream) {
   // Parse the arguments into a FileList.
-  std::vector<absl::string_view> cmdline_args(args.begin(),args.end());
-  auto parsed_file_list = verilog::ParseSourceFileListFromCommandline(cmdline_args);
+  std::vector<absl::string_view> cmdline_args(args.begin(), args.end());
+  auto parsed_file_list =
+      verilog::ParseSourceFileListFromCommandline(cmdline_args);
   if (!parsed_file_list.ok()) {
     return parsed_file_list.status();
   }
@@ -155,8 +157,7 @@ static absl::Status GenerateVariants(const SubcommandArgsRange& args,
   const int limit_variants = absl::GetFlag(FLAGS_limit_variants);
 
   if (files.empty()) {
-    return absl::InvalidArgumentError(
-        "ERROR: Missing file argument.");
+    return absl::InvalidArgumentError("ERROR: Missing file argument.");
   }
   if (files.size() > 1) {
     return absl::InvalidArgumentError(

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -26,6 +26,7 @@
 #include "common/util/subcommand.h"
 #include "verilog/analysis/flow_tree.h"
 #include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/analysis/verilog_project.h"
 #include "verilog/parser/verilog_lexer.h"
 #include "verilog/preprocessor/verilog_preprocess.h"
 #include "verilog/transform/strip_comments.h"
@@ -80,7 +81,7 @@ static absl::Status PreprocessSingleFile(absl::string_view source_file,
     return status;
   }
   verilog::VerilogPreprocess::Config config;
-  config.filter_branches = 1;
+  config.filter_branches = true;
   // config.expand_macros=1;
   verilog::VerilogPreprocess preprocessor(config);
   verilog::VerilogLexer lexer(source_contents);
@@ -90,8 +91,9 @@ static absl::Status PreprocessSingleFile(absl::string_view source_file,
     // For now we will store the syntax tree tokens only, ignoring all the
     // white-space characters. however that should be stored to output the
     // source code just like it was, but with conditionals filtered.
-    if (verilog::VerilogLexer::KeepSyntaxTreeTokens(lexer.GetLastToken()))
+    if (verilog::VerilogLexer::KeepSyntaxTreeTokens(lexer.GetLastToken())) {
       lexed_sequence.push_back(lexer.GetLastToken());
+    }
   }
   verible::TokenStreamView lexed_streamview;
   // Initializing the lexed token stream view.


### PR DESCRIPTION
This PR implements: `ParseSourceFileListFromCommandline(const std::vector<absl::string_view>& cmdline_args)`
Which parses the command line arguments into a `FileList` that now contains a vector holding the definitions passed through `+define+`.

Note: `ParseSourceFileListFromCommandline` is not yet used in the preprocessor tool.