### PR TITLE
Initialize positive condition always. Simplify ifdef/ifndef block init

### DIFF
--- a/verilog/analysis/flow_tree.cc
+++ b/verilog/analysis/flow_tree.cc
@@ -178,10 +178,7 @@ absl::Status FlowTree::GenerateVariants(const VariantReceiver &receiver) {
 absl::Status FlowTree::GenerateControlFlowTree() {
   // Adding edges for if blocks.
   int current_token_enum = 0;
-  ConditionalBlock empty_block;
-  empty_block.if_location = source_sequence_.end();
-  empty_block.else_location = source_sequence_.end();
-  empty_block.endif_location = source_sequence_.end();
+  const TokenSequenceConstIterator non_location = source_sequence_.end();
 
   for (TokenSequenceConstIterator iter = source_sequence_.begin();
        iter != source_sequence_.end(); iter++) {
@@ -190,9 +187,7 @@ absl::Status FlowTree::GenerateControlFlowTree() {
     if (IsConditional(iter)) {
       switch (current_token_enum) {
         case PP_ifdef: {
-          if_blocks_.push_back(empty_block);
-          if_blocks_.back().if_location = iter;
-          if_blocks_.back().positive_condition = 1;
+          if_blocks_.emplace_back(iter, true, non_location);
           auto status = AddMacroOfConditional(iter);
           if (!status.ok()) {
             return absl::InvalidArgumentError(
@@ -201,9 +196,7 @@ absl::Status FlowTree::GenerateControlFlowTree() {
           break;
         }
         case PP_ifndef: {
-          if_blocks_.push_back(empty_block);
-          if_blocks_.back().if_location = iter;
-          if_blocks_.back().positive_condition = 0;
+          if_blocks_.emplace_back(iter, false, non_location);
           auto status = AddMacroOfConditional(iter);
           if (!status.ok()) {
             return absl::InvalidArgumentError(

--- a/verilog/analysis/flow_tree.cc
+++ b/verilog/analysis/flow_tree.cc
@@ -187,8 +187,7 @@ absl::Status FlowTree::GenerateControlFlowTree() {
       switch (current_token_enum) {
         case PP_ifdef:
         case PP_ifndef: {
-          const bool is_positive = (current_token_enum == PP_ifdef);
-          if_blocks_.emplace_back(iter, is_positive, non_location);
+          if_blocks_.emplace_back(iter, non_location);
           auto status = AddMacroOfConditional(iter);
           if (!status.ok()) {
             return absl::InvalidArgumentError(

--- a/verilog/analysis/flow_tree.cc
+++ b/verilog/analysis/flow_tree.cc
@@ -177,26 +177,18 @@ absl::Status FlowTree::GenerateVariants(const VariantReceiver &receiver) {
 // edges_.
 absl::Status FlowTree::GenerateControlFlowTree() {
   // Adding edges for if blocks.
-  int current_token_enum = 0;
   const TokenSequenceConstIterator non_location = source_sequence_.end();
 
   for (TokenSequenceConstIterator iter = source_sequence_.begin();
        iter != source_sequence_.end(); iter++) {
-    current_token_enum = iter->token_enum();
+    int current_token_enum = iter->token_enum();
 
     if (IsConditional(iter)) {
       switch (current_token_enum) {
-        case PP_ifdef: {
-          if_blocks_.emplace_back(iter, true, non_location);
-          auto status = AddMacroOfConditional(iter);
-          if (!status.ok()) {
-            return absl::InvalidArgumentError(
-                "ERROR: couldn't give a macro an ID.");
-          }
-          break;
-        }
+        case PP_ifdef:
         case PP_ifndef: {
-          if_blocks_.emplace_back(iter, false, non_location);
+          const bool is_positive = (current_token_enum == PP_ifdef);
+          if_blocks_.emplace_back(iter, is_positive, non_location);
           auto status = AddMacroOfConditional(iter);
           if (!status.ok()) {
             return absl::InvalidArgumentError(

--- a/verilog/analysis/flow_tree.h
+++ b/verilog/analysis/flow_tree.h
@@ -88,8 +88,7 @@ class FlowTree {
 
  private:
   struct ConditionalBlock {
-    ConditionalBlock(TokenSequenceConstIterator if_location,
-                     bool is_positive,
+    ConditionalBlock(TokenSequenceConstIterator if_location, bool is_positive,
                      TokenSequenceConstIterator non_location)
         : if_location(if_location),
           positive_condition(is_positive),

--- a/verilog/analysis/flow_tree.h
+++ b/verilog/analysis/flow_tree.h
@@ -88,6 +88,14 @@ class FlowTree {
 
  private:
   struct ConditionalBlock {
+    ConditionalBlock(TokenSequenceConstIterator if_location,
+                     bool is_positive,
+                     TokenSequenceConstIterator non_location)
+        : if_location(if_location),
+          positive_condition(is_positive),
+          else_location(non_location),
+          endif_location(non_location) {}
+
     // "if_location" points to `ifdef or `ifndef.
     TokenSequenceConstIterator if_location;
 

--- a/verilog/analysis/flow_tree.h
+++ b/verilog/analysis/flow_tree.h
@@ -88,19 +88,14 @@ class FlowTree {
 
  private:
   struct ConditionalBlock {
-    ConditionalBlock(TokenSequenceConstIterator if_location, bool is_positive,
+    ConditionalBlock(TokenSequenceConstIterator if_location,
                      TokenSequenceConstIterator non_location)
         : if_location(if_location),
-          positive_condition(is_positive),
           else_location(non_location),
           endif_location(non_location) {}
 
     // "if_location" points to `ifdef or `ifndef.
     TokenSequenceConstIterator if_location;
-
-    // When "positive_condition" equals 1, then "if_location" points to `ifdef,
-    // Otherwise it points to `ifndef.
-    bool positive_condition;
     std::vector<TokenSequenceConstIterator> elsif_locations;
     TokenSequenceConstIterator else_location;
     TokenSequenceConstIterator endif_location;


### PR DESCRIPTION
Provide a constructor in ConditionalBlock that enforces setting the whole struct correctly at instruction time. Use that constructor when emplacing_back it into our `if_blocks`.

Since the positive/negative conditional can be expressed as a boolean, use that as an opportunity to simplify the initialization and eliminate duplicate code.