### PR TITLE
Introduce the concept of MemBlock to prepare for zero-copy file reading.

### DIFF
--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -114,6 +114,14 @@ cc_test(
 )
 
 cc_library(
+    name = "mem_block",
+    hdrs = ["mem-block.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
     name = "naming_utils",
     srcs = ["naming_utils.cc"],
     hdrs = ["naming_utils.h"],

--- a/common/strings/mem-block.h
+++ b/common/strings/mem-block.h
@@ -1,0 +1,59 @@
+// Copyright 2022 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMON_STRINGS_MEM_BLOCK_H
+#define COMMON_STRINGS_MEM_BLOCK_H
+
+#include <string>
+
+#include "absl/strings/string_view.h"
+
+namespace verible {
+// A representation of a block of (readonly) memory that is owned by MemBlock.
+// Recommended use is to create it somewhere and pass a pointer in a
+// std::unique_ptr<> to explicitly pass unique ownership in a move semantic or
+// as std::shared_ptr<> if needed in multiple places.
+class MemBlock {
+ public:
+  virtual ~MemBlock() {}
+  virtual absl::string_view AsStringView() const = 0;
+
+ protected:
+  MemBlock() = default;
+
+ private:
+  MemBlock(const MemBlock&) = delete;
+  MemBlock(MemBlock&&) = delete;
+  MemBlock& operator=(MemBlock&) = delete;
+  MemBlock& operator=(MemBlock&&) = delete;
+};
+
+// An implementation of MemBlock backed by a std::string
+class StringMemBlock final : public MemBlock {
+ public:
+  StringMemBlock() {}
+  StringMemBlock(absl::string_view copy_from)
+      : content_(copy_from.begin(), copy_from.end()) {}
+
+  // Assign/modify content. Use sparingly, ideally only in initialization
+  // as the expectation of the MemBlock is that it won't change later.
+  std::string* mutable_content() { return &content_; }
+
+  absl::string_view AsStringView() const final { return content_; }
+
+ private:
+  std::string content_;
+};
+}  // namespace verible
+#endif  // COMMON_STRINGS_MEM_BLOCK_H

--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -248,6 +248,7 @@ cc_library(
         ":token_stream_view",
         ":tree_utils",
         "//common/strings:line_column_map",
+        "//common/strings:mem_block",
         "//common/util:iterator_range",
         "//common/util:logging",
         "//common/util:range",

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -35,6 +35,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "common/strings/line_column_map.h"
+#include "common/strings/mem-block.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
 #include "common/text/token_stream_view.h"
@@ -234,6 +235,9 @@ class TextStructureView {
 // the same owned memory can be used for multiple analysis views.
 class TextStructure {
  public:
+  explicit TextStructure(std::unique_ptr<MemBlock> contents);
+
+  // Convenience constructor in case our input is a string.
   explicit TextStructure(absl::string_view contents);
 
   TextStructure(const TextStructure&) = delete;
@@ -259,9 +263,7 @@ class TextStructure {
  protected:
   // This string owns the memory referenced by all substring string_views
   // in this object.
-  // TODO(hzeller): avoid local copy and just require that the string-view
-  // we are called with outlives this object?
-  const std::string owned_contents_;
+  std::unique_ptr<MemBlock> owned_contents_;
 
   // The data_ object's string_views are owned by owned_contents_.
   TextStructureView data_;


### PR DESCRIPTION
Right now files are read into a string, then copied into another string in TextStructure. With this abstraction of the block of memory we can allow for two things
  a) read files into the string that is then moved into the
     TextStructure with zero copy.
  b) Allow for mmap()-ing a file for platforms that support it.

This is the first change towards this goal, introducing the MemBlock concept.
