### PR TITLE
Add more variants to ClassPropertyColumnSchemaScanner

### DIFF
--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -823,6 +823,15 @@ class ClassPropertyColumnSchemaScanner : public VerilogColumnSchemaScanner {
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
     switch (tag) {
+      case NodeEnum::kDeclarationDimensions: {
+        if (current_path_ == SyntaxTreePath{1, 0, 0, 3, 0}) {
+          SyntaxTreePath new_path{1, 0, 0, 3};
+          const ValueSaver<SyntaxTreePath> path_saver(&current_path_, new_path);
+          TreeContextPathVisitor::Visit(node);
+          return;
+        }
+        break;
+      }
       case NodeEnum::kDataDeclaration:
       case NodeEnum::kVariableDeclarationAssignment: {
         // Don't wait for the type node, just start the first column right away.

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -15218,6 +15218,48 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "   // c2\n"
      "   // c3\n"},
 
+    {"class C; T1 b; logic [$] a; T1 [$] c; endclass\n",
+     "class C;\n"
+     "  T1        b;\n"
+     "  logic [$] a;\n"
+     "  T1    [$] c;\n"
+     "endclass\n"},
+    {"class C;\n"
+     "  T1 b; //test\n"
+     "  logic [$] a; //test\n"
+     "  T1    [$] c; //test\n"
+     "endclass\n",
+     "class C;\n"
+     "  T1        b;  //test\n"
+     "  logic [$] a;  //test\n"
+     "  T1    [$] c;  //test\n"
+     "endclass\n"},
+    {"class C;\n"
+     "  T1\n"
+     "  b;\n"
+     "  logic\n"
+     "  [$]\n"
+     "  a;\n"
+     "  T1\n"
+     "  [$]\n"
+     "  c;\n"
+     "endclass\n",
+     "class C;\n"
+     "  T1        b;\n"
+     "  logic [$] a;\n"
+     "  T1    [$] c;\n"
+     "endclass\n"},
+    {"class C;\n"
+     "  logic/*t*/ [0 : 1] /*t*/\n"
+     "  a;/*t*/\n"
+     "  T1/*t*/[0 : 1]/*t*/\n"
+     "  c;/*t*/\n"
+     "endclass\n",
+     "class C;\n"
+     "  logic/*t*/ [0 : 1]  /*t*/ a;  /*t*/\n"
+     "  T1/*t*/    [0 : 1]  /*t*/ c;  /*t*/\n"
+     "endclass\n"},
+
     // -----------------------------------------------------------------
 };
 


### PR DESCRIPTION
Fixes #1146

With this PR `ivtest/ivltests/packed_dims_invalid_class.v` no longer fails. Also, it is formatted correctly.
I also added some test cases for this case.