### PR TITLE
Keep the code clean from using RTTI

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -82,6 +82,10 @@ case "$MODE" in
     bazel test --keep_going --cache_test_results=no --test_output=errors $BAZEL_OPTS ${CHOSEN_TARGETS}
     ;;
 
+  test-nortti)
+    bazel test --keep_going --cache_test_results=no --test_output=errors $BAZEL_OPTS --cxxopt=-fno-rtti ${CHOSEN_TARGETS}
+    ;;
+
   asan|asan-clang)
     if [[ "${MODE}" == "asan" ]]; then
       # Some gcc 12 issue with regexp it seems.
@@ -113,7 +117,7 @@ case "$MODE" in
 
   smoke-test-analyzer)
     SMOKE_LOGGING_DIR=/tmp/error-logs/ $(dirname $0)/smoke-test.sh
-    python3 $(dirname $0)/error-log-analyzer.py /tmp/error-logs/ --verible-path $(dirname $0)/../../ 
+    python3 $(dirname $0)/error-log-analyzer.py /tmp/error-logs/ --verible-path $(dirname $0)/../../
     cat sta.md >> $GITHUB_STEP_SUMMARY
     ;;
 

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -114,6 +114,7 @@ jobs:
       matrix:
         mode:
         - test
+        - test-nortti
         - smoke-test
         - smoke-test-analyzer
         - asan

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -87,12 +87,11 @@ class SyntaxTreeNode final : public Symbol {
   // If node is actually a leaf, just append the leaf.
   void AppendChild(ForwardChildren forwarded_children) {
     if (forwarded_children.node == nullptr) return;
-    auto* node = dynamic_cast<SyntaxTreeNode*>(forwarded_children.node.get());
-    if (node == nullptr) {
-      // Could be a SyntaxTreeLeaf, for instance.
+    if (forwarded_children.node->Kind() != SymbolKind::kNode) {
       children_.push_back(std::move(forwarded_children.node));
       return;
     }
+    auto* node = down_cast<SyntaxTreeNode*>(forwarded_children.node.get());
     const auto new_size = children_.size() + node->children_.size();
     children_.reserve(new_size);
     for (auto& child : node->children_) {

--- a/verilog/analysis/checkers/always_comb_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.cc
@@ -25,6 +25,7 @@
 #include "common/analysis/syntax_tree_search.h"
 #include "common/text/symbol.h"
 #include "common/text/syntax_tree_context.h"
+#include "common/util/casts.h"
 #include "verilog/CST/verilog_matchers.h"  // IWYU pragma: keep
 #include "verilog/analysis/descriptions.h"
 #include "verilog/analysis/lint_rule_registry.h"
@@ -32,6 +33,7 @@
 namespace verilog {
 namespace analysis {
 
+using verible::down_cast;
 using verible::LintRuleStatus;
 using verible::LintViolation;
 using verible::SearchSyntaxTree;
@@ -68,10 +70,9 @@ void AlwaysCombBlockingRule::HandleSymbol(const verible::Symbol& symbol,
   if (AlwaysCombMatcher().Matches(symbol, &manager)) {
     for (const auto& match :
          SearchSyntaxTree(symbol, NodekNonblockingAssignmentStatement())) {
-      const auto* node =
-          dynamic_cast<const verible::SyntaxTreeNode*>(match.match);
+      if (match.match->Kind() != verible::SymbolKind::kNode) continue;
 
-      if (node == nullptr) continue;
+      const auto* node = down_cast<const verible::SyntaxTreeNode*>(match.match);
 
       const verible::SyntaxTreeLeaf* leaf = verible::GetSubtreeAsLeaf(
           *node, NodeEnum::kNonblockingAssignmentStatement, 1);

--- a/verilog/analysis/lint_rule_registry_test.cc
+++ b/verilog/analysis/lint_rule_registry_test.cc
@@ -104,8 +104,10 @@ TEST(LintRuleRegistryTest, CreateTreeLintRuleInvalid) {
 TEST(LintRuleRegistryTest, CreateTreeLintRuleValid) {
   auto any_rule = CreateSyntaxTreeLintRule("test-rule-1");
   EXPECT_NE(any_rule, nullptr);
+#if defined(__GXX_RTTI)
   auto rule_1 = dynamic_cast<TreeRule1*>(any_rule.get());
   EXPECT_NE(rule_1, nullptr);
+#endif
 }
 
 // Verifies that GetAllRuleDescriptionsHelpFlag correctly gets the descriptions
@@ -155,8 +157,10 @@ TEST(LintRuleRegistryTest, CreateTokenLintRuleInvalid) {
 TEST(LintRuleRegistryTest, CreateTokenLintRuleValid) {
   auto any_rule = CreateTokenStreamLintRule("token-rule-1");
   EXPECT_NE(any_rule, nullptr);
+#if defined(__GXX_RTTI)
   auto rule_1 = dynamic_cast<TokenRule1*>(any_rule.get());
   EXPECT_NE(rule_1, nullptr);
+#endif
 }
 
 // Verifies that GetAllRuleDescriptionsHelpFlag correctly gets the descriptions
@@ -202,8 +206,10 @@ TEST(LintRuleRegistryTest, CreateLineLintRuleInvalid) {
 TEST(LintRuleRegistryTest, CreateLineLintRuleValid) {
   auto any_rule = CreateLineLintRule("line-rule-1");
   EXPECT_NE(any_rule, nullptr);
+#if defined(__GXX_RTTI)
   auto rule_1 = dynamic_cast<LineRule1*>(any_rule.get());
   EXPECT_NE(rule_1, nullptr);
+#endif
 }
 
 // Verifies that GetAllRuleDescriptionsHelpFlag correctly gets the descriptions
@@ -249,8 +255,10 @@ TEST(LintRuleRegistryTest, CreateTextLintRuleInvalid) {
 TEST(LintRuleRegistryTest, CreateTextLintRuleValid) {
   auto any_rule = CreateTextStructureLintRule("text-rule-1");
   EXPECT_NE(any_rule, nullptr);
+#if defined(__GXX_RTTI)
   auto rule_1 = dynamic_cast<TextRule1*>(any_rule.get());
   EXPECT_NE(rule_1, nullptr);
+#endif
 }
 
 TEST(LintRuleRegistryTest, ConfigureFactoryCreatedRule) {


### PR DESCRIPTION
There were two instances of using dynamic_cast<> that could already be implemented with calling Symbol::Kind().

Add a test that compiles without RTTI, so that it is discovered automatically when a dynamic_cast is added.

For now, keeping the binaries as-is compiled with RTTI, but they would be about 100kiB smaller without.
Leaving it for another day to check if the performance improved marginally.
