### PR TITLE
Remove undefined behavior when creating Kythe Anchors.  If the source…

### DIFF
--- a/verilog/tools/kythe/indexing_facts_tree.cc
+++ b/verilog/tools/kythe/indexing_facts_tree.cc
@@ -28,43 +28,40 @@ namespace verilog {
 namespace kythe {
 
 Anchor::Anchor(const Anchor& other)
-    : content_(other.content_),
-      source_text_offset_(other.source_text_offset_) {}
+    : content_(other.content_), source_text_range_(other.source_text_range_) {}
 
-std::string Anchor::DebugString(absl::string_view base) const {
-  if (source_text_offset_) {
-    return absl::StrCat(
-        "{", Text(), " @", source_text_offset_->begin, "-",
-        source_text_offset_->begin + source_text_offset_->length, "}");
+std::string Anchor::DebugString() const {
+  if (source_text_range_) {
+    return absl::StrCat("{", Text(), " @", source_text_range_->begin, "-",
+                        source_text_range_->begin + source_text_range_->length,
+                        "}");
   }
   return absl::StrCat("{", Text(), "}");
 }
 
 std::ostream& operator<<(std::ostream& stream, const Anchor& anchor) {
-  return stream << "{" << anchor.Text() << " @" << anchor.StartLocation() << "+"
-                << anchor.ContentLength() << "}";
+  return stream << anchor.DebugString();
 }
 
 bool Anchor::operator==(const Anchor& rhs) const {
-  if (source_text_offset_) {
-    if (!rhs.source_text_offset_) {
+  if (source_text_range_) {
+    if (!rhs.source_text_range_) {
       return false;
     }
-    if (std::tie(source_text_offset_->begin, source_text_offset_->length) !=
-        std::tie(rhs.source_text_offset_->begin,
-                 rhs.source_text_offset_->length)) {
+    if (std::tie(source_text_range_->begin, source_text_range_->length) !=
+        std::tie(rhs.source_text_range_->begin,
+                 rhs.source_text_range_->length)) {
       return false;
     }
   }
   return Text() == rhs.Text();
 }
 
-std::ostream& IndexingNodeData::DebugString(std::ostream* stream,
-                                            absl::string_view base) const {
+std::ostream& IndexingNodeData::DebugString(std::ostream* stream) const {
   *stream << indexing_fact_type_ << ": ["
           << absl::StrJoin(anchors_.begin(), anchors_.end(), ", ",
-                           [&base](std::string* out, const Anchor& anchor) {
-                             absl::StrAppend(out, anchor.DebugString(base));
+                           [](std::string* out, const Anchor& anchor) {
+                             absl::StrAppend(out, anchor.DebugString());
                            })
           << ']';
   return *stream;
@@ -86,7 +83,7 @@ bool IndexingNodeData::operator==(const IndexingNodeData& rhs) const {
 
 std::ostream& operator<<(std::ostream& stream,
                          const PrintableIndexingNodeData& printable_node) {
-  return printable_node.data.DebugString(&stream, printable_node.base);
+  return printable_node.data.DebugString(&stream);
 }
 
 std::ostream& operator<<(std::ostream& stream,

--- a/verilog/tools/kythe/indexing_facts_tree.h
+++ b/verilog/tools/kythe/indexing_facts_tree.h
@@ -47,7 +47,7 @@ class Anchor {
 
   explicit Anchor(absl::string_view value, size_t begin, size_t length)
       : content_(value) {
-    source_text_offset_.emplace(begin, length);
+    source_text_range_.emplace(begin, length);
   }
 
   // Delegates construction to use only the string_view spanned by a TokenInfo.
@@ -58,7 +58,7 @@ class Anchor {
       : content_(token.text()) {
     const int token_left = token.left(source_content);
     const int token_right = token.right(source_content);
-    source_text_offset_.emplace(token_left, token_right - token_left);
+    source_text_range_.emplace(token_left, token_right - token_left);
   }
 
   Anchor(const Anchor&);  // TODO(fangism): delete, move-only
@@ -66,18 +66,15 @@ class Anchor {
   Anchor& operator=(const Anchor&) = delete;
   Anchor& operator=(Anchor&&) = delete;
 
-  // This function is for debugging only and isn't intended to be a textual
-  // representation of this class.
-  // 'base' is the superstring of which Anchor's text is a substring.
-  std::string DebugString(absl::string_view base) const;
+  // Returns human readable view of this Anchor.
+  std::string DebugString() const;
 
   absl::string_view Text() const { return content_; }
 
   // Returns the location of the Anchor's content in the original string.
-  size_t StartLocation() const { return source_text_offset_->begin; }
-
-  // Returns the size of the Anchor's content.
-  size_t ContentLength() const { return source_text_offset_->length; }
+  const std::optional<AnchorRange>& SourceTextRange() const {
+    return source_text_range_;
+  }
 
   bool operator==(const Anchor&) const;
   bool operator!=(const Anchor& other) const { return !(*this == other); }
@@ -86,7 +83,7 @@ class Anchor {
   // Substring of the original text that corresponds to this Anchor.
   std::string content_;
 
-  std::optional<AnchorRange> source_text_offset_;
+  std::optional<AnchorRange> source_text_range_;
 };
 
 std::ostream& operator<<(std::ostream&, const Anchor&);
@@ -122,9 +119,8 @@ class IndexingNodeData {
   // Swaps the anchors with the given IndexingNodeData.
   void SwapAnchors(IndexingNodeData* other) { anchors_.swap(other->anchors_); }
 
-  // This function is for debugging only and isn't intended to be textual
-  // representation of this class.
-  std::ostream& DebugString(std::ostream* stream, absl::string_view base) const;
+  // Returns human readable view of this node.
+  std::ostream& DebugString(std::ostream* stream) const;
 
   const std::vector<Anchor>& Anchors() const { return anchors_; }
   IndexingFactType GetIndexingFactType() const { return indexing_fact_type_; }

--- a/verilog/tools/kythe/indexing_facts_tree_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_test.cc
@@ -40,16 +40,8 @@ class TestAnchor : public Anchor {
 TEST(AnchorTest, DebugStringUsingOffsets) {
   constexpr absl::string_view text("abcdefghij");
   const Anchor anchor(text.substr(4, 3), /*begin=*/4, /*length=*/3);
-  const std::string debug_string(anchor.DebugString(text));
+  const std::string debug_string(anchor.DebugString());
   EXPECT_EQ(debug_string, "{efg @4-7}");
-}
-
-TEST(AnchorTest, DebugStringUsingAddresses) {
-  constexpr absl::string_view text("abcdefghij");
-  const Anchor anchor(text.substr(3, 4));
-  std::ostringstream stream;
-  stream << anchor;
-  EXPECT_TRUE(absl::StrContains(stream.str(), "{defg @"));
 }
 
 TEST(AnchorTest, EqualityNotOwned) {
@@ -166,7 +158,7 @@ TEST(IndexingNodeDataTest, DebugStringUsingOffsets) {
   constexpr absl::string_view expected("kClass: [{bc @1-3}, {efg @4-7}]");
   {
     std::ostringstream stream;
-    data.DebugString(&stream, text);
+    data.DebugString(&stream);
     EXPECT_EQ(stream.str(), expected);
   }
   {
@@ -174,17 +166,6 @@ TEST(IndexingNodeDataTest, DebugStringUsingOffsets) {
     stream << PrintableIndexingNodeData(data, text);
     EXPECT_EQ(stream.str(), expected);
   }
-}
-
-TEST(IndexingNodeDataTest, DebugStringUsingAddresses) {
-  constexpr absl::string_view text("abcdefghij");
-  const IndexingNodeData data(IndexingFactType::kFile,
-                              Anchor(text.substr(1, 2)),
-                              Anchor(text.substr(4, 3)));
-  std::ostringstream stream;
-  stream << data;
-  EXPECT_TRUE(absl::StrContains(stream.str(), "kFile: [{bc @"));
-  EXPECT_TRUE(absl::StrContains(stream.str(), "efg @"));
 }
 
 TEST(IndexingFactNodeTest, StreamPrint) {

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -1243,10 +1243,19 @@ void KytheFactsExtractor::CreateAnchorReferences(
 }
 
 VName KytheFactsExtractor::CreateAnchor(const Anchor& anchor) {
-  const int start_location = anchor.StartLocation();
-  const int end_location = start_location + anchor.ContentLength();
+  const auto& anchor_range = anchor.SourceTextRange();
+  if (!anchor_range) {
+    LOG(ERROR) << "Anchor not set! This is a bug. Skipping this Anchor. File: "
+               << FilePath() << " Anchor text: " << anchor.Text();
+    return VName();
+  }
+  const int start_location = anchor_range->begin;
+  const int end_location = start_location + anchor_range->length;
   if (start_location == end_location) {
-    LOG(ERROR) << "Zero-sized Anchor! File: " << FilePath();
+    LOG(ERROR)
+        << "Zero-sized Anchor! This is a bug. Skipping this Anchor. File: "
+        << FilePath() << " Anchor text: " << anchor.Text();
+    return VName();
   }
   const auto [location_str, _] = signature_locations_.emplace(
       absl::StrCat("@", start_location, ":", end_location));


### PR DESCRIPTION
… anchor doesn't have a range, make CreateAnchor return an empty VName -- as the anchor would anyway be bogus. This is just a workaround. We still have a bug in the code.