### PR TITLE
Don't use Kate symbol mapping by default. Choose a mapping for VSCode.

### DIFF
--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -26,12 +26,23 @@
 // Magic value to hint that we have to fill out the start range.
 static constexpr int kUninitializedStartLine = -1;
 
+// verible::lsp::SymbolKind::Module is just shown as {} namespace symbol
+// in vscode. 'Method' looks slightly nicer as little block. So emit a
+// symbol in the document tree that has the nicer look.
+// TODO(hzeller): This is hacky. We already have a mapping for kate. Looks
+//  like it is a good idea to have some re-mapping per editor (which we then
+//  identify via the initialization script. So we pass in a mapping instead
+//  of a flag.
+//  Well _ideally_ the editors would just show proper icons.
+static constexpr verible::lsp::SymbolKind kVSCodeModule =
+    verible::lsp::SymbolKind::Method;
+
 namespace verilog {
 DocumentSymbolFiller::DocumentSymbolFiller(
     bool kate_workaround, const verible::TextStructureView &text,
     verible::lsp::DocumentSymbol *toplevel)
     : kModuleSymbolKind(kate_workaround ? verible::lsp::SymbolKind::Method
-                                        : verible::lsp::SymbolKind::Module),
+                                        : kVSCodeModule),
       kBlockSymbolKind(kate_workaround ? verible::lsp::SymbolKind::Class
                                        : verible::lsp::SymbolKind::Namespace),
       text_view_(text),

--- a/verilog/tools/ls/verible-lsp-adapter.h
+++ b/verilog/tools/ls/verible-lsp-adapter.h
@@ -50,7 +50,7 @@ verible::lsp::FullDocumentDiagnosticReport GenerateDiagnosticReport(
 // boolean to make it visible what is needed.
 nlohmann::json CreateDocumentSymbolOutline(
     const BufferTracker *tracker, const verible::lsp::DocumentSymbolParams &p,
-    bool kate_compatible_tags = true);
+    bool kate_compatible_tags = false);
 
 // Given a position in a document, return ranges in the buffer that should
 // be highlighted.

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -281,7 +281,7 @@ endmodule
   // Descent tree into module and find labelled block.
   std::vector<verible::lsp::DocumentSymbol> module = toplevel[1].children;
   EXPECT_EQ(module.size(), 1);
-  EXPECT_EQ(module[0].kind, verible::lsp::SymbolKind::Class);  // namespace
+  EXPECT_EQ(module[0].kind, verible::lsp::SymbolKind::Namespace);
   EXPECT_EQ(module[0].name, "labelled_block");
 }
 


### PR DESCRIPTION
VSCode is a larger user-base, so by default don't enable symbol mapping from the document outline to match Kate.

However, to look good in vscode, another hack was needed: the icon for 'module' looks like a generic namespace icon, which is already pretty common with labelled blocks. So instead, emit a symbol whose representation looks 'nicer' in vscode.

TODO: at some point, add some editor-specific mappings that then attempt to map correctly from the initailzation string sent to the language server.
