### PR TITLE
Allow skipping string view maps when opening files as part of Verilog…

### DIFF
--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -142,22 +142,29 @@ absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenFile(
   const absl::Status status = file.Open();
   if (!status.ok()) return status;
 
-  const absl::string_view contents(file.GetTextStructure()->Contents());
+  // NOTE: string view maps don't support removal operation. The following block
+  // is valid only if files won't be removed from the project.
+  if (populate_string_maps_) {
+    const absl::string_view contents(file.GetTextStructure()->Contents());
 
-  // Register the file's contents range in string_view_map_.
-  string_view_map_.must_emplace(contents);
+    // Register the file's contents range in string_view_map_.
+    string_view_map_.must_emplace(contents);
 
-  // Map the start of the file's contents to its corresponding owner
-  // VerilogSourceFile.
-  const auto map_inserted =
-      buffer_to_analyzer_map_.emplace(contents.begin(), file_iter);
-  CHECK(map_inserted.second);
+    // Map the start of the file's contents to its corresponding owner
+    // VerilogSourceFile.
+    const auto map_inserted =
+        buffer_to_analyzer_map_.emplace(contents.begin(), file_iter);
+    CHECK(map_inserted.second);
+  }
 
   return &file;
 }
 
 bool VerilogProject::RemoveRegisteredFile(
     absl::string_view referenced_filename) {
+  CHECK(!populate_string_maps_)
+      << "Removing of files added to string maps is not supported! Disable "
+         "populating string maps.";
   if (files_.erase(std::string(referenced_filename)) == 1) {
     LOG(INFO) << "Removed " << referenced_filename << " from the project.";
     return true;

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -298,6 +298,8 @@ void VerilogProject::AddVirtualFile(absl::string_view resolved_filename,
 
 const VerilogSourceFile* VerilogProject::LookupFileOrigin(
     absl::string_view content_substring) const {
+  CHECK(populate_string_maps_)
+      << "Populating string maps must be enabled for LookupFileOrigin!";
   // Look for corresponding source text (superstring) buffer start.
   const auto found_superstring = string_view_map_.find(content_substring);
   if (found_superstring == string_view_map_.end()) return nullptr;

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -215,6 +215,9 @@ class VerilogProject {
   typedef file_set_type::iterator iterator;
   typedef file_set_type::const_iterator const_iterator;
 
+  // Constructor. Note that `populate_string_maps` (populating internal string
+  // view maps) fragments the class's usage. Enabling it prevents removing files
+  // from the project (which is required for Kythe facts extraction).
   VerilogProject(absl::string_view root,
                  const std::vector<std::string>& include_paths,
                  absl::string_view corpus = "",

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -217,10 +217,12 @@ class VerilogProject {
 
   VerilogProject(absl::string_view root,
                  const std::vector<std::string>& include_paths,
-                 absl::string_view corpus = "")
+                 absl::string_view corpus = "",
+                 bool populate_string_maps = true)
       : translation_unit_root_(root),
         include_paths_(include_paths),
-        corpus_(corpus) {}
+        corpus_(corpus),
+        populate_string_maps_(populate_string_maps) {}
 
   VerilogProject(const VerilogProject&) = delete;
   VerilogProject(VerilogProject&&) = delete;
@@ -306,6 +308,12 @@ class VerilogProject {
   // The corpus to which this project belongs (e.g.,
   // 'github.com/chipsalliance/verible').
   const std::string corpus_;
+
+  // If true, opening a file will add its contents to string_view_map_ and
+  // buffer_to_analyzer_map_. NOTE: string view maps don't support removal
+  // operation. Setting this option prevents removing of the files from the
+  // project (removing the files leads to undefined behavior).
+  const bool populate_string_maps_;
 
   // Set of opened files, keyed by referenced (not resolved) filename.
   file_set_type files_;

--- a/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
@@ -97,7 +97,8 @@ class SimpleTestProject : public TempDir, public VerilogProject {
   explicit SimpleTestProject(absl::string_view code_text,
                              const std::vector<std::string>& include_paths = {})
       : TempDir(),
-        VerilogProject(temp_dir_, include_paths),
+        VerilogProject(temp_dir_, include_paths, /*corpus=*/"unittest",
+                       /*populate_string_maps=*/false),
         code_text_(code_text),
         translation_unit_(code_text, temp_dir_,
                           [this](absl::string_view full_file_name)

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -106,6 +106,9 @@ e.g --include_dir_paths directory1,directory2
 if "A.sv" exists in both "directory1" and "directory2" the one in "directory1" is the one we will use.
 )");
 
+ABSL_FLAG(std::string, verilog_project_name, "",
+          "Verilog project name to use as Kythe corpus. Optional");
+
 namespace verilog {
 namespace kythe {
 
@@ -204,7 +207,9 @@ Output: Produces Indexing Facts for kythe (http://kythe.io).
   include_dir_paths.insert(include_dir_paths.end(),
                            file_list.preprocessing.include_dirs.begin(),
                            file_list.preprocessing.include_dirs.end());
-  verilog::VerilogProject project(file_list_root, include_dir_paths);
+  verilog::VerilogProject project(file_list_root, include_dir_paths,
+                                  absl::GetFlag(FLAGS_verilog_project_name),
+                                  /*populate_string_maps=*/false);
 
   const std::vector<absl::Status> errors(
       verilog::kythe::ExtractTranslationUnits(file_list_path, &project,


### PR DESCRIPTION
… project. String view maps are not compatible with file removals, as these structures don't support that operation.

These structures are only used by they project_tool to print the dependency graph.

TBH, this is a bit hacky. But the overall setting for dependencies lib is convoluted. IMO, let's go with this change until we fully migrate to the symbol table implementation.

Closes #1499