### PR TITLE
Adds the defines passed through +define+ into the preprocessor.

### DIFF
--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -586,6 +586,20 @@ absl::Status VerilogPreprocess::HandleTokenIterator(
   return absl::OkStatus();
 }
 
+// Adds a define passed to the tool with +define+<foo>[=<value>].
+void VerilogPreprocess::AddDefineFromCmdLine(absl::string_view define_name,
+                                             absl::string_view define_body) {
+  // manually create the tokens to save them into a MacroDefinition.
+  verible::TokenInfo macro_directive(PP_define, "`define");
+  verible::TokenInfo macro_name(PP_Identifier, define_name);
+  verible::TokenInfo macro_body(PP_define_body, define_body);
+  verible::MacroDefinition macro_definition(macro_directive, macro_name);
+  macro_definition.SetDefinitionText(macro_body);
+
+  // Registers the macro definition to memeory.
+  RegisterMacroDefinition(macro_definition);
+}
+
 VerilogPreprocessData VerilogPreprocess::ScanStream(
     const TokenStreamView& token_stream) {
   preprocess_data_.preprocessed_token_stream.reserve(token_stream.size());

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -586,9 +586,9 @@ absl::Status VerilogPreprocess::HandleTokenIterator(
   return absl::OkStatus();
 }
 
-// Adds a define passed to the tool with +define+<foo>[=<value>].
-void VerilogPreprocess::AddDefineFromCmdLine(absl::string_view define_name,
-                                             absl::string_view define_body) {
+// Sets a define passed to the tool with +define+<foo>[=<value>].
+void VerilogPreprocess::SetExternalDefine(absl::string_view define_name,
+                                          absl::string_view define_body) {
   // manually create the tokens to save them into a MacroDefinition.
   verible::TokenInfo macro_directive(PP_define, "`define");
   verible::TokenInfo macro_name(PP_Identifier, define_name);

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -125,8 +125,9 @@ class VerilogPreprocess {
 
   // Add defines passed to the tool with +define+<foo>[=<value>].
   // NOTE: Since both of the arguments are string_views, it doesn't own the
-  // referenced memory. The user should ensure that owning strings outlive these
-  // string_views.
+  // referenced memory.
+  // The user should ensure that owning strings outlive the VerilogPreprocess
+  // object.
   void SetExternalDefine(absl::string_view define_name,
                          absl::string_view define_body);
   // TODO(karimtera): It would be better to pass the "FileList" all at once,

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -124,8 +124,14 @@ class VerilogPreprocess {
   // TODO(b/111544845): ExpandEvalStringLiteral
 
   // Add defines passed to the tool with +define+<foo>[=<value>].
-  void AddDefineFromCmdLine(absl::string_view define_name,
-                            absl::string_view define_body);
+  // NOTE: Since both of the arguments are string_views, it doesn't own the
+  // referenced memory. The user should ensure that owning strings outlive these
+  // string_views.
+  void SetExternalDefine(absl::string_view define_name,
+                         absl::string_view define_body);
+  // TODO(karimtera): It would be better to pass the "FileList" all at once,
+  // and hold it inside the preprocessor object, that way it can use the incdirs
+  // also, without needing to pass another obeject.
 
  private:
   using StreamIteratorGenerator =

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -123,6 +123,10 @@ class VerilogPreprocess {
   // TODO(fangism): ExpandMacro, ExpandMacroCall
   // TODO(b/111544845): ExpandEvalStringLiteral
 
+  // Add defines passed to the tool with +define+<foo>[=<value>].
+  void AddDefineFromCmdLine(absl::string_view define_name,
+                            absl::string_view define_body);
+
  private:
   using StreamIteratorGenerator =
       std::function<TokenStreamView::const_iterator()>;

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -791,5 +791,25 @@ endmodule
   }
 }
 
+TEST(VerilogPreprocessTest, SetExternalDefines) {
+  // Test case input tokens.
+  const verible::TokenSequence test_case_tokens = {
+      {verible::TokenInfo(MacroIdentifier, "`MACRO1")},
+      {MacroIdentifier, "`MACRO2"}};
+  verible::TokenStreamView test_case_stream_view;
+  verible::InitTokenStreamView(test_case_tokens, &test_case_stream_view);
+
+  VerilogPreprocess::Config test_config({.expand_macros = true});
+  VerilogPreprocess preprocessor(test_config);
+
+  preprocessor.SetExternalDefine("MACRO1", "VALUE1");
+  preprocessor.SetExternalDefine("MACRO2", "VALUE2");
+
+  const auto& pp_data = preprocessor.ScanStream(test_case_stream_view);
+
+  EXPECT_THAT(pp_data.preprocessed_token_stream[0]->text(), "VALUE1");
+  EXPECT_THAT(pp_data.preprocessed_token_stream[1]->text(), "VALUE2");
+}
+
 }  // namespace
 }  // namespace verilog

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -791,6 +791,9 @@ endmodule
   }
 }
 
+// TODO(karimtera): This test doesn't use "PreprocessorTester",
+// as there isn't a way to tell "VerilogAnalyzer" about external defines.
+// Typically, all tests should use "PreprocessorTester".
 TEST(VerilogPreprocessTest, SetExternalDefines) {
   // Test case input tokens.
   const verible::TokenSequence test_case_tokens = {
@@ -809,6 +812,34 @@ TEST(VerilogPreprocessTest, SetExternalDefines) {
 
   EXPECT_THAT(pp_data.preprocessed_token_stream[0]->text(), "VALUE1");
   EXPECT_THAT(pp_data.preprocessed_token_stream[1]->text(), "VALUE2");
+}
+
+// TODO(karimtera): This test doesn't use "PreprocessorTester",
+// as there isn't a way to tell "VerilogAnalyzer" about external defines.
+// Typically, all tests should use "PreprocessorTester".
+TEST(VerilogPreprocessTest, ExternalDefinesWithUndef) {
+  // Test case input tokens.
+  const verible::TokenSequence test_case_tokens = {
+      {verible::TokenInfo(PP_undef, "`undef")},
+      {verible::TokenInfo(PP_Identifier, "MACRO1")},
+      {verible::TokenInfo(MacroIdentifier, "`MACRO1")},
+      {verible::TokenInfo(MacroIdentifier, "`MACRO2")}};
+  verible::TokenStreamView test_case_stream_view;
+  verible::InitTokenStreamView(test_case_tokens, &test_case_stream_view);
+
+  VerilogPreprocess::Config test_config({.expand_macros = true});
+  VerilogPreprocess preprocessor(test_config);
+
+  preprocessor.SetExternalDefine("MACRO1", "VALUE1");
+  preprocessor.SetExternalDefine("MACRO2", "VALUE2");
+
+  const auto& pp_data = preprocessor.ScanStream(test_case_stream_view);
+
+  const auto& errors = pp_data.errors;
+
+  EXPECT_THAT(errors.size(), 1);
+  EXPECT_THAT(errors.front().error_message,
+              StartsWith("Error expanding macro identifier"));
 }
 
 }  // namespace

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -96,9 +96,9 @@ static absl::Status PreprocessSingleFile(
   // config.expand_macros=1;
   verilog::VerilogPreprocess preprocessor(config);
 
-  // Adding defines to the preprocessor.
+  // Setting defines in the preprocessor.
   for (const auto& define : defines) {
-    preprocessor.AddDefineFromCmdLine(define.name, define.value);
+    preprocessor.SetExternalDefine(define.name, define.value);
   }
 
   verilog::VerilogLexer lexer(source_contents);

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -35,6 +35,7 @@
 using verible::SubcommandArgsRange;
 using verible::SubcommandEntry;
 
+// TODO(karimtera): Add a boolean flag to configure the macro expansion.
 ABSL_FLAG(int, limit_variants, 20, "Maximum number of variants printed");
 
 static absl::Status StripComments(const SubcommandArgsRange& args,

--- a/verilog/tools/preprocessor/verilog_preprocessor_test.sh
+++ b/verilog/tools/preprocessor/verilog_preprocessor_test.sh
@@ -492,4 +492,73 @@ diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
 }
 
 ################################################################################
+echo "=== Test multiple-compilation-unit: passing defines"
+
+cat > "$MY_INPUT_FILE" <<EOF
+\`ifdef A
+  A_TRUE
+\`else
+  A_FALSE
+\`endif
+
+\`ifndef B
+  B_FALSE
+\`else
+  B_TRUE
+\`endif
+EOF
+
+
+cat > "$MY_EXPECT_FILE" <<EOF
+(#293: "A_TRUE")
+(#293: "B_FALSE")
+
+EOF
+
+"$preprocessor" multiple-compilation-unit "$MY_INPUT_FILE" +define+A > "$MY_OUTPUT_FILE" 
+
+status="$?"
+
+[[ $status == 0 ]] || {
+  "Expected exit code 0, but got $status"
+  exit 0
+}
+
+diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
+  exit 1
+}
+
+cat > "$MY_EXPECT_FILE" <<EOF
+(#293: "A_TRUE")
+(#293: "B_TRUE")
+
+EOF
+
+"$preprocessor" multiple-compilation-unit "$MY_INPUT_FILE" +define+A=a_value+B=b_value > "$MY_OUTPUT_FILE" 
+
+status="$?"
+
+[[ $status == 0 ]] || {
+  "Expected exit code 0, but got $status"
+  exit 0
+}
+
+diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
+  exit 1
+}
+
+"$preprocessor" multiple-compilation-unit "$MY_INPUT_FILE" +define+A +define+B > "$MY_OUTPUT_FILE" 
+
+status="$?"
+
+[[ $status == 0 ]] || {
+  "Expected exit code 0, but got $status"
+  exit 0
+}
+
+diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
+  exit 1
+}
+
+################################################################################
 echo "PASS"


### PR DESCRIPTION
The goal is to register the defines passed to the processor tool through `+define+<macro>[=<value>]` into the preprocessor defines map.

Added the method `VerilogPreprocess::AddDefineFromCmdLine` wihch internally registers defines using the method `VerilogPreprocess::RegisterMacroDefinition` to ensure that everything is aligned, and these passed defines are treated the same way as macros defined by `` `define <macro> <body>``.

Suggestion:
- It might be the time to use `MacroDefinition` instead of `TextMacroDefinition` to save defines in the `FileList` struct.
But, I am not sure about who will own the data itself as `MacroDefinition` only holds Tokens (string-views).