### PR TITLE
Fix line continuation wrapping

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -5616,6 +5616,13 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    .rst  (rst),\n"
      "    .value(value)\n"
      ");\n"},
+    {"bind foo bar baz(\\\n"
+     "`undef d\\\n"
+     "`undef d);",
+     "bind foo bar baz (\\\n"
+     "    `undef d\\\n"
+     "    `undef d\n"
+     ");\n"},
     {
         "bind expaaaaaaaaaaand_meeee looooooooong_name# ("
         ".W(W_CONST), .H(H_CONST), .D(D_CONST)  )"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -469,7 +469,8 @@ void TreeUnwrapper::LookAheadBeyondCurrentLeaf() {
   while (!NextUnfilteredToken()->isEOF()) {
     EatSpaces();
     VLOG(4) << "lookahead token: " << VerboseToken(*NextUnfilteredToken());
-    if (IsComment(verilog_tokentype(NextUnfilteredToken()->token_enum()))) {
+    if (auto next_tok = verilog_tokentype(NextUnfilteredToken()->token_enum());
+        IsComment(next_tok) || next_tok == verilog_tokentype::TK_LINE_CONT) {
       // TODO(fangism): or IsAttribute().  Basically, any token that is not
       // in the syntax tree and not a space.
       AdvanceLastVisitedLeaf();


### PR DESCRIPTION
This PR fixes #1055 

There was a problem where the `TK_LINE_CONT` tokens were not included while `LookAheadBeyondCurrentLeaf()` was running causing the `\` characters were not attached to their lines in the test case eg. `bind bi i FP(\` was trying to get converted to 
```
bind bi i FP(
    \
```
if the check that failed was to be disabled. This has made it attach itself to the line, no longer failing the condition `first_tree_token_it->before.break_decision != SpacingOptions::MustWrap`

There is also a test that had failed before the fix and now it doesn't.
