### PR TITLE
Make clang-tidy happy.

### DIFF
--- a/common/util/simple_zip.h
+++ b/common/util/simple_zip.h
@@ -62,7 +62,7 @@ class Encoder {
   ~Encoder();
 
   // Add a file with given filename and content.
-  bool AddFile(absl::string_view filename, ByteSource content);
+  bool AddFile(absl::string_view filename, const ByteSource &content_generator);
 
   // Finalize container. Note if your byte-sink is wrapping a file, you
   // might need to close it after Finish() returns.


### PR DESCRIPTION
Copying the ByteSource and ByteSink std::function objects is less preferred than using const references.

Don't pass member variable as parameter when calling a member function (for Copy.., Compress..).

While at it: use suggested std::clamp as we already require C++17.

Signed-off-by: Henner Zeller <h.zeller@acm.org>