### PR TITLE
Move std::function in constructor.

### DIFF
--- a/common/lsp/json-rpc-dispatcher.h
+++ b/common/lsp/json-rpc-dispatcher.h
@@ -76,7 +76,7 @@ class JsonRpcDispatcher {
   using StatsMap = std::map<std::string, int>;
 
   // Responses are written using the "out" write function.
-  explicit JsonRpcDispatcher(const WriteFun &out) : write_fun_(out) {}
+  explicit JsonRpcDispatcher(WriteFun out) : write_fun_(std::move(out)) {}
   JsonRpcDispatcher(const JsonRpcDispatcher &) = delete;
 
   // Add a request handler for RPC calls that receive data and send a response.


### PR DESCRIPTION
Recent gcc 12 emits warnings when copying functions (which looks like some result if a standard library implementation detail). This doesn't happen if we simply std::move the function, so let's do that.

Signed-off-by: Henner Zeller <h.zeller@acm.org>