### PR TITLE
Fixed symbol cast check failure in tree_unwrapper

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -99,23 +99,7 @@ readonly TEST_GIT_PROJECTS="https://github.com/lowRISC/ibex \
 # Goal: The following list shall be empty :)
 declare -A KnownIssue
 
-#--- Opentitan
-# Original issue - 1006 has been resolved
-# There is also bug 1008 which only shows up if compiled with asan
-
-#--- ivtest
-KnownIssue[formatter:$BASE_TEST_DIR/ivtest/ivltests/pr2202846c.v]=1015
-
-#--- nontrivial-mips
-KnownIssue[formatter:$BASE_TEST_DIR/nontrivial-mips/src/cpu/decode/decoder.sv]=984
-KnownIssue[formatter:$BASE_TEST_DIR/nontrivial-mips/src/cpu/exec/multi_cycle_exec.sv]=984
-
-#--- rsd
-KnownIssue[formatter:$BASE_TEST_DIR/rsd/Processor/Src/Privileged/CSR_Unit.sv]=984
-
-#--- scr1
-KnownIssue[formatter:$BASE_TEST_DIR/scr1/src/core/scr1_tapc.sv]=1015
-KnownIssue[formatter:$BASE_TEST_DIR/scr1/src/tb/scr1_memory_tb_ahb.sv]=1015
+# At the moment, the list is empty
 
 #--- Too many to mention manually, so here we do the 'waive all' approach
 declare -A KnownProjectToolIssue

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -2970,7 +2970,8 @@ void TreeUnwrapper::ReshapeTokenPartitions(
 
       // In these cases, merge the 'begin' partition of the statement block
       // with the preceding keyword or header partition.
-      if (NodeIsBeginEndBlock(
+      if (!verible::is_leaf(partition.Children().back()) &&
+          NodeIsBeginEndBlock(
               verible::SymbolCastToNode(*node.children().back()))) {
         auto& seq_block_partition = partition.Children().back();
         VLOG(4) << "block partition: " << seq_block_partition;


### PR DESCRIPTION
This PR Fixes a problem where formatter is trying to cast a preprocessor's operator (in the tree a Leaf) as a Node, where it causes a check failure and a hard crash. To solve it, I have added a check whether a given child is not a leaf.

Fixes #984 
Fixes #1015 