### PR TITLE
Refine test and documentation of JoinPath().

### DIFF
--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -233,6 +233,12 @@ absl::Status SetContents(absl::string_view filename,
 }
 
 std::string JoinPath(absl::string_view base, absl::string_view name) {
+  // Nothing to join with ? Original name is good as is.
+  if (base.empty()) {
+    fs::path p = fs::path(std::string(name));
+    return p.lexically_normal().string();
+  }
+
   // Make sure the second element is not already absolute, otherwise
   // the fs::path() uses this as toplevel path. This is only an issue with
   // Unix paths. Windows paths will have a c:\ for explicit full-pathness

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -74,7 +74,12 @@ absl::StatusOr<std::unique_ptr<MemBlock>> GetContentAsMemBlock(
 // Create file "filename" and store given content in it.
 absl::Status SetContents(absl::string_view filename, absl::string_view content);
 
-// Join directory + filename
+// Join directory + filename and lightly canonicalize.
+// The canonicalization step unifies ./ and ../ path elements lexically
+// without touching the underlying file-system.
+//
+// Even if "filename" already looks absolute, "base" is still prepended.
+// TODO(hzeller): Need something like JoinPathRespectAbsolute() ?
 std::string JoinPath(absl::string_view base, absl::string_view name);
 
 // Create directory with given name, return success.

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -98,14 +98,23 @@ TEST(FileUtil, JoinPath) {
   EXPECT_EQ(file::JoinPath("foo", "bar"), PlatformPath("foo/bar"));
 
   // Assemble an absolute path
-  EXPECT_EQ(file::JoinPath("", "bar"), "bar");
+  EXPECT_EQ(file::JoinPath("", "/bar"), PlatformPath("/bar"));
   EXPECT_EQ(file::JoinPath("/", "bar"), PlatformPath("/bar"));
+  EXPECT_EQ(file::JoinPath("/", "/bar"), PlatformPath("/bar"));
 
   // Lightly canonicalize multiple consecutive slashes
   EXPECT_EQ(file::JoinPath("foo/", "bar"), PlatformPath("foo/bar"));
   EXPECT_EQ(file::JoinPath("foo///", "bar"), PlatformPath("foo/bar"));
   EXPECT_EQ(file::JoinPath("foo/", "/bar"), PlatformPath("foo/bar"));
   EXPECT_EQ(file::JoinPath("foo/", "///bar"), PlatformPath("foo/bar"));
+
+  // Lightly canonicalize ./ and ../
+  EXPECT_EQ(file::JoinPath("", "./bar"), PlatformPath("bar"));
+  EXPECT_EQ(file::JoinPath("", "./bar/../bar"), PlatformPath("bar"));
+  EXPECT_EQ(file::JoinPath(".", "./bar"), PlatformPath("bar"));
+  EXPECT_EQ(file::JoinPath("foo/./", "./bar"), PlatformPath("foo/bar"));
+  EXPECT_EQ(file::JoinPath("/foo/./", "./bar"), PlatformPath("/foo/bar"));
+  EXPECT_EQ(file::JoinPath("/foo/baz/../", "./bar"), PlatformPath("/foo/bar"));
 
 #ifdef _WIN32
   EXPECT_EQ(file::JoinPath("C:\\foo", "bar"), "C:\\foo\\bar");


### PR DESCRIPTION
Also fix a case in which an existing absolute path would become relative if the base directory to prepend was an empty string.
