### PR TITLE
Use opportunity to make extracted_facts_num const.

### DIFF
--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -367,7 +367,7 @@ void KytheFactsExtractor::ExtractFile(const IndexingFactNode& root) {
 
 bool KytheFactsExtractor::IndexingFactNodeTagResolver(
     const IndexingFactNode& node) {
-  size_t extracted_facts_num = seen_kythe_hashes_.size();
+  const size_t previously_extracted_facts_num = seen_kythe_hashes_.size();
   const auto tag = node.Value().GetIndexingFactType();
 
   // Dispatch a node handler based on the node's tag.
@@ -487,7 +487,7 @@ bool KytheFactsExtractor::IndexingFactNodeTagResolver(
   CreateChildOfEdge(tag, vname);
   VisitAutoConstructScope(node, vname);
 
-  return seen_kythe_hashes_.size() > extracted_facts_num;
+  return seen_kythe_hashes_.size() > previously_extracted_facts_num;
 }
 
 void KytheFactsExtractor::AddDefinitionToCurrentScope(IndexingFactType tag,


### PR DESCRIPTION
Also, rename to previously_extracted_facts_num, to make the `return` line read like a sentence.

Signed-off-by: Henner Zeller <hzeller@google.com>