### PR TITLE
Revert #1595 as it creates regressions.

### DIFF
--- a/verilog/CST/verilog_matchers.h
+++ b/verilog/CST/verilog_matchers.h
@@ -286,10 +286,6 @@ static const auto AlwaysStatementHasEventControlStar =
     verible::matcher::MakePathMatcher(
         {N(kProceduralTimingControlStatement), N(kEventControl), L('*')});
 
-static const auto AlwaysStatementHasParenthesis =
-    verible::matcher::MakePathMatcher({N(kProceduralTimingControlStatement),
-                                       N(kEventControl), N(kParenGroup)});
-
 // Matches occurrence of the 'always' keyword.
 // This is needed to distinguish between various kAlwaysStatement's.
 // This matches 'always', but not 'always_ff', nor 'always_comb'.

--- a/verilog/CST/verilog_matchers_test.cc
+++ b/verilog/CST/verilog_matchers_test.cc
@@ -511,31 +511,13 @@ TEST(VerilogMatchers, AlwaysStatementHasEventControlStarTests) {
       {AlwaysStatementHasEventControlStar(),
        EmbedInModule("always @* begin a = b; end"), 1},
       {AlwaysStatementHasEventControlStar(),
+       EmbedInModule("always @(*) begin a = b; end"), 1},
+      {AlwaysStatementHasEventControlStar(),
        EmbedInModule("always @(posedge foo) begin a <= b; end"), 0},
       {AlwaysStatementHasEventControlStar(),
        EmbedInModule("always_ff begin a <= b; end\n"
                      "always_comb begin a = b; end"),
        0},
-  };
-  for (const auto& test : tests)
-    verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
-}
-
-// Tests for AlwaysStatementHaParenthesis matching
-TEST(VerilogMatchers, AlwaysStatementHasParenthesis) {
-  const RawMatcherTestCase tests[] = {
-      {AlwaysStatementHasParenthesis(),
-       EmbedInModule("always @* begin a = b; end"), 0},
-      {AlwaysStatementHasParenthesis(),
-       EmbedInModule("always @(*) begin a = b; end"), 1},
-      {AlwaysStatementHasParenthesis(),
-       EmbedInModule("always @( *) begin a = b; end"), 1},
-      {AlwaysStatementHasParenthesis(),
-       EmbedInModule("always @(* ) begin a = b; end"), 1},
-      {AlwaysStatementHasParenthesis(),
-       EmbedInModule("always @( * ) begin a = b; end"), 1},
-      {AlwaysStatementHasParenthesis(),
-       EmbedInModule("always @(posedge foo) begin a <= b; end"), 1},
   };
   for (const auto& test : tests)
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);

--- a/verilog/analysis/checkers/always_comb_rule_test.cc
+++ b/verilog/analysis/checkers/always_comb_rule_test.cc
@@ -39,6 +39,7 @@ TEST(AlwaysCombTest, FunctionFailures) {
       {"module m;\nendmodule\n"},
       {"module m;\ninitial begin end\nendmodule"},
       {"module m;\n", {kToken, "always"}, " @* begin end\nendmodule"},
+      {"module m;\n", {kToken, "always"}, " @(*) begin end\nendmodule"},
       {"module m;\nalways_ff begin a <= b; end\nendmodule"},
       {"module m;\nalways_comb begin a = b; end\nendmodule"},
   };

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -15336,38 +15336,6 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  logic/*t*/ [0 : 1]  /*t*/ a;  /*t*/\n"
      "  T1/*t*/    [0 : 1]  /*t*/ c;  /*t*/\n"
      "endclass\n"},
-    {"always @(*/*t*/) begin\n"
-     "end\n",
-     "always @(*  /*t*/) begin\n"
-     "end\n"},
-    {"always @(/*t*/*) begin\n"
-     "end\n",
-     "always @(  /*t*/ *) begin\n"
-     "end\n"},
-    {"always @(/*t*/*/*t*/) begin\n"
-     "end\n",
-     "always @(  /*t*/ *  /*t*/) begin\n"
-     "end\n"},
-    {"always @(*) begin\n"
-     "end\n",
-     "always @(*) begin\n"
-     "end\n"},
-    {"always @(* ) begin\n"
-     "end\n",
-     "always @(*) begin\n"
-     "end\n"},
-    {"always @( *) begin\n"
-     "end\n",
-     "always @(*) begin\n"
-     "end\n"},
-    {"always @( * ) begin\n"
-     "end\n",
-     "always @(*) begin\n"
-     "end\n"},
-    {"always @(  /*t*/  *   /*t*/    ) begin\n"
-     "end\n",
-     "always @(  /*t*/ *  /*t*/) begin\n"
-     "end\n"},
 
     // -----------------------------------------------------------------
 };

--- a/verilog/parser/verilog.lex
+++ b/verilog/parser/verilog.lex
@@ -184,7 +184,9 @@ AngleBracketInclude {UnterminatedAngleBracketString}>
 /* attribute lists, treated like comments */
 AttributesBegin "(*"
 AttributesEnd   [*]+")"
-AttributesContent ([^*)])*
+/* was TK_PSTAR and TK_STARP */
+AttributesContinue [^ \r\n\t\f\b)]
+AttributesContent ([^*]|("*"+[^)*]))*
 Attributes {AttributesBegin}{AttributesContent}{AttributesEnd}
 
 /* comments */
@@ -857,10 +859,36 @@ zi_zp { UpdateLocation(); return TK_zi_zp; }
 "[->" { UpdateLocation(); return TK_LBRARROW; }
 "@@" { UpdateLocation(); return TK_ATAT; }
 
-{Attributes} {
+  /* Watch out for the tricky case of (*). Cannot parse this as "(*"
+     and ")", but since I know that this is really ( * ), replace it
+     with "*" and return that. */
+  /* TODO(fangism): see if this can be simplified without lexer states. */
+{AttributesBegin} {
+  yy_push_state(ATTRIBUTE_START);
+  yymore();
+}
+<ATTRIBUTE_START>{Space}+ {
+  yymore();
+}
+<ATTRIBUTE_START>{LineTerminator} {
+  yymore();
+}
+<ATTRIBUTE_START>")" {
+  /* This is the (*) case. */
+  yy_pop_state();
+  UpdateLocation();
+  return '*';
+}
+<ATTRIBUTE_START,ATTRIBUTE_MIDDLE>{AttributesEnd} {
+  yy_pop_state();
   UpdateLocation();
   return TK_ATTRIBUTE;
 }
+<ATTRIBUTE_START>{AttributesContinue} {
+  yy_set_top_state(ATTRIBUTE_MIDDLE);
+  yymore();
+}
+<ATTRIBUTE_MIDDLE>{AttributesContent} { yymore(); }
 
   /* Only enter the EDGES state if the next token is '[', otherwise, rewind. */
 <EDGES_POSSIBLY>{

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -4129,6 +4129,7 @@ event_control
     { $$ = MakeTaggedNode(N::kEventControl, $1, MakeParenGroup($2, $3, $4));}
   | '@' '*'
     { $$ = MakeTaggedNode(N::kEventControl, $1, $2);}
+    /* same as @ (*), which the lexer returns as just '*' */
   ;
 event_control_opt
   : event_control

--- a/verilog/parser/verilog_lexer_unittest.cc
+++ b/verilog/parser/verilog_lexer_unittest.cc
@@ -79,14 +79,13 @@ static std::initializer_list<LexerTestData> kCommentTests = {
 // treating attributes lists as C-style comments,
 // except they are not returned as comment blocks.
 static std::initializer_list<SimpleTestData> kAttributeTests = {
-    {"(**)"},
-    {"(*     *)"},
-    {"(***)"},
-    {"(*\n*)"},
-    {"(* style=flat *)"},
-    {"(*foo=bar*)"},
-    {"(* style=flat, fill=empty *)"},
+    {"(**)"},        {"(*     *)"},
+    {"(* x)*)"},     {"(* **  *)"},
+    {"(***)"},       {"(** **)"},
+    {"(*\n*)"},      {"(* style=flat *)"},
+    {"(*foo=bar*)"}, {"(* style=flat, fill=empty *)"},
 };
+
 static std::initializer_list<LexerTestData> kAttributeSequenceTests = {
     {{TK_ATTRIBUTE, "(**)"}, {TK_ATTRIBUTE, "(**)"}},
     {{TK_ATTRIBUTE, "(* style=flat,\nfill=empty *)"}, {TK_NEWLINE, "\n"}},
@@ -1363,6 +1362,7 @@ static std::initializer_list<SimpleTestData> kEvalStringLiteralTests = {
 
 // tokens with special handling in lexer
 static std::initializer_list<LexerTestData> kTrickyTests = {
+    {{'*', "(*)"}},
     {{TK_COLON_DIV, ":/"}, {TK_SPACE, " "}},
     {{TK_COLON_DIV, ":/"}, {TK_DecNumber, "8"}},
     {':', {TK_EOL_COMMENT, "//"}, {TK_NEWLINE, "\n"}},
@@ -1426,6 +1426,9 @@ static std::initializer_list<LexerTestData> kSequenceTests = {
     {{MacroNumericWidth, "`WIDTH"},
      {TK_BinBase, "'b"},
      {MacroIdentifier, "`DIGITS"}},
+    {{'*', "(*)"}, {'*', "(*)"}},
+    {{'*', "(*)"}, " ", {'*', "(*)"}},
+    {{'*', "(* )"}, {'*', "(*  )"}},
 };
 
 static std::initializer_list<LexerTestData> kContextKeywordTests = {


### PR DESCRIPTION
Attributes that contain parenthesis are affected. Example:

```systemverilog
(* foo="bar()" *)
module top ();
endmodule
```

Signed-off-by: Henner Zeller <hzeller@google.com>