### PR TITLE
Emacs Verilog-Mode AUTOARG expansion in the language server

### DIFF
--- a/verilog/CST/identifier.cc
+++ b/verilog/CST/identifier.cc
@@ -39,6 +39,11 @@ std::vector<verible::TreeSearchMatch> FindAllIdentifierUnpackedDimensions(
   return verible::SearchSyntaxTree(root, NodekIdentifierUnpackedDimensions());
 }
 
+std::vector<verible::TreeSearchMatch> FindAllPortIdentifiers(
+    const verible::Symbol& root) {
+  return verible::SearchSyntaxTree(root, NodekPortIdentifier());
+}
+
 std::vector<verible::TreeSearchMatch> FindAllUnqualifiedIds(
     const verible::Symbol& root) {
   return verible::SearchSyntaxTree(root, NodekUnqualifiedId());
@@ -63,7 +68,9 @@ bool IdIsQualified(const verible::Symbol& symbol) {
 const verible::SyntaxTreeLeaf* GetIdentifier(const verible::Symbol& symbol) {
   auto t = symbol.Tag();
   if (t.kind != SymbolKind::kNode) return nullptr;
-  if (NodeEnum(t.tag) != NodeEnum::kUnqualifiedId) return nullptr;
+  if (NodeEnum(t.tag) != NodeEnum::kUnqualifiedId &&
+      NodeEnum(t.tag) != NodeEnum::kPortIdentifier)
+    return nullptr;
   const auto& node = down_cast<const verible::SyntaxTreeNode&>(symbol);
   const auto* leaf = down_cast<const verible::SyntaxTreeLeaf*>(node[0].get());
   return leaf;

--- a/verilog/CST/identifier.h
+++ b/verilog/CST/identifier.h
@@ -27,6 +27,10 @@ namespace verilog {
 std::vector<verible::TreeSearchMatch> FindAllIdentifierUnpackedDimensions(
     const verible::Symbol&);
 
+// Returns all sub-nodes tagged with kPortIdentifier
+std::vector<verible::TreeSearchMatch> FindAllPortIdentifiers(
+    const verible::Symbol&);
+
 // Returns all sub-nodes tagged with kUnqualifiedId
 std::vector<verible::TreeSearchMatch> FindAllUnqualifiedIds(
     const verible::Symbol&);

--- a/verilog/CST/identifier_test.cc
+++ b/verilog/CST/identifier_test.cc
@@ -130,6 +130,29 @@ TEST(GetIdentifierTest, UnqualifiedIds) {
   }
 }
 
+// Tests that all expected unqualified ids are found.
+TEST(GetIdentifierTest, PortIdentifiers) {
+  constexpr int kTag = 1;  // value doesn't matter
+  const SyntaxTreeSearchTestCase kTestCases[] = {
+      {"module t; output reg ", {kTag, "o"}, "; endmodule"},
+  };
+  // Test GetIdentifier
+  for (const auto& test : kTestCases) {
+    VLOG(1) << "[GetIdentifier] code:\n" << test.code;
+    TestVerilogSyntaxRangeMatches(
+        __FUNCTION__, test, [](const TextStructureView& text_structure) {
+          const auto& root = text_structure.SyntaxTree();
+          const auto ids = FindAllPortIdentifiers(*root);
+          std::vector<verible::TreeSearchMatch> got_ids;
+          for (const auto& id : ids) {
+            const verible::SyntaxTreeLeaf* base = GetIdentifier(*id.match);
+            got_ids.push_back(TreeSearchMatch{base, /* ignored context */});
+          }
+          return got_ids;
+        });
+  }
+}
+
 TEST(GetIdentifierTest, IdentifierUnpackedDimensions) {
   constexpr int kTag = 1;  // value doesn't matter
   const SyntaxTreeSearchTestCase kTestCases[] = {

--- a/verilog/CST/port_test.cc
+++ b/verilog/CST/port_test.cc
@@ -277,6 +277,11 @@ TEST(GetIdentifierFromModulePortDeclarationTest, VariousPorts) {
        " [3:0]; input logic [3:0] ",
        {kTag, "bar2"},
        "; endmodule"},
+      {"module foo(bar, bar2); input logic ",
+       {kTag, "bar"},
+       " [3:0]; input reg [3:0] ",
+       {kTag, "bar2"},
+       "; endmodule"},
   };
   for (const auto& test : kTestCases) {
     TestVerilogSyntaxRangeMatches(

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -11,7 +11,23 @@ package(
         "//:__subpackages__",
     ],
 )
-
+ 
+cc_library(
+    name = "autoexpand",
+    srcs = ["autoexpand.cc"],
+    hdrs = ["autoexpand.h"],
+    deps = [
+        ":lsp-parse-buffer",
+        "//common/lsp:lsp-protocol",
+        "//common/text:text_structure",
+        "//verilog/CST:identifier",
+        "//verilog/CST:module",
+        "//verilog/CST:port",
+        "//verilog/formatting:format_style_init",
+        "//verilog/formatting:formatter",
+    ],
+)
+ 
 cc_library(
     name = "lsp-parse-buffer",
     srcs = ["lsp-parse-buffer.cc"],
@@ -30,6 +46,7 @@ cc_library(
     srcs = ["verible-lsp-adapter.cc"],
     hdrs = ["verible-lsp-adapter.h"],
     deps = [
+        ":autoexpand",
         ":document-symbol-filler",
         ":lsp-parse-buffer",
         "//common/lsp:lsp-protocol",
@@ -102,4 +119,14 @@ sh_test_with_runfiles_lib(
         "//common/lsp:json-rpc-expect",
     ],
     deps = [],
+)
+
+cc_test(
+    name = "autoexpand_test",
+    srcs = ["autoexpand_test.cc"],
+    deps = [
+        ":autoexpand",
+        ":verible-lsp-adapter",
+        "@com_google_googletest//:gtest_main",
+    ],
 )

--- a/verilog/tools/ls/autoexpand.cc
+++ b/verilog/tools/ls/autoexpand.cc
@@ -1,0 +1,289 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "verilog/tools/ls/autoexpand.h"
+
+#include <algorithm>
+#include <regex>
+
+#include "common/text/text_structure.h"
+#include "verilog/CST/identifier.h"
+#include "verilog/CST/module.h"
+#include "verilog/CST/port.h"
+#include "verilog/formatting/format_style_init.h"
+#include "verilog/formatting/formatter.h"
+
+namespace verilog {
+using verible::LineColumn;
+using verible::StringSpanOfSymbol;
+using verible::Symbol;
+using verible::SymbolKind;
+using verible::SymbolPtr;
+using verible::SyntaxTreeLeaf;
+using verible::SyntaxTreeNode;
+using verible::TextStructureView;
+using verible::TokenInfo;
+using verible::lsp::CodeAction;
+using verible::lsp::CodeActionParams;
+using verible::lsp::TextEdit;
+using verilog::formatter::FormatStyle;
+using verilog::formatter::InitializeFromFlags;
+
+namespace {
+// Takes a TextStructureView and generates LSP TextEdits for AUTO expansion
+class AutoExpander {
+ public:
+  // Information about an AUTO comment
+  struct AutoComment {
+    LineColumn linecol;          // Line and column where the comment starts
+    int start_offset;            // Byte offset of the comment in the buffer
+    absl::string_view contents;  // The contents of the comment
+  };
+
+  AutoExpander(const TextStructureView &text_structure)
+      : text_structure_(text_structure), context_(text_structure.Contents()) {
+    // Get the indentation from the format style
+    FormatStyle format_style;
+    InitializeFromFlags(&format_style);
+    line_end_str_ = "\n" + std::string(format_style.indentation_spaces, ' ');
+  }
+
+  // Write given port names to the output stream, under the specified header
+  // comment
+  void EmitPortDeclarations(absl::string_view header,
+                            const std::vector<absl::string_view> &port_names,
+                            std::ostream &output);
+
+  // Find the location and span of an AUTO comment given
+  absl::optional<AutoComment> FindInSpan(const std::regex &re,
+                                         absl::string_view span);
+
+  // Retrieves port names from a module declared before the given offset
+  std::set<absl::string_view> GetPortsDeclaredBefore(const Symbol &module,
+                                                     int offset);
+
+  // Expand AUTOARG for the given module (skip given port set)
+  std::string ExpandAutoarg(
+      const Symbol &module,
+      const std::set<absl::string_view> &predeclared_ports);
+
+  // Expand all AUTOs in the buffer
+  std::vector<TextEdit> Expand();
+
+ private:
+  // Text structure of the buffer to expand AUTOs in
+  const TextStructureView &text_structure_;
+
+  // Token context created from the buffer contents
+  const TokenInfo::Context context_;
+
+  // String to add at the end of each generated line
+  std::string line_end_str_;
+
+  // Regex for finding AUTOARG comments
+  static std::regex autoarg_re_;
+};
+
+std::regex AutoExpander::autoarg_re_{R"(/\*\s*AUTOARG\s*\*/)"};
+
+void AutoExpander::EmitPortDeclarations(
+    const absl::string_view header,
+    const std::vector<absl::string_view> &port_names, std::ostream &output) {
+  if (port_names.empty()) return;
+  output << line_end_str_ << "// " << header << line_end_str_;
+  bool first = true;
+  for (auto port : port_names) {
+    if (!first) {
+      output << ',' << line_end_str_;
+    }
+    first = false;
+    output << port;
+  }
+}
+
+absl::optional<AutoExpander::AutoComment> AutoExpander::FindInSpan(
+    const std::regex &re, const absl::string_view span) {
+  std::match_results<const char *> match;
+  if (!std::regex_search(span.begin(), span.end(), match, re)) return {};
+  const int start_offset =
+      std::distance(context_.base.begin(), span.begin() + match.position());
+  return {{.linecol = text_structure_.GetLineColAtOffset(start_offset),
+           .start_offset = start_offset,
+           .contents = {span.begin() + match.position(),
+                        static_cast<size_t>(match.length())}}};
+}
+
+std::set<absl::string_view> AutoExpander::GetPortsDeclaredBefore(
+    const Symbol &module, const int offset) {
+  std::set<absl::string_view> ports_before;
+  const auto all_ports = GetModulePortDeclarationList(module);
+  if (!all_ports) return {};
+  for (const SymbolPtr &port : all_ports->children()) {
+    if (port->Kind() == SymbolKind::kLeaf) continue;
+    // Find the identifier of the port
+    const SyntaxTreeNode &port_node = SymbolCastToNode(*port);
+    const NodeEnum tag = NodeEnum(port_node.Tag().tag);
+    const SyntaxTreeLeaf *port_id_node = nullptr;
+    if (tag == NodeEnum::kPortDeclaration) {
+      port_id_node = GetIdentifierFromPortDeclaration(port_node);
+    } else if (tag == NodeEnum::kPort) {
+      const SyntaxTreeNode *const port_ref_node =
+          GetPortReferenceFromPort(port_node);
+      if (port_ref_node) {
+        port_id_node = GetIdentifierFromPortReference(*port_ref_node);
+      }
+    }
+    // If there is no identifier, continue
+    if (!port_id_node) continue;
+    // Check if this port is declared before `offset`
+    const absl::string_view port_id = port_id_node->get().text();
+    const int port_offset =
+        std::distance(context_.base.begin(), port_id.begin());
+    if (port_offset < offset) {
+      // If so, add it to the set
+      ports_before.insert(port_id);
+    }
+  }
+  return ports_before;
+}
+
+std::string AutoExpander::ExpandAutoarg(
+    const Symbol &module,
+    const std::set<absl::string_view> &predeclared_ports) {
+  std::vector<absl::string_view> input_port_names;
+  std::vector<absl::string_view> inout_port_names;
+  std::vector<absl::string_view> output_port_names;
+  const auto ports = FindAllModulePortDeclarations(module);
+  for (const auto &port : ports) {
+    // Get the direction and identifier leaves
+    const SyntaxTreeLeaf *const dir_leaf =
+        GetDirectionFromModulePortDeclaration(*port.match);
+    const SyntaxTreeLeaf *const id_leaf =
+        GetIdentifierFromModulePortDeclaration(*port.match);
+    // Get the direction and identifier string views
+    const absl::string_view dir = dir_leaf->get().text();
+    const absl::string_view name = id_leaf->get().text();
+    // If declared before AUTOARG, do not print it
+    if (predeclared_ports.find(name) != predeclared_ports.end()) continue;
+    // Else put in the right container
+    if (dir == "input") {
+      input_port_names.push_back(name);
+    } else if (dir == "inout") {
+      inout_port_names.push_back(name);
+    } else if (dir == "output") {
+      output_port_names.push_back(name);
+    }
+  }
+  // Emit the port names under the correct heading
+  std::ostringstream output;
+  EmitPortDeclarations("Inputs", input_port_names, output);
+  if (output.tellp() != 0 && !inout_port_names.empty()) {
+    output << ',';
+  }
+  EmitPortDeclarations("Inouts", inout_port_names, output);
+  if (output.tellp() != 0 && !output_port_names.empty()) {
+    output << ',';
+  }
+  EmitPortDeclarations("Outputs", output_port_names, output);
+  if (output.tellp() != 0) {
+    output << line_end_str_;
+  }
+  return output.str();
+}
+
+std::vector<TextEdit> AutoExpander::Expand() {
+  std::vector<TextEdit> edits;
+  if (!text_structure_.SyntaxTree()) return {};
+  const auto modules = FindAllModuleDeclarations(*text_structure_.SyntaxTree());
+  for (const auto &module : modules) {
+    // Find the port list paren group
+    const SyntaxTreeNode *const port_parens =
+        GetModulePortParenGroup(*module.match);
+    if (!port_parens) continue;
+    // Find the port list span
+    const absl::string_view port_paren_span = StringSpanOfSymbol(*port_parens);
+    // Find the AUTOARG comment
+    const std::optional<AutoComment> comment =
+        FindInSpan(autoarg_re_, port_paren_span);
+    if (!comment.has_value()) continue;
+    // Find the range which should be replaced by the generated port list
+    const LineColumn start_linecol = comment.value().linecol;
+    const LineColumn end_linecol =
+        text_structure_.GetRangeForText(port_paren_span).end;
+    // Find the ports declared before the comment
+    const auto predeclared_ports =
+        GetPortsDeclaredBefore(*module.match, comment.value().start_offset);
+    // Generate the code to replace the port list with
+    const std::string new_text =
+        absl::StrCat(comment.value().contents,
+                     ExpandAutoarg(*module.match, predeclared_ports));
+    edits.push_back(
+        TextEdit{.range =
+                     {
+                         .start = {.line = start_linecol.line,
+                                   .character = start_linecol.column},
+                         .end = {.line = end_linecol.line,
+                                 .character = end_linecol.column - 1},
+                     },
+                 .newText = new_text});
+  }
+  return edits;
+}
+
+}  // namespace
+
+std::vector<TextEdit> GenerateAutoExpandTextEdits(
+    const BufferTracker *const tracker) {
+  if (!tracker) return {};
+  const ParsedBuffer *const current = tracker->current();
+  if (!current) return {};  // Can only expand if we have latest version
+  AutoExpander expander(current->parser().Data());
+  return expander.Expand();
+}
+
+std::vector<CodeAction> GenerateAutoExpandCodeActions(
+    const BufferTracker *const tracker, const CodeActionParams &p) {
+  auto edits = GenerateAutoExpandTextEdits(tracker);
+  if (edits.empty()) return {};
+  std::vector<CodeAction> result;
+  // Make a code action for expanding all AUTOs in the current buffer
+  result.emplace_back(CodeAction{
+      .title = "Expand all AUTOs in file",
+      .kind = "refactor.rewrite",
+      .diagnostics = {},
+      .isPreferred = false,
+      .edit = {.changes = {{p.textDocument.uri, edits}}},
+  });
+  // Remove edits outside of the code action range
+  auto it = std::remove_if(edits.begin(), edits.end(), [&](TextEdit &edit) {
+    return p.range.end.line < edit.range.start.line ||
+           p.range.start.line > edit.range.end.line;
+  });
+  edits.erase(it, edits.end());
+  // If no remaining edits, just return the global action
+  if (edits.empty()) return result;
+  // Else make a local code action as well
+  result.emplace_back(CodeAction{
+      .title = edits.size() > 1 ? "Expand all AUTOs in selected range"
+                                : "Expand this AUTO",
+      .kind = "refactor.rewrite",
+      .diagnostics = {},
+      .isPreferred = false,
+      .edit = {.changes = {{p.textDocument.uri, edits}}},
+  });
+  return result;
+}
+
+}  // namespace verilog

--- a/verilog/tools/ls/autoexpand.h
+++ b/verilog/tools/ls/autoexpand.h
@@ -1,0 +1,37 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef VERILOG_TOOLS_LS_AUTOEXPAND_H
+#define VERILOG_TOOLS_LS_AUTOEXPAND_H
+
+#include <vector>
+
+#include "common/lsp/lsp-protocol.h"
+#include "verilog/tools/ls/lsp-parse-buffer.h"
+
+// Functions for Emacs' Verilog-Mode-style AUTO expansion.
+
+namespace verilog {
+
+// Generate AUTO expansion text edits for the given buffer
+std::vector<verible::lsp::TextEdit> GenerateAutoExpandTextEdits(
+    const BufferTracker *tracker);
+
+// Generate AUTO expansion code actions for the given code action params
+std::vector<verible::lsp::CodeAction> GenerateAutoExpandCodeActions(
+    const BufferTracker *tracker, const verible::lsp::CodeActionParams &p);
+
+}  // namespace verilog
+#endif  // VERILOG_TOOLS_LS_VERIBLE_LSP_ADAPTER_H

--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -1,0 +1,281 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/tools/ls/autoexpand.h"
+
+#include "common/lsp/lsp-protocol.h"
+#include "gtest/gtest.h"
+#include "verilog/tools/ls/verible-lsp-adapter.h"
+
+namespace verilog {
+namespace {
+using verible::lsp::CodeActionParams;
+using verible::lsp::EditTextBuffer;
+using verible::lsp::Range;
+using verible::lsp::TextDocumentContentChangeEvent;
+using verible::lsp::TextEdit;
+
+void TestTextEdits(
+    const std::function<std::vector<TextEdit>(BufferTracker*)>& editFun,
+    absl::string_view textBefore, absl::string_view textGolden,
+    bool repeat = true) {
+  EditTextBuffer buffer(textBefore);
+  BufferTracker tracker;
+  tracker.Update("<<test>>", buffer);
+  std::vector<TextEdit> edits = editFun(&tracker);
+  // Sort the TextEdits from the last one in the buffer to the first one. This
+  // way we can apply them one by one and have the following ones still be
+  // valid.
+  // Note: according to the spec, TextEdits should never overlap.
+  std::sort(edits.begin(), edits.end(), [](auto& first, auto& second) {
+    if (first.range.start.line == second.range.end.line) {
+      return first.range.start.character > second.range.end.character;
+    }
+    return first.range.start.line > second.range.end.line;
+  });
+  // Sort the TextEdits from the last one in the buffer to the first one. This
+  for (const auto& edit : edits) {
+    buffer.ApplyChange(TextDocumentContentChangeEvent{
+        .range = edit.range, .has_range = true, .text = edit.newText});
+  }
+  buffer.RequestContent([&](absl::string_view textAfter) {
+    EXPECT_EQ(textAfter, textGolden);
+    if (repeat) {
+      TestTextEdits(editFun, textGolden, textGolden, false);
+    }
+  });
+}
+
+std::vector<TextEdit> AutoExpandCodeActionToTextEdits(BufferTracker* tracker,
+                                                      Range range,
+                                                      absl::string_view title) {
+  CodeActionParams p = {.textDocument = {tracker->current()->uri()},
+                        .range = range};
+  nlohmann::json changes;
+  for (auto& action : GenerateAutoExpandCodeActions(tracker, p)) {
+    if (action.title == title) {
+      EXPECT_TRUE(changes.empty());
+      changes = action.edit.changes;
+    }
+  }
+  EXPECT_FALSE(changes.empty());
+  return changes[p.textDocument.uri];
+}
+
+TEST(Autoexpand, ExpandEmpty) {
+  TestTextEdits(GenerateAutoExpandTextEdits,
+                R"(
+module t1(/*AUTOARG*/);
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+module t2(/*AUTOARG*/);
+  input logic clk;
+  input rst;
+  output reg o;
+endmodule
+)",
+                R"(
+module t1(/*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Outputs
+  o
+  );
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+module t2(/*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Outputs
+  o
+  );
+  input logic clk;
+  input rst;
+  output reg o;
+endmodule
+)");
+}
+
+TEST(Autoexpand, NoExpand) {
+  TestTextEdits(GenerateAutoExpandTextEdits,
+                R"(
+module t();
+  /*AUTOARG*/
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+)",
+                R"(
+module t();
+  /*AUTOARG*/
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+)");
+}
+
+TEST(Autoexpand, ExpandReplace) {
+  TestTextEdits(GenerateAutoExpandTextEdits,
+                R"(
+module t(/*AUTOARG*/
+  //Inputs
+  clk, rst
+// some comment
+);
+  input logic clk;
+  input logic rst;
+  inout logic io;
+  output logic o;
+endmodule)",
+                R"(
+module t(/*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Inouts
+  io,
+  // Outputs
+  o
+  );
+  input logic clk;
+  input logic rst;
+  inout logic io;
+  output logic o;
+endmodule)");
+}
+
+TEST(Autoexpand, SkipPredeclared) {
+  TestTextEdits(GenerateAutoExpandTextEdits,
+                R"(
+module t(i,
+         o1, /*AUTOARG*/
+//Inputs
+clk, rst
+);
+  input logic clk;
+  input logic rst;
+  input logic i;
+  output logic o1;
+  output logic o2;
+endmodule)",
+                R"(
+module t(i,
+         o1, /*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Outputs
+  o2
+  );
+  input logic clk;
+  input logic rst;
+  input logic i;
+  output logic o1;
+  output logic o2;
+endmodule)");
+}
+
+TEST(Autoexpand, CodeActionExpandAll) {
+  TestTextEdits(
+      [](BufferTracker* tracker) {
+        return AutoExpandCodeActionToTextEdits(tracker, {},
+                                               "Expand all AUTOs in file");
+      },
+      R"(
+module t1(/*AUTOARG*/);
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+module t2(/*AUTOARG*/);
+  input logic clk;
+  input rst;
+  output logic o;
+endmodule
+)",
+      R"(
+module t1(/*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Outputs
+  o
+  );
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+module t2(/*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Outputs
+  o
+  );
+  input logic clk;
+  input rst;
+  output logic o;
+endmodule
+)");
+}
+
+TEST(Autoexpand, CodeActionExpandRange) {
+  TestTextEdits(
+      [](BufferTracker* tracker) {
+        return AutoExpandCodeActionToTextEdits(
+            tracker, {.start = {.line = 0}, .end = {.line = 1}},
+            "Expand this AUTO");
+      },
+      R"(
+module t1(/*AUTOARG*/);
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+module t2(/*AUTOARG*/);
+  input logic clk;
+  input rst;
+  output logic o;
+endmodule
+)",
+      R"(
+module t1(/*AUTOARG*/
+  // Inputs
+  clk,
+  rst,
+  // Outputs
+  o
+  );
+  input logic clk;
+  input logic rst;
+  output logic o;
+endmodule
+module t2(/*AUTOARG*/);
+  input logic clk;
+  input rst;
+  output logic o;
+endmodule
+)");
+}
+
+}  // namespace
+}  // namespace verilog

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -24,6 +24,7 @@
 #include "verilog/formatting/format_style_init.h"
 #include "verilog/formatting/formatter.h"
 #include "verilog/parser/verilog_token_enum.h"
+#include "verilog/tools/ls/autoexpand.h"
 #include "verilog/tools/ls/document-symbol-filler.h"
 #include "verilog/tools/ls/lsp-parse-buffer.h"
 
@@ -182,6 +183,23 @@ std::vector<verible::lsp::CodeAction> GenerateLinterCodeActions(
       preferred_fix = false;  // only the first is preferred.
     }
   }
+  return result;
+}
+
+std::vector<verible::lsp::CodeAction> GenerateCodeActions(
+    const BufferTracker *tracker, const verible::lsp::CodeActionParams &p) {
+  std::vector<verible::lsp::CodeAction> result;
+
+  if (!tracker) return result;
+  const ParsedBuffer *const current = tracker->current();
+  if (!current) return result;
+
+  result = GenerateLinterCodeActions(tracker, p);
+
+  auto auto_expand = GenerateAutoExpandCodeActions(tracker, p);
+  result.insert(result.end(), std::make_move_iterator(auto_expand.begin()),
+                make_move_iterator(auto_expand.end()));
+
   return result;
 }
 

--- a/verilog/tools/ls/verible-lsp-adapter.h
+++ b/verilog/tools/ls/verible-lsp-adapter.h
@@ -35,6 +35,10 @@ std::vector<verible::lsp::Diagnostic> CreateDiagnostics(const BufferTracker &,
 std::vector<verible::lsp::CodeAction> GenerateLinterCodeActions(
     const BufferTracker *tracker, const verible::lsp::CodeActionParams &p);
 
+// Generate all available code actions.
+std::vector<verible::lsp::CodeAction> GenerateCodeActions(
+    const BufferTracker *tracker, const verible::lsp::CodeActionParams &p);
+
 verible::lsp::FullDocumentDiagnosticReport GenerateDiagnosticReport(
     const BufferTracker *tracker,
     const verible::lsp::DocumentDiagnosticParams &p);

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -58,7 +58,7 @@ void VerilogLanguageServer::SetRequestHandlers() {
   dispatcher_.AddRequestHandler(  // Provide autofixes
       "textDocument/codeAction",
       [this](const verible::lsp::CodeActionParams &p) {
-        return verilog::GenerateLinterCodeActions(
+        return verilog::GenerateCodeActions(
             parsed_buffers_.FindBufferTrackerOrNull(p.textDocument.uri), p);
       });
 


### PR DESCRIPTION
Adds simple AUTO statement expansion support to the language server. This feature is modeled after [Emacs' Verilog-Mode](https://www.veripool.org/verilog-mode/) AUTO expansion. For now, it is limited to only the AUTOARG statement.

The AUTO expansion is implemented as LSP code actions. Two actions are currently available: a buffer-wide expansion, which works on the entire buffer, and a range-based one, which expands all AUTO statement within the range selected by the user.

Requires #1578.