### PR TITLE
Use already pre-split lines to create LineColumnMap.

### DIFF
--- a/common/strings/line_column_map.h
+++ b/common/strings/line_column_map.h
@@ -66,15 +66,21 @@ struct LineColumnRange {
 
 std::ostream& operator<<(std::ostream&, const LineColumnRange&);
 
+// Fast mapping of substring position to human-useful line/column
 class LineColumnMap {
  public:
-  explicit LineColumnMap(absl::string_view);
-
+  // Build line column map from pre-split contiguous blob of content.
+  // The distance between consecutive string_views is expected to have
+  // a gap of one character (the splitting '\n' character).
   explicit LineColumnMap(const std::vector<absl::string_view>& lines);
 
-  void Clear() { beginning_of_line_offsets_.clear(); }
+  // This constructor is only used in LintStatusFormatter and
+  // LintWaiverBuilder.
+  // TODO: If these already have access to pre-split lines, then this
+  // constructor is not needed.
+  explicit LineColumnMap(absl::string_view);
 
-  bool Empty() const { return beginning_of_line_offsets_.empty(); }
+  bool empty() const { return beginning_of_line_offsets_.empty(); }
 
   // Returns byte offset corresponding to the 0-based line number.
   // If lineno exceeds number of lines, return the final byte offset.
@@ -102,8 +108,7 @@ class LineColumnMap {
 
   // Byte-offset of start of last line after last newline in file.
   int LastLineOffset() const {
-    if (Empty()) return 0;
-    return beginning_of_line_offsets_.back();
+    return empty() ? 0 : beginning_of_line_offsets_.back();
   }
 
  private:

--- a/common/strings/line_column_map_test.cc
+++ b/common/strings/line_column_map_test.cc
@@ -100,14 +100,6 @@ TEST(LineColumnTextTest, PrintLineColumnRange) {
   }
 }
 
-// Test that Clear resets the map.
-TEST(LineColumnMapTest, ClearEmpty) {
-  LineColumnMap line_map("hello\nworld\n");
-  EXPECT_FALSE(line_map.Empty());
-  line_map.Clear();
-  EXPECT_TRUE(line_map.Empty());
-}
-
 // Test offset lookup values by line number.
 TEST(LineColumnMapTest, OffsetAtLine) {
   LineColumnMap line_map("hello\n\nworld\n");

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -277,7 +277,7 @@ const TextStructureView::LinesInfo& TextStructureView::LinesInfo::Get(
   if (valid) return *this;
 
   lines = absl::StrSplit(contents, '\n');
-  line_column_map.reset(new LineColumnMap(contents));
+  line_column_map.reset(new LineColumnMap(lines));
   valid = true;
 
   return *this;


### PR DESCRIPTION
.. no need to do the line-splitting twice.

Also, document the remaining users of raw content
input of the constructor.
Remove unnecessary Clear() method on LineColumnMap (it never can be re-populated, so Clear() does not make sense).