### PR TITLE
Disable a warning for newer gcc in protobuf

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -68,8 +68,9 @@ BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-array-bounds"
 # This option is only recognized by gcc
 if [[ ! "${CXX}" == clang* ]]; then
   BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-cast-function-type"       # gflags
-  # Once we use gcc-11 this might be needed for protobuf
-  #BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-stringop-overflow"
+  # Current protobuf creates a warning on newer compilers, hopefully
+  # fixed with protobuf > 21.5
+  BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-stringop-overflow"        # protobuf
 else
   # -- only recognized by clang
   # Don't rely on implicit template type deduction


### PR DESCRIPTION
This is not an issue in the CI as we're running an older compiler there, but running build-and-test.sh locally on a current machine can easily trigger that.

Once we have a newer protobuf (attempt #1436 failed due to non-compatible changes), this should not be necessary anymore.

Signed-off-by: Henner Zeller <h.zeller@acm.org>