### PR TITLE
Preserve the sequence of commands provided by the user.

### DIFF
--- a/common/util/subcommand.h
+++ b/common/util/subcommand.h
@@ -92,6 +92,9 @@ class SubcommandRegistry {
 
   // The map of names to functions.
   SubcommandMap subcommand_map_;
+
+  // Sequence in which commands have been registered for display purposes.
+  std::vector<std::string> command_listing_;
 };  // class SubcommandRegistry
 
 }  // namespace verible


### PR DESCRIPTION
Without that, the commands are just shown alphabetically, but the user of the subcommands might want to group these by importance. Always provide 'help' as first command.

While at it: remove the heterogenous lookup ifdefs as we are using C++17 throughout these days.

Update the "error" text so that calling 'help invalidcommand' provides a sensible message.
