### PR TITLE
Reduce dependencies kzip writer; fix name.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,7 @@ filegroup(
         "//verilog/tools/diff:verible-verilog-diff",
         "//verilog/tools/formatter:verible-verilog-format",
         "//verilog/tools/kythe:verible-verilog-kythe-extractor",
-        "//verilog/tools/kythe:verilog-kythe-kzip-writer",
+        "//verilog/tools/kythe:verible-verilog-kythe-kzip-writer",
         "//verilog/tools/lint:verible-verilog-lint",
         "//verilog/tools/ls:verible-verilog-ls",
         "//verilog/tools/obfuscator:verible-verilog-obfuscate",

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -278,7 +278,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "verilog-kythe-kzip-writer",
+    name = "verible-verilog-kythe-kzip-writer",
     srcs = [
         "verilog_kythe_kzip_writer.cc",
     ],

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -289,7 +289,7 @@ cc_binary(
         "//common/util:init_command_line",
         "//common/util:logging",
         "//third_party/proto/kythe:analysis_cc_proto",
-        "//verilog/analysis:verilog_project",
+        "//verilog/analysis:verilog_filelist",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
     ],

--- a/verilog/tools/kythe/verilog_kythe_kzip_writer.cc
+++ b/verilog/tools/kythe/verilog_kythe_kzip_writer.cc
@@ -24,7 +24,7 @@
 #include "common/util/init_command_line.h"
 #include "common/util/logging.h"
 #include "third_party/proto/kythe/analysis.pb.h"
-#include "verilog/analysis/verilog_project.h"
+#include "verilog/analysis/verilog_filelist.h"
 #include "verilog/tools/kythe/kzip_creator.h"
 
 ABSL_FLAG(std::string, filelist_path, "",


### PR DESCRIPTION
We only need filelist as project dependency in filelist writer.
    
That reduces the project-specific dependencies significantly:
    
before:

    $ bazel query 'deps(//verilog/tools/kythe:verilog-kythe-kzip-writer)' | grep -v '^@' | wc -l
        246

after:

    $ bazel query 'deps(//verilog/tools/kythe:verilog-kythe-kzip-writer)' | grep -v '^@' | wc -l
         37
    
Unfortunately, this does not result in a binary size reduction for the
stripped binary. In both cases the binary is about the same size (and
one of the larger binaries in verible), which is probably because the
linker works well in figuring out cruft.
Maybe the size comes from the additional libraries, such as proto buffer
and crypto that it is so bloated ?

Also rename `verilog-kythe-kzip-writer` to `verible-verilog-kythe-kzip-writer`, as all our verible binaries are have the verible prefix.