### PR TITLE
Custom runners ci

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -94,6 +94,7 @@ case "$MODE" in
     bazel coverage \
           --combined_report=lcov \
           --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main \
+          --java_runtime_version=remotejdk_11 \
           ${CHOSEN_TARGETS}
     # output will be in bazel-out/_coverage/_coverage_report.dat
     ;;

--- a/.github/bin/install-bazel.sh
+++ b/.github/bin/install-bazel.sh
@@ -18,6 +18,6 @@ if [ -z "${BAZEL_VERSION}" ]; then
         exit 1
 fi
 wget --no-verbose "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb" -O /tmp/bazel.deb
-sudo dpkg -i /tmp/bazel.deb || true
-sudo apt-get -f install
+dpkg -i /tmp/bazel.deb || true
+apt-get -f install
 bazel --version

--- a/.github/bin/set-compiler.sh
+++ b/.github/bin/set-compiler.sh
@@ -15,12 +15,12 @@
 
 VERSION=$1
 
-sudo dpkg --list | grep gcc
-sudo dpkg --list | grep libstdc++
+dpkg --list | grep gcc
+dpkg --list | grep libstdc++
 
-sudo ln -sf /usr/bin/gcc-$VERSION /usr/bin/gcc
-sudo ln -sf /usr/bin/g++-$VERSION /usr/bin/g++
-sudo ln -sf /usr/bin/gcov-$VERSION /usr/bin/gcov
+ln -sf /usr/bin/gcc-$VERSION /usr/bin/gcc
+ln -sf /usr/bin/g++-$VERSION /usr/bin/g++
+ln -sf /usr/bin/gcov-$VERSION /usr/bin/gcov
 
 gcc --version || true
 gcov --version

--- a/.github/settings.sh
+++ b/.github/settings.sh
@@ -32,7 +32,7 @@ export BAZEL_CXXOPTS="-std=c++17"
 export BAZEL_OPTS="-c opt --show_progress_rate_limit=10.0"
 
 # Used to fetch the BAZEL version where needed.
-export BAZEL_VERSION=4.0.0
+export BAZEL_VERSION=5.3.2
 
 # TODO(b/171989992): revert to using release version after upgrading system
 #   libraries/image (need: GLIBCXX_3.4.26, CXXABI_1.3.11, GLIBC_2.29).

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -20,7 +20,8 @@ jobs:
 
 
   VerifyFormatting:
-    runs-on: ubuntu-20.04
+    container: ubuntu:20.04
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
 
@@ -43,7 +44,8 @@ jobs:
       run: ./.github/bin/run-clang-format.sh
 
   ClangTidy:
-    runs-on: ubuntu-20.04
+    container: ubuntu:20.04
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
 
@@ -82,7 +84,8 @@ jobs:
 
 
   Check:
-    runs-on: ubuntu-20.04
+    container: ubuntu:20.04
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -78,7 +78,7 @@ jobs:
         format: 'YYYY-MM-DD-HH-mm-ss'
 
     - name: Retrieve cached results
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           /tmp/clang-tidy-hashes.cache
@@ -129,7 +129,7 @@ jobs:
         format: 'YYYY-MM-DD-HH-mm-ss'
 
     - name: Mount bazel cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: matrix.mode != 'clean' && matrix.mode != 'coverage'
       with:
         path: "/root/.cache/bazel"

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         path: |
           /tmp/clang-tidy-hashes.cache
-          /home/runner/.cache/bazel
+          /root/.cache/bazel
         key: clang-tidy-${{ steps.cache_timestamp.outputs.time }}
         restore-keys: clang-tidy-
 
@@ -129,7 +129,7 @@ jobs:
       uses: actions/cache@v2
       if: matrix.mode != 'clean' && matrix.mode != 'coverage'
       with:
-        path: "/home/runner/.cache/bazel"
+        path: "/root/.cache/bazel"
         key: bazelcache_${{ matrix.mode }}_${{ steps.cache_timestamp.outputs.time }}
         restore-keys: bazelcache_${{ matrix.mode }}_
 

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt -qq -y install clang-format
+        apt -qq -y install clang-format
         clang-format --version
 
     - name: Run formatting style check
@@ -61,7 +61,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt -qq -y install clang-tidy-11
+        apt -qq -y install clang-tidy-11
         echo "TMPDIR=/tmp" >> $GITHUB_ENV
 
     - name: Create Cache Timestamp
@@ -133,7 +133,7 @@ jobs:
       run: |
         set -x
         source ./.github/settings.sh
-        sudo apt -qq -y install clang-10
+        apt -qq -y install clang-10
         ./.github/bin/set-compiler.sh 9
         ./.github/bin/install-bazel.sh
 

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -14,6 +14,7 @@ on:
 env:
   BOT_USER: "Deployment Bot"
   BOT_EMAIL: "verible-dev@googlegroups.com"
+  GHA_MACHINE_TYPE: "n2-standard-8"
 
 jobs:
 
@@ -46,6 +47,9 @@ jobs:
   ClangTidy:
     container: ubuntu:20.04
     runs-on: [self-hosted, Linux, X64]
+
+    env:
+      GHA_MACHINE_TYPE: "n2-standard-4"
 
     steps:
 
@@ -226,6 +230,7 @@ jobs:
     env:
       MATRIX_OS: '${{ matrix.os }}:${{ matrix.ver }}'
       DOCKER_DATA_ROOT: "/root/.docker"
+      GHA_MACHINE_TYPE: "n2-highcpu-8"
     name: 'Build · ${{ matrix.os }}:${{ matrix.ver }}'
 
     steps:

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -44,6 +44,13 @@ jobs:
     - name: Run formatting style check
       run: ./.github/bin/run-clang-format.sh
 
+    - name: 📤 Upload performance graphs
+      uses: actions/upload-artifact@v2
+      if: success() || failure() 
+      with:
+        name: "diag"
+        path: "**/plot_*.svg"
+
   ClangTidy:
     container: ubuntu:20.04
     runs-on: [self-hosted, Linux, X64]
@@ -88,6 +95,13 @@ jobs:
 
     - name: Run clang tidy
       run: ./.github/bin/run-clang-tidy.sh
+
+    - name: 📤 Upload performance graphs
+      uses: actions/upload-artifact@v2
+      if: success() || failure() 
+      with:
+        name: "diag"
+        path: "**/plot_*.svg"
 
 
   Check:
@@ -169,6 +183,13 @@ jobs:
         BRANCH: gh-pages
         FOLDER: /tmp/pages
         CLEAN: true
+
+    - name: 📤 Upload performance graphs
+      uses: actions/upload-artifact@v2
+      if: success() || failure() 
+      with:
+        name: "diag"
+        path: "**/plot_*.svg"
 
 
   Kythe:
@@ -265,6 +286,13 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: releasing/out/verible-*.tar.gz
+
+    - name: 📤 Upload performance graphs
+      uses: actions/upload-artifact@v2
+      if: success() || failure() 
+      with:
+        name: "diag"
+        path: "**/plot_*.svg"
 
   MacOsBuild:
     runs-on: macos-latest

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -37,7 +37,8 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        apt -qq -y install clang-format
+        apt -qqy update
+        apt -qq -y install clang-format git
         clang-format --version
 
     - name: Run formatting style check
@@ -61,7 +62,10 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        apt -qq -y install clang-tidy-11
+        apt -qqy update
+        apt -qq -y install clang-tidy-11 build-essential git wget
+        source ./.github/settings.sh
+        ./.github/bin/install-bazel.sh
         echo "TMPDIR=/tmp" >> $GITHUB_ENV
 
     - name: Create Cache Timestamp
@@ -132,8 +136,9 @@ jobs:
     - name: Install Dependencies
       run: |
         set -x
+        apt -qqy update
+        apt -qq -y install clang-10 build-essential wget git python3 python-is-python3
         source ./.github/settings.sh
-        apt -qq -y install clang-10
         ./.github/bin/set-compiler.sh 9
         ./.github/bin/install-bazel.sh
 

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -172,8 +172,8 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         files: bazel-out/_coverage/_coverage_report.dat
-        fail_ci_if_error: true
         verbose: true
+      continue-on-error: true
 
     - name: Deployment
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.mode == 'compile'

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -12,7 +12,6 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_BUILDKIT: 1
   BOT_USER: "Deployment Bot"
   BOT_EMAIL: "verible-dev@googlegroups.com"
 
@@ -215,7 +214,8 @@ jobs:
 
   Build:
     needs: Matrix
-    runs-on: ubuntu-20.04
+    container: debian:bullseye
+    runs-on: [self-hosted, Linux, X64]
     # Github actions resources are limited; don't build artifacts for all
     # platforms on every pull request, only on push.
     if: ${{github.event_name == 'push'}}
@@ -225,6 +225,7 @@ jobs:
         include: ${{ fromJson(needs.Matrix.outputs.matrix) }}
     env:
       MATRIX_OS: '${{ matrix.os }}:${{ matrix.ver }}'
+      DOCKER_DATA_ROOT: "/root/.docker"
     name: 'Build · ${{ matrix.os }}:${{ matrix.ver }}'
 
     steps:
@@ -234,11 +235,24 @@ jobs:
        # Download complete repository + tags
        fetch-depth: 0
 
-    - run: docker pull $MATRIX_OS
+    - name: Install and setup Docker
+      run: "apt -qqy update && apt -qqy --no-install-recommends install docker.io cgroupfs-mount crun fuse-overlayfs pigz ca-certificates git && cgroupfs-mount"
 
     - name: Main script
       run: |
         set -x
+
+        mkdir -p "$DOCKER_DATA_ROOT"
+        dockerd \
+          -s fuse-overlayfs \
+          --add-runtime=crun=/usr/bin/crun \
+          --default-runtime=crun \
+          --config-file="" \
+          --data-root=$DOCKER_DATA_ROOT > /dev/null 2>&1 &
+        while ! test -S /var/run/docker.sock; do echo "Waiting for Docker..." && sleep 1; done; docker info
+        trap "kill $(cat /var/run/docker.pid)" EXIT
+
+        docker pull $MATRIX_OS
         source ./.github/settings.sh
         ./releasing/docker-run.sh $MATRIX_OS
 

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -154,9 +154,9 @@ jobs:
       run: |
         set -x
         apt -qqy update
-        apt -qq -y install clang-10 build-essential wget git python3 python-is-python3
+        apt -qq -y install clang-10 build-essential wget git python3 python-is-python3 gcc-10 g++-10
         source ./.github/settings.sh
-        ./.github/bin/set-compiler.sh 9
+        ./.github/bin/set-compiler.sh 10
         ./.github/bin/install-bazel.sh
 
     - name: ${{ matrix.mode }} Verible


### PR DESCRIPTION
This pull request modifies the CI pipeline definition and some related scripts so that the [custom runners](https://github.com/antmicro/runner) deployment for this repository is used.

What was changed:
* the `coverage` job will use the `@bazel_tools//tools/jdk:remote_jdk11` Java toolchain, as Java is not automatically installed in the container picked for the job.
* `sudo` is no longer necessary as the execution takes place in a container where privileges are already elevated.
* the `build` jobs install and start Docker explicitly. This way, the scripts that use Docker were left unchanged.
* all jobs run on `n2-highcpu-8` GCP machines, except for `ClangTidy` which runs on `n2-standard-4` (no need for a beefy machine as it doesn't do anything expensive).

The CI does not run on branches so during the development phase I used a "drop me" commit to test it: https://github.com/chipsalliance/verible/actions/runs/3549496319. I did drop the aforementioned commit before submitting this PR.