### PR TITLE
Lint Violation grammar nitpicks

### DIFF
--- a/verilog/analysis/checkers/struct_union_name_style_rule.cc
+++ b/verilog/analysis/checkers/struct_union_name_style_rule.cc
@@ -80,7 +80,7 @@ void StructUnionNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
     if (!absl::EndsWith(name, "_t")) {
       violations_.insert(
           LintViolation(*identifier_leaf,
-                        absl::StrCat(msg, " have to ends with _t"), context));
+                        absl::StrCat(msg, " have to end with _t"), context));
       return;
     }
     if (name[0] == '_') {
@@ -110,7 +110,7 @@ void StructUnionNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
       if (exceptions_.find(ns_substr) == exceptions_.end()) {
         violations_.insert(LintViolation(*identifier_leaf,
                                          "found digit followed by unit that is "
-                                         "not configured as allowed exception",
+                                         "not configured as an allowed exception",
                                          context));
         return;
       }
@@ -141,7 +141,7 @@ absl::Status StructUnionNameStyleRule::Configure(
       if (alpha == ex.end()) {
         return absl::Status(
             absl::StatusCode::kInvalidArgument,
-            "The exception have to contain at least one alphabetic character");
+            "The exception has to contain at least one alphabetic character");
       }
       const auto& digit = std::find_if(alpha, ex.end(), absl::ascii_isdigit);
       if (digit != ex.end()) {


### PR DESCRIPTION
Just noticed the `have to ends with _t` violation and felt like cleaning up the grammar in `verilog/analysis/checkers/struct_union_name_style_rule.cc` 