### PR TITLE
Fix comment following a delay

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -5503,6 +5503,43 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  );\n"
      "endmodule\n"},
 
+    {// comment following a delay in next line
+     "module t;\n"
+     "reg x;\n"
+     "initial begin\n"
+     "#20\n"
+     "//comment\n"
+     "x = 1;\n"
+     "x = 2;\n"
+     "end\n"
+     "endmodule\n",
+     "module t;\n"
+     "  reg x;\n"
+     "  initial begin\n"
+     "    #20\n"
+     "    //comment\n"
+     "    x = 1;\n"
+     "    x = 2;\n"
+     "  end\n"
+     "endmodule\n"},
+    {// comment following a delay in the same line
+     "module t;\n"
+     "reg x;\n"
+     "initial begin\n"
+     "#20 //comment\n"
+     "x = 1;\n"
+     "x = 2;\n"
+     "end\n"
+     "endmodule\n",
+     "module t;\n"
+     "  reg x;\n"
+     "  initial begin\n"
+     "    #20  //comment\n"
+     "    x = 1;\n"
+     "    x = 2;\n"
+     "  end\n"
+     "endmodule\n"},
+
     {
         // test that alternate top-syntax mode works
         "// verilog_syntax: parse-as-module-body\n"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -2874,7 +2874,8 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       // RHS may have been further partitioned, e.g. a macro call.
       auto& children = partition.Children();
       if (children.size() == 2 &&
-          verible::is_leaf(children.front()) /* left side */) {
+          verible::is_leaf(children.front()) /* left side */ &&
+          !PartitionIsForcedIntoNewLine(children.back())) {
         verible::MergeLeafIntoNextLeaf(&children.front());
         VLOG(4) << "after merge leaf (left-into-right):\n" << partition;
       }

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -971,9 +971,11 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     {
       // Single statements directly inside a flow-control construct
       // should be properly indented one level.
-      const int indent = ShouldIndentRelativeToDirectParent(Context())
-                             ? style_.indentation_spaces
-                             : 0;
+      const int indent = Context().IsInside(NodeEnum::kBlockItemStatementList)
+                             ? 0
+                             : ShouldIndentRelativeToDirectParent(Context())
+                                   ? style_.indentation_spaces
+                                   : 0;
       VisitIndentedSection(node, indent,
                            PartitionPolicyEnum::kFitOnLineElseExpand);
       break;


### PR DESCRIPTION
This PR fixes the following case:
```systemverilog
module test ();
  reg x;
  initial begin
    #20 //test
    x = 1;
    x = 2;
  end
endmodule
```

Fixes #1113.