### PR TITLE
Bump glog

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,9 +58,9 @@ http_archive(
 
 http_archive(
     name = "com_github_google_glog",
-    sha256 = "087a3de2eccce54a597fbb9d1530d4b8c1bae6ff6083511c19fe56b01a1f4f05",
-    strip_prefix = "glog-0.5.0-rc2",
-    urls = ["https://github.com/google/glog/archive/v0.5.0-rc2.tar.gz"],
+    sha256 = "8a83bf982f37bb70825df71a9709fa90ea9f4447fb3c099e1d720a439d88bad6",
+    strip_prefix = "glog-0.6.0",
+    urls = ["https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"],
 )
 
 #


### PR DESCRIPTION
This bumps the glog dependency to the latest version.

It solved the following problem on macOS with strict warning settings:

```bash
ERROR: /private/var/tmp/_bazel_sschaetz/58178f5cbadb135b3179e421ef008716/external/com_github_google_glog/BUILD.bazel:5:13: Compiling src/raw_logging.cc failed: (Aborted): wrapped_clang_pp failed: error executing command external/local_config_cc/wrapped_clang_pp '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -g0 -O2 -DNDEBUG ... (remaining 61 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox
external/com_github_google_glog/src/raw_logging.cc:139:3: error: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Werror,-Wdeprecated-declarations]
  safe_write(STDERR_FILENO, buffer, strlen(buffer));
  ^
external/com_github_google_glog/src/raw_logging.cc:63:34: note: expanded from macro 'safe_write'
# define safe_write(fd, s, len)  syscall(SYS_write, fd, s, len)
                                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/unistd.h:746:6: note: 'syscall' has been explicitly marked deprecated here
int      syscall(int, ...);
         ^
1 error generated.
Error in child process '/usr/bin/xcrun'. 1
```