### PR TITLE
Point CI badge to the right image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Continuous Integration](https://github.com/chipsalliance/verible/workflows/verible-ci/badge.svg)](https://github.com/chipsalliance/verible/actions/workflows/verible-ci.yml)
+[![Continuous Integration](https://github.com/chipsalliance/verible/workflows/ci/badge.svg)](https://github.com/chipsalliance/verible/actions/workflows/verible-ci.yml)
 [![codecov](https://codecov.io/gh/chipsalliance/verible/branch/master/graph/badge.svg?token=5f656dpmDT)](https://codecov.io/gh/chipsalliance/verible)
 
 <!--*


### PR DESCRIPTION
The old name was verible-ci.svg and that was passing ... however now that the CI currently is failing it became apparent, that we're pointing to the wrong image (the [name](https://github.com/chipsalliance/verible/blob/master/.github/workflows/verible-ci.yml#L1) determines the svg name; that was changed in [this commit](https://github.com/chipsalliance/verible/commit/dba385b7b0ec4610ec1c6d0d03229d2418900abd))

  * Outdated CI image ![](https://github.com/chipsalliance/verible/workflows/verible-ci/badge.svg)
  * Correct CI image ![](https://github.com/chipsalliance/verible/workflows/ci/badge.svg)