### PR TITLE
JoinPath(): if path is already absolute, don't prepend anything.

### DIFF
--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -233,19 +233,6 @@ absl::Status SetContents(absl::string_view filename,
 }
 
 std::string JoinPath(absl::string_view base, absl::string_view name) {
-  // Nothing to join with ? Original name is good as is.
-  if (base.empty()) {
-    fs::path p = fs::path(std::string(name));
-    return p.lexically_normal().string();
-  }
-
-  // Make sure the second element is not already absolute, otherwise
-  // the fs::path() uses this as toplevel path. This is only an issue with
-  // Unix paths. Windows paths will have a c:\ for explicit full-pathness
-  while (!name.empty() && name[0] == '/') {
-    name = name.substr(1);
-  }
-
   fs::path p = fs::path(std::string(base)) / fs::path(std::string(name));
   return p.lexically_normal().string();
 }

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -76,10 +76,9 @@ absl::Status SetContents(absl::string_view filename, absl::string_view content);
 
 // Join directory + filename and lightly canonicalize.
 // The canonicalization step unifies ./ and ../ path elements lexically
-// without touching the underlying file-system.
+// without looking at the underlying file-system.
 //
-// Even if "filename" already looks absolute, "base" is still prepended.
-// TODO(hzeller): Need something like JoinPathRespectAbsolute() ?
+// If "filename" is already absolute, "base" is not prepended.
 std::string JoinPath(absl::string_view base, absl::string_view name);
 
 // Create directory with given name, return success.

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -102,11 +102,13 @@ TEST(FileUtil, JoinPath) {
   EXPECT_EQ(file::JoinPath("/", "bar"), PlatformPath("/bar"));
   EXPECT_EQ(file::JoinPath("/", "/bar"), PlatformPath("/bar"));
 
+  // Absolute path stays absolute, base not prepended.
+  EXPECT_EQ(file::JoinPath("foo/", "/bar"), PlatformPath("/bar"));
+  EXPECT_EQ(file::JoinPath("foo/", "///bar"), PlatformPath("/bar"));
+
   // Lightly canonicalize multiple consecutive slashes
   EXPECT_EQ(file::JoinPath("foo/", "bar"), PlatformPath("foo/bar"));
   EXPECT_EQ(file::JoinPath("foo///", "bar"), PlatformPath("foo/bar"));
-  EXPECT_EQ(file::JoinPath("foo/", "/bar"), PlatformPath("foo/bar"));
-  EXPECT_EQ(file::JoinPath("foo/", "///bar"), PlatformPath("foo/bar"));
 
   // Lightly canonicalize ./ and ../
   EXPECT_EQ(file::JoinPath("", "./bar"), PlatformPath("bar"));
@@ -115,6 +117,12 @@ TEST(FileUtil, JoinPath) {
   EXPECT_EQ(file::JoinPath("foo/./", "./bar"), PlatformPath("foo/bar"));
   EXPECT_EQ(file::JoinPath("/foo/./", "./bar"), PlatformPath("/foo/bar"));
   EXPECT_EQ(file::JoinPath("/foo/baz/../", "./bar"), PlatformPath("/foo/bar"));
+
+  // Document behavior of concatenating current directory.
+  EXPECT_EQ(file::JoinPath("", "."), PlatformPath("."));
+  EXPECT_EQ(file::JoinPath("", "./"), PlatformPath("."));
+  EXPECT_EQ(file::JoinPath("./", ""), PlatformPath("."));
+  EXPECT_EQ(file::JoinPath(".", ""), PlatformPath("."));
 
 #ifdef _WIN32
   EXPECT_EQ(file::JoinPath("C:\\foo", "bar"), "C:\\foo\\bar");

--- a/verilog/tools/project/project_tool_test.sh
+++ b/verilog/tools/project/project_tool_test.sh
@@ -233,6 +233,21 @@ grep -q "(@fooo -> \$root::fooo)" "$MY_OUTPUT_FILE" || {
 }
 
 ################################################################################
+echo "=== Same as above, but with absolute file on cmdline"
+
+"$project_tool" \
+  symbol-table-refs \
+  $MY_INPUT_FILE \
+  > "$MY_OUTPUT_FILE" 2>&1
+
+status="$?"
+[[ $status == 0 ]] || {
+  cat "$MY_OUTPUT_FILE"
+  echo "$LINENO: Expected exit code 0, but got $status"
+  exit 1
+}
+
+################################################################################
 echo "=== Load one file containing syntax error (build-and-resolve)."
 
 cat > "$MY_INPUT_FILE" <<EOF


### PR DESCRIPTION
The behavior of JoinPath() used to be that paths are just concatenated inddpendent if the path in question is already absolute.

  JoinPath("foo/", "bar") -> "foo/bar"  OK
  JoinPath("foo", "/bar") -> "foo/bar"  questionable

This looks like it is a left-over from keeping the behavior the same from the simplistic old implementation that just concatenated strings. (https://github.com/chipsalliance/verible/commit/495dda72923d1a13422a6f3a3fd131ed3b1fff37)

However, this results in unexpected behavior. The new behavior is to keep absolute paths as-is.

  JoinPath("foo", "/bar") -> "/bar"  EXPECTED

Add a test on project tool test that illustrates the problem that is solved.