### PR TITLE
Disable clang-tidy in CI for now, as it results in false positives.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -43,6 +43,7 @@ jobs:
       run: ./.github/bin/run-clang-format.sh
 
   ClangTidy:
+    if: false  # currently disabled, see #1434
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
See #1434 for details.

Signed-off-by: Henner Zeller <h.zeller@acm.org>