### PR TITLE
Issue #1647 Handling `textDocument/definition` request without FileList

### DIFF
--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -199,9 +199,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinition(
     const verible::lsp::DefinitionParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
   const absl::Time finddefinition_start = absl::Now();
-  bool filelist_loaded =
-      LoadProjectFileList(curr_project_->TranslationUnitRoot());
-  if (!filelist_loaded) return {};
+  LoadProjectFileList(curr_project_->TranslationUnitRoot());
   if (files_dirty_) {
     std::vector<absl::Status> diagnostics = BuildProjectSymbolTable();
     bool success = true;


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/verible/issues/1647

This PR adds a fix for the `textDocument/definition` request - when we work on currently edited file, we don't need a `verible.filelist` file to perform go-to definition jump.

Here we remove quitting `FindDefinition` function when `FileList` is not available - it will collect symbols from currently opened buffers.