### PR TITLE
Add a size check before merging leaves in kDPIImportItem/kDPIExportItem

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -3425,6 +3425,7 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  // c3+\n"
      "  input bit second\n"
      ");\n"},
+    {"export \"\" t;\n", "export \"\" t;\n"},
     {"import \"DPI-C\" context function void func(input bit impl_i,"
      "input bit op_i,"
      "input bit [5:0] mode_i,"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -2596,8 +2596,10 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       //   [function ... ] (task header/prototype)
       // Push the "import..." down.
       {
-        verible::MergeLeafIntoNextLeaf(&partition.Children().front());
-        AttachTrailingSemicolonToPreviousPartition(&partition);
+        if (partition.Children().size() > 1) {
+          verible::MergeLeafIntoNextLeaf(&partition.Children().front());
+          AttachTrailingSemicolonToPreviousPartition(&partition);
+        }
         break;
       }
     case NodeEnum::kBindDirective: {


### PR DESCRIPTION
Add a size check before merging leaves in `kDPIImportItem`/`kDPIExportItem`
Also add test to cover that case.

Fixes #1198
