### PR TITLE
Don't log before logging is initialized.

### DIFF
--- a/verilog/tools/project/project_tool.cc
+++ b/verilog/tools/project/project_tool.cc
@@ -291,7 +291,6 @@ Project options, including source file list.
 };
 
 int main(int argc, char* argv[]) {
-  VLOG(1) << __FUNCTION__;
   // Create a registry of subcommands (locally, rather than as a static global).
   verible::SubcommandRegistry commands;
   for (const auto& entry : kCommands) {


### PR DESCRIPTION
Otherwise it might print out to stderr.

Signed-off-by: Henner Zeller <h.zeller@acm.org>