### PR TITLE
Provide content of file in a MemBlock living in VerilogSourceFile.

### DIFF
--- a/common/analysis/file_analyzer.h
+++ b/common/analysis/file_analyzer.h
@@ -87,7 +87,12 @@ std::ostream& operator<<(std::ostream&, const RejectedToken&);
 // FileAnalyzer holds the results of lexing and parsing.
 class FileAnalyzer {
  public:
-  explicit FileAnalyzer(absl::string_view contents, absl::string_view filename)
+  FileAnalyzer(std::shared_ptr<MemBlock> contents, absl::string_view filename)
+      : text_structure_(new TextStructure(std::move(contents))),
+        filename_(filename) {}
+
+  // Legacy constructor.
+  FileAnalyzer(absl::string_view contents, absl::string_view filename)
       : text_structure_(new TextStructure(contents)), filename_(filename) {}
 
   virtual ~FileAnalyzer() {}

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -265,7 +265,7 @@ class TextStructure {
   friend class TextStructureViewPublicTest_ExpandSubtreesMultipleLeaves_Test;
   friend class verilog::VerilogPreprocess;
 
-  explicit TextStructure(std::unique_ptr<MemBlock> contents);
+  explicit TextStructure(std::shared_ptr<MemBlock> contents);
 
   // Convenience constructor in case our input is a string.
   explicit TextStructure(absl::string_view contents);
@@ -292,9 +292,11 @@ class TextStructure {
   absl::Status InternalConsistencyCheck() const;
 
  protected:
-  // This string owns the memory referenced by all substring string_views
-  // in this object.
-  std::unique_ptr<MemBlock> owned_contents_;
+  // The content of this memblock is referenced in the TextStructureView.
+  // The data itself might be shared between multiple entitites
+  // (using a heavy shared_ptr might very well intermediate while refactoring
+  // the details. https://github.com/chipsalliance/verible/issues/1502 )
+  std::shared_ptr<MemBlock> contents_;
 
   // The data_ object's string_views are owned by owned_contents_.
   TextStructureView data_;

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -166,6 +166,7 @@ cc_library(
         "//common/analysis:file_analyzer",
         "//common/lexer:token_stream_adapter",
         "//common/strings:comment_utils",
+        "//common/strings:mem_block",
         "//common/text:concrete_syntax_leaf",
         "//common/text:concrete_syntax_tree",
         "//common/text:symbol",
@@ -358,8 +359,8 @@ cc_library(
     srcs = ["verilog_filelist.cc"],
     hdrs = ["verilog_filelist.h"],
     deps = [
-        "//common/util:iterator_range",
         "//common/util:file_util",
+        "//common/util:iterator_range",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -383,6 +384,7 @@ cc_library(
     deps = [
         ":verilog_analyzer",
         ":verilog_filelist",
+        "//common/strings:mem_block",
         "//common/strings:string_memory_map",
         "//common/text:text_structure",
         "//common/util:file_util",

--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -23,6 +23,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "common/analysis/file_analyzer.h"
+#include "common/strings/mem-block.h"
 #include "common/text/token_stream_view.h"
 #include "verilog/preprocessor/verilog_preprocess.h"
 
@@ -31,6 +32,13 @@ namespace verilog {
 // VerilogAnalyzer analyzes Verilog and SystemVerilog code syntax.
 class VerilogAnalyzer : public verible::FileAnalyzer {
  public:
+  VerilogAnalyzer(std::shared_ptr<verible::MemBlock> text,
+                  absl::string_view name,
+                  const VerilogPreprocess::Config& preprocess_config)
+      : verible::FileAnalyzer(std::move(text), name),
+        preprocess_config_(preprocess_config) {}
+
+  // Legacy constructor.
   VerilogAnalyzer(absl::string_view text, absl::string_view name,
                   const VerilogPreprocess::Config& preprocess_config)
       : verible::FileAnalyzer(text, name),

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -53,12 +53,15 @@ absl::Status VerilogSourceFile::Open() {
   status_ = verible::file::GetContents(ResolvedPath(), &content);
   if (!status_.ok()) return status_;
 
-  // TODO(fangism): std::move or memory-map to avoid a short-term copy.
+  // TODO(hzeller): have a file::GetContents() that returns a MemBlock directly
+  content_ = std::make_shared<verible::StringMemBlock>(content);
+
+  // TODO(hzeller): populate this analyzed structure lazily.
   analyzed_structure_ = std::make_unique<VerilogAnalyzer>(
-      content, ResolvedPath(), kPreprocessConfig);
+      content_, ResolvedPath(), kPreprocessConfig);
   state_ = State::kOpened;
-  // status_ is Ok here.
-  return status_;
+
+  return status_;  // status_ is Ok here.
 }
 
 absl::Status VerilogSourceFile::Parse() {

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -24,6 +24,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "common/strings/mem-block.h"
 #include "common/strings/string_memory_map.h"
 #include "common/text/text_structure.h"
 #include "verilog/analysis/verilog_analyzer.h"
@@ -145,6 +146,9 @@ class VerilogSourceFile {
 
   // Holds any diagostics for problems encountered finding/reading this file.
   absl::Status status_;
+
+  // MemBock holding the file content so that it can be used in other contexts.
+  std::shared_ptr<verible::MemBlock> content_;
 
   // Holds the file's string contents in owned memory, along with other forms
   // like token streams and syntax tree.

--- a/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
@@ -77,7 +77,7 @@ struct TestFileEntry {
 
   // Returns the string_view of text owned by this->source_file.
   absl::string_view SourceText() const {
-    return source_file->GetTextStructure()->Contents();
+    return source_file->GetContent()->AsStringView();
   }
 
   T::value_type ExpectedFileData() const {


### PR DESCRIPTION
To be able to have VerilogSourceFile content be used in contexts other than Analysis (as currently needed with preprocessing), break out the file content to live in a MemBlock in VerilogSourceFile. That way it can be used independently.

Then use that all the way down the VerilogAnalyzer chain for the regular behavior.

Using shared_ptr<MemBlock> for now limits worry about ownership while refactoring is going on: everyone can have their own (referenced counted-) copy of the MemBlock, minimizing the changes needed otherwise. Once the final picture is clear, this might be simplified by having a true central owner of the MemBlock with guaranteed life-time; then handing out Stringviews from there is cheaper.

Issues #1502
