### PR TITLE
Get Verible ready to be compiled with bazel 6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,17 @@ http_archive(
 )
 
 http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+    ],
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+http_archive(
     name = "com_google_absl",
     # On MSVC's STL implementation, string_view cannot be constructed from
     # a string_view::iterator. This patch forces the use of absl's string_view


### PR DESCRIPTION
We need to explicitly use a newer bazel_skylib.
