### PR TITLE
Automatically call Finish() in zip::Encoder on destruction.

### DIFF
--- a/common/util/simple_zip.cc
+++ b/common/util/simple_zip.cc
@@ -255,7 +255,7 @@ struct Encoder::Impl {
 Encoder::Encoder(int compression_level, ByteSink out)
     : impl_(new Impl(compression_level, std::move(out))) {}
 
-Encoder::~Encoder() {}
+Encoder::~Encoder() { Finish(); }
 
 bool Encoder::AddFile(absl::string_view filename,
                       const ByteSource &content_generator) {

--- a/common/util/simple_zip.h
+++ b/common/util/simple_zip.h
@@ -54,16 +54,20 @@ ByteSource FileByteSource(const char *filename);
 // No more files can be added after Finish().
 class Encoder {
  public:
-  // Create an encoder writing to ByteSink.
+  // Create a zip file encoder writing to ByteSink.
   // No compression on "compression_level" zero, otherwise deflate
   Encoder(int compression_level, ByteSink out);
+
+  // Will also Finish() if not called already.
   ~Encoder();
 
-  // Add a file with given filename and content.
+  // Add a file with given filename and content from the generator function.
   bool AddFile(absl::string_view filename, const ByteSource &content_generator);
 
-  // Finalize container. Note if your byte-sink is wrapping a file, you
-  // might need to close it after Finish() returns.
+  // Finalize container.
+  // After this, no new files can be added.
+  // Note if your byte-sink is wrapping a file, you might need to close it
+  // after Finish() returns.
   bool Finish();
 
  private:

--- a/common/util/simple_zip_test.cc
+++ b/common/util/simple_zip_test.cc
@@ -97,3 +97,21 @@ TEST(SimpleZip, ReadFromFileByteSource) {
   EXPECT_EQ(CountSubstr("PK\x01\x02", result), 1);  // one per file in directory
   EXPECT_EQ(CountSubstr("PK\x05\x06", result), 1);  // directory footer
 }
+
+TEST(SimpleZip, ImplicitFinishOnDestruction) {
+  std::string result;
+
+  {
+    verible::zip::Encoder zipper(0, [&result](absl::string_view out) {
+      result.append(out.begin(), out.end());
+      return true;
+    });
+    zipper.AddFile("foo.txt", verible::zip::MemoryByteSource("Hello world"));
+    // no explicit call to Finish()
+  }
+
+  EXPECT_EQ(CountSubstr("Hello world", result), 1);
+  EXPECT_EQ(CountSubstr("PK\x03\x04", result), 1);  // one per file
+  EXPECT_EQ(CountSubstr("PK\x01\x02", result), 1);  // one per file in directory
+  EXPECT_EQ(CountSubstr("PK\x05\x06", result), 1);  // directory footer
+}

--- a/verilog/tools/kythe/kzip_creator.h
+++ b/verilog/tools/kythe/kzip_creator.h
@@ -33,7 +33,6 @@ class KzipCreator final {
  public:
   // Initializes the archive. Crashes if initialization fails.
   explicit KzipCreator(absl::string_view output_path);
-  ~KzipCreator();
 
   // Adds source code file to the Kzip. Returns its SHA digest.
   std::string AddSourceFile(absl::string_view path, absl::string_view content);
@@ -44,7 +43,7 @@ class KzipCreator final {
 
  private:
   std::unique_ptr<FILE, decltype(&fclose)> zip_file_;
-  std::unique_ptr<verible::zip::Encoder> archive_ = nullptr;
+  verible::zip::Encoder archive_;
 };
 
 }  // namespace kythe


### PR DESCRIPTION
That way, it is easier to use. Add a test to verify functionality.
Removed corresponding call to Finish() in KzipCreator; while at it, RAII the zip::Encoder.
