### PR TITLE
std::move functions passed in constructors if possible.

### DIFF
--- a/common/analysis/lint_waiver.h
+++ b/common/analysis/lint_waiver.h
@@ -124,8 +124,8 @@ class LintWaiverBuilder {
         waive_one_line_keyword_(waive_line_command),
         waive_range_start_keyword_(waive_start_command),
         waive_range_stop_keyword_(waive_stop_command),
-        is_token_comment_(is_comment),
-        is_token_whitespace_(is_space) {}
+        is_token_comment_(std::move(is_comment)),
+        is_token_whitespace_(std::move(is_space)) {}
 
   // Takes a single line's worth of tokens and determines updates to the set of
   // waived lines.  Pass a slice of tokens using make_range.

--- a/common/text/token_info.h
+++ b/common/text/token_info.h
@@ -68,8 +68,8 @@ class TokenInfo {
     explicit Context(absl::string_view b);
 
     Context(absl::string_view b,
-            const std::function<void(std::ostream&, int)>& translator)
-        : base(b), token_enum_translator(translator) {}
+            std::function<void(std::ostream&, int)> translator)
+        : base(b), token_enum_translator(std::move(translator)) {}
 
     Context(const Context&) = default;
   };


### PR DESCRIPTION
The copy construction does seem to generate warnings with later compilers.

It is not quite clear to me _why_ exactly this is happening (seems to be some implementation detail of std_function.h), but using std::move instad of function copy gets this working without warning.
 
```
/usr/include/c++/12/bits/std_function.h: In constructor 'verilog::VerilogLinter::VerilogLinter()':
/usr/include/c++/12/bits/std_function.h:267:7: note: by argument 2 of type 'const std::_Any_data&' to 'static bool std::_Function_handler<_Res(_ArgTypes ...), _Functor>::_M_manager(std::_Any_data&, const std::_Any_data&, std::_Manager_operation) [with _Res = bool; _Functor = verilog::VerilogLinter::VerilogLinter()::<lambda(const verible::TokenInfo&)>; _ArgTypes = {const verible::TokenInfo&}]' declared here
  267 |       _M_manager(_Any_data& __dest, const _Any_data& __source,
      |       ^~~~~~~~~~
verilog/analysis/verilog_linter.cc:175:7: note: '<anonymous>' declared here
  175 |     : lint_waiver_(
      |       ^~~~~~~~~~~~~
  176 |           [](const TokenInfo& t) {
      |           ~~~~~~~~~~~~~~~~~~~~~~~~
  177 |             return IsComment(verilog_tokentype(t.token_enum()));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  178 |           },
      |           ~~
  179 |           [](const TokenInfo& t) {
      |           ~~~~~~~~~~~~~~~~~~~~~~~~
  180 |             return IsWhitespace(verilog_tokentype(t.token_enum()));
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  181 |           },
      |           ~~
  182 |           kLinterTrigger, kLinterWaiveLineCommand, kLinterWaiveStartCommand,
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  183 |           kLinterWaiveStopCommand) {}
      |           ~~~~~~~~~~~~~~~~~~~~~~~~

```