### PR TITLE
Fix adding disable range starting after EOF

### DIFF
--- a/verilog/formatting/comment_controls.cc
+++ b/verilog/formatting/comment_controls.cc
@@ -81,8 +81,10 @@ ByteOffsetSet DisableFormattingRanges(absl::string_view text,
     }
   }
   // If the disabling interval remains open, close it (to end-of-buffer).
-  if (begin_disable_offset != kNullOffset) {
-    disable_set.Add({begin_disable_offset, static_cast<int>(text.length())});
+  int text_length = static_cast<int>(text.length());
+  if (begin_disable_offset != kNullOffset &&
+      begin_disable_offset <= text_length) {
+    disable_set.Add({begin_disable_offset, text_length});
   }
   return disable_set;
 }

--- a/verilog/formatting/comment_controls_test.cc
+++ b/verilog/formatting/comment_controls_test.cc
@@ -92,6 +92,7 @@ TEST(DisableFormattingRangesTest, FormatOnNoEffect) {
 TEST(DisableFormattingRangesTest, FormatOffDisableToEndEOLComment) {
   const DisableRangeTestData kTestCases[] = {
       {"xxx yyy;\n  // verilog_format: off\n"},  // range to EOF is empty
+      {"xxx yyy;\n  // verilog_format: off"},
       {"xxx yyy;\n  // verilog_format: off\n", {kOff, "\n"}},
       {"xxx yyy;\n  // verilog_format: off     \n", {kOff, "\n"}},
       {"xxx yyy;\n  // verilog_format: off\n", {kOff, "\n    "}},


### PR DESCRIPTION
Addresses the #1549 issue.
This PR fixes the case when `formatter::DisableFormattingRanges` started disabling range with the offset greater than text length, which happened when `//verilog_format:off` was the last line without newline character at the end.