### PR TITLE
Wrap hanging_indentation calculation  to avoid negative indentation values

### DIFF
--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -570,10 +570,14 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
           }
         }
       }
+      // std::max(hanging_indentation, 0) serves to resolve a case where
+      // the subsequent nodes will try to be indented below zero following
+      // a less-indented token eg. a macro
       const int hanging_indentation =
           (node.Children().size() > 1)
-              ? (node.Children()[1].Value().IndentationSpaces() -
-                 node.Value().IndentationSpaces())
+              ? std::max(node.Children()[1].Value().IndentationSpaces() -
+                             node.Value().IndentationSpaces(),
+                         0)
               : 0;
 
       return factory_.Wrap(layouts.begin(), layouts.end(), false,

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -434,6 +434,10 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "             aaaa     == zzz;\n"
      "             ggg      == vv::w;,\n"
      "             \"Failed to ..........\")\n"},
+    {// macro call nested with function call containing an ifdef
+     "`J(D(`ifdef e))\n",
+     "`J(D(\n"
+     "   `ifdef e))\n"},
 
     // `uvm macros indenting
     {


### PR DESCRIPTION
This PR wraps the calculation of hanging_indentation in
`TokenPartitionsLayoutOptimizer::CalculateOptimalLayout`'s `kWrap` case to never let the value be negative, as it caused a check failure down the line.

This PR fixes #1242
