### PR TITLE
Bring kPortList back as a special case for comment formatting

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -100,7 +100,7 @@ readonly TEST_GIT_PROJECTS="https://github.com/lowRISC/ibex \
 declare -A KnownIssue
 
 #--- Opentitan
-KnownIssue[formatter:$BASE_TEST_DIR/opentitan/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi_pkg.sv]=1006
+# Original issue - 1006 has been resolved
 # There is also bug 1008 which only shows up if compiled with asan
 
 #--- ivtest

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -4299,6 +4299,21 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    endfunction\n"
      "  endclass\n"
      "endpackage\n"},
+    {"package fedex;\n"
+     "  import \"asdf\" context function void bar(\n"
+     "    input bit              [2:1] aaaa,   // EOL COMMENT\n"
+     "                                          // another\n"
+     "    input bit foo\n"
+     "  );\n"
+     "endpackage\n",
+     "package fedex;\n"
+     "  import \"asdf\" context\n"
+     "      function void bar(\n"
+     "    input\n        bit [2:1] aaaa,  // EOL COMMENT\n"
+     "                         // another\n"
+     "    input bit foo\n"
+     "  );\n"
+     "endpackage\n"},
 
     // function test cases
     {"function f ;endfunction", "function f;\nendfunction\n"},

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -563,7 +563,7 @@ void TreeUnwrapper::InterChildNodeHook(const SyntaxTreeNode& node) {
     case NodeEnum::kPortDeclarationList:
     case NodeEnum::kActualParameterByNameList:
     case NodeEnum::kPortActualList:
-    // case NodeEnum::kPortList:  // TODO(fangism): for task/function ports
+    case NodeEnum::kPortList:
     case NodeEnum::kModuleItemList:
     case NodeEnum::kGenerateItemList:
     case NodeEnum::kClassItems:


### PR DESCRIPTION
This PR fixes #1006

In `void TreeUnwrapper::InterChildNodeHook`, `kPortList` was listed but commented out, making the comments not align properly. In the special case mentioned in #1006, an additional comment on a subsequent line triggered a CHECK fail in `common/formatting/align.h:419`. 

The change did not break any tests from `.github/bin/generate-coverage-html.sh`.