### PR TITLE
Treat kNetDeclarationAssignment the same as kNetVariable in DataDeclarationColumnSchemaScanner…

### DIFF
--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -733,6 +733,7 @@ class DataDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
         ReserveNewColumn(node, FlushLeft);
         break;
       }
+      case NodeEnum::kNetDeclarationAssignment:
       case NodeEnum::kNetVariable: {
         // at path [2,0] in kNetDeclaration
         // contains the declared id

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -15217,6 +15217,18 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      ";  // c1\n"
      "   // c2\n"
      "   // c3\n"},
+    {"module indent();\n"
+     "   reg     a;\n"
+     "   reg [32:0] b;\n"
+     "   wire    c;\n"
+     "   wire    d = e ? kFoo : kBar;\n"
+     "endmodule\n",
+     "module indent ();\n"
+     "  reg         a;\n"
+     "  reg  [32:0] b;\n"
+     "  wire        c;\n"
+     "  wire        d = e ? kFoo : kBar;\n"
+     "endmodule\n"},
 
     // -----------------------------------------------------------------
 };


### PR DESCRIPTION
Treat `kNetDeclarationAssignment` the same as `kNetVariable` in `DataDeclarationColumnSchemaScanner`.
Also add a test for this case.

Fixes #1317