### PR TITLE
Make SyntaxTree{Node,Leaf} final for better documentation.

### DIFF
--- a/common/text/concrete_syntax_leaf.h
+++ b/common/text/concrete_syntax_leaf.h
@@ -28,7 +28,7 @@
 
 namespace verible {
 
-class SyntaxTreeLeaf : public Symbol {
+class SyntaxTreeLeaf final : public Symbol {
  public:
   SyntaxTreeLeaf() = delete;
 

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -71,7 +71,7 @@ struct ForwardChildren {
 // SyntaxTreeNode is a language-agnostic node structure, supporting an
 // arbitrary number of children.  The 'tag' field is a node type enumeration
 // used by various language front-ends.
-class SyntaxTreeNode : public Symbol {
+class SyntaxTreeNode final : public Symbol {
  public:
   explicit SyntaxTreeNode(const int tag = kUntagged) : tag_(tag) {}
 


### PR DESCRIPTION
Having them final makes it clear for the reader that these are the only SyntaxTree classes to worry about when working with these.
