### PR TITLE
Cleanup: Define SymbolPtr only in one place.

### DIFF
--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -65,7 +65,10 @@ cc_library(
 cc_library(
     name = "symbol",
     srcs = ["symbol.cc"],
-    hdrs = ["symbol.h"],
+    hdrs = [
+        "symbol.h",
+        "symbol_ptr.h",
+    ],
     deps = [
         ":token_info",
         ":visitors",

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -51,9 +51,6 @@
 
 namespace verible {
 
-// Using unique_ptr in the symbol stack requires careful moving.
-using SymbolPtr = std::unique_ptr<Symbol>;
-
 // Currently, a tree *is* a tree-node, but this may change in the future.
 // Treat this as an opaque type.
 using ConcreteSyntaxTree = SymbolPtr;

--- a/common/text/symbol.h
+++ b/common/text/symbol.h
@@ -22,14 +22,11 @@
 #include <iosfwd>
 #include <memory>
 
+#include "common/text/symbol_ptr.h"
 #include "common/text/token_info.h"
 #include "common/text/visitors.h"
 
 namespace verible {
-
-class Symbol;
-
-using SymbolPtr = std::unique_ptr<Symbol>;
 using TokenComparator =
     std::function<bool(const TokenInfo &, const TokenInfo &)>;
 

--- a/common/text/symbol_ptr.h
+++ b/common/text/symbol_ptr.h
@@ -1,0 +1,24 @@
+// Copyright 2017-2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_COMMON_TEXT_SYMBOLPTR_H__
+#define VERIBLE_COMMON_TEXT_SYMBOLPTR_H__
+
+#include <memory>
+
+namespace verible {
+class Symbol;
+using SymbolPtr = std::unique_ptr<Symbol>;
+}  // namespace verible
+#endif  // VERIBLE_COMMON_TEXT_SYMBOLPTR_H__

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -61,7 +61,7 @@ class TextStructureView {
   // TODO(b/136014603): Replace with expandable token stream view abstraction.
   struct DeferredExpansion {
     // Position in the syntax tree to expand (leaf or node).
-    std::unique_ptr<Symbol>* expansion_point;
+    SymbolPtr* expansion_point;
 
     // Analysis of the substring that corresponds to the expansion_point.
     std::unique_ptr<TextStructure> subanalysis;

--- a/common/text/visitors.h
+++ b/common/text/visitors.h
@@ -15,12 +15,11 @@
 #ifndef VERIBLE_COMMON_TEXT_VISITORS_H_
 #define VERIBLE_COMMON_TEXT_VISITORS_H_
 
-#include <memory>
+#include "common/text/symbol_ptr.h"
 
 namespace verible {
 
 // forward declaration to allow pointers in function prototypes
-class Symbol;
 class SyntaxTreeLeaf;
 class SyntaxTreeNode;
 
@@ -65,8 +64,8 @@ class SymbolVisitor {
 class MutableTreeVisitorRecursive {
  public:
   virtual ~MutableTreeVisitorRecursive() {}
-  virtual void Visit(const SyntaxTreeLeaf& leaf, std::unique_ptr<Symbol>*) = 0;
-  virtual void Visit(const SyntaxTreeNode& node, std::unique_ptr<Symbol>*) = 0;
+  virtual void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr*) = 0;
+  virtual void Visit(const SyntaxTreeNode& node, SymbolPtr*) = 0;
 };
 
 }  // namespace verible

--- a/verilog/CST/verilog_tree_json_test.cc
+++ b/verilog/CST/verilog_tree_json_test.cc
@@ -32,7 +32,7 @@ TEST(VerilogTreeJsonTest, GeneratesGoodJsonTree) {
       "module foo;\nendmodule\n", "fake_file.sv");
   const auto status = ABSL_DIE_IF_NULL(analyzer_ptr)->Analyze();
   EXPECT_TRUE(status.ok()) << status.message();
-  const std::unique_ptr<verible::Symbol>& tree_ptr = analyzer_ptr->SyntaxTree();
+  const verible::SymbolPtr& tree_ptr = analyzer_ptr->SyntaxTree();
   ASSERT_NE(tree_ptr, nullptr);
 
   const json tree_json(verilog::ConvertVerilogTreeToJson(

--- a/verilog/CST/verilog_tree_print_test.cc
+++ b/verilog/CST/verilog_tree_print_test.cc
@@ -35,7 +35,7 @@ TEST(VerilogTreePrintTest, Prints) {
   EXPECT_TRUE(status.ok());
   std::ostringstream stream;
   EXPECT_TRUE(stream.str().empty());
-  const std::unique_ptr<verible::Symbol>& tree_ptr = analyzer->SyntaxTree();
+  const verible::SymbolPtr& tree_ptr = analyzer->SyntaxTree();
   ASSERT_NE(tree_ptr, nullptr);
 
   PrettyPrintVerilogTree(*tree_ptr, analyzer->Data().Contents(), &stream);

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -81,7 +81,7 @@ static bool NodeIsBeginEndBlock(const SyntaxTreeNode& node) {
   return node.MatchesTagAnyOf({NodeEnum::kSeqBlock, NodeEnum::kGenerateBlock});
 }
 
-static SyntaxTreeNode& GetBlockEnd(const SyntaxTreeNode& block) {
+static const SyntaxTreeNode& GetBlockEnd(const SyntaxTreeNode& block) {
   CHECK(NodeIsBeginEndBlock(block));
   return verible::SymbolCastToNode(*block.children().back());
 }


### PR DESCRIPTION
This was mostly already happening, however a few places explicitly mentioned std::unique_ptr<Symbol> 'manually'.
