### PR TITLE
Fix calling system functions without parentheses

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -3426,13 +3426,22 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  input  bit [7:0]       data_i   [],\n"
      "  output bit [7:0]       data_o   []\n"
      ");\n"},
-    {// module with system task call
+    {// module with system task call w or w/o parentheses
      "module m; initial begin #10 $display(\"foo\"); $display(\"bar\");"
      "end endmodule",
      "module m;\n"
      "  initial begin\n"
      "    #10 $display(\"foo\");\n"
      "    $display(\"bar\");\n"
+     "  end\n"
+     "endmodule\n"},
+    {// module with system task call
+     "module m; initial begin #10 $display; $display;"
+     "end endmodule",
+     "module m;\n"
+     "  initial begin\n"
+     "    #10 $display;\n"
+     "    $display;\n"
      "  end\n"
      "endmodule\n"},
 

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -2060,8 +2060,9 @@ class MacroCallReshaper {
 
     paren_group_ = FindDirectChild(main_node_,
                                    OriginTagIs{NodeTag(NodeEnum::kParenGroup)});
+
+    // Macro can be used without parentheses
     if (!paren_group_) {
-      LOG_PARTITION_BUG("paren_group not found.");
       return false;
     }
 


### PR DESCRIPTION
This commit removes the error message when formatting system functions without parentheses, because they are formatted well after all.

Fixes #1280,
Fixes #1223,
Fixes #1247,
Fixes #1392.