### PR TITLE
Added delay tracking to verilog_lexical_context

### DIFF
--- a/verilog/parser/verilog_lexical_context.cc
+++ b/verilog/parser/verilog_lexical_context.cc
@@ -567,6 +567,7 @@ void LexicalContext::_UpdateState(const TokenInfo& token) {
       if (in_initial_always_final_construct_) {
         // Exit construct for single-statement bodies.
         // e.g. initial $foo();
+        seen_delay_value_in_initial_always_final_construct_context = false;
         if (block_stack_.empty()) {
           in_initial_always_final_construct_ = false;
         }
@@ -625,6 +626,12 @@ void LexicalContext::_UpdateState(const TokenInfo& token) {
       if (in_extern_declaration_) {
         in_extern_declaration_ = false;  // reset
       }
+      break;
+    case '#':
+      if (in_initial_always_final_construct_) {
+        seen_delay_value_in_initial_always_final_construct_context = true;
+      }
+      // std::cout << "Found delay" << std::endl;
       break;
     default:
       break;
@@ -740,6 +747,9 @@ WithReason<bool> LexicalContext::ExpectingBodyItemStart() const {
   }
   // return {true, "inside 'always/initial/final'"};
   // }
+  if (seen_delay_value_in_initial_always_final_construct_context) {
+    return {true, "seen a delay value, expecting another statement"};
+  }
   return {false, "all other cases (default)"};
 }
 

--- a/verilog/parser/verilog_lexical_context.h
+++ b/verilog/parser/verilog_lexical_context.h
@@ -296,6 +296,8 @@ class LexicalContext {
 
   bool in_initial_always_final_construct_ = false;
 
+  bool seen_delay_value_in_initial_always_final_construct_context = false;
+
   bool in_function_declaration_ = false;
   bool in_function_body_ = false;
 


### PR DESCRIPTION
This PR implements tracking of the delays in the context of `initial/always/final` constructs, where when delaying a statement which was an event trigger, the `_TK_RARROW` would be misinterpreted as an implication. This adds another condition to the `ExpectingStatement()` method such that after a delay it returns `true`.

Fixes #1596