### PR TITLE
Fix C++20-incompatible instances of aggregate initialization

### DIFF
--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -909,12 +909,8 @@ class SymbolTable::Builder : public TreeContextVisitor {
   SymbolTableNode* EmplaceElementInCurrentScope(const verible::Symbol& element,
                                                 absl::string_view name,
                                                 SymbolMetaType metatype) {
-    const auto p =
-        current_scope_->TryEmplace(name, SymbolInfo{
-                                             .metatype = metatype,
-                                             .file_origin = source_,
-                                             .syntax_origin = &element,
-                                         });
+    const auto p = current_scope_->TryEmplace(
+        name, SymbolInfo{metatype, source_, &element});
     if (!p.second) {
       DiagnoseSymbolAlreadyExists(name, p.first->first);
     }
@@ -931,14 +927,11 @@ class SymbolTable::Builder : public TreeContextVisitor {
     VLOG(1) << "  type info: " << *ABSL_DIE_IF_NULL(declaration_type_info_);
     VLOG(1) << "  full text: " << AutoTruncate{StringSpanOfSymbol(element), 40};
     const auto p = current_scope_->TryEmplace(
-        name,
-        SymbolInfo{
-            .metatype = metatype,
-            .file_origin = source_,
-            .syntax_origin = &element,
-            // associate this instance with its declared type
-            .declared_type = *ABSL_DIE_IF_NULL(declaration_type_info_),  // copy
-        });
+        name, SymbolInfo{
+                  metatype, source_, &element,
+                  // associate this instance with its declared type
+                  *ABSL_DIE_IF_NULL(declaration_type_info_),  // copy
+              });
     if (!p.second) {
       DiagnoseSymbolAlreadyExists(name, p.first->first);
     }
@@ -1253,11 +1246,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const absl::string_view inner_key = inner_ref.identifier;
 
     const auto p = outer_scope->TryEmplace(
-        inner_key, SymbolInfo{
-                       .metatype = metatype,
-                       .file_origin = source_,
-                       .syntax_origin = definition_syntax,
-                   });
+        inner_key, SymbolInfo{metatype, source_, definition_syntax});
     SymbolTableNode* inner_symbol = &p.first->second;
     if (p.second) {
       // If injection succeeded, then the outer_scope did not already contain a

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -180,6 +180,9 @@ struct DependentReferences {
 
  public:
   DependentReferences() = default;
+  explicit DependentReferences(
+      std::unique_ptr<ReferenceComponentNode> components)
+      : components(std::move(components)) {}
   // move-only
   DependentReferences(const DependentReferences&) = delete;
   DependentReferences(DependentReferences&&) = default;
@@ -251,14 +254,6 @@ struct DeclarationTypeInfo {
   bool implicit = false;
 
  public:
-  DeclarationTypeInfo() = default;
-
-  // copy-able, move-able, assignable
-  DeclarationTypeInfo(const DeclarationTypeInfo&) = default;
-  DeclarationTypeInfo(DeclarationTypeInfo&&) = default;
-  DeclarationTypeInfo& operator=(const DeclarationTypeInfo&) = default;
-  DeclarationTypeInfo& operator=(DeclarationTypeInfo&&) = default;
-
   // Structural consistency check.
   void VerifySymbolTableRoot(const SymbolTableNode* root) const;
 };
@@ -328,6 +323,13 @@ struct SymbolInfo {
 
  public:  // methods
   SymbolInfo() = default;
+  SymbolInfo(SymbolMetaType metatype, const VerilogSourceFile* file_origin = {},
+             const verible::Symbol* syntax_origin = {},
+             DeclarationTypeInfo declared_type = {})
+      : metatype(metatype),
+        file_origin(file_origin),
+        syntax_origin(syntax_origin),
+        declared_type(declared_type) {}
 
   // move-only
   SymbolInfo(const SymbolInfo&) = delete;
@@ -422,7 +424,7 @@ class SymbolTable {
   // and string memory, otherwise string memory is owned by 'project'.
   explicit SymbolTable(VerilogProject* project)
       : project_(project),
-        symbol_table_root_(SymbolInfo{.metatype = SymbolMetaType::kRoot}) {}
+        symbol_table_root_(SymbolInfo{SymbolMetaType::kRoot}) {}
 
   // can become move-able when needed
   SymbolTable(const SymbolTable&) = delete;

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -245,12 +245,11 @@ TEST(DependentReferencesTest, PrintEmpty) {
 }
 
 TEST(DependentReferencesTest, PrintOnlyRootNodeUnresolved) {
-  const DependentReferences dep_refs{
-      .components = std::make_unique<ReferenceComponentNode>(
-          ReferenceComponent{.identifier = "foo",
-                             .ref_type = ReferenceType::kUnqualified,
-                             .required_metatype = SymbolMetaType::kUnspecified,
-                             .resolved_symbol = nullptr})};
+  const DependentReferences dep_refs{std::make_unique<ReferenceComponentNode>(
+      ReferenceComponent{.identifier = "foo",
+                         .ref_type = ReferenceType::kUnqualified,
+                         .required_metatype = SymbolMetaType::kUnspecified,
+                         .resolved_symbol = nullptr})};
   std::ostringstream stream;
   stream << dep_refs;
   EXPECT_EQ(stream.str(), "{ (@foo -> <unresolved>) }");
@@ -260,29 +259,27 @@ TEST(DependentReferencesTest, PrintNonRootResolved) {
   // Synthesize a symbol table.
   typedef SymbolTableNode::key_value_type KV;
   SymbolTableNode root(
-      SymbolInfo{.metatype = SymbolMetaType::kRoot},
+      SymbolInfo{SymbolMetaType::kRoot},
       KV{"p_pkg",
-         SymbolTableNode(
-             SymbolInfo{.metatype = SymbolMetaType::kPackage},
-             KV{"c_class", SymbolTableNode(SymbolInfo{
-                               .metatype = SymbolMetaType::kClass})})});
+         SymbolTableNode(SymbolInfo{SymbolMetaType::kPackage},
+                         KV{"c_class", SymbolTableNode(SymbolInfo{
+                                           SymbolMetaType::kClass})})});
 
   // Bookmark symbol table nodes.
   MUST_ASSIGN_LOOKUP_SYMBOL(p_pkg, root, "p_pkg");
   MUST_ASSIGN_LOOKUP_SYMBOL(c_class, p_pkg, "c_class");
 
   // Construct references already resolved to above nodes.
-  const DependentReferences dep_refs{
-      .components = std::make_unique<ReferenceComponentNode>(
-          ReferenceComponent{.identifier = "p_pkg",
-                             .ref_type = ReferenceType::kUnqualified,
-                             .required_metatype = SymbolMetaType::kPackage,
-                             .resolved_symbol = &p_pkg},
-          ReferenceComponentNode(
-              ReferenceComponent{.identifier = "c_class",
-                                 .ref_type = ReferenceType::kDirectMember,
-                                 .required_metatype = SymbolMetaType::kClass,
-                                 .resolved_symbol = &c_class}))};
+  const DependentReferences dep_refs{std::make_unique<ReferenceComponentNode>(
+      ReferenceComponent{.identifier = "p_pkg",
+                         .ref_type = ReferenceType::kUnqualified,
+                         .required_metatype = SymbolMetaType::kPackage,
+                         .resolved_symbol = &p_pkg},
+      ReferenceComponentNode(
+          ReferenceComponent{.identifier = "c_class",
+                             .ref_type = ReferenceType::kDirectMember,
+                             .required_metatype = SymbolMetaType::kClass,
+                             .resolved_symbol = &c_class}))};
 
   // Print and compare.
   std::ostringstream stream;
@@ -398,12 +395,11 @@ TEST(BuildSymbolTableTest, IntegrityCheckResolvedSymbol) {
     // symbol_table1 will outlive symbol_table_2, so give symbol_table_2 a
     // pointer to symbol_table_1.
     root2.Value().local_references_to_bind.push_back(DependentReferences{
-        .components =
-            std::make_unique<ReferenceComponentNode>(ReferenceComponent{
-                .identifier = "foo",
-                .ref_type = ReferenceType::kUnqualified,
-                .required_metatype = SymbolMetaType::kUnspecified,
-                .resolved_symbol = &root1})});
+        std::make_unique<ReferenceComponentNode>(ReferenceComponent{
+            .identifier = "foo",
+            .ref_type = ReferenceType::kUnqualified,
+            .required_metatype = SymbolMetaType::kUnspecified,
+            .resolved_symbol = &root1})});
     // CheckIntegrity() will fail on destruction of symbol_table_2.
   };
   EXPECT_DEATH(test_func(),
@@ -421,12 +417,11 @@ TEST(BuildSymbolTableTest, IntegrityCheckDeclaredType) {
     // symbol_table1 will outlive symbol_table_2, so give symbol_table_2 a
     // pointer to symbol_table_1.
     root1.Value().local_references_to_bind.push_back(DependentReferences{
-        .components =
-            std::make_unique<ReferenceComponentNode>(ReferenceComponent{
-                .identifier = "foo",
-                .ref_type = ReferenceType::kUnqualified,
-                .required_metatype = SymbolMetaType::kUnspecified,
-                .resolved_symbol = &root1})});
+        std::make_unique<ReferenceComponentNode>(ReferenceComponent{
+            .identifier = "foo",
+            .ref_type = ReferenceType::kUnqualified,
+            .required_metatype = SymbolMetaType::kUnspecified,
+            .resolved_symbol = &root1})});
     root2.Value().declared_type.user_defined_type =
         root1.Value().local_references_to_bind.front().components.get();
     // CheckIntegrity() will fail on destruction of symbol_table_2.


### PR DESCRIPTION
In C++20, types that declare or delete any constructors are no longer aggregates, breaking compilation of many existing uses of aggregate initialization.

Fixes include:
  * removing defaultings or deletions of only the default constructor
  * removing defaultings of copy/move constructors
  * adding constructors that accept the arguments passed to existing aggregate initialization sites, leaving the type no longer an aggregate
  * removing a set of clearly-marked-as-boiler-plate copy/move/default constructor declarations

Also adds default member initializers for trivially default constructible members that can now be left uninitialized by construction of the form `Foo f;`