### PR TITLE
Enable C++20 Support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,12 +12,12 @@ common:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXX
 
 # https://github.com/abseil/abseil-cpp/issues/848
 # https://github.com/bazelbuild/bazel/issues/4341#issuecomment-758361769
-common:macos --features=-supports_dynamic_linker --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+common:macos --features=-supports_dynamic_linker --cxxopt=-std=c++20 --host_cxxopt=-std=c++20 --client_env=BAZEL_CXXOPTS=-std=c++20
 
 # Force the use clang-cl on Windows instead of MSVC. MSVC has some issues with
 # the codebase, so we focus the effort for now is to have a Windows Verible
 # compiled with clang-cl before fixing the issues unique to MSVC.
-common:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17
+common:windows --compiler=clang-cl --cxxopt=/std:c++20 --host_cxxopt=/std:c++20 --client_env=BAZEL_CXXOPTS=/std:c++20
 
 # Address sanitizer settings.
 build:asan --strip=never

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -201,6 +201,20 @@ using LayoutTree = VectorTree<LayoutItem>;
 // Single segment of LayoutFunction
 // Maps starting column to a linear cost function and its optimal layout.
 struct LayoutFunctionSegment {
+  LayoutFunctionSegment(
+    int column,
+    const LayoutTree& layout,
+    int span,
+    float intercept,
+    int gradient
+  ) :
+    column(column),
+    layout(layout),
+    span(span),
+    intercept(intercept),
+    gradient(gradient)
+  {}
+
   // Starting column.
   // AKA: knot.
   int column;

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -201,19 +201,13 @@ using LayoutTree = VectorTree<LayoutItem>;
 // Single segment of LayoutFunction
 // Maps starting column to a linear cost function and its optimal layout.
 struct LayoutFunctionSegment {
-  LayoutFunctionSegment(
-    int column,
-    const LayoutTree& layout,
-    int span,
-    float intercept,
-    int gradient
-  ) :
-    column(column),
-    layout(layout),
-    span(span),
-    intercept(intercept),
-    gradient(gradient)
-  {}
+  LayoutFunctionSegment(int column, const LayoutTree& layout, int span,
+                        float intercept, int gradient)
+      : column(column),
+        layout(layout),
+        span(span),
+        intercept(intercept),
+        gradient(gradient) {}
 
   // Starting column.
   // AKA: knot.

--- a/common/util/expandable_tree_view.h
+++ b/common/util/expandable_tree_view.h
@@ -215,10 +215,10 @@ class ExpandableTreeView<WrappedNodeType>::iterator {
                                                      // constructor
  public:
   using iterator_category = std::forward_iterator_tag;
-  using value_type = value_type;
+  using value_type = typename TreeTraits::Value::type;
   using difference_type = int;
-  using pointer = value_type*;
-  using reference = value_type&;
+  using pointer = typename TreeTraits::Value::type*;
+  using reference = typename TreeTraits::Value::type&;
 
  private:
   explicit iterator(const impl_type* node) : node_(node) {}

--- a/common/util/expandable_tree_view.h
+++ b/common/util/expandable_tree_view.h
@@ -210,10 +210,15 @@ class ExpandableTreeView {
 // node is visited unexpanded, or that node's children is visited; iteration
 // never visits both a node AND its children, only one or the other.
 template <class WrappedNodeType>
-class ExpandableTreeView<WrappedNodeType>::iterator
-    : public std::iterator<std::forward_iterator_tag, const value_type> {
+class ExpandableTreeView<WrappedNodeType>::iterator {
   friend class ExpandableTreeView<WrappedNodeType>;  // grant access to private
                                                      // constructor
+ public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = value_type;
+  using difference_type = int;
+  using pointer = value_type*;
+  using reference = value_type&;
 
  private:
   explicit iterator(const impl_type* node) : node_(node) {}

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -478,12 +478,9 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // Create a self-reference to this struct type so that it can be linked
     // for declarations that use this type.
     const ReferenceComponent anon_type_ref(
-        anon_name,
-        ReferenceType::kImmediate,
-        SymbolMetaType::kStruct,
+        anon_name, ReferenceType::kImmediate, SymbolMetaType::kStruct,
         // pre-resolve this symbol immediately
-        new_struct
-    );
+        new_struct);
 
     const CaptureDependentReference capture(this);
     capture.Ref().PushReferenceComponent(anon_type_ref);
@@ -501,12 +498,9 @@ class SymbolTable::Builder : public TreeContextVisitor {
         enum_type, anon_name, SymbolMetaType::kEnumType);
 
     const ReferenceComponent anon_type_ref(
-        anon_name,
-        ReferenceType::kImmediate,
-        SymbolMetaType::kEnumType,
+        anon_name, ReferenceType::kImmediate, SymbolMetaType::kEnumType,
         // pre-resolve this symbol immediately
-        new_enum
-    );
+        new_enum);
 
     const CaptureDependentReference capture(this);
     capture.Ref().PushReferenceComponent(anon_type_ref);
@@ -522,13 +516,11 @@ class SymbolTable::Builder : public TreeContextVisitor {
       const auto& syntax_origin =
           *ABSL_DIE_IF_NULL(symbol.Value().syntax_origin);
 
-      const ReferenceComponent itr_ref(
-          enum_constant_name,
-          ReferenceType::kImmediate,
-          SymbolMetaType::kEnumConstant,
-          // pre-resolve this symbol immediately
-          &symbol
-      );
+      const ReferenceComponent itr_ref(enum_constant_name,
+                                       ReferenceType::kImmediate,
+                                       SymbolMetaType::kEnumConstant,
+                                       // pre-resolve this symbol immediately
+                                       &symbol);
 
       // CaptureDependentReference class doesn't support
       // copy constructor
@@ -703,11 +695,8 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // reference.
     DependentReferences& ref(reference_builders_.top());
 
-    const ReferenceComponent new_ref(
-        text,
-        InferReferenceType(),
-        InferMetaType()
-    );
+    const ReferenceComponent new_ref(text, InferReferenceType(),
+                                     InferMetaType());
 
     // For instances' named ports, and types' named parameters,
     // add references as siblings of the same parent.
@@ -729,13 +718,10 @@ class SymbolTable::Builder : public TreeContextVisitor {
             EmplaceTypedElementInCurrentScope(
                 leaf, text, SymbolMetaType::kDataNetVariableInstance);
 
-        const ReferenceComponent implicit_ref(
-            text,
-            InferReferenceType(),
-            InferMetaType(),
-            // pre-resolve
-            &implicit_declaration
-        );
+        const ReferenceComponent implicit_ref(text, InferReferenceType(),
+                                              InferMetaType(),
+                                              // pre-resolve
+                                              &implicit_declaration);
 
         ref.PushReferenceComponent(implicit_ref);
         return;
@@ -908,12 +894,8 @@ class SymbolTable::Builder : public TreeContextVisitor {
   SymbolTableNode* EmplaceElementInCurrentScope(const verible::Symbol& element,
                                                 absl::string_view name,
                                                 SymbolMetaType metatype) {
-    const auto p =
-        current_scope_->TryEmplace(name, SymbolInfo(
-                                             metatype,
-                                             source_,
-                                             &element
-                                         ));
+    const auto p = current_scope_->TryEmplace(
+        name, SymbolInfo(metatype, source_, &element));
     if (!p.second) {
       DiagnoseSymbolAlreadyExists(name, p.first->first);
     }
@@ -930,14 +912,10 @@ class SymbolTable::Builder : public TreeContextVisitor {
     VLOG(1) << "  type info: " << *ABSL_DIE_IF_NULL(declaration_type_info_);
     VLOG(1) << "  full text: " << AutoTruncate{StringSpanOfSymbol(element), 40};
     const auto p = current_scope_->TryEmplace(
-        name,
-        SymbolInfo(
-            metatype,
-            source_,
-            &element,
-            // associate this instance with its declared type
-            *ABSL_DIE_IF_NULL(declaration_type_info_)  // copy
-        ));
+        name, SymbolInfo(metatype, source_, &element,
+                         // associate this instance with its declared type
+                         *ABSL_DIE_IF_NULL(declaration_type_info_)  // copy
+                         ));
     if (!p.second) {
       DiagnoseSymbolAlreadyExists(name, p.first->first);
     }
@@ -1047,8 +1025,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // Create a self-reference to this class.
     const ReferenceComponent class_type_ref(
         new_keyword->get().text(),  // "new"
-        ReferenceType::kImmediate,
-        SymbolMetaType::kClass,
+        ReferenceType::kImmediate, SymbolMetaType::kClass,
         // pre-resolve this symbol to the enclosing class immediately
         current_scope_  // the current class
     );
@@ -1060,9 +1037,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
     DeclarationTypeInfo decl_type_info(
         // There is no actual source text that references the type here.
         // We arbitrarily designate the 'new' keyword as the reference point.
-        new_keyword,
-        capture.Ref().LastLeaf()
-    );
+        new_keyword, capture.Ref().LastLeaf());
     const ValueSaver<DeclarationTypeInfo*> function_return_type(
         &declaration_type_info_, &decl_type_info);
 
@@ -1161,12 +1136,10 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // This is a self-reference.
     const CaptureDependentReference capture(this);
     capture.Ref().PushReferenceComponent(ReferenceComponent(
-        instance_name,
-        ReferenceType::kUnqualified,
+        instance_name, ReferenceType::kUnqualified,
         SymbolMetaType::kDataNetVariableInstance,
         // Start with its type already resolved to the node we just declared.
-        &new_instance
-    ));
+        &new_instance));
 
     // Inform that named port identifiers will yield parallel children from
     // this reference branch point.
@@ -1252,11 +1225,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const absl::string_view inner_key = inner_ref.identifier;
 
     const auto p = outer_scope->TryEmplace(
-        inner_key, SymbolInfo(
-                       metatype,
-                       source_,
-                       definition_syntax
-                   ));
+        inner_key, SymbolInfo(metatype, source_, definition_syntax));
     SymbolTableNode* inner_symbol = &p.first->second;
     if (p.second) {
       // If injection succeeded, then the outer_scope did not already contain a

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -477,13 +477,13 @@ class SymbolTable::Builder : public TreeContextVisitor {
 
     // Create a self-reference to this struct type so that it can be linked
     // for declarations that use this type.
-    const ReferenceComponent anon_type_ref{
-        .identifier = anon_name,
-        .ref_type = ReferenceType::kImmediate,
-        .required_metatype = SymbolMetaType::kStruct,
+    const ReferenceComponent anon_type_ref(
+        anon_name,
+        ReferenceType::kImmediate,
+        SymbolMetaType::kStruct,
         // pre-resolve this symbol immediately
-        .resolved_symbol = new_struct,
-    };
+        new_struct
+    );
 
     const CaptureDependentReference capture(this);
     capture.Ref().PushReferenceComponent(anon_type_ref);
@@ -500,13 +500,13 @@ class SymbolTable::Builder : public TreeContextVisitor {
     SymbolTableNode* new_enum = DeclareScopedElementAndDescend(
         enum_type, anon_name, SymbolMetaType::kEnumType);
 
-    const ReferenceComponent anon_type_ref{
-        .identifier = anon_name,
-        .ref_type = ReferenceType::kImmediate,
-        .required_metatype = SymbolMetaType::kEnumType,
+    const ReferenceComponent anon_type_ref(
+        anon_name,
+        ReferenceType::kImmediate,
+        SymbolMetaType::kEnumType,
         // pre-resolve this symbol immediately
-        .resolved_symbol = new_enum,
-    };
+        new_enum
+    );
 
     const CaptureDependentReference capture(this);
     capture.Ref().PushReferenceComponent(anon_type_ref);
@@ -522,13 +522,13 @@ class SymbolTable::Builder : public TreeContextVisitor {
       const auto& syntax_origin =
           *ABSL_DIE_IF_NULL(symbol.Value().syntax_origin);
 
-      const ReferenceComponent itr_ref{
-          .identifier = enum_constant_name,
-          .ref_type = ReferenceType::kImmediate,
-          .required_metatype = SymbolMetaType::kEnumConstant,
+      const ReferenceComponent itr_ref(
+          enum_constant_name,
+          ReferenceType::kImmediate,
+          SymbolMetaType::kEnumConstant,
           // pre-resolve this symbol immediately
-          .resolved_symbol = &symbol,
-      };
+          &symbol
+      );
 
       // CaptureDependentReference class doesn't support
       // copy constructor
@@ -703,11 +703,11 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // reference.
     DependentReferences& ref(reference_builders_.top());
 
-    const ReferenceComponent new_ref{
-        .identifier = text,
-        .ref_type = InferReferenceType(),
-        .required_metatype = InferMetaType(),
-    };
+    const ReferenceComponent new_ref(
+        text,
+        InferReferenceType(),
+        InferMetaType()
+    );
 
     // For instances' named ports, and types' named parameters,
     // add references as siblings of the same parent.
@@ -729,13 +729,13 @@ class SymbolTable::Builder : public TreeContextVisitor {
             EmplaceTypedElementInCurrentScope(
                 leaf, text, SymbolMetaType::kDataNetVariableInstance);
 
-        const ReferenceComponent implicit_ref{
-            .identifier = text,
-            .ref_type = InferReferenceType(),
-            .required_metatype = InferMetaType(),
+        const ReferenceComponent implicit_ref(
+            text,
+            InferReferenceType(),
+            InferMetaType(),
             // pre-resolve
-            .resolved_symbol = &implicit_declaration,
-        };
+            &implicit_declaration
+        );
 
         ref.PushReferenceComponent(implicit_ref);
         return;
@@ -909,11 +909,11 @@ class SymbolTable::Builder : public TreeContextVisitor {
                                                 absl::string_view name,
                                                 SymbolMetaType metatype) {
     const auto p =
-        current_scope_->TryEmplace(name, SymbolInfo{
-                                             .metatype = metatype,
-                                             .file_origin = source_,
-                                             .syntax_origin = &element,
-                                         });
+        current_scope_->TryEmplace(name, SymbolInfo(
+                                             metatype,
+                                             source_,
+                                             &element
+                                         ));
     if (!p.second) {
       DiagnoseSymbolAlreadyExists(name, p.first->first);
     }
@@ -931,13 +931,13 @@ class SymbolTable::Builder : public TreeContextVisitor {
     VLOG(1) << "  full text: " << AutoTruncate{StringSpanOfSymbol(element), 40};
     const auto p = current_scope_->TryEmplace(
         name,
-        SymbolInfo{
-            .metatype = metatype,
-            .file_origin = source_,
-            .syntax_origin = &element,
+        SymbolInfo(
+            metatype,
+            source_,
+            &element,
             // associate this instance with its declared type
-            .declared_type = *ABSL_DIE_IF_NULL(declaration_type_info_),  // copy
-        });
+            *ABSL_DIE_IF_NULL(declaration_type_info_)  // copy
+        ));
     if (!p.second) {
       DiagnoseSymbolAlreadyExists(name, p.first->first);
     }
@@ -1045,24 +1045,24 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const SyntaxTreeLeaf* new_keyword =
         GetConstructorPrototypeNewKeyword(constructor_node);
     // Create a self-reference to this class.
-    const ReferenceComponent class_type_ref{
-        .identifier = new_keyword->get().text(),  // "new"
-        .ref_type = ReferenceType::kImmediate,
-        .required_metatype = SymbolMetaType::kClass,
+    const ReferenceComponent class_type_ref(
+        new_keyword->get().text(),  // "new"
+        ReferenceType::kImmediate,
+        SymbolMetaType::kClass,
         // pre-resolve this symbol to the enclosing class immediately
-        .resolved_symbol = current_scope_,  // the current class
-    };
+        current_scope_  // the current class
+    );
 
     // Build-up a reference to the constructor, rooted at the class node.
     const CaptureDependentReference capture(this);
     capture.Ref().PushReferenceComponent(class_type_ref);
 
-    DeclarationTypeInfo decl_type_info{
+    DeclarationTypeInfo decl_type_info(
         // There is no actual source text that references the type here.
         // We arbitrarily designate the 'new' keyword as the reference point.
-        .syntax_origin = new_keyword,
-        .user_defined_type = capture.Ref().LastLeaf(),
-    };
+        new_keyword,
+        capture.Ref().LastLeaf()
+    );
     const ValueSaver<DeclarationTypeInfo*> function_return_type(
         &declaration_type_info_, &decl_type_info);
 
@@ -1160,13 +1160,13 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // so that named port references are direct children of this reference root.
     // This is a self-reference.
     const CaptureDependentReference capture(this);
-    capture.Ref().PushReferenceComponent(ReferenceComponent{
-        .identifier = instance_name,
-        .ref_type = ReferenceType::kUnqualified,
-        .required_metatype = SymbolMetaType::kDataNetVariableInstance,
+    capture.Ref().PushReferenceComponent(ReferenceComponent(
+        instance_name,
+        ReferenceType::kUnqualified,
+        SymbolMetaType::kDataNetVariableInstance,
         // Start with its type already resolved to the node we just declared.
-        .resolved_symbol = &new_instance,
-    });
+        &new_instance
+    ));
 
     // Inform that named port identifiers will yield parallel children from
     // this reference branch point.
@@ -1252,11 +1252,11 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const absl::string_view inner_key = inner_ref.identifier;
 
     const auto p = outer_scope->TryEmplace(
-        inner_key, SymbolInfo{
-                       .metatype = metatype,
-                       .file_origin = source_,
-                       .syntax_origin = definition_syntax,
-                   });
+        inner_key, SymbolInfo(
+                       metatype,
+                       source_,
+                       definition_syntax
+                   ));
     SymbolTableNode* inner_symbol = &p.first->second;
     if (p.second) {
       // If injection succeeded, then the outer_scope did not already contain a

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -131,6 +131,17 @@ struct ReferenceComponent {
   const SymbolTableNode* resolved_symbol = nullptr;
 
  public:
+  ReferenceComponent(
+    const absl::string_view& identifier,
+    const ReferenceType& ref_type,
+    const SymbolMetaType required_metatype = SymbolMetaType::kUnspecified,
+    const SymbolTableNode* resolved_symbol = nullptr) :
+  identifier(identifier),
+  ref_type(ref_type),
+  required_metatype(required_metatype),
+  resolved_symbol(resolved_symbol)
+  {}
+
   ReferenceComponent(const ReferenceComponent&) = default;  // safe to copy
   ReferenceComponent(ReferenceComponent&&) = default;
   ReferenceComponent& operator=(const ReferenceComponent&) = delete;
@@ -184,6 +195,10 @@ struct DependentReferences {
   std::unique_ptr<ReferenceComponentNode> components;
 
  public:
+  DependentReferences(
+    std::unique_ptr<ReferenceComponentNode> components
+  ) : components(std::move(components)) {}
+
   DependentReferences() = default;
   // move-only
   DependentReferences(const DependentReferences&) = delete;
@@ -256,7 +271,11 @@ struct DeclarationTypeInfo {
   bool implicit = false;
 
  public:
-  DeclarationTypeInfo() = default;
+  DeclarationTypeInfo(const verible::Symbol* syntax_origin = nullptr,
+    const ReferenceComponentNode* user_defined_type = nullptr) :
+    syntax_origin(syntax_origin),
+    user_defined_type(user_defined_type)
+  {}
 
   // copy-able, move-able, assignable
   DeclarationTypeInfo(const DeclarationTypeInfo&) = default;
@@ -333,6 +352,17 @@ struct SymbolInfo {
 
  public:  // methods
   SymbolInfo() = default;
+
+  SymbolInfo(const SymbolMetaType& metatype,
+    const VerilogSourceFile* file_origin = nullptr,
+    const verible::Symbol* syntax_origin = nullptr,
+    const DeclarationTypeInfo& declared_type = DeclarationTypeInfo()
+    ) :
+    metatype(metatype),
+    file_origin(file_origin),
+    syntax_origin(syntax_origin),
+    declared_type(declared_type)
+  {}
 
   // move-only
   SymbolInfo(const SymbolInfo&) = delete;
@@ -427,7 +457,7 @@ class SymbolTable {
   // and string memory, otherwise string memory is owned by 'project'.
   explicit SymbolTable(VerilogProject* project)
       : project_(project),
-        symbol_table_root_(SymbolInfo{.metatype = SymbolMetaType::kRoot}) {}
+        symbol_table_root_(SymbolInfo(SymbolMetaType::kRoot)) {}
 
   // can become move-able when needed
   SymbolTable(const SymbolTable&) = delete;

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -193,7 +193,8 @@ struct DependentReferences {
   std::unique_ptr<ReferenceComponentNode> components;
 
  public:
-  DependentReferences(std::unique_ptr<ReferenceComponentNode> components)
+  explicit DependentReferences(
+      std::unique_ptr<ReferenceComponentNode> components)
       : components(std::move(components)) {}
 
   DependentReferences() = default;
@@ -268,8 +269,9 @@ struct DeclarationTypeInfo {
   bool implicit = false;
 
  public:
-  DeclarationTypeInfo(const verible::Symbol* syntax_origin = nullptr,
-                      const ReferenceComponentNode* user_defined_type = nullptr)
+  explicit DeclarationTypeInfo(
+      const verible::Symbol* syntax_origin = nullptr,
+      const ReferenceComponentNode* user_defined_type = nullptr)
       : syntax_origin(syntax_origin), user_defined_type(user_defined_type) {}
 
   // copy-able, move-able, assignable
@@ -348,10 +350,11 @@ struct SymbolInfo {
  public:  // methods
   SymbolInfo() = default;
 
-  SymbolInfo(const SymbolMetaType& metatype,
-             const VerilogSourceFile* file_origin = nullptr,
-             const verible::Symbol* syntax_origin = nullptr,
-             const DeclarationTypeInfo& declared_type = DeclarationTypeInfo())
+  explicit SymbolInfo(
+      const SymbolMetaType& metatype,
+      const VerilogSourceFile* file_origin = nullptr,
+      const verible::Symbol* syntax_origin = nullptr,
+      const DeclarationTypeInfo& declared_type = DeclarationTypeInfo())
       : metatype(metatype),
         file_origin(file_origin),
         syntax_origin(syntax_origin),

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -132,15 +132,13 @@ struct ReferenceComponent {
 
  public:
   ReferenceComponent(
-    const absl::string_view& identifier,
-    const ReferenceType& ref_type,
-    const SymbolMetaType required_metatype = SymbolMetaType::kUnspecified,
-    const SymbolTableNode* resolved_symbol = nullptr) :
-  identifier(identifier),
-  ref_type(ref_type),
-  required_metatype(required_metatype),
-  resolved_symbol(resolved_symbol)
-  {}
+      const absl::string_view& identifier, const ReferenceType& ref_type,
+      const SymbolMetaType required_metatype = SymbolMetaType::kUnspecified,
+      const SymbolTableNode* resolved_symbol = nullptr)
+      : identifier(identifier),
+        ref_type(ref_type),
+        required_metatype(required_metatype),
+        resolved_symbol(resolved_symbol) {}
 
   ReferenceComponent(const ReferenceComponent&) = default;  // safe to copy
   ReferenceComponent(ReferenceComponent&&) = default;
@@ -195,9 +193,8 @@ struct DependentReferences {
   std::unique_ptr<ReferenceComponentNode> components;
 
  public:
-  DependentReferences(
-    std::unique_ptr<ReferenceComponentNode> components
-  ) : components(std::move(components)) {}
+  DependentReferences(std::unique_ptr<ReferenceComponentNode> components)
+      : components(std::move(components)) {}
 
   DependentReferences() = default;
   // move-only
@@ -272,10 +269,8 @@ struct DeclarationTypeInfo {
 
  public:
   DeclarationTypeInfo(const verible::Symbol* syntax_origin = nullptr,
-    const ReferenceComponentNode* user_defined_type = nullptr) :
-    syntax_origin(syntax_origin),
-    user_defined_type(user_defined_type)
-  {}
+                      const ReferenceComponentNode* user_defined_type = nullptr)
+      : syntax_origin(syntax_origin), user_defined_type(user_defined_type) {}
 
   // copy-able, move-able, assignable
   DeclarationTypeInfo(const DeclarationTypeInfo&) = default;
@@ -354,15 +349,13 @@ struct SymbolInfo {
   SymbolInfo() = default;
 
   SymbolInfo(const SymbolMetaType& metatype,
-    const VerilogSourceFile* file_origin = nullptr,
-    const verible::Symbol* syntax_origin = nullptr,
-    const DeclarationTypeInfo& declared_type = DeclarationTypeInfo()
-    ) :
-    metatype(metatype),
-    file_origin(file_origin),
-    syntax_origin(syntax_origin),
-    declared_type(declared_type)
-  {}
+             const VerilogSourceFile* file_origin = nullptr,
+             const verible::Symbol* syntax_origin = nullptr,
+             const DeclarationTypeInfo& declared_type = DeclarationTypeInfo())
+      : metatype(metatype),
+        file_origin(file_origin),
+        syntax_origin(syntax_origin),
+        declared_type(declared_type) {}
 
   // move-only
   SymbolInfo(const SymbolInfo&) = delete;

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -147,10 +147,8 @@ TEST(SymbolTableNodeFullPathTest, Print) {
 
 TEST(ReferenceComponentTest, MatchesMetatypeTest) {
   {  // kUnspecified matches all metatypes
-    const ReferenceComponent component(
-        "",
-        ReferenceType::kUnqualified,
-        SymbolMetaType::kUnspecified);
+    const ReferenceComponent component("", ReferenceType::kUnqualified,
+                                       SymbolMetaType::kUnspecified);
     for (const auto& other :
          {SymbolMetaType::kUnspecified, SymbolMetaType::kParameter,
           SymbolMetaType::kFunction, SymbolMetaType::kTask}) {
@@ -159,10 +157,8 @@ TEST(ReferenceComponentTest, MatchesMetatypeTest) {
     }
   }
   {  // kCallable matches only kFunction and kTask
-    const ReferenceComponent component(
-        "",
-        ReferenceType::kUnqualified,
-        SymbolMetaType::kCallable);
+    const ReferenceComponent component("", ReferenceType::kUnqualified,
+                                       SymbolMetaType::kCallable);
     for (const auto& other :
          {SymbolMetaType::kFunction, SymbolMetaType::kTask}) {
       const auto status = component.MatchesMetatype(other);
@@ -176,10 +172,8 @@ TEST(ReferenceComponentTest, MatchesMetatypeTest) {
     }
   }
   {  // kClass matches only kClass and kTypeAlias
-    const ReferenceComponent component(
-        "",
-        ReferenceType::kUnqualified,
-        SymbolMetaType::kClass);
+    const ReferenceComponent component("", ReferenceType::kUnqualified,
+                                       SymbolMetaType::kClass);
     for (const auto& other :
          {SymbolMetaType::kClass, SymbolMetaType::kTypeAlias}) {
       const auto status = component.MatchesMetatype(other);
@@ -194,10 +188,8 @@ TEST(ReferenceComponentTest, MatchesMetatypeTest) {
     }
   }
   {  // all other types must be matched exactly
-    const ReferenceComponent component(
-        "",
-        ReferenceType::kUnqualified,
-        SymbolMetaType::kFunction);
+    const ReferenceComponent component("", ReferenceType::kUnqualified,
+                                       SymbolMetaType::kFunction);
 
     for (const auto& other :
          {SymbolMetaType::kUnspecified, SymbolMetaType::kParameter,
@@ -214,11 +206,9 @@ TEST(ReferenceNodeFullPathTest, Print) {
   typedef ReferenceComponentNode Node;
   typedef ReferenceComponent Data;
   const Node root(
-      Data("xx",
-           ReferenceType::kUnqualified,
-           SymbolMetaType::kClass),
+      Data("xx", ReferenceType::kUnqualified, SymbolMetaType::kClass),
       Node(Data("yy", ReferenceType::kDirectMember),
-      Node(Data("zz", ReferenceType::kMemberOfTypeOfParent))));
+           Node(Data("zz", ReferenceType::kMemberOfTypeOfParent))));
   {
     std::ostringstream stream;
     ReferenceNodeFullPath(stream, root);
@@ -244,12 +234,9 @@ TEST(DependentReferencesTest, PrintEmpty) {
 }
 
 TEST(DependentReferencesTest, PrintOnlyRootNodeUnresolved) {
-  const DependentReferences dep_refs(
-      absl::make_unique<ReferenceComponentNode>(
-          ReferenceComponent("foo",
-                             ReferenceType::kUnqualified,
-                             SymbolMetaType::kUnspecified,
-                             nullptr)));
+  const DependentReferences dep_refs(absl::make_unique<ReferenceComponentNode>(
+      ReferenceComponent("foo", ReferenceType::kUnqualified,
+                         SymbolMetaType::kUnspecified, nullptr)));
   std::ostringstream stream;
   stream << dep_refs;
   EXPECT_EQ(stream.str(), "{ (@foo -> <unresolved>) }");
@@ -261,27 +248,21 @@ TEST(DependentReferencesTest, PrintNonRootResolved) {
   SymbolTableNode root(
       SymbolInfo(SymbolMetaType::kRoot),
       KV{"p_pkg",
-         SymbolTableNode(
-             SymbolInfo(SymbolMetaType::kPackage),
-             KV{"c_class", SymbolTableNode(SymbolInfo(
-                               SymbolMetaType::kClass))})});
+         SymbolTableNode(SymbolInfo(SymbolMetaType::kPackage),
+                         KV{"c_class", SymbolTableNode(SymbolInfo(
+                                           SymbolMetaType::kClass))})});
 
   // Bookmark symbol table nodes.
   MUST_ASSIGN_LOOKUP_SYMBOL(p_pkg, root, "p_pkg");
   MUST_ASSIGN_LOOKUP_SYMBOL(c_class, p_pkg, "c_class");
 
   // Construct references already resolved to above nodes.
-  const DependentReferences dep_refs(
-      absl::make_unique<ReferenceComponentNode>(
-          ReferenceComponent("p_pkg",
-                             ReferenceType::kUnqualified,
-                             SymbolMetaType::kPackage,
-                             &p_pkg),
-          ReferenceComponentNode(
-              ReferenceComponent("c_class",
-                                 ReferenceType::kDirectMember,
-                                 SymbolMetaType::kClass,
-                                 &c_class))));
+  const DependentReferences dep_refs(absl::make_unique<ReferenceComponentNode>(
+      ReferenceComponent("p_pkg", ReferenceType::kUnqualified,
+                         SymbolMetaType::kPackage, &p_pkg),
+      ReferenceComponentNode(
+          ReferenceComponent("c_class", ReferenceType::kDirectMember,
+                             SymbolMetaType::kClass, &c_class))));
 
   // Print and compare.
   std::ostringstream stream;
@@ -396,12 +377,10 @@ TEST(BuildSymbolTableTest, IntegrityCheckResolvedSymbol) {
     // mind the destruction ordering here:
     // symbol_table1 will outlive symbol_table_2, so give symbol_table_2 a
     // pointer to symbol_table_1.
-    root2.Value().local_references_to_bind.push_back(DependentReferences(
-          absl::make_unique<ReferenceComponentNode>(ReferenceComponent(
-                "foo",
-                ReferenceType::kUnqualified,
-                SymbolMetaType::kUnspecified,
-                &root1))));
+    root2.Value().local_references_to_bind.push_back(
+        DependentReferences(absl::make_unique<ReferenceComponentNode>(
+            ReferenceComponent("foo", ReferenceType::kUnqualified,
+                               SymbolMetaType::kUnspecified, &root1))));
     // CheckIntegrity() will fail on destruction of symbol_table_2.
   };
   EXPECT_DEATH(test_func(),
@@ -418,12 +397,10 @@ TEST(BuildSymbolTableTest, IntegrityCheckDeclaredType) {
     // mind the destruction ordering here:
     // symbol_table1 will outlive symbol_table_2, so give symbol_table_2 a
     // pointer to symbol_table_1.
-    root1.Value().local_references_to_bind.push_back(DependentReferences(
-        absl::make_unique<ReferenceComponentNode>(ReferenceComponent(
-                "foo",
-                ReferenceType::kUnqualified,
-                SymbolMetaType::kUnspecified,
-                &root1))));
+    root1.Value().local_references_to_bind.push_back(
+        DependentReferences(absl::make_unique<ReferenceComponentNode>(
+            ReferenceComponent("foo", ReferenceType::kUnqualified,
+                               SymbolMetaType::kUnspecified, &root1))));
     root2.Value().declared_type.user_defined_type =
         root1.Value().local_references_to_bind.front().components.get();
     // CheckIntegrity() will fail on destruction of symbol_table_2.


### PR DESCRIPTION
This change-set enables compilation of all of verible targets with C++20 support. Integration of verible into a C++20 enabled repo motivated this change.

There are 2 main deprecations that this change-set remedies:

1. The deprecation of `std::iterator` (a good summary of what is going on can be found [here](https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/)) - this prompted the change in `common/util/expandable_tree_view.h`
2. The deprecation of support for aggregate initialization for types with user-declared constructors (prompted by [P1008](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1008r1.pdf)); a good explanation of the situation can be found in [this stackoverflow question](https://stackoverflow.com/questions/57271400/why-does-aggregate-initialization-not-work-anymore-since-c20-if-a-constructor).
  This change-set works around this change by adding constructors to the types in question. I don't think this is the only solution; I believe one could also try to remove the user-declared constructors but I'm not 100% sure this would work for all types.

I'm happy to address any comments including trying to solve (2.) in a different manner if what is proposed here is not a good path forward.

 