### PR TITLE
Support whitespaces in VerilogPreprocess

### DIFF
--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -58,10 +58,21 @@ VerilogPreprocess::VerilogPreprocess(const Config& config, FileOpener opener)
       BranchBlock(true, true, verible::TokenInfo::EOFToken()));
 }
 
+TokenStreamView::const_iterator VerilogPreprocess::GenerateBypassWhiteSpaces(
+    const StreamIteratorGenerator& generator) {
+  auto iterator =
+      generator();  // iterator should be pointing to a non-whitespace token;
+  while (verilog::VerilogLexer::KeepSyntaxTreeTokens(**iterator) == 0) {
+    iterator = generator();
+  }
+  return iterator;
+}
+
 absl::StatusOr<TokenStreamView::const_iterator>
 VerilogPreprocess::ExtractMacroName(const StreamIteratorGenerator& generator) {
   // Next token to expect is macro definition name.
-  TokenStreamView::const_iterator token_iter = generator();
+  TokenStreamView::const_iterator token_iter =
+      GenerateBypassWhiteSpaces(generator);
   if ((*token_iter)->isEOF()) {
     preprocess_data_.errors.push_back(
         {**token_iter, "unexpected EOF where expecting macro name"});
@@ -92,7 +103,7 @@ absl::Status VerilogPreprocess::ConsumeMacroDefinition(
   // Everything else covers macro parameters and the definition body.
   TokenStreamView::const_iterator token_iter;
   do {
-    token_iter = generator();
+    token_iter = GenerateBypassWhiteSpaces(generator);
     if ((*token_iter)->isEOF()) {
       // Diagnose unexpected EOF downstream instead of erroring here.
       // Other subroutines can give better context about the parsing state.
@@ -226,10 +237,11 @@ absl::Status VerilogPreprocess::ConsumeAndParseMacroCall(
   macro_call->has_parameters = 1;
 
   // Parsing parameters.
-  TokenStreamView::const_iterator token_iter = generator();
+  TokenStreamView::const_iterator token_iter =
+      GenerateBypassWhiteSpaces(generator);
   int parameters_size = macro_definition.Parameters().size();
   if ((*token_iter)->text() == "(") {
-    token_iter = generator();  // skip the "("
+    token_iter = GenerateBypassWhiteSpaces(generator);  // skip the "("
   } else {
     return absl::InvalidArgumentError(
         "Error it is illegal to call a callable macro without ().");
@@ -238,14 +250,15 @@ absl::Status VerilogPreprocess::ConsumeAndParseMacroCall(
   while (parameters_size > 0) {
     if ((*token_iter)->token_enum() == MacroArg) {
       macro_call->positional_arguments.emplace_back(**token_iter);
-      token_iter = generator();
-      if ((*token_iter)->text() == ",") token_iter = generator();
+      token_iter = GenerateBypassWhiteSpaces(generator);
+      if ((*token_iter)->text() == ",")
+        token_iter = GenerateBypassWhiteSpaces(generator);
       parameters_size--;
       continue;
     } else if ((*token_iter)->text() == ",") {
       macro_call->positional_arguments.emplace_back(
           verible::DefaultTokenInfo());
-      token_iter = generator();
+      token_iter = GenerateBypassWhiteSpaces(generator);
       parameters_size--;
       continue;
     } else if ((*token_iter)->text() == ")")
@@ -582,7 +595,8 @@ absl::Status VerilogPreprocess::HandleInclude(
   // TODO(karimtera): Support inclduing <file>,
   // which should look for files defined by language standard in a compiler
   // dependent path.
-  TokenStreamView::const_iterator token_iter = generator();
+  TokenStreamView::const_iterator token_iter =
+      GenerateBypassWhiteSpaces(generator);
   auto file_token_iter = *token_iter;
   if (file_token_iter->token_enum() != TK_StringLiteral) {
     preprocess_data_.errors.push_back(
@@ -626,8 +640,7 @@ absl::Status VerilogPreprocess::HandleInclude(
   verilog::VerilogLexer lexer(included_structure.Data().Contents());
   for (lexer.DoNextToken(); !lexer.GetLastToken().isEOF();
        lexer.DoNextToken()) {
-    if (verilog::VerilogLexer::KeepSyntaxTreeTokens(lexer.GetLastToken()))
-      included_sequence.push_back(lexer.GetLastToken());
+    included_sequence.push_back(lexer.GetLastToken());
   }
 
   // Preprocessing the included file tokens.

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -186,6 +186,10 @@ class VerilogPreprocess {
   absl::Status HandleInclude(TokenStreamView::const_iterator,
                              const StreamIteratorGenerator&);
 
+  // Generate a const_iterator to a non-whitespace token.
+  static TokenStreamView::const_iterator GenerateBypassWhiteSpaces(
+      const StreamIteratorGenerator&);
+
   const Config config_;
 
   // State of a block that can have a sequence of sub-blocks with conditions

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -48,9 +48,7 @@ class LexerTester {
   LexerTester(absl::string_view text) : lexer_(text) {
     for (lexer_.DoNextToken(); !lexer_.GetLastToken().isEOF();
          lexer_.DoNextToken()) {
-      if (verilog::VerilogLexer::KeepSyntaxTreeTokens(lexer_.GetLastToken())) {
-        lexed_sequence_.push_back(lexer_.GetLastToken());
-      }
+      lexed_sequence_.push_back(lexer_.GetLastToken());
     }
     InitTokenStreamView(lexed_sequence_, &stream_view_);
   }
@@ -882,7 +880,7 @@ TEST(VerilogPreprocessTest, IncludingFileWithAbsolutePath) {
   const auto tempdir = testing::TempDir();
   const std::string includes_dir = JoinPath(tempdir, "includes");
   constexpr absl::string_view included_content(
-      "module included_file(); endmodule\n");
+      "module included_file(); endmodule");
   const absl::string_view included_filename = "included_file.sv";
   const std::string included_absolute_path =
       JoinPath(includes_dir, included_filename);
@@ -934,7 +932,7 @@ TEST(VerilogPreprocessTest, IncludingFileWithRelativePath) {
   const std::string includes_dir = JoinPath(tempdir, "includes");
   EXPECT_TRUE(CreateDir(includes_dir).ok());
   constexpr absl::string_view included_content(
-      "module included_file(); endmodule\n");
+      "module included_file(); endmodule");
   const absl::string_view included_filename = "included_file.sv";
   const std::string included_absolute_path =
       JoinPath(includes_dir, included_filename);

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -92,7 +92,7 @@ static absl::Status PreprocessSingleFile(
   verilog::VerilogPreprocess::Config config;
   config.filter_branches = true;
   config.include_files = true;
-  // config.expand_macros=1;
+  config.expand_macros = 1;
 
   verilog::VerilogProject project(".", preprocessing_info.include_dirs);
 
@@ -115,9 +115,7 @@ static absl::Status PreprocessSingleFile(
     // For now we will store the syntax tree tokens only, ignoring all the
     // white-space characters. however that should be stored to output the
     // source code just like it was, but with conditionals filtered.
-    if (verilog::VerilogLexer::KeepSyntaxTreeTokens(lexer.GetLastToken())) {
-      lexed_sequence.push_back(lexer.GetLastToken());
-    }
+    lexed_sequence.push_back(lexer.GetLastToken());
   }
   verible::TokenStreamView lexed_streamview;
   // Initializing the lexed token stream view.
@@ -125,7 +123,7 @@ static absl::Status PreprocessSingleFile(
   verilog::VerilogPreprocessData preprocessed_data =
       preprocessor.ScanStream(lexed_streamview);
   auto& preprocessed_stream = preprocessed_data.preprocessed_token_stream;
-  for (auto u : preprocessed_stream) outs << *u << '\n';
+  for (auto u : preprocessed_stream) outs << u->text();
   for (auto& u : preprocessed_data.errors) outs << u.error_message << '\n';
   if (!preprocessed_data.errors.empty())
     return absl::InvalidArgumentError("Error: The preprocessing has failed.");

--- a/verilog/tools/preprocessor/verilog_preprocessor_test.sh
+++ b/verilog/tools/preprocessor/verilog_preprocessor_test.sh
@@ -274,22 +274,15 @@ endmodule
 EOF
 
 cat > "$MY_EXPECT_FILE" <<EOF
-(#359: "module")
-(#293: "m")
-(#40: "(")
-(#41: ")")
-(#59: ";")
-(#417: "wire")
-(#293: "x")
-(#61: "=")
-(#300: "1")
-(#59: ";")
-(#379: "real")
-(#293: "is_defined")
-(#61: "=")
-(#300: "0")
-(#59: ";")
-(#336: "endmodule")
+module m();
+  wire x = 1;
+
+  real is_defined = 0;
+
+// pre-blank line
+
+// post-blank line
+endmodule
 
 EOF
 
@@ -473,9 +466,13 @@ EOF
 
 
 cat > "$MY_EXPECT_FILE" <<EOF
-(#293: "A_FALSE")
 
-(#293: "A_FALSE")
+  A_FALSE
+
+
+
+  A_FALSE
+
 
 EOF
 
@@ -510,8 +507,13 @@ EOF
 
 
 cat > "$MY_EXPECT_FILE" <<EOF
-(#293: "A_TRUE")
-(#293: "B_FALSE")
+
+  A_TRUE
+
+
+
+  B_FALSE
+
 
 EOF
 
@@ -529,8 +531,13 @@ diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || {
 }
 
 cat > "$MY_EXPECT_FILE" <<EOF
-(#293: "A_TRUE")
-(#293: "B_TRUE")
+
+  A_TRUE
+
+
+
+  B_TRUE
+
 
 EOF
 
@@ -576,9 +583,10 @@ EOF
 
 cat > "$MY_EXPECT_FILE" <<EOF
 ${MY_INPUT_FILE}:
-(#293: "input_content_0")
-(#293: "included1_content")
-(#293: "input_content_1")
+input_content_0
+included1_content
+
+input_content_1
 
 EOF
 
@@ -610,8 +618,9 @@ EOF
 
 cat > "$MY_EXPECT_FILE" <<EOF
 ${MY_INPUT_FILE}:
-(#293: "included1_content")
-(#293: "input_content")
+included1_content
+
+input_content
 
 EOF
 
@@ -668,9 +677,11 @@ EOF
 
 cat > "$MY_EXPECT_FILE" <<EOF
 ${MY_INPUT_FILE}:
-(#293: "included2_content")
-(#293: "included1_content")
-(#293: "input_content")
+included2_content
+
+included1_content
+
+input_content
 
 EOF
 
@@ -706,9 +717,11 @@ EOF
 
 cat > "$MY_EXPECT_FILE" <<EOF
 ${MY_INPUT_FILE}:
-(#293: "included2_content")
-(#293: "included1_content")
-(#293: "input_content")
+included2_content
+
+included1_content
+
+input_content
 
 EOF
 
@@ -779,12 +792,20 @@ EOF
 
 cat > "$MY_EXPECT_FILE" <<EOF
 ${MY_INPUT_FILE}:
-(#293: "included2_content")
-(#293: "A_TRUE")
-(#293: "included1_content")
-(#293: "A_TRUE")
-(#293: "input_content")
-(#293: "A_TRUE")
+included2_content
+
+A_TRUE
+
+
+included1_content
+
+A_TRUE
+
+
+input_content
+
+A_TRUE
+
 
 EOF
 


### PR DESCRIPTION
### Description
The goal is to support white-spaces in the prepreprocessor.
It's done by discarding some white-spaces (will not be able to regenerate them).
In `VerilogPreprocess` sometimes a token iterator is incremented to look for a macro name, or a include file name, in these situations we will not be able to retrieve the white-spaces.

### Standalone preprocessor
The support for white-spaces should be added to the  preprocessor standalone tool in all modes:
- [X] Multiple compilation units mode.
- [ ] Generate variants. (`flow_tree` need some work)


A discussion about this problem is at #1358 