### PR TITLE
Provide a build version and use in language server.

### DIFF
--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -31,6 +31,15 @@
 
 namespace verible {
 
+std::string GetRepositoryVersion() {
+#ifdef VERIBLE_GIT_DESCRIBE
+  return VERIBLE_GIT_DESCRIBE;
+#else
+  return "<unknown repository version>";
+#endif
+}
+
+// Long-form of build version, might contain multiple lines
 static std::string GetBuildVersion() {
   std::string result;
   // Build a version string with as much as possible info.

--- a/common/util/init_command_line.h
+++ b/common/util/init_command_line.h
@@ -21,6 +21,9 @@
 
 namespace verible {
 
+// Get a one-line build version string that based on the repository version.
+std::string GetRepositoryVersion();
+
 // Initializes command-line tool, including parsing flags.
 // The recognized flags are initialized and their text removed from the
 // input command line, returning the remaining positional parameters.

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -91,6 +91,7 @@ cc_library(
         "//common/lsp:lsp-protocol",
         "//common/lsp:lsp-text-buffer",
         "//common/lsp:message-stream-splitter",
+        "//common/util:init_command_line",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
     ],

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -18,6 +18,7 @@
 
 #include "absl/strings/string_view.h"
 #include "common/lsp/lsp-protocol.h"
+#include "common/util/init_command_line.h"
 #include "verilog/tools/ls/verible-lsp-adapter.h"
 
 namespace verilog {
@@ -129,7 +130,7 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
   verible::lsp::InitializeResult result;
   result.serverInfo = {
       .name = "Verible Verilog language server.",
-      .version = GetVersionNumber(),
+      .version = verible::GetRepositoryVersion(),
   };
   result.capabilities = {
       {

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -29,8 +29,6 @@ class VerilogLanguageServer {
   using ReadFun = verible::lsp::MessageStreamSplitter::ReadFun;
   using WriteFun = verible::lsp::JsonRpcDispatcher::WriteFun;
 
-  static std::string GetVersionNumber() { return "0.0 alpha"; }
-
   // Constructor preparing the callbacks for Language Server requests
   VerilogLanguageServer(const WriteFun &write_fun);
 

--- a/verilog/tools/ls/verilog_ls.cc
+++ b/verilog/tools/ls/verilog_ls.cc
@@ -39,14 +39,14 @@ static void FormatHeaderBodyReply(absl::string_view reply) {
 int main(int argc, char *argv[]) {
   verible::InitCommandLine(argv[0], &argc, &argv);
 
-  std::cerr << "Verible Alpha Language Server "
-            << verilog::VerilogLanguageServer::GetVersionNumber() << std::endl;
-
 #ifdef _WIN32
   // Windows messes with newlines by default. Fix this here.
   _setmode(_fileno(stdin), _O_BINARY);
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
+
+  std::cerr << "Verible Verilog Language Server built at "
+            << verible::GetRepositoryVersion() << "\n";
 
   // Input and output is stdin and stdout
   constexpr int kInputFD = 0;  // STDIN_FILENO, but Win does not have that macro


### PR DESCRIPTION
The language server used to just output a generic version number. Change this to contain the repository version to provide more information for issued found in the field.
