### PR TITLE
[LSP] Add support for providing definitions from the SymbolTable

### DIFF
--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -26,6 +26,17 @@ ServerInfo:
   name: string
   version: string
 
+InitializeParams:
+  # processId
+  # clientInfo
+  # locale
+  rootPath?: string
+  rootUri?: string
+  # initializationOptions
+  # capabilities
+  # trace
+  # workspaceFolders
+
 InitializeResult:
   capabilities: object          # Lots. We output that directly as plain json.
   serverInfo: ServerInfo

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -289,6 +289,7 @@ cc_library(
         "//common/text:__pkg__",
         "//verilog/analysis:__pkg__",
         "//verilog/formatting:__pkg__",
+        "//verilog/tools/ls:__pkg__",
     ],
     deps = [
         ":utf8",

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -1768,11 +1768,19 @@ static void ResolveReferenceComponentNode(
           parent_scope->Value().declared_type;
       // Primitive types do not have members.
       if (type_info.user_defined_type == nullptr) {
-        diagnostics->push_back(absl::InvalidArgumentError(
-            absl::StrCat("Type of parent reference ",
-                         ReferenceNodeFullPathString(*node->Parent()), " (",
-                         verible::StringSpanOfSymbol(*type_info.syntax_origin),
-                         ") does not have any members.")));
+        if (type_info.syntax_origin == nullptr) {
+          diagnostics->push_back(absl::InvalidArgumentError(
+              absl::StrCat("Type of parent reference ",
+                           ReferenceNodeFullPathString(*node->Parent()),
+                           " does not have syntax origin.")));
+        }
+        diagnostics->push_back(absl::InvalidArgumentError(absl::StrCat(
+            "Type of parent reference ",
+            ReferenceNodeFullPathString(*node->Parent()), " (",
+            type_info.syntax_origin
+                ? verible::StringSpanOfSymbol(*type_info.syntax_origin)
+                : "nullptr",
+            ") does not have any members.")));
         return;
       }
 

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -197,7 +197,7 @@ std::string VerilogProject::GetRelativePathToSource(
   return relative.string();
 }
 
-absl::Status VerilogProject::UpdateFileContents(
+void VerilogProject::UpdateFileContents(
     absl::string_view path, const verible::TextStructureView* updatedtext) {
   std::string projectpath = GetRelativePathToSource(path);
   auto fileptr = files_.find(projectpath);
@@ -211,7 +211,6 @@ absl::Status VerilogProject::UpdateFileContents(
         projectpath, path, updatedtext,
         /*corpus=*/"");
   }
-  return absl::OkStatus();
 }
 
 VerilogSourceFile* VerilogProject::LookupRegisteredFileInternal(

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -200,16 +200,17 @@ std::string VerilogProject::GetRelativePathToSource(
 void VerilogProject::UpdateFileContents(
     absl::string_view path, const verible::TextStructureView* updatedtext) {
   std::string projectpath = GetRelativePathToSource(path);
+  std::unique_ptr<VerilogSourceFile> contents = nullptr;
+  if (updatedtext)
+    contents = std::make_unique<ParsedVerilogSourceFile>(
+        projectpath, path, updatedtext, /*corpus=*/"");
+  else
+    contents = std::make_unique<VerilogSourceFile>(projectpath, path, "");
   auto fileptr = files_.find(projectpath);
   if (fileptr == files_.end()) {
-    files_.insert(
-        std::make_pair(projectpath, std::make_unique<ParsedVerilogSourceFile>(
-                                        projectpath, path, updatedtext,
-                                        /*corpus=*/"")));
+    files_.insert(std::make_pair(projectpath, std::move(contents)));
   } else {
-    fileptr->second = std::make_unique<ParsedVerilogSourceFile>(
-        projectpath, path, updatedtext,
-        /*corpus=*/"");
+    fileptr->second = std::move(contents);
   }
 }
 

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -197,7 +197,7 @@ std::string VerilogProject::GetRelativePathToSource(
   return relative.string();
 }
 
-absl::Status VerilogProject::updateFileContents(
+absl::Status VerilogProject::UpdateFileContents(
     absl::string_view path, const verible::TextStructureView* updatedtext) {
   std::string projectpath = GetRelativePathToSource(path);
   auto fileptr = files_.find(projectpath);

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/verilog_project.h"
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -183,6 +184,15 @@ bool VerilogProject::RemoveRegisteredFile(
     }
   }
   return false;
+}
+
+std::string VerilogProject::GetRelativePathToSource(
+    const std::string& absolute_filepath) {
+  // TODO add check if the absolute_filepath is out of the VerilogProject
+  std::filesystem::path absolutepath{absolute_filepath};
+  std::filesystem::path projectpath{std::string{TranslationUnitRoot()}};
+  auto relative = std::filesystem::relative(absolutepath, projectpath);
+  return relative.string();
 }
 
 VerilogSourceFile* VerilogProject::LookupRegisteredFileInternal(

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -202,14 +202,14 @@ absl::Status VerilogProject::UpdateFileContents(
   std::string projectpath = GetRelativePathToSource(path);
   auto fileptr = files_.find(projectpath);
   if (fileptr == files_.end()) {
-    files_.insert(std::make_pair(
-        projectpath,
-        std::make_unique<ParsedVerilogSourceFile>(projectpath, updatedtext,
-                                                  /*corpus=*/"")));
+    files_.insert(
+        std::make_pair(projectpath, std::make_unique<ParsedVerilogSourceFile>(
+                                        projectpath, path, updatedtext,
+                                        /*corpus=*/"")));
   } else {
-    fileptr->second =
-        std::make_unique<ParsedVerilogSourceFile>(projectpath, updatedtext,
-                                                  /*corpus=*/"");
+    fileptr->second = std::make_unique<ParsedVerilogSourceFile>(
+        projectpath, path, updatedtext,
+        /*corpus=*/"");
   }
   return absl::OkStatus();
 }

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -195,6 +195,15 @@ std::string VerilogProject::GetRelativePathToSource(
   return relative.string();
 }
 
+absl::Status VerilogProject::updateFileContents(
+    absl::string_view path, const verible::TextStructureView* updatedtext) {
+  auto projectpath = GetRelativePathToSource(static_cast<std::string>(path));
+  files_[projectpath] =
+      std::make_unique<ParsedVerilogSourceFile>(projectpath, updatedtext,
+                                                /*corpus=*/"");
+  return absl::OkStatus();
+}
+
 VerilogSourceFile* VerilogProject::LookupRegisteredFileInternal(
     absl::string_view referenced_filename) const {
   const auto opened_file = FindOpenedFile(referenced_filename);

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -297,7 +297,12 @@ class VerilogProject {
   const VerilogSourceFile* LookupFileOrigin(
       absl::string_view content_substring) const;
 
+  // Returns relative path to the VerilogProject
   std::string GetRelativePathToSource(const std::string& absolute_filepath);
+
+  // Updates file from external source, e.g. Language Server
+  absl::Status updateFileContents(
+      absl::string_view path, const verible::TextStructureView* updatedtext);
 
  private:
   absl::StatusOr<VerilogSourceFile*> OpenFile(

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -306,7 +306,10 @@ class VerilogProject {
 
   // Adds include directory to the project
   void AddIncludePath(absl::string_view includepath) {
-    include_paths_.push_back({includepath.begin(), includepath.end()});
+    std::string path = {includepath.begin(), includepath.end()};
+    if (std::find(include_paths_.begin(), include_paths_.end(), path) ==
+        include_paths_.end())
+      include_paths_.push_back(path);
   }
 
  private:

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -298,7 +298,7 @@ class VerilogProject {
       absl::string_view content_substring) const;
 
   // Returns relative path to the VerilogProject
-  std::string GetRelativePathToSource(const std::string& absolute_filepath);
+  std::string GetRelativePathToSource(absl::string_view absolute_filepath);
 
   // Updates file from external source, e.g. Language Server
   absl::Status updateFileContents(

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -301,12 +301,12 @@ class VerilogProject {
   std::string GetRelativePathToSource(absl::string_view absolute_filepath);
 
   // Updates file from external source, e.g. Language Server
-  absl::Status updateFileContents(
+  absl::Status UpdateFileContents(
       absl::string_view path, const verible::TextStructureView* updatedtext);
 
   // Adds include directory to the project
-  void addIncludePath(const std::string& includepath) {
-    include_paths_.push_back(includepath);
+  void AddIncludePath(absl::string_view includepath) {
+    include_paths_.push_back({includepath.begin(), includepath.end()});
   }
 
  private:

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -304,6 +304,11 @@ class VerilogProject {
   absl::Status updateFileContents(
       absl::string_view path, const verible::TextStructureView* updatedtext);
 
+  // Adds include directory to the project
+  void addIncludePath(const std::string& includepath) {
+    include_paths_.push_back(includepath);
+  }
+
  private:
   absl::StatusOr<VerilogSourceFile*> OpenFile(
       absl::string_view referenced_filename,
@@ -329,7 +334,7 @@ class VerilogProject {
 
   // The sequence of directories from which to search for `included files.
   // These can be absolute, or relative to the process's working directory.
-  const std::vector<std::string> include_paths_;
+  std::vector<std::string> include_paths_;
 
   // The corpus to which this project belongs (e.g.,
   // 'github.com/chipsalliance/verible').

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -297,6 +297,8 @@ class VerilogProject {
   const VerilogSourceFile* LookupFileOrigin(
       absl::string_view content_substring) const;
 
+  std::string GetRelativePathToSource(const std::string& absolute_filepath);
+
  private:
   absl::StatusOr<VerilogSourceFile*> OpenFile(
       absl::string_view referenced_filename,

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -310,8 +310,8 @@ class VerilogProject {
   std::string GetRelativePathToSource(absl::string_view absolute_filepath);
 
   // Updates file from external source, e.g. Language Server
-  absl::Status UpdateFileContents(
-      absl::string_view path, const verible::TextStructureView* updatedtext);
+  void UpdateFileContents(absl::string_view path,
+                          const verible::TextStructureView* updatedtext);
 
   // Adds include directory to the project
   void AddIncludePath(absl::string_view includepath) {

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -187,6 +187,15 @@ class InMemoryVerilogSourceFile final : public VerilogSourceFile {
 // Doesn't require file-system access, nor create temporary files.
 class ParsedVerilogSourceFile final : public VerilogSourceFile {
  public:
+  // this constructor is used for updating file contents in the language server
+  // it sets referenced_path and resolved_path based on URI from language server
+  ParsedVerilogSourceFile(absl::string_view referenced_path,
+                          absl::string_view resolved_path,
+                          const verible::TextStructureView* text_structure,
+                          absl::string_view corpus = "")
+      : VerilogSourceFile(referenced_path, resolved_path, corpus),
+        text_structure_(text_structure) {}
+
   // filename can be fake, it is not used to open any file.
   // text_structure is a pointer to a TextStructureView object of
   //     already parsed file. Current implementation does _not_ make a

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -80,6 +80,16 @@ cc_library(
 )
 
 cc_library(
+    name = "symbol-table-handler",
+    srcs = ["symbol-table-handler.cc"],
+    hdrs = ["symbol-table-handler.h"],
+    deps = [
+        "//verilog/analysis:symbol_table",
+        "//common/lsp:lsp-protocol",
+    ],
+)
+
+cc_library(
     name = "verilog-language-server",
     srcs = ["verilog-language-server.cc"],
     hdrs = ["verilog-language-server.h"],

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -96,6 +96,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":lsp-parse-buffer",
+        ":symbol-table-handler",
         ":verible-lsp-adapter",
         "//common/lsp:json-rpc-dispatcher",
         "//common/lsp:lsp-protocol",

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -86,7 +86,8 @@ cc_library(
     deps = [
         "//verilog/analysis:symbol_table",
         "//common/lsp:lsp-protocol",
-        "@com_google_absl//absl/container:flat_hash_set"
+        "@com_google_absl//absl/container:flat_hash_set",
+        ":lsp-parse-buffer"
     ],
 )
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -84,10 +84,14 @@ cc_library(
     srcs = ["symbol-table-handler.cc"],
     hdrs = ["symbol-table-handler.h"],
     deps = [
-        "//verilog/analysis:symbol_table",
-        "//common/lsp:lsp-protocol",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/strings",
+        "//common/lsp:lsp-protocol",
+        "//common/util:file_util",
+        "//verilog/analysis:symbol_table",
+        "//verilog/analysis:verilog_filelist",
+        "//verilog/analysis:verilog_project",
         ":lsp-parse-buffer"
     ],
 )

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -88,6 +88,7 @@ cc_library(
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
         "//common/lsp:lsp-protocol",
+        "//common/strings:line_column_map",
         "//common/util:file_util",
         "//verilog/analysis:symbol_table",
         "//verilog/analysis:verilog_filelist",

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -97,6 +97,15 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "symbol-table-handler_test",
+    srcs = ["symbol-table-handler_test.cc"],
+    deps = [
+        ":symbol-table-handler",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "verilog-language-server",
     srcs = ["verilog-language-server.cc"],

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -93,7 +93,7 @@ cc_library(
         "//verilog/analysis:symbol_table",
         "//verilog/analysis:verilog_filelist",
         "//verilog/analysis:verilog_project",
-        ":lsp-parse-buffer"
+        ":lsp-parse-buffer",
     ],
 )
 
@@ -115,6 +115,7 @@ cc_library(
         ":lsp-parse-buffer",
         ":symbol-table-handler",
         ":verible-lsp-adapter",
+        "//common/util:file_util",
         "//common/lsp:json-rpc-dispatcher",
         "//common/lsp:lsp-protocol",
         "//common/lsp:lsp-text-buffer",

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -86,6 +86,7 @@ cc_library(
     deps = [
         "//verilog/analysis:symbol_table",
         "//common/lsp:lsp-protocol",
+        "@com_google_absl//absl/container:flat_hash_set"
     ],
 )
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -87,6 +87,7 @@ cc_library(
         "//verilog/analysis:symbol_table",
         "//common/lsp:lsp-protocol",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/flags:flag",
         ":lsp-parse-buffer"
     ],
 )

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -68,9 +68,7 @@ BufferTrackerContainer::GetSubscriptionCallback() {
           const BufferTracker *tracker = Update(uri, *txt);
           // Now inform our listeners.
           for (const auto &change_listener : change_listeners_) {
-            if (change_listener) {
-              change_listener(uri, *tracker);
-            }
+            change_listener(uri, *tracker);
           }
         } else {
           Remove(uri);

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -68,10 +68,13 @@ BufferTrackerContainer::GetSubscriptionCallback() {
           const BufferTracker *tracker = Update(uri, *txt);
           // Now inform our listeners.
           for (const auto &change_listener : change_listeners_) {
-            change_listener(uri, *tracker);
+            change_listener(uri, tracker);
           }
         } else {
           Remove(uri);
+          for (const auto &change_listener : change_listeners_) {
+            change_listener(uri, nullptr);
+          }
         }
       };
 }

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -67,7 +67,11 @@ BufferTrackerContainer::GetSubscriptionCallback() {
         if (txt) {
           const BufferTracker *tracker = Update(uri, *txt);
           // Now inform our listeners.
-          if (change_listener_) change_listener_(uri, *tracker);
+          for (const auto &change_listener : change_listeners_) {
+            if (change_listener) {
+              change_listener(uri, *tracker);
+            }
+          }
         } else {
           Remove(uri);
         }

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -87,11 +87,17 @@ class BufferTrackerContainer {
   verible::lsp::BufferCollection::UriBufferCallback GetSubscriptionCallback();
 
   // type for buffer change callback function
+  // The callback takes uri of the file, and the pointer to the BufferTracker
+  // The pointer can be nullptr, meaning that e.g. the file was closed.
+  // The nullptr case should be handled by callback.
   using ChangeCallback =
       std::function<void(const std::string &uri, const BufferTracker *tracker)>;
 
   // Add a change listener for clients of ours interested in updated fresly
   // parsed content.
+  // The callback takes uri of the file, and the pointer to the BufferTracker
+  // The pointer can be nullptr, meaning that e.g. the file was closed.
+  // The nullptr case should be handled by callback.
   void AddChangeListener(const ChangeCallback &cb) {
     change_listeners_.push_back(ABSL_DIE_IF_NULL(cb));
   }

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -93,7 +93,7 @@ class BufferTrackerContainer {
   // Add a change listener for clients of ours interested in updated fresly
   // parsed content.
   void AddChangeListener(const ChangeCallback &cb) {
-    change_listeners_.push_back(cb);
+    change_listeners_.push_back(ABSL_DIE_IF_NULL(cb));
   }
 
   // Given the URI, find the associated parse buffer if it exists.

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -86,11 +86,15 @@ class BufferTrackerContainer {
   // (internally, they exercise Update() and Remove())
   verible::lsp::BufferCollection::UriBufferCallback GetSubscriptionCallback();
 
-  // Add a change listener for clients of ours interested in updated fresly
-  // parsed content.
+  // type for buffer change callback function
   using ChangeCallback =
       std::function<void(const std::string &uri, const BufferTracker &tracker)>;
-  void SetChangeListener(const ChangeCallback &cb) { change_listener_ = cb; }
+
+  // Add a change listener for clients of ours interested in updated fresly
+  // parsed content.
+  void AddChangeListener(const ChangeCallback &cb) {
+    change_listeners_.push_back(cb);
+  }
 
   // Given the URI, find the associated parse buffer if it exists.
   const BufferTracker *FindBufferTrackerOrNull(const std::string &uri) const;
@@ -104,7 +108,7 @@ class BufferTrackerContainer {
   // Remove the buffer tracker for the given "uri".
   void Remove(const std::string &uri) { buffers_.erase(uri); }
 
-  ChangeCallback change_listener_ = nullptr;
+  std::vector<ChangeCallback> change_listeners_;
   std::unordered_map<std::string, std::unique_ptr<BufferTracker>> buffers_;
 };
 }  // namespace verilog

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -88,7 +88,7 @@ class BufferTrackerContainer {
 
   // type for buffer change callback function
   using ChangeCallback =
-      std::function<void(const std::string &uri, const BufferTracker &tracker)>;
+      std::function<void(const std::string &uri, const BufferTracker *tracker)>;
 
   // Add a change listener for clients of ours interested in updated fresly
   // parsed content.

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -57,6 +57,27 @@ void SymbolTableHandler::buildSymbolTableFor(VerilogSourceFile &file) {
   auto result = BuildSymbolTable(file, symboltable.get(), currproject.get());
 }
 
+const SymbolTableNode* SymbolTableHandler::ScanSymbolTreeForDefinition(const SymbolTableNode* context, absl::string_view symbol)
+{
+  if (!context)
+  {
+    return nullptr;
+  }
+  if (context->Key() && *context->Key() == symbol)
+  {
+    return context;
+  }
+  for (const auto &child : context->Children())
+  {
+    auto res = ScanSymbolTreeForDefinition(&child.second, symbol);
+    if (res)
+    {
+      return res;
+    }
+  }
+  return nullptr;
+}
+
 std::vector<verible::lsp::Location> SymbolTableHandler::findDefinition(
     const verible::lsp::DefinitionParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -59,7 +59,14 @@ void SymbolTableHandler::buildProjectSymbolTable() {
   LOG(INFO) << "Parsing project files...";
   std::vector<absl::Status> buildstatus;
   symboltable->Build(&buildstatus);
-  LOG(INFO) << "Parsed project files";
+  for (const auto &diagnostic : buildstatus) {
+    LOG(WARNING) << diagnostic.message();
+  }
+  std::vector<absl::Status> resolvestatus;
+  symboltable->Resolve(&resolvestatus);
+  for (const auto &diagnostic : resolvestatus) {
+    LOG(WARNING) << diagnostic.message();
+  }
 }
 
 void SymbolTableHandler::loadProjectFileList(absl::string_view current_dir) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -16,11 +16,13 @@
 #include "verilog/tools/ls/symbol-table-handler.h"
 
 #include "common/strings/line_column_map.h"
+#include <filesystem>
 
 namespace verilog {
 
+static const std::string fileschemeprefix = "file://";
+
 bool LSPUriToPath(absl::string_view uri, std::string &path) {
-  static const std::string fileschemeprefix = "file://";
   auto found = uri.find(fileschemeprefix);
   if (found == std::string::npos) {
     return false;
@@ -30,6 +32,12 @@ bool LSPUriToPath(absl::string_view uri, std::string &path) {
   }
   std::string res{uri.substr(found + fileschemeprefix.size())};
   path = res;
+  return true;
+}
+
+bool PathToLSPUri(absl::string_view path, std::string &uri) {
+  std::filesystem::path p = std::string(path);
+  uri = fileschemeprefix + std::filesystem::absolute(p).string();
   return true;
 }
 

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -207,14 +207,11 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
     bool success = true;
     for (const auto &diagnostic : diagnostics) {
       if (!diagnostic.ok())
-        LOG(ERROR) << "Error on textDocument/definition:  " << diagnostic;
+        LOG(WARNING) << "Error on textDocument/definition:  " << diagnostic;
       success &= diagnostic.ok();
     }
     if (!success) {
-      LOG(ERROR) << "Could not find definition due to symbol table errors";
-      LOG(INFO) << "textDocument/definition processing time:  "
-                << (absl::Now() - finddefinition_start);
-      return {};
+      LOG(WARNING) << "There were errors during symbol table building";
     }
   }
   absl::string_view filepath = LSPUriToPath(params.textDocument.uri);

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -17,6 +17,20 @@
 
 namespace verilog {
 
+bool LSPUriToPath(absl::string_view uri, std::string &path) {
+  static const std::string fileschemeprefix = "file://";
+  auto found = uri.find(fileschemeprefix);
+  if (found == std::string::npos) {
+    return false;
+  }
+  if (found != 0) {
+    return false;
+  }
+  std::string res{uri.substr(found + fileschemeprefix.size())};
+  path = res;
+  return true;
+}
+
 void SymbolTableHandler::setProject(
     absl::string_view root, const std::vector<std::string> &include_paths,
     absl::string_view corpus) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -1,0 +1,56 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "verilog/tools/ls/symbol-table-handler.h"
+
+namespace verilog {
+
+void SymbolTableHandler::setProject(
+    absl::string_view root, const std::vector<std::string> &include_paths,
+    absl::string_view corpus) {
+  currproject = std::make_shared<VerilogProject>(root, include_paths, corpus);
+  resetSymbolTable();
+}
+
+void SymbolTableHandler::resetSymbolTable() {
+  checkedfiles.clear();
+  symboltable = std::make_shared<SymbolTable>(currproject.get());
+}
+
+void SymbolTableHandler::buildSymbolTableFor(VerilogSourceFile &file) {
+  auto result = BuildSymbolTable(file, symboltable.get(), currproject.get());
+}
+
+std::vector<verible::lsp::Location> SymbolTableHandler::findDefinition(
+    const verible::lsp::DefinitionParams &params) {
+  auto filepath = params.textDocument.uri;
+  if (checkedfiles.find(filepath) == checkedfiles.end()) {
+    // File hasn't been tracked yet in the symbol table, add it
+    auto openedfile = currproject->OpenTranslationUnit(filepath);
+    if (!openedfile.ok()) {
+      std::cerr << "Could not open " << filepath << " in project "
+                << currproject->TranslationUnitRoot() << std::endl;
+      return {};
+    }
+    auto buildstatus =
+        BuildSymbolTable(**openedfile, symboltable.get(), currproject.get());
+    std::cerr << "Symbol definitions:" << std::endl << std::endl;
+    symboltable->PrintSymbolDefinitions(std::cerr);
+    std::cerr << std::endl;
+  }
+  return {};
+}
+
+};  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -35,24 +35,24 @@ std::string PathToLSPUri(absl::string_view path) {
   return absl::StrCat(fileschemeprefix, std::filesystem::absolute(p).string());
 }
 
-void SymbolTableHandler::setProject(
+void SymbolTableHandler::SetProject(
     absl::string_view root, const std::vector<std::string> &include_paths,
     absl::string_view corpus) {
   currproject = std::make_unique<VerilogProject>(root, include_paths, corpus);
-  resetSymbolTable();
+  ResetSymbolTable();
 }
 
-void SymbolTableHandler::resetSymbolTable() {
+void SymbolTableHandler::ResetSymbolTable() {
   checkedfiles.clear();
   symboltable = std::make_unique<SymbolTable>(currproject.get());
 }
 
-void SymbolTableHandler::buildSymbolTableFor(VerilogSourceFile &file) {
+void SymbolTableHandler::BuildSymbolTableFor(VerilogSourceFile &file) {
   auto result = BuildSymbolTable(file, symboltable.get(), currproject.get());
 }
 
-void SymbolTableHandler::buildProjectSymbolTable() {
-  resetSymbolTable();
+void SymbolTableHandler::BuildProjectSymbolTable() {
+  ResetSymbolTable();
   if (!currproject) {
     return;
   }
@@ -70,7 +70,7 @@ void SymbolTableHandler::buildProjectSymbolTable() {
   files_dirty_ = false;
 }
 
-void SymbolTableHandler::loadProjectFileList(absl::string_view current_dir) {
+void SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
   LOG(INFO) << __FUNCTION__;
   if (!currproject) return;
   // search for FileList file up the directory hierarchy
@@ -111,7 +111,7 @@ void SymbolTableHandler::loadProjectFileList(absl::string_view current_dir) {
       continue;
     }
     LOG(INFO) << "Creating symbol table for:  " << incfile;
-    buildSymbolTableFor(*incsource.value());
+    BuildSymbolTableFor(*incsource.value());
   }
 }
 
@@ -157,12 +157,12 @@ const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
   return nullptr;
 }
 
-std::vector<verible::lsp::Location> SymbolTableHandler::findDefinition(
+std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
     const verible::lsp::DefinitionParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
   const absl::Time finddefinition_start = absl::Now();
   if (files_dirty_) {
-    buildProjectSymbolTable();
+    BuildProjectSymbolTable();
   }
   absl::string_view filepath = LSPUriToPath(params.textDocument.uri);
   if (filepath.empty()) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -125,15 +125,17 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
     curr_project_->AddIncludePath(incdir);
   }
   // add files from file list to the project
-  for (auto &incfile : filelist.file_paths) {
-    auto incsource = curr_project_->OpenIncludedFile(incfile);
-    if (!incsource.ok()) {
+  for (const auto &file_in_project : filelist.file_paths) {
+    auto source = curr_project_->OpenTranslationUnit(file_in_project);
+    if (!source.ok()) source = curr_project_->OpenIncludedFile(file_in_project);
+    if (!source.ok()) {
       LOG(WARNING) << "File included in " << filelist_path_
-                   << " not found:  " << incfile << ":  " << incsource.status();
+                   << " not found:  " << file_in_project << ":  "
+                   << source.status();
       continue;
     }
-    LOG(INFO) << "Creating symbol table for:  " << incfile;
-    BuildSymbolTableFor(*incsource.value());
+    LOG(INFO) << "Creating symbol table for:  " << file_in_project;
+    BuildSymbolTableFor(*source.value());
   }
   return true;
 }

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -58,6 +58,27 @@ void SymbolTableHandler::buildSymbolTableFor(VerilogSourceFile &file) {
   auto result = BuildSymbolTable(file, symboltable.get(), currproject.get());
 }
 
+void SymbolTableHandler::buildProjectSymbolTable() {
+  resetSymbolTable();
+  if (!currproject) {
+    return;
+  }
+  LOG(INFO) << "Parsing project files...";
+  for (const auto &file : *currproject) {
+    auto status = file.second->Parse();
+    if (!status.ok()) {
+      LOG(ERROR) << "Failed to parse file:  " << file.second->ReferencedPath();
+      return;
+    }
+    LOG(INFO) << "Successfully parsed:  " << file.second->ReferencedPath();
+    auto result =
+        BuildSymbolTable(*file.second, symboltable.get(), currproject.get());
+  }
+  LOG(INFO) << "Parsed project files";
+  LOG(INFO) << "Symbol table for the project";
+  symboltable->PrintSymbolDefinitions(std::cerr);
+}
+
 const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
     const SymbolTableNode *context, absl::string_view symbol) {
   if (!context) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -168,7 +168,19 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
     const verilog::BufferTrackerContainer &parsed_buffers) {
   const absl::Time finddefinition_start = absl::Now();
   if (files_dirty_) {
-    BuildProjectSymbolTable();
+    std::vector<absl::Status> diagnostics = BuildProjectSymbolTable();
+    bool success = true;
+    for (const auto &diagnostic : diagnostics) {
+      if (!diagnostic.ok())
+        LOG(ERROR) << "Error on textDocument/definition:  " << diagnostic;
+      success &= diagnostic.ok();
+    }
+    if (!success) {
+      LOG(ERROR) << "Could not find definition due to symbol table errors";
+      LOG(INFO) << "textDocument/definition processing time:  "
+                << (absl::Now() - finddefinition_start);
+      return {};
+    }
   }
   absl::string_view filepath = LSPUriToPath(params.textDocument.uri);
   if (filepath.empty()) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -20,13 +20,13 @@ namespace verilog {
 void SymbolTableHandler::setProject(
     absl::string_view root, const std::vector<std::string> &include_paths,
     absl::string_view corpus) {
-  currproject = std::make_shared<VerilogProject>(root, include_paths, corpus);
+  currproject = std::make_unique<VerilogProject>(root, include_paths, corpus);
   resetSymbolTable();
 }
 
 void SymbolTableHandler::resetSymbolTable() {
   checkedfiles.clear();
-  symboltable = std::make_shared<SymbolTable>(currproject.get());
+  symboltable = std::make_unique<SymbolTable>(currproject.get());
 }
 
 void SymbolTableHandler::buildSymbolTableFor(VerilogSourceFile &file) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -294,10 +294,10 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   return {location};
 }
 
-absl::Status SymbolTableHandler::UpdateFileContent(
+void SymbolTableHandler::UpdateFileContent(
     absl::string_view path, const verible::TextStructureView *content) {
   files_dirty_ = true;
-  return curr_project_->UpdateFileContents(path, content);
+  curr_project_->UpdateFileContents(path, content);
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -187,8 +187,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
     LOG(ERROR) << "Could not convert URI " << params.textDocument.uri
                << " to filesystem path." << std::endl;
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
   std::string relativepath = curr_project_->GetRelativePathToSource(filepath);
@@ -197,8 +196,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   if (!tracker) {
     LOG(ERROR) << "Could not find buffer with URI " << params.textDocument.uri;
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
   const verilog::ParsedBuffer *parsedbuffer = tracker->current();
@@ -206,8 +204,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
     LOG(ERROR) << "Buffer not found among opened buffers:  "
                << params.textDocument.uri;
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
   const verible::LineColumn cursor{params.position.line,
@@ -220,8 +217,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   if (!reffile) {
     LOG(ERROR) << "Unable to lookup " << params.textDocument.uri;
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
 
@@ -231,8 +227,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   if (!node) {
     LOG(INFO) << "Symbol " << symbol << " not found in symbol table:  " << node;
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
   // TODO add iterating over multiple definitions?
@@ -241,8 +236,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   if (!symbolinfo.file_origin) {
     LOG(ERROR) << "Origin file not available";
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
   location.uri = PathToLSPUri(symbolinfo.file_origin->ResolvedPath());
@@ -250,8 +244,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   if (!textstructure) {
     LOG(ERROR) << "Origin file's text structure is not parsed";
     LOG(INFO) << "textDocument/definition processing time:  "
-              << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-              << "ms";
+              << (absl::Now() - finddefinition_start);
     return {};
   }
   verible::LineColumnRange symbollocation =
@@ -261,8 +254,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
   location.range.end = {.line = symbollocation.end.line,
                         .character = symbollocation.end.column};
   LOG(INFO) << "textDocument/definition processing time:  "
-            << absl::ToInt64Milliseconds(absl::Now() - finddefinition_start)
-            << "ms";
+            << (absl::Now() - finddefinition_start);
   return {location};
 }
 

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -67,6 +67,7 @@ void SymbolTableHandler::buildProjectSymbolTable() {
   for (const auto &diagnostic : resolvestatus) {
     LOG(WARNING) << diagnostic.message();
   }
+  files_dirty_ = false;
 }
 
 void SymbolTableHandler::loadProjectFileList(absl::string_view current_dir) {
@@ -134,7 +135,9 @@ const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
 std::vector<verible::lsp::Location> SymbolTableHandler::findDefinition(
     const verible::lsp::DefinitionParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
-  buildProjectSymbolTable();
+  if (files_dirty_) {
+    buildProjectSymbolTable();
+  }
   absl::string_view filepath = LSPUriToPath(params.textDocument.uri);
   if (filepath.empty()) {
     std::cerr << "Could not convert URI " << params.textDocument.uri

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -25,6 +25,7 @@
 #include "common/lsp/lsp-protocol.h"
 #include "verilog/analysis/symbol_table.h"
 #include "verilog/analysis/verilog_project.h"
+#include "verilog/tools/ls/lsp-parse-buffer.h"
 
 namespace verilog {
 
@@ -61,7 +62,8 @@ class SymbolTableHandler {
   // message delivered i.e. in textDocument/definition message.
   // Provides a list of locations with symbol's definitions.
   std::vector<verible::lsp::Location> findDefinition(
-      const verible::lsp::DefinitionParams &params);
+      const verible::lsp::DefinitionParams &params,
+      const verilog::BufferTrackerContainer &parsed_buffers);
 
  private:
   // current VerilogProject for which the symbol table is created

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -16,11 +16,13 @@
 #ifndef VERILOG_TOOLS_LS_SYMBOL_TABLE_HANDLER_H
 #define VERILOG_TOOLS_LS_SYMBOL_TABLE_HANDLER_H
 
+#include <filesystem>
 #include <memory>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include "common/lsp/lsp-protocol.h"
 #include "verilog/analysis/symbol_table.h"
 #include "verilog/analysis/verilog_project.h"
@@ -82,6 +84,11 @@ class SymbolTableHandler {
   std::shared_ptr<VerilogProject> curr_project_;
   // symbol table structure
   std::unique_ptr<SymbolTable> symbol_table_;
+  // path to the filelist file for the project
+  std::string filelist_path_;
+  // last timestamp of filelist file - used to check whether SymbolTable should
+  // be updated
+  absl::optional<std::filesystem::file_time_type> last_filelist_update_;
 
   // Scans the symbol table tree to find a given symbol.
   // When succeds, returns the pointer to table node with the symbol, otherwise
@@ -92,7 +99,7 @@ class SymbolTableHandler {
   // Looks for verible.filelist file down in directory structure and loads data
   // to project.
   // It is meant to be executed once per VerilogProject setup
-  void LoadProjectFileList(absl::string_view current_dir);
+  bool LoadProjectFileList(absl::string_view current_dir);
 };
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -73,6 +73,10 @@ class SymbolTableHandler {
   // set of checked files to prevent unnecessary calls for creating
   // a symbol table for already seen files
   absl::flat_hash_set<std::string> checkedfiles;
+
+  // Scans the symbol table tree to find a given symbol.
+  // When succeds, returns the pointer to table node with the symbol, otherwise returns false.
+  const SymbolTableNode* ScanSymbolTreeForDefinition(const SymbolTableNode *context, absl::string_view symbol);
 };
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -30,12 +30,11 @@
 namespace verilog {
 
 // Converts file:// scheme entries to actual system paths.
-// If other scheme is provided, method returns false.
-// TODO move to other header?
-bool LSPUriToPath(absl::string_view uri, absl::string_view path);
+// If other scheme is provided, method returns empty string_view.
+absl::string_view LSPUriToPath(absl::string_view uri);
 
 // Converts filesystem paths to file:// scheme entries.
-bool PathToLSPUri(absl::string_view path, std::string *uri);
+std::string PathToLSPUri(absl::string_view path);
 
 // A class interfacing the SymbolTable with the LSP messages.
 // It manages the SymbolTable and its necessary components,

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -39,6 +39,9 @@ absl::string_view LSPUriToPath(absl::string_view uri);
 // Converts filesystem paths to file:// scheme entries.
 std::string PathToLSPUri(absl::string_view path);
 
+// Looks for FileList file for SymbolTableHandler
+std::string FindFileList(absl::string_view current_dir);
+
 // A class interfacing the SymbolTable with the LSP messages.
 // It manages the SymbolTable and its necessary components,
 // and provides such information as symbol definitions

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -75,8 +75,10 @@ class SymbolTableHandler {
   absl::flat_hash_set<std::string> checkedfiles;
 
   // Scans the symbol table tree to find a given symbol.
-  // When succeds, returns the pointer to table node with the symbol, otherwise returns false.
-  const SymbolTableNode* ScanSymbolTreeForDefinition(const SymbolTableNode *context, absl::string_view symbol);
+  // When succeds, returns the pointer to table node with the symbol, otherwise
+  // returns false.
+  const SymbolTableNode *ScanSymbolTreeForDefinition(
+      const SymbolTableNode *context, absl::string_view symbol);
 };
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -17,9 +17,9 @@
 #define VERILOG_TOOLS_LS_SYMBOL_TABLE_HANDLER_H
 
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "common/lsp/lsp-protocol.h"
@@ -59,13 +59,13 @@ class SymbolTableHandler {
       const verible::lsp::DefinitionParams &params);
 
  private:
-  std::unordered_set<std::string>
-      checkedfiles;  // set of checked files to prevent unnecessary calls for
-                     // creating a symbol table for already seen files
   // current VerilogProject for which the symbol table is created
   std::unique_ptr<VerilogProject> currproject;
   // symbol table structure
   std::unique_ptr<SymbolTable> symboltable;
+  // set of checked files to prevent unnecessary calls for creating
+  // a symbol table for already seen files
+  absl::flat_hash_set<std::string> checkedfiles;
 };
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -31,6 +31,8 @@ namespace verilog {
 
 // Converts file:// scheme entries to actual system paths.
 // If other scheme is provided, method returns empty string_view.
+// TODO (glatosinski) current resolving of LSP URIs is very naive
+// and supports only narrow use cases of file:// specifier.
 absl::string_view LSPUriToPath(absl::string_view uri);
 
 // Converts filesystem paths to file:// scheme entries.
@@ -65,6 +67,10 @@ class SymbolTableHandler {
 
   // Creates a symbol table for entire project
   void buildProjectSymbolTable();
+
+  // Looks for verible.filelist file down in directory structure and loads data
+  // to project.
+  void loadProjectFileList(absl::string_view current_dir);
 
   // Finds the definition for a symbol provided in the DefinitionParams
   // message delivered i.e. in textDocument/definition message.

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -79,6 +79,8 @@ class SymbolTableHandler {
       const verible::lsp::DefinitionParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
 
+  bool files_dirty_ = true;
+
  private:
   // current VerilogProject for which the symbol table is created
   std::shared_ptr<VerilogProject> currproject;

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -51,6 +51,9 @@ class SymbolTableHandler {
                   const std::vector<std::string> &include_paths,
                   absl::string_view corpus);
 
+  // Returns the current project.
+  std::shared_ptr<VerilogProject> getProject() { return currproject; }
+
   // Creates a new symbol table given the VerilogProject in setProject
   // method.
   void resetSymbolTable();
@@ -67,7 +70,7 @@ class SymbolTableHandler {
 
  private:
   // current VerilogProject for which the symbol table is created
-  std::unique_ptr<VerilogProject> currproject;
+  std::shared_ptr<VerilogProject> currproject;
   // symbol table structure
   std::unique_ptr<SymbolTable> symboltable;
   // set of checked files to prevent unnecessary calls for creating

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -32,7 +32,7 @@ namespace verilog {
 // Converts file:// scheme entries to actual system paths.
 // If other scheme is provided, method returns false.
 // TODO move to other header?
-bool LSPUriToPath(absl::string_view uri, std::string *path);
+bool LSPUriToPath(absl::string_view uri, absl::string_view path);
 
 // Converts filesystem paths to file:// scheme entries.
 bool PathToLSPUri(absl::string_view path, std::string *uri);

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -1,0 +1,72 @@
+// Copyright 2021 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef VERILOG_TOOLS_LS_SYMBOL_TABLE_HANDLER_H
+#define VERILOG_TOOLS_LS_SYMBOL_TABLE_HANDLER_H
+
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "common/lsp/lsp-protocol.h"
+#include "verilog/analysis/symbol_table.h"
+#include "verilog/analysis/verilog_project.h"
+
+namespace verilog {
+
+// A class interfacing the SymbolTable with the LSP messages.
+// It manages the SymbolTable and its necessary components,
+// and provides such information as symbol definitions
+// based on LSP requests.
+// The provided information is in LSP-friendly format.
+class SymbolTableHandler {
+ public:
+  SymbolTableHandler(){};
+
+  // Sets the project for the symbol table.
+  // VerilogProject requires root, include_paths and corpus to
+  // create a base of files that may contain definitions for symbols.
+  // Once the project's root is set, a new SymbolTable is created.
+  void setProject(absl::string_view root,
+                  const std::vector<std::string> &include_paths,
+                  absl::string_view corpus);
+
+  // Creates a new symbol table given the VerilogProject in setProject
+  // method.
+  void resetSymbolTable();
+
+  // Fills the symbol table for a given verilog source file.
+  void buildSymbolTableFor(VerilogSourceFile &file);
+
+  // Finds the definition for a symbol provided in the DefinitionParams
+  // message delivered i.e. in textDocument/definition message.
+  // Provides a list of locations with symbol's definitions.
+  std::vector<verible::lsp::Location> findDefinition(
+      const verible::lsp::DefinitionParams &params);
+
+ private:
+  std::shared_ptr<VerilogProject> currproject =
+      nullptr;  // current VerilogProject for which the symbol table is created
+  std::shared_ptr<SymbolTable> symboltable = nullptr;  // symbol table structure
+  std::unordered_set<std::string>
+      checkedfiles;  // set of checked files to prevent unnecessary calls for
+                     // creating a symbol table for already seen files
+};
+
+};  // namespace verilog
+
+#endif  // VERILOG_TOOLS_LS_SYMBOL_TABLE_HANDLER_H

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
-#include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "common/lsp/lsp-protocol.h"
 #include "verilog/analysis/symbol_table.h"
@@ -54,17 +53,17 @@ class SymbolTableHandler {
   void SetProject(const std::shared_ptr<VerilogProject> &project);
 
   // Returns the current project.
-  std::shared_ptr<VerilogProject> mutable_project() { return currproject; }
+  std::shared_ptr<VerilogProject> mutable_project() { return curr_project_; }
 
   // Creates a new symbol table given the VerilogProject in setProject
   // method.
   void ResetSymbolTable();
 
   // Fills the symbol table for a given verilog source file.
-  void BuildSymbolTableFor(const VerilogSourceFile &file);
+  std::vector<absl::Status> BuildSymbolTableFor(const VerilogSourceFile &file);
 
   // Creates a symbol table for entire project
-  void BuildProjectSymbolTable();
+  std::vector<absl::Status> BuildProjectSymbolTable();
 
   // Finds the definition for a symbol provided in the DefinitionParams
   // message delivered i.e. in textDocument/definition message.
@@ -80,12 +79,9 @@ class SymbolTableHandler {
   // tells that symbol table should be rebuilt due to changes in files
   bool files_dirty_ = true;
   // current VerilogProject for which the symbol table is created
-  std::shared_ptr<VerilogProject> currproject;
+  std::shared_ptr<VerilogProject> curr_project_;
   // symbol table structure
-  std::unique_ptr<SymbolTable> symboltable;
-  // set of checked files to prevent unnecessary calls for creating
-  // a symbol table for already seen files
-  absl::flat_hash_set<std::string> checkedfiles;
+  std::unique_ptr<SymbolTable> symbol_table_;
 
   // Scans the symbol table tree to find a given symbol.
   // When succeds, returns the pointer to table node with the symbol, otherwise

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -32,7 +32,10 @@ namespace verilog {
 // Converts file:// scheme entries to actual system paths.
 // If other scheme is provided, method returns false.
 // TODO move to other header?
-bool LSPUriToPath(absl::string_view uri, std::string &path);
+bool LSPUriToPath(absl::string_view uri, std::string *path);
+
+// Converts filesystem paths to file:// scheme entries.
+bool PathToLSPUri(absl::string_view path, std::string *uri);
 
 // A class interfacing the SymbolTable with the LSP messages.
 // It manages the SymbolTable and its necessary components,

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -77,8 +77,8 @@ class SymbolTableHandler {
       const verible::lsp::DefinitionParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
 
-  absl::Status UpdateFileContent(absl::string_view path,
-                                 const verible::TextStructureView *content);
+  void UpdateFileContent(absl::string_view path,
+                         const verible::TextStructureView *content);
 
  private:
   // tells that symbol table should be rebuilt due to changes in files

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -59,12 +59,13 @@ class SymbolTableHandler {
       const verible::lsp::DefinitionParams &params);
 
  private:
-  std::shared_ptr<VerilogProject> currproject =
-      nullptr;  // current VerilogProject for which the symbol table is created
-  std::shared_ptr<SymbolTable> symboltable = nullptr;  // symbol table structure
   std::unordered_set<std::string>
       checkedfiles;  // set of checked files to prevent unnecessary calls for
                      // creating a symbol table for already seen files
+  // current VerilogProject for which the symbol table is created
+  std::unique_ptr<VerilogProject> currproject;
+  // symbol table structure
+  std::unique_ptr<SymbolTable> symboltable;
 };
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -51,37 +51,40 @@ class SymbolTableHandler {
   // VerilogProject requires root, include_paths and corpus to
   // create a base of files that may contain definitions for symbols.
   // Once the project's root is set, a new SymbolTable is created.
-  void setProject(absl::string_view root,
+  void SetProject(absl::string_view root,
                   const std::vector<std::string> &include_paths,
                   absl::string_view corpus);
 
   // Returns the current project.
-  std::shared_ptr<VerilogProject> getProject() { return currproject; }
+  std::shared_ptr<VerilogProject> GetProject() { return currproject; }
 
   // Creates a new symbol table given the VerilogProject in setProject
   // method.
-  void resetSymbolTable();
+  void ResetSymbolTable();
 
   // Fills the symbol table for a given verilog source file.
-  void buildSymbolTableFor(VerilogSourceFile &file);
+  void BuildSymbolTableFor(VerilogSourceFile &file);
 
   // Creates a symbol table for entire project
-  void buildProjectSymbolTable();
+  void BuildProjectSymbolTable();
 
   // Looks for verible.filelist file down in directory structure and loads data
   // to project.
-  void loadProjectFileList(absl::string_view current_dir);
+  void LoadProjectFileList(absl::string_view current_dir);
 
   // Finds the definition for a symbol provided in the DefinitionParams
   // message delivered i.e. in textDocument/definition message.
   // Provides a list of locations with symbol's definitions.
-  std::vector<verible::lsp::Location> findDefinition(
+  std::vector<verible::lsp::Location> FindDefinition(
       const verible::lsp::DefinitionParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
 
-  bool files_dirty_ = true;
+  // Marks current symbol table as outdated
+  void RequestTableUpdate() { files_dirty_ = true; }
 
  private:
+  // tells that symbol table should be rebuilt due to changes in files
+  bool files_dirty_ = true;
   // current VerilogProject for which the symbol table is created
   std::shared_ptr<VerilogProject> currproject;
   // symbol table structure

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -61,6 +61,9 @@ class SymbolTableHandler {
   // Fills the symbol table for a given verilog source file.
   void buildSymbolTableFor(VerilogSourceFile &file);
 
+  // Creates a symbol table for entire project
+  void buildProjectSymbolTable();
+
   // Finds the definition for a symbol provided in the DefinitionParams
   // message delivered i.e. in textDocument/definition message.
   // Provides a list of locations with symbol's definitions.

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -28,6 +28,11 @@
 
 namespace verilog {
 
+// Converts file:// scheme entries to actual system paths.
+// If other scheme is provided, method returns false.
+// TODO move to other header?
+bool LSPUriToPath(absl::string_view uri, std::string &path);
+
 // A class interfacing the SymbolTable with the LSP messages.
 // It manages the SymbolTable and its necessary components,
 // and provides such information as symbol definitions

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -51,26 +51,20 @@ class SymbolTableHandler {
   // VerilogProject requires root, include_paths and corpus to
   // create a base of files that may contain definitions for symbols.
   // Once the project's root is set, a new SymbolTable is created.
-  void SetProject(absl::string_view root,
-                  const std::vector<std::string> &include_paths,
-                  absl::string_view corpus);
+  void SetProject(const std::shared_ptr<VerilogProject> &project);
 
   // Returns the current project.
-  std::shared_ptr<VerilogProject> GetProject() { return currproject; }
+  std::shared_ptr<VerilogProject> mutable_project() { return currproject; }
 
   // Creates a new symbol table given the VerilogProject in setProject
   // method.
   void ResetSymbolTable();
 
   // Fills the symbol table for a given verilog source file.
-  void BuildSymbolTableFor(VerilogSourceFile &file);
+  void BuildSymbolTableFor(const VerilogSourceFile &file);
 
   // Creates a symbol table for entire project
   void BuildProjectSymbolTable();
-
-  // Looks for verible.filelist file down in directory structure and loads data
-  // to project.
-  void LoadProjectFileList(absl::string_view current_dir);
 
   // Finds the definition for a symbol provided in the DefinitionParams
   // message delivered i.e. in textDocument/definition message.
@@ -79,8 +73,8 @@ class SymbolTableHandler {
       const verible::lsp::DefinitionParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
 
-  // Marks current symbol table as outdated
-  void RequestTableUpdate() { files_dirty_ = true; }
+  absl::Status UpdateFileContent(absl::string_view path,
+                                 const verible::TextStructureView *content);
 
  private:
   // tells that symbol table should be rebuilt due to changes in files
@@ -98,6 +92,11 @@ class SymbolTableHandler {
   // returns false.
   const SymbolTableNode *ScanSymbolTreeForDefinition(
       const SymbolTableNode *context, absl::string_view symbol);
+
+  // Looks for verible.filelist file down in directory structure and loads data
+  // to project.
+  // It is meant to be executed once per VerilogProject setup
+  void LoadProjectFileList(absl::string_view current_dir);
 };
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -206,5 +206,16 @@ TEST(SymbolTableHandlerTest, DefinitionNotTrackedFile) {
   EXPECT_EQ(location.size(), 0);
 }
 
+TEST(SymbolTableHandlerTest, MissingVerilogProject) {
+  SymbolTableHandler symbol_table_handler;
+  std::vector<absl::Status> diagnostics =
+      symbol_table_handler.BuildProjectSymbolTable();
+
+  ASSERT_EQ(diagnostics.size(), 1);
+  ASSERT_FALSE(diagnostics[0].ok());
+}
+
+TEST(SymbolTableHandlerTest, GoToDefinitionTest) {}
+
 }  // namespace
 }  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -1,0 +1,210 @@
+// Copyright 2017-2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/tools/ls/symbol-table-handler.h"
+
+#include <memory>
+
+#include "absl/strings/string_view.h"
+#include "common/util/file_util.h"
+#include "gtest/gtest.h"
+#include "verilog/analysis/verilog_project.h"
+
+namespace verilog {
+namespace {
+
+constexpr absl::string_view  //
+    kSampleModuleA(
+        "module a;\n"
+        "  assign var1 = 1'b0;\n"
+        "  assign var2 = var1 | 1'b1;\n"
+        "endmodule\n"),
+    kSampleModuleB(
+        "module b;\n"
+        "  assign var1 = 1'b0;\n"
+        "  assign var2 = var1 | 1'b1;\n"
+        "  a vara;\n"
+        "  assign vara.var1 = 1'b1;\n"
+        "endmodule\n");
+
+// Tests the behavior of SymbolTableHandler for not existing directory.
+TEST(SymbolTableHandlerTest, InitializationNoRoot) {
+  std::shared_ptr<VerilogProject> project = std::make_shared<VerilogProject>(
+      "non-existing-root", std::vector<std::string>());
+
+  SymbolTableHandler symbol_table_handler;
+
+  symbol_table_handler.SetProject(project);
+}
+
+// Tests the behavior of SymbolTableHandler for an empty directory.
+TEST(SymbolTableHandlerTest, EmptyDirectoryProject) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir =
+      verible::file::JoinPath(tempdir, __FUNCTION__);
+  ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
+
+  std::shared_ptr<VerilogProject> project =
+      std::make_shared<VerilogProject>(sources_dir, std::vector<std::string>());
+
+  SymbolTableHandler symbol_table_handler;
+
+  symbol_table_handler.SetProject(project);
+
+  symbol_table_handler.BuildProjectSymbolTable();
+}
+
+TEST(SymbolTableHandlerTest, NullVerilogProject) {
+  SymbolTableHandler symbol_table_handler;
+  symbol_table_handler.SetProject(nullptr);
+}
+
+TEST(SymbolTableHandlerTest, InvalidFileListSyntax) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir =
+      verible::file::JoinPath(tempdir, __FUNCTION__);
+  ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
+
+  const verible::file::testing::ScopedTestFile filelist(sources_dir, "@@",
+                                                        "verible.filelist");
+
+  std::shared_ptr<VerilogProject> project =
+      std::make_shared<VerilogProject>(sources_dir, std::vector<std::string>());
+
+  SymbolTableHandler symbol_table_handler;
+  symbol_table_handler.SetProject(project);
+
+  symbol_table_handler.BuildProjectSymbolTable();
+}
+
+TEST(SymbolTableHandlerTest, LoadFileList) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir =
+      verible::file::JoinPath(tempdir, __FUNCTION__);
+  ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
+
+  absl::string_view filelist_content =
+      "a.sv\n"
+      "b.sv\n";
+
+  const verible::file::testing::ScopedTestFile filelist(
+      sources_dir, filelist_content, "verible.filelist");
+  const verible::file::testing::ScopedTestFile module_a(sources_dir,
+                                                        kSampleModuleA, "a.sv");
+  const verible::file::testing::ScopedTestFile module_b(sources_dir,
+                                                        kSampleModuleB, "b.sv");
+
+  std::shared_ptr<VerilogProject> project =
+      std::make_shared<VerilogProject>(sources_dir, std::vector<std::string>{});
+
+  SymbolTableHandler symbol_table_handler;
+  symbol_table_handler.SetProject(project);
+
+  std::vector<absl::Status> diagnostics =
+      symbol_table_handler.BuildProjectSymbolTable();
+  ASSERT_EQ(diagnostics.size(), 0);
+}
+
+TEST(SymbolTableHandlerTest, FileListWithNonExistingFile) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir =
+      verible::file::JoinPath(tempdir, __FUNCTION__);
+  ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
+
+  absl::string_view filelist_content =
+      "a.sv\n"
+      "b.sv\n";
+
+  const verible::file::testing::ScopedTestFile filelist(
+      sources_dir, filelist_content, "verible.filelist");
+  const verible::file::testing::ScopedTestFile module_a(sources_dir,
+                                                        kSampleModuleA, "a.sv");
+
+  std::shared_ptr<VerilogProject> project =
+      std::make_shared<VerilogProject>(sources_dir, std::vector<std::string>{});
+
+  SymbolTableHandler symbol_table_handler;
+  symbol_table_handler.SetProject(project);
+
+  std::vector<absl::Status> diagnostics =
+      symbol_table_handler.BuildProjectSymbolTable();
+  ASSERT_EQ(diagnostics.size(), 1);
+}
+
+TEST(SymbolTableHandlerTest, MissingFileList) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir =
+      verible::file::JoinPath(tempdir, __FUNCTION__);
+  ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
+
+  const verible::file::testing::ScopedTestFile module_a(sources_dir,
+                                                        kSampleModuleA, "a.sv");
+  const verible::file::testing::ScopedTestFile module_b(sources_dir,
+                                                        kSampleModuleB, "b.sv");
+
+  std::shared_ptr<VerilogProject> project =
+      std::make_shared<VerilogProject>(sources_dir, std::vector<std::string>{});
+
+  SymbolTableHandler symbol_table_handler;
+  symbol_table_handler.SetProject(project);
+
+  std::vector<absl::Status> diagnostics =
+      symbol_table_handler.BuildProjectSymbolTable();
+  ASSERT_EQ(diagnostics.size(), 0);
+}
+
+TEST(SymbolTableHandlerTest, DefinitionNotTrackedFile) {
+  const auto tempdir = ::testing::TempDir();
+  const std::string sources_dir =
+      verible::file::JoinPath(tempdir, __FUNCTION__);
+  ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
+
+  absl::string_view filelist_content =
+      "a.sv\n"
+      "b.sv\n";
+
+  const verible::file::testing::ScopedTestFile filelist(
+      sources_dir, filelist_content, "verible.filelist");
+  const verible::file::testing::ScopedTestFile module_a(sources_dir,
+                                                        kSampleModuleA, "a.sv");
+  const verible::file::testing::ScopedTestFile module_b(sources_dir,
+                                                        kSampleModuleB, "b.sv");
+
+  std::shared_ptr<VerilogProject> project =
+      std::make_shared<VerilogProject>(sources_dir, std::vector<std::string>{});
+
+  SymbolTableHandler symbol_table_handler;
+  symbol_table_handler.SetProject(project);
+
+  verible::lsp::DefinitionParams gotorequest;
+  gotorequest.textDocument.uri = "file://b.sv";
+  gotorequest.position.line = 2;
+  gotorequest.position.character = 17;
+
+  std::vector<absl::Status> diagnostics =
+      symbol_table_handler.BuildProjectSymbolTable();
+
+  verilog::BufferTrackerContainer parsed_buffers;
+  parsed_buffers.FindBufferTrackerOrNull(gotorequest.textDocument.uri);
+  EXPECT_EQ(
+      parsed_buffers.FindBufferTrackerOrNull(gotorequest.textDocument.uri),
+      nullptr);
+
+  std::vector<verible::lsp::Location> location =
+      symbol_table_handler.FindDefinition(gotorequest, parsed_buffers);
+  EXPECT_EQ(location.size(), 0);
+}
+
+}  // namespace
+}  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -24,12 +24,14 @@
 namespace verilog {
 namespace {
 
-constexpr absl::string_view  //
+static constexpr absl::string_view  //
     kSampleModuleA(
         "module a;\n"
         "  assign var1 = 1'b0;\n"
         "  assign var2 = var1 | 1'b1;\n"
-        "endmodule\n"),
+        "endmodule\n");
+
+static constexpr absl::string_view  //
     kSampleModuleB(
         "module b;\n"
         "  assign var1 = 1'b0;\n"

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -26,19 +26,21 @@ namespace {
 
 static constexpr absl::string_view  //
     kSampleModuleA(
-        "module a;\n"
-        "  assign var1 = 1'b0;\n"
-        "  assign var2 = var1 | 1'b1;\n"
-        "endmodule\n");
+        R"(module a;
+  assign var1 = 1'b0;
+  assign var2 = var1 | 1'b1;
+endmodule
+)");
 
 static constexpr absl::string_view  //
     kSampleModuleB(
-        "module b;\n"
-        "  assign var1 = 1'b0;\n"
-        "  assign var2 = var1 | 1'b1;\n"
-        "  a vara;\n"
-        "  assign vara.var1 = 1'b1;\n"
-        "endmodule\n");
+        R"(module b;
+  assign var1 = 1'b0;
+  assign var2 = var1 | 1'b1;
+  a vara;
+  assign vara.var1 = 1'b1;
+endmodule
+)");
 
 // Tests the behavior of SymbolTableHandler for not existing directory.
 TEST(SymbolTableHandlerTest, InitializationNoRoot) {

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -219,7 +219,5 @@ TEST(SymbolTableHandlerTest, MissingVerilogProject) {
   ASSERT_FALSE(diagnostics[0].ok());
 }
 
-TEST(SymbolTableHandlerTest, GoToDefinitionTest) {}
-
 }  // namespace
 }  // namespace verilog

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -133,7 +133,7 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
   // set VerilogProject for the symbol table, if possible
   if (!p.rootUri.empty()) {
     std::string path;
-    if (!verilog::LSPUriToPath(p.rootUri, path)) {
+    if (!verilog::LSPUriToPath(p.rootUri, &path)) {
       LOG(ERROR) << "Unsupported rootUri in initialize request:  " << p.rootUri
                  << std::endl;
       path = p.rootUri;
@@ -204,7 +204,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
     return;
   }
   std::string path;
-  if (!verilog::LSPUriToPath(uri, path)) {
+  if (!verilog::LSPUriToPath(uri, &path)) {
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
   }
   absl::Status status = project->updateFileContents(

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -15,6 +15,7 @@
 #include "verilog/tools/ls/verilog-language-server.h"
 
 #include <functional>
+#include <memory>
 
 #include "absl/strings/string_view.h"
 #include "common/lsp/lsp-protocol.h"
@@ -177,8 +178,9 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
 }
 
 void VerilogLanguageServer::ConfigureProject(absl::string_view project_root) {
-  symbol_table_handler_.SetProject(project_root, {}, "");
-  symbol_table_handler_.LoadProjectFileList(project_root);
+  std::shared_ptr<VerilogProject> proj = std::make_shared<VerilogProject>(
+      project_root, std::vector<std::string>(), "");
+  symbol_table_handler_.SetProject(proj);
 
   parsed_buffers_.AddChangeListener(
       [this](const std::string &uri,
@@ -207,24 +209,20 @@ void VerilogLanguageServer::SendDiagnostics(
 
 void VerilogLanguageServer::UpdateEditedFileInProject(
     const std::string &uri, const verilog::BufferTracker &buffer_tracker) {
-  auto project = symbol_table_handler_.GetProject();
-  if (!project) {
-    return;
-  }
+  if (!buffer_tracker.last_good()) return;
   absl::string_view path = verilog::LSPUriToPath(uri);
   if (path.empty()) {
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
+    return;
   }
-  if (buffer_tracker.last_good()) {
-    symbol_table_handler_.RequestTableUpdate();
-    absl::Status status = project->updateFileContents(
-        path, &buffer_tracker.last_good()->parser().Data());
-    if (!status.ok()) {
-      LOG(ERROR) << "Could not update the file " << path
-                 << " tracked by VerilogProject";
-    }
-    LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
+  absl::Status status = symbol_table_handler_.UpdateFileContent(
+      path, &buffer_tracker.last_good()->parser().Data());
+  if (!status.ok()) {
+    LOG(ERROR) << "Could not update the file " << path
+               << " tracked by VerilogProject:  " << status;
+    return;
   }
+  LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -224,7 +224,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
                << " tracked by VerilogProject:  " << status;
     return;
   }
-  LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
+  LOG(INFO) << "Updated file:  " << uri << " (" << path << ")";
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -123,7 +123,7 @@ void VerilogLanguageServer::SetRequestHandlers() {
   dispatcher_.AddRequestHandler(  // go-to definition
       "textDocument/definition",
       [this](const verible::lsp::DefinitionParams &p) {
-        return symbol_table_handler_.findDefinition(p, parsed_buffers_);
+        return symbol_table_handler_.FindDefinition(p, parsed_buffers_);
       });
   // The client sends a request to shut down. Use that to exit our loop.
   dispatcher_.AddRequestHandler("shutdown", [this](const nlohmann::json &) {
@@ -177,8 +177,8 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
 }
 
 void VerilogLanguageServer::ConfigureProject(absl::string_view project_root) {
-  symbol_table_handler_.setProject(project_root, {}, "");
-  symbol_table_handler_.loadProjectFileList(project_root);
+  symbol_table_handler_.SetProject(project_root, {}, "");
+  symbol_table_handler_.LoadProjectFileList(project_root);
 
   parsed_buffers_.AddChangeListener(
       [this](const std::string &uri,
@@ -207,7 +207,7 @@ void VerilogLanguageServer::SendDiagnostics(
 
 void VerilogLanguageServer::UpdateEditedFileInProject(
     const std::string &uri, const verilog::BufferTracker &buffer_tracker) {
-  auto project = symbol_table_handler_.getProject();
+  auto project = symbol_table_handler_.GetProject();
   if (!project) {
     return;
   }
@@ -216,7 +216,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
   }
   if (buffer_tracker.last_good()) {
-    symbol_table_handler_.files_dirty_ = true;
+    symbol_table_handler_.RequestTableUpdate();
     absl::Status status = project->updateFileContents(
         path, &buffer_tracker.last_good()->parser().Data());
     if (!status.ok()) {

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -214,6 +214,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
                << " tracked by VerilogProject";
   }
   LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
+  symbol_table_handler_.buildProjectSymbolTable();
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -124,9 +124,15 @@ void VerilogLanguageServer::PrintStatistics() const {
 }
 
 verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
-    const nlohmann::json &params) const {
-  // Ignore passed client capabilities from params right now,
-  // just announce what we do.
+    const verible::lsp::InitializeParams &p) {
+  // set VerilogProject for the symbol table, if possible
+  if (!p.rootUri.empty()) {
+    symbol_table_handler_.setProject(p.rootUri, {}, "");
+  } else if (!p.rootPath.empty()) {
+    symbol_table_handler_.setProject(p.rootPath, {}, "");
+  }
+
+  // send response with information what we do.
   verible::lsp::InitializeResult result;
   result.serverInfo = {
       .name = "Verible Verilog language server.",

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -184,7 +184,7 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
 void VerilogLanguageServer::ConfigureProject(absl::string_view project_root) {
   std::string proj_root = {project_root.begin(), project_root.end()};
   if (proj_root.empty()) {
-    proj_root = verible::file::Dirname(FindFileList(".")).data();
+    proj_root = std::string(verible::file::Dirname(FindFileList(".")));
   }
   if (proj_root.empty()) proj_root = ".";
   proj_root =

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -132,7 +132,13 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
     const verible::lsp::InitializeParams &p) {
   // set VerilogProject for the symbol table, if possible
   if (!p.rootUri.empty()) {
-    symbol_table_handler_.setProject(p.rootUri, {}, "");
+    std::string path;
+    if (!verilog::LSPUriToPath(p.rootUri, path)) {
+      LOG(ERROR) << "Unsupported rootUri in initialize request:  " << p.rootUri
+                 << std::endl;
+      path = p.rootUri;
+    }
+    symbol_table_handler_.setProject(path, {}, "");
   } else if (!p.rootPath.empty()) {
     symbol_table_handler_.setProject(p.rootPath, {}, "");
   }

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -92,7 +92,7 @@ void VerilogLanguageServer::SetRequestHandlers() {
   dispatcher_.AddRequestHandler(  // go-to definition
       "textDocument/definition",
       [this](const verible::lsp::DefinitionParams &p) {
-        return symbol_table_handler_.findDefinition(p);
+        return symbol_table_handler_.findDefinition(p, parsed_buffers_);
       });
   // The client sends a request to shut down. Use that to exit our loop.
   dispatcher_.AddRequestHandler("shutdown", [this](const nlohmann::json &) {

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -19,9 +19,9 @@
 
 #include "absl/strings/string_view.h"
 #include "common/lsp/lsp-protocol.h"
+#include "common/util/file_util.h"
 #include "common/util/init_command_line.h"
 #include "verilog/tools/ls/verible-lsp-adapter.h"
-#include "common/util/file_util.h"
 
 namespace verilog {
 
@@ -186,9 +186,9 @@ void VerilogLanguageServer::ConfigureProject(absl::string_view project_root) {
   if (proj_root.empty()) {
     proj_root = verible::file::Dirname(FindFileList(".")).data();
   }
-  if (proj_root.empty())
-    proj_root = ".";
-  proj_root = std::filesystem::absolute({proj_root.begin(), proj_root.end()}).string();
+  if (proj_root.empty()) proj_root = ".";
+  proj_root =
+      std::filesystem::absolute({proj_root.begin(), proj_root.end()}).string();
   std::shared_ptr<VerilogProject> proj = std::make_shared<VerilogProject>(
       proj_root, std::vector<std::string>(), "");
   symbol_table_handler_.SetProject(proj);

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -132,7 +132,7 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
     const verible::lsp::InitializeParams &p) {
   // set VerilogProject for the symbol table, if possible
   if (!p.rootUri.empty()) {
-    absl::string_view path = verilog::LSPUriToPath(p.rootUri) ;
+    absl::string_view path = verilog::LSPUriToPath(p.rootUri);
     if (path.empty()) {
       LOG(ERROR) << "Unsupported rootUri in initialize request:  " << p.rootUri
                  << std::endl;
@@ -207,14 +207,16 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
   if (path.empty()) {
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
   }
-  absl::Status status = project->updateFileContents(
-      path, &buffer_tracker.last_good()->parser().Data());
-  if (!status.ok()) {
-    LOG(ERROR) << "Could not update the file " << path
-               << " tracked by VerilogProject";
+  if (buffer_tracker.last_good()) {
+    absl::Status status = project->updateFileContents(
+        path, &buffer_tracker.last_good()->parser().Data());
+    if (!status.ok()) {
+      LOG(ERROR) << "Could not update the file " << path
+                 << " tracked by VerilogProject";
+    }
+    LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
+    symbol_table_handler_.buildProjectSymbolTable();
   }
-  LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
-  symbol_table_handler_.buildProjectSymbolTable();
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -132,8 +132,8 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
     const verible::lsp::InitializeParams &p) {
   // set VerilogProject for the symbol table, if possible
   if (!p.rootUri.empty()) {
-    std::string path;
-    if (!verilog::LSPUriToPath(p.rootUri, &path)) {
+    absl::string_view path;
+    if (!verilog::LSPUriToPath(p.rootUri, path)) {
       LOG(ERROR) << "Unsupported rootUri in initialize request:  " << p.rootUri
                  << std::endl;
       path = p.rootUri;
@@ -203,8 +203,8 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
   if (!project) {
     return;
   }
-  std::string path;
-  if (!verilog::LSPUriToPath(uri, &path)) {
+  absl::string_view path;
+  if (!verilog::LSPUriToPath(uri, path)) {
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
   }
   absl::Status status = project->updateFileContents(

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -132,8 +132,8 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
     const verible::lsp::InitializeParams &p) {
   // set VerilogProject for the symbol table, if possible
   if (!p.rootUri.empty()) {
-    absl::string_view path;
-    if (!verilog::LSPUriToPath(p.rootUri, path)) {
+    absl::string_view path = verilog::LSPUriToPath(p.rootUri) ;
+    if (path.empty()) {
       LOG(ERROR) << "Unsupported rootUri in initialize request:  " << p.rootUri
                  << std::endl;
       path = p.rootUri;
@@ -203,8 +203,8 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
   if (!project) {
     return;
   }
-  absl::string_view path;
-  if (!verilog::LSPUriToPath(uri, path)) {
+  absl::string_view path = verilog::LSPUriToPath(uri);
+  if (path.empty()) {
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
   }
   absl::Status status = project->updateFileContents(

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -226,13 +226,8 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
     return;
   }
-  absl::Status status = symbol_table_handler_.UpdateFileContent(
+  symbol_table_handler_.UpdateFileContent(
       path, &buffer_tracker.last_good()->parser().Data());
-  if (!status.ok()) {
-    LOG(ERROR) << "Could not update the file " << path
-               << " tracked by VerilogProject:  " << status;
-    return;
-  }
   LOG(INFO) << "Updated file:  " << uri << " (" << path << ")";
 }
 

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -34,7 +34,7 @@ VerilogLanguageServer::VerilogLanguageServer(const WriteFun &write_fun)
   // Whenever there is a new parse result ready, use that as an opportunity
   // to send diagnostics to the client.
   buffers_.SetChangeListener(parsed_buffers_.GetSubscriptionCallback());
-  parsed_buffers_.SetChangeListener(
+  parsed_buffers_.AddChangeListener(
       [this](const std::string &uri,
              const verilog::BufferTracker &buffer_tracker) {
         SendDiagnostics(uri, buffer_tracker);

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -216,6 +216,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
     LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
   }
   if (buffer_tracker.last_good()) {
+    symbol_table_handler_.files_dirty_ = true;
     absl::Status status = project->updateFileContents(
         path, &buffer_tracker.last_good()->parser().Data());
     if (!status.ok()) {

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -139,8 +139,10 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
       path = p.rootUri;
     }
     symbol_table_handler_.setProject(path, {}, "");
+    symbol_table_handler_.loadProjectFileList(path);
   } else if (!p.rootPath.empty()) {
     symbol_table_handler_.setProject(p.rootPath, {}, "");
+    symbol_table_handler_.loadProjectFileList(p.rootPath);
   }
 
   parsed_buffers_.AddChangeListener(
@@ -215,7 +217,6 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
                  << " tracked by VerilogProject";
     }
     LOG(INFO) << "Updated file:  " << uri << "(" << path << ")";
-    symbol_table_handler_.buildProjectSymbolTable();
   }
 }
 

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -173,6 +173,8 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
     ConfigureProject(path);
   } else if (!p.rootPath.empty()) {
     ConfigureProject(p.rootPath);
+  } else {
+    LOG(WARNING) << "Could not configure Verilog Project root";
   }
   return GetCapabilities();
 }

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -89,6 +89,11 @@ void VerilogLanguageServer::SetRequestHandlers() {
         return verilog::FormatRange(
             parsed_buffers_.FindBufferTrackerOrNull(p.textDocument.uri), p);
       });
+  dispatcher_.AddRequestHandler(  // go-to definition
+      "textDocument/definition",
+      [this](const verible::lsp::DefinitionParams &p) {
+        return symbol_table_handler_.findDefinition(p);
+      });
   // The client sends a request to shut down. Use that to exit our loop.
   dispatcher_.AddRequestHandler("shutdown", [this](const nlohmann::json &) {
     shutdown_requested_ = true;
@@ -151,6 +156,7 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
       {"documentRangeFormattingProvider", true},  // Format selection
       {"documentFormattingProvider", true},       // Full file format
       {"documentHighlightProvider", true},        // Highlight same symbol
+      {"definitionProvider", true},               // Provide going to definition
       {"diagnosticProvider",                      // Pull model of diagnostics.
        {
            {"interFileDependencies", false},

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -60,7 +60,9 @@ class VerilogLanguageServer {
 
   // sets up the VerilogProject structure for symbol table, sets listeners for
   // updating VerilogProject views for edited files
-  void ConfigureProject(absl::string_view project_root);
+  // if no project_root is provided, it is set to either current directory
+  // or directory containing verible.filelist
+  void ConfigureProject(absl::string_view project_root = "");
 
   // Publish a diagnostic sent to the server.
   void SendDiagnostics(const std::string &uri,

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -20,8 +20,13 @@
 #include "common/lsp/lsp-text-buffer.h"
 #include "common/lsp/message-stream-splitter.h"
 #include "verilog/tools/ls/lsp-parse-buffer.h"
+#include "verilog/tools/ls/symbol-table-handler.h"
+#include "verilog/tools/ls/verible-lsp-adapter.h"
 
 namespace verilog {
+
+// TODO add support for changing workspace
+// TODO reset symbol table on workspace change?
 
 // Class implementing the Language Server for Verilog
 class VerilogLanguageServer {
@@ -47,7 +52,7 @@ class VerilogLanguageServer {
 
   // The "initialize" method requests server capabilities.
   verible::lsp::InitializeResult InitializeRequestHandler(
-      const nlohmann::json &params) const;
+      const verible::lsp::InitializeParams &params);
 
   // Publish a diagnostic sent to the server.
   void SendDiagnostics(const std::string &uri,
@@ -64,6 +69,9 @@ class VerilogLanguageServer {
 
   // Tracks changes in buffers from BufferCollection and parses their contents
   verilog::BufferTrackerContainer parsed_buffers_;
+
+  // Handles requests relying on the symbol table
+  verilog::SymbolTableHandler symbol_table_handler_;
 
   // A flag for indicating "shutdown" request
   bool shutdown_requested_ = false;

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -58,6 +58,10 @@ class VerilogLanguageServer {
   void SendDiagnostics(const std::string &uri,
                        const verilog::BufferTracker &buffer_tracker);
 
+  // Updates file contents in the project on change in Language Server Client
+  void UpdateEditedFileInProject(const std::string &uri,
+                                 const verilog::BufferTracker &buffer_tracker);
+
   // Stream splitter splits the input stream into messages (header/body).
   verible::lsp::MessageStreamSplitter stream_splitter_;
 

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -54,6 +54,14 @@ class VerilogLanguageServer {
   verible::lsp::InitializeResult InitializeRequestHandler(
       const verible::lsp::InitializeParams &params);
 
+  // Returns language server capabilities in textDocument/initialize response
+  // format
+  verible::lsp::InitializeResult GetCapabilities();
+
+  // sets up the VerilogProject structure for symbol table, sets listeners for
+  // updating VerilogProject views for edited files
+  void ConfigureProject(absl::string_view project_root);
+
   // Publish a diagnostic sent to the server.
   void SendDiagnostics(const std::string &uri,
                        const verilog::BufferTracker &buffer_tracker);

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -70,7 +70,7 @@ class VerilogLanguageServer {
 
   // Updates file contents in the project on change in Language Server Client
   void UpdateEditedFileInProject(const std::string &uri,
-                                 const verilog::BufferTracker &buffer_tracker);
+                                 const verilog::BufferTracker *buffer_tracker);
 
   // Stream splitter splits the input stream into messages (header/body).
   verible::lsp::MessageStreamSplitter stream_splitter_;

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -36,20 +36,23 @@ namespace {
 
 using namespace nlohmann;
 
-// FIXME (glatosinski) use more plausible modules
-constexpr absl::string_view  //
+// TODO (glatosinski) use better sample modules
+static constexpr absl::string_view  //
     kSampleModuleA(
-        "module a;\n"
-        "  assign var1 = 1'b0;\n"
-        "  assign var2 = var1 | 1'b1;\n"
-        "endmodule\n"),
+        R"(module a;
+  assign var1 = 1'b0;
+  assign var2 = var1 | 1'b1;
+endmodule
+)");
+static constexpr absl::string_view  //
     kSampleModuleB(
-        "module b;\n"
-        "  assign var1 = 1'b0;\n"
-        "  assign var2 = var1 | 1'b1;\n"
-        "  a vara;\n"
-        "  assign vara.var1 = 1'b1;\n"
-        "endmodule\n");
+        R"(module b;
+  assign var1 = 1'b0;
+  assign var2 = var1 | 1'b1;
+  a vara;
+  assign vara.var1 = 1'b1;
+endmodule
+)");
 
 class VerilogLanguageServerTest : public ::testing::Test {
  public:

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -34,7 +34,7 @@ namespace {
 
 // TODO (glatosinski) for JSON messages use types defined in lsp-protocol.h
 
-using namespace nlohmann;
+using nlohmann::json;
 
 // TODO (glatosinski) use better sample modules
 static constexpr absl::string_view  //

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -584,6 +584,7 @@ TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestTest) {
   ASSERT_EQ(response["result"][0]["range"]["start"]["character"], 9);
   ASSERT_EQ(response["result"][0]["range"]["end"]["line"], 1);
   ASSERT_EQ(response["result"][0]["range"]["end"]["character"], 13);
+  ASSERT_EQ(response["result"][0]["uri"], "file://" + module_a.filename());
 }
 
 // Tests correctness of Language Server shutdown request


### PR DESCRIPTION
This PR is Work in Progress.

It adds support for creating a [SymbolTable](https://github.com/chipsalliance/verible/blob/master/verilog/analysis/symbol_table.cc) in the [Language Server](https://github.com/chipsalliance/verible/blob/master/verilog/tools/ls/verilog_ls.cc) and utilizing it for finding definitions.

The current status is:

- [X] Created an initial class that interfaces the symbol table with the LSP requests
- [X] Added parsing and reading the workspace directory from `textDocument/initialize` request
- [X] Added creating VerilogProject object used by symbol table
- [X] Added finding symbol based on `textDocument/definition` and current state of the buffers from LS client
- [X] Added filling the symbol table based on opened files
- [x] Added matching symbol from request to definition from SymbolTable
- [x] Added initial `textDocument/definition` support
- [X] Added providing project files via `verible.filelist` file, parsed by [verilog::FileList from verilog_filelist](https://github.com/chipsalliance/verible/blob/master/verilog/analysis/verilog_filelist.h)
- [X] Added integration for SymbolTable with LS API (to look for symbols in opened buffers)
- [X] Added providing additional include paths to the VerilogProject - it is done via `verible.filelist` file
- [X] Added creating complete SymbolTable for project and its includes - initial support is ready
- [x] Added taking symbol's scope into consideration when looking for definition
- [x] Implement tests for `SymbolTableHandler`
- [x] Implement tests for `VerilogLanguageServer` regarding `SymbolTableHandler` support

Currently, the workspace directory provided by the editor is used as VerilogProject root (however, emacs uses git repository root directory as the workspace directory, if available).