### PR TITLE
Make sure to include all the used depdnencies in the BUILD file.

### DIFF
--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -68,8 +68,14 @@ cc_library(
     hdrs = ["verilog-language-server.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":lsp-parse-buffer",
         ":verible-lsp-adapter",
+        "//common/lsp:json-rpc-dispatcher",
+        "//common/lsp:lsp-protocol",
+        "//common/lsp:lsp-text-buffer",
         "//common/lsp:message-stream-splitter",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -14,6 +14,12 @@
 
 #include "verilog/tools/ls/verilog-language-server.h"
 
+#include <functional>
+
+#include "absl/strings/string_view.h"
+#include "common/lsp/lsp-protocol.h"
+#include "verilog/tools/ls/verible-lsp-adapter.h"
+
 namespace verilog {
 
 VerilogLanguageServer::VerilogLanguageServer(const WriteFun &write_fun)

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -15,14 +15,11 @@
 #ifndef VERILOG_TOOLS_LS_LS_WRAPPER_H
 #define VERILOG_TOOLS_LS_LS_WRAPPER_H
 
-#include <functional>
-
 #include "absl/status/status.h"
-#include "absl/strings/string_view.h"
 #include "common/lsp/json-rpc-dispatcher.h"
-#include "common/lsp/lsp-protocol.h"
+#include "common/lsp/lsp-text-buffer.h"
 #include "common/lsp/message-stream-splitter.h"
-#include "verilog/tools/ls/verible-lsp-adapter.h"
+#include "verilog/tools/ls/lsp-parse-buffer.h"
 
 namespace verilog {
 

--- a/verilog/tools/ls/verilog_ls.cc
+++ b/verilog/tools/ls/verilog_ls.cc
@@ -31,7 +31,7 @@
 #endif
 
 static void FormatHeaderBodyReply(absl::string_view reply) {
-  // Output formatting as header/body chunk as required by LSP spec.
+  // Output formatting as header/body chunk as required by LSP spec to stdout.
   std::cout << "Content-Length: " << reply.size() << "\r\n\r\n";
   std::cout << reply << std::flush;
 }
@@ -42,18 +42,20 @@ int main(int argc, char *argv[]) {
   std::cerr << "Verible Alpha Language Server "
             << verilog::VerilogLanguageServer::GetVersionNumber() << std::endl;
 
-  // Input and output is stdin and stdout
-  constexpr int in_fd = 0;  // STDIN_FILENO
-
 #ifdef _WIN32
+  // Windows messes with newlines by default. Fix this here.
   _setmode(_fileno(stdin), _O_BINARY);
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
+  // Input and output is stdin and stdout
+  constexpr int kInputFD = 0;  // STDIN_FILENO, but Win does not have that macro
+
   verilog::VerilogLanguageServer server(FormatHeaderBodyReply);
 
-  absl::Status status = server.Run(
-      [](char *buf, int size) -> int { return read(in_fd, buf, size); });
+  absl::Status status = server.Run([](char *buf, int size) -> int {  //
+    return read(kInputFD, buf, size);
+  });
 
   std::cerr << status.message() << std::endl;
 


### PR DESCRIPTION
The BUILD file was not containing all the dependencies yet that the header includes of the verilog-language-server needed.

While at it, move some headers that are only needed in the compilation unit there.

Encourage the formatter to format the closure wrapping the read() function to look more pleasing by adding a EOL comment at a strategic place.
