### PR TITLE
Import base class constructor: document rare use of using statement.

### DIFF
--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -179,7 +179,6 @@ cc_library(
         ":syntax_tree_context",
         ":visitors",
         "//common/strings:display_utils",
-        "//common/util:logging",
     ],
 )
 

--- a/common/text/tree_context_visitor.cc
+++ b/common/text/tree_context_visitor.cc
@@ -17,7 +17,6 @@
 #include <vector>
 
 #include "common/text/syntax_tree_context.h"
-#include "common/util/logging.h"
 
 namespace verible {
 

--- a/common/text/tree_context_visitor.h
+++ b/common/text/tree_context_visitor.h
@@ -61,7 +61,7 @@ int CompareSyntaxTreePath(const SyntaxTreePath& a, const SyntaxTreePath& b);
 // minimize heap allocations, because these are expected to be small.
 class SyntaxTreePath : public std::vector<int> {
  public:
-  using std::vector<int>::vector;
+  using std::vector<int>::vector;  // Import base class constructors
 
   bool operator==(const SyntaxTreePath& rhs) const {
     return CompareSyntaxTreePath(*this, rhs) == 0;


### PR DESCRIPTION
So that they are not accidentally interpreted as importing a std:: namespace object.

While at it: remove an unused dependency.