### PR TITLE
Fix missing dependency, drop header not needed

### DIFF
--- a/verilog/analysis/flow_tree_test.cc
+++ b/verilog/analysis/flow_tree_test.cc
@@ -141,13 +141,13 @@ TEST(FlowTree, UnvalidConditionals) {
       A_FALSE
       )",
       R"(
-    `ifdef 
+    `ifdef
       A_TRUE
     `else
       A_FALSE
       )",
       R"(
-    `ifndef 
+    `ifndef
       A_TRUE
     `else
       A_FALSE
@@ -325,7 +325,7 @@ TEST(FlowTree, CompleteConditional) {
       B_TRUE
     `elsif C
       C_TRUE
-    `else 
+    `else
       ALL_FALSE
     `endif)";
 

--- a/verilog/tools/preprocessor/BUILD
+++ b/verilog/tools/preprocessor/BUILD
@@ -18,6 +18,7 @@ cc_binary(
         "//verilog/parser:verilog_lexer",
         "//verilog/analysis:verilog_analyzer",
         "//verilog/analysis:flow_tree",
+        "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:usage",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -21,7 +21,6 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "common/lexer/token_stream_adapter.h"
 #include "common/util/file_util.h"
 #include "common/util/init_command_line.h"
 #include "common/util/subcommand.h"


### PR DESCRIPTION
 * Since we're using the flag header, need to also link the
   corresponding library
 * We never use token_stream_adapter, so let's not add
   that dependency.
 * Remove some unnecessary trailing whitespace.

Signed-off-by: Henner Zeller <hzeller@google.com>