### PR TITLE
Add test for two EOL comments in KDPIImportItem

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -3411,6 +3411,20 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
         "  );\n"
         "endmodule\n",
     },
+    {// Two consecutive EOL comments in kDPIImportItem
+     "import \"DPI-C\" context function void foo(\n"
+     "  input bit first,\n"
+     "  // c3\n"
+     "  // c3+\n"
+     "  input bit second\n"
+     ");\n",
+     "import \"DPI-C\" context\n"
+     "    function void foo(\n"
+     "  input bit first,\n"
+     "  // c3\n"
+     "  // c3+\n"
+     "  input bit second\n"
+     ");\n"},
     {"import \"DPI-C\" context function void func(input bit impl_i,"
      "input bit op_i,"
      "input bit [5:0] mode_i,"


### PR DESCRIPTION
When I was looking for another issue to fix, I came across #1035, which turned out to already work and format the case in a good way. In that case, I add the test to this case, and the issue related to it can be closed.

Fixes #1035.