### PR TITLE
Remove file_list_path in filelist struct as it is not used.

### DIFF
--- a/verilog/analysis/verilog_filelist.cc
+++ b/verilog/analysis/verilog_filelist.cc
@@ -32,7 +32,6 @@ absl::Status AppendFileListFromContent(absl::string_view file_list_path,
                                        FileList* append_to) {
   // TODO(hzeller): parse +define+ and stash into preprocessing configuration.
   constexpr absl::string_view kIncludeDirPrefix = "+incdir+";
-  append_to->file_list_path = std::string(file_list_path);
   append_to->preprocessing.include_dirs.push_back(".");  // Should we do that?
   std::string file_path;
   std::istringstream stream(file_list_content);

--- a/verilog/analysis/verilog_filelist.h
+++ b/verilog/analysis/verilog_filelist.h
@@ -38,10 +38,7 @@ struct TextMacroDefinition {
 //       the first files don't see all the incdirs yet, but after more incdirs
 //       are added, all of them are relevant ? If so, this would require some
 //       restructering.
-// TODO: document if files are relative to tool invocation or relative to
-//       file_list_path (the latter makes more sense, but I think currently that
-//       is underspecified).
-// TODO: Alongside previous: also introduce file_list_root field ?
+// TODO: Introduce file_list_root field ?
 struct FileList {
   // A struct holding information relevant to "VerilogPreprocess" preprocessor.
   struct PreprocessingInfo {
@@ -51,9 +48,6 @@ struct FileList {
     // Defined macros.
     std::vector<TextMacroDefinition> defines;
   };
-
-  // Path to the file list.
-  std::string file_list_path;
 
   // Ordered list of files to compile.
   std::vector<std::string> file_paths;

--- a/verilog/analysis/verilog_filelist_test.cc
+++ b/verilog/analysis/verilog_filelist_test.cc
@@ -40,7 +40,6 @@ TEST(FileListTest, AppendFileListFromFile) {
   auto status = AppendFileListFromFile(file_list_file.filename(), &result);
   ASSERT_TRUE(status.ok()) << status;
 
-  EXPECT_EQ(result.file_list_path, file_list_file.filename());
   EXPECT_THAT(result.file_paths,
               ElementsAre("/a/source/file/1.sv", "/a/source/file/2.sv"));
   EXPECT_THAT(result.preprocessing.include_dirs,

--- a/verilog/tools/project/project_tool.cc
+++ b/verilog/tools/project/project_tool.cc
@@ -75,10 +75,8 @@ struct VerilogProjectConfig {
         include_paths.end());
 
     file_list_root = absl::GetFlag(FLAGS_file_list_root);
-    file_list.file_list_path = absl::GetFlag(FLAGS_file_list_path);
-    if (!file_list.file_list_path.empty()) {
-      return verilog::AppendFileListFromFile(file_list.file_list_path,
-                                             &file_list);
+    if (auto fl_path = absl::GetFlag(FLAGS_file_list_path); !fl_path.empty()) {
+      return verilog::AppendFileListFromFile(fl_path, &file_list);
     }
 
     if (file_list.file_paths.empty()) {


### PR DESCRIPTION
This just adds confusion as it is unclear if files are relative to that path, but it does not do any of that function.
