### PR TITLE
[WIP] adding exit code to the preprocessor

### DIFF
--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -41,6 +41,7 @@
 #include <stack>
 #include <string>
 #include <vector>
+#include <bitset>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -87,6 +88,10 @@ struct VerilogPreprocessData {
   // are two separate vectors.
   std::vector<VerilogPreprocessError> errors;
   std::vector<VerilogPreprocessError> warnings;
+
+  // An exit code of 4 bits is used to distinguish between errors met during 
+  // preprocessing.
+  std::bitset<4> exit_code;
 };
 
 // VerilogPreprocess transforms a TokenStreamView.


### PR DESCRIPTION
### Description:
Adding exit code to the preprocessor, to allow continuing the preprocessing even after some errors are met.
So, the preprocessed output might contain a macro call that couldn't be expanded, or an include directive that file can't be found, that way the output would still be usable.

### Exit code description:
It's a 4 bit code, with each bit shows if an error of a certain type is faced at least once or not.
First bit (rightmost significant bit): At least one System-Verilog file is not found.
2nd bit: At least one macro definition is not expanded.
3rd bit: At least one include file couldn't be found.
4-th bit is left for now.

