### PR TITLE
Fix a syntax tree problem when processing a single `verilog_syntax` directive

### DIFF
--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -194,6 +194,13 @@ void TextStructureView::FocusOnSubtreeSpanningSubstring(int left_offset,
   VLOG(2) << __FUNCTION__ << " at " << left_offset << " +" << length;
   const int right_offset = left_offset + length;
   TrimSyntaxTree(left_offset, right_offset);
+
+  // Don't let the syntax tree be empty.
+  // Always return a tree with one node.
+  // This can happen when TrimSyntaxTree() yields a nullptr syntax tree
+  if (syntax_tree_ == nullptr) {
+    syntax_tree_ = MakeNode();
+  }
   TrimTokensToSubstring(left_offset, right_offset);
   TrimContents(left_offset, length);
   lazy_lines_info_.valid = false;

--- a/verilog/analysis/verilog_analyzer_test.cc
+++ b/verilog/analysis/verilog_analyzer_test.cc
@@ -353,6 +353,70 @@ TEST(AnalyzeVerilogAutomaticMode, NormalModeModule) {
   EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
 }
 
+TEST(AnalyzeVerilogAutomaticMode, StatementsModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-statements", "<file>",
+          kDefaultPreprocess);
+  EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, ModuleBodyModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-module-body", "<file>",
+          kDefaultPreprocess);
+  EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, ClassBodyModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-class-body", "<file>",
+          kDefaultPreprocess);
+  EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, PackageBodyModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-package-body", "<file>",
+          kDefaultPreprocess);
+  EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, LibraryMapModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-library-map", "<file>",
+          kDefaultPreprocess);
+  EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, SingleDirectiveInvalidSelection) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: does-not-exist-mode", "<file>",
+          kDefaultPreprocess);
+  EXPECT_OK(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, ExpressionModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-expression", "<file>",
+          kDefaultPreprocess);
+  EXPECT_FALSE(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus().ok());
+}
+
+TEST(AnalyzeVerilogAutomaticMode, PropertySpecModeSingleDirective) {
+  std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
+      VerilogAnalyzer::AnalyzeAutomaticMode(
+          "// verilog_syntax: parse-as-property-spec", "<file>",
+          kDefaultPreprocess);
+  EXPECT_FALSE(ABSL_DIE_IF_NULL(analyzer_ptr)->ParseStatus().ok());
+}
+
 TEST(AnalyzeVerilogAutomaticMode, NormalModeModuleInvalidSelection) {
   std::unique_ptr<VerilogAnalyzer> analyzer_ptr =
       VerilogAnalyzer::AnalyzeAutomaticMode(

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -9895,6 +9895,24 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
 
     // between identifier and '(', no args
 
+    {"// verilog_syntax: parse-as-module-body",
+     "// verilog_syntax: parse-as-module-body\n"},
+    {"// verilog_syntax: parse-as-statements",
+     "// verilog_syntax: parse-as-statements\n"},
+    {"// verilog_syntax: parse-as-class-body",
+     "// verilog_syntax: parse-as-class-body\n"},
+    {"// verilog_syntax: parse-as-package-body",
+     "// verilog_syntax: parse-as-package-body\n"},
+    {"// verilog_syntax: parse-as-library-map",
+     "// verilog_syntax: parse-as-library-map\n"},
+    {"// verilog_syntax: does-not-exist-mode",
+     "// verilog_syntax: does-not-exist-mode\n"},
+    {"// verilog_syntax: parse-as-module-body\n",
+     "// verilog_syntax: parse-as-module-body\n"},
+    {"// verilog_syntax: parse-as-module-body\n"
+     "// comment",
+     "// verilog_syntax: parse-as-module-body\n"
+     "// comment\n"},
     {"// verilog_syntax: parse-as-module-body\n"
      "$foobarbaz /* c */ ();\n",
      "// verilog_syntax: parse-as-module-body\n"


### PR DESCRIPTION
Fixes a syntax tree problem when processing a single `verilog_syntax` directive returning `syntax_tree_` as `nullptr`.

Fixes #1552