### PR TITLE
Don't provide constructors for objects meant to be initialized in aggregate init.

### DIFF
--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -223,12 +223,6 @@ struct LayoutFunctionSegment {
     CHECK_GE(margin, column);
     return intercept + gradient * (margin - column);
   }
-
-  LayoutFunctionSegment(const LayoutFunctionSegment&) = default;
-  LayoutFunctionSegment& operator=(const LayoutFunctionSegment&) = default;
-
-  LayoutFunctionSegment(LayoutFunctionSegment&&) = default;
-  LayoutFunctionSegment& operator=(LayoutFunctionSegment&&) = default;
 };
 
 template <bool IsConstIterator>

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -131,11 +131,6 @@ struct ReferenceComponent {
   const SymbolTableNode* resolved_symbol = nullptr;
 
  public:
-  ReferenceComponent(const ReferenceComponent&) = default;  // safe to copy
-  ReferenceComponent(ReferenceComponent&&) = default;
-  ReferenceComponent& operator=(const ReferenceComponent&) = delete;
-  ReferenceComponent& operator=(ReferenceComponent&&) = delete;
-
   absl::Status MatchesMetatype(SymbolMetaType) const;
 
   // Resolves this symbol and verifies that metatypes are compatible, which is


### PR DESCRIPTION
Context: C++20 compatibility.

Constraint proposed in
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1008r1.pdf

Newer compilers will warn about it.

Derived from #1428 (by @sschaetz) which used a slightly different but more involved proposal.