### PR TITLE
Make clang-tidy cache dependent on WORKSPACE

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,7 @@ Checks: >
   -readability-redundant-access-specifiers,
   -readability-use-anyofallof,
   -readability-identifier-length,
+  -readability-convert-member-functions-to-static,  # creates false positive ?
   google-*,
   -google-readability-braces-around-statements,
   -google-readability-todo,


### PR DESCRIPTION
There is a recent change in glog that apparently triggers some clang-tidy issues (reason: unclar currently), but make sure that such things are detected properly.

Signed-off-by: Henner Zeller <h.zeller@acm.org>