### PR TITLE
Utilize absl::Duration formatting to print times in human readable form.

### DIFF
--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -78,7 +78,7 @@ absl::Status VerilogSourceFile::Parse() {
   const absl::Time analyze_start = absl::Now();
   status_ = analyzed_structure_->Analyze();
   LOG(INFO) << "Analyzed " << ResolvedPath() << " in "
-            << absl::ToInt64Milliseconds(absl::Now() - analyze_start) << "ms";
+            << (absl::Now() - analyze_start);
   state_ = State::kParsed;
   return status_;
 }

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -289,8 +289,7 @@ void StreamKytheFactsEntries(KytheOutput* kythe_output,
     // Output facts and edges.
     kythe_extractor.ExtractFile(root);
     LOG(INFO) << "Extracted Kythe facts of " << file_path << " in "
-              << absl::ToInt64Milliseconds(absl::Now() - extraction_start)
-              << "ms";
+              << (absl::Now() - extraction_start);
   }
 
   VLOG(1) << "end of " << __FUNCTION__;


### PR DESCRIPTION
Code that runs faster than a millisecond was otherwise just printed as 0ms.
