### PR TITLE
Provide a simple platform-independent thread_pool.

### DIFF
--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -54,6 +54,17 @@ cc_library(
 )
 
 cc_library(
+    name = "thread_pool",
+    srcs = ["thread_pool.cc"],
+    hdrs = ["thread_pool.h"],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-fexceptions"],
+    }),
+    features = ["-use_header_modules"],  # precompiled headers incompatible with -fexceptions.
+)
+
+cc_library(
     name = "file_util",
     srcs = ["file_util.cc"],
     hdrs = ["file_util.h"],
@@ -405,6 +416,21 @@ cc_test(
         ":iterator_range",
         ":range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "thread_pool_test",
+    srcs = ["thread_pool_test.cc"],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-fexceptions"],
+    }),
+    features = ["-use_header_modules"],  # precompiled headers incompatible with -fexceptions.
+    deps = [
+        ":thread_pool",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/util/thread_pool.cc
+++ b/common/util/thread_pool.cc
@@ -1,0 +1,66 @@
+// Copyright 2017-2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/util/thread_pool.h"
+
+namespace verible {
+ThreadPool::ThreadPool(int thread_count) {
+  for (int i = 0; i < thread_count; ++i) {
+    threads_.push_back(new std::thread(&ThreadPool::Runner, this));
+  }
+}
+
+ThreadPool::~ThreadPool() {
+  CancelAllWork();
+  for (auto *t : threads_) {
+    t->join();
+    delete t;
+  }
+}
+
+void ThreadPool::Runner() {
+  std::function<void()> process_work_item;
+  for (;;) {
+    {
+      std::unique_lock<std::mutex> l(lock_);
+      cv_.wait(l, [this]() { return !work_queue_.empty() || exiting_; });
+      if (exiting_) return;
+      process_work_item = work_queue_.front();
+      work_queue_.pop_front();
+    }
+    process_work_item();
+  }
+}
+
+void ThreadPool::EnqueueWork(const std::function<void()> &work) {
+  if (threads_.empty()) {
+    work();  // synchronous execution
+    return;
+  }
+
+  {
+    std::unique_lock<std::mutex> l(lock_);
+    work_queue_.emplace_back(work);
+  }
+  cv_.notify_one();
+}
+
+void ThreadPool::CancelAllWork() {
+  {
+    std::unique_lock<std::mutex> l(lock_);
+    exiting_ = true;
+  }
+  cv_.notify_all();
+}
+}  // namespace verible

--- a/common/util/thread_pool.h
+++ b/common/util/thread_pool.h
@@ -1,0 +1,75 @@
+// Copyright 2017-2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_COMMON_UTIL_THREAD_POOL_H
+#define VERIBLE_COMMON_UTIL_THREAD_POOL_H
+
+#include <deque>
+#include <functional>
+#include <future>
+#include <thread>
+#include <vector>
+
+namespace verible {
+// Simple thread-pool.
+// Passing in functions, returning futures.
+//
+// Why not use std::async() ? That standard is so generic and vaguely
+// specified that in practice there is no implementation of a policy that
+// provides a thread-pool behavior with a guaranteed upper bound of cores used
+// on all platforms.
+class ThreadPool {
+ public:
+  // Create thread pool with "thread_count" threads.
+  // If that count is zero, functions will be executed synchronously.
+  ThreadPool(int thread_count);
+
+  // Exit ASAP and leave remaining work in queue unfinished.
+  ~ThreadPool();
+
+  // Add a function returning T, that is to be executed asynchronously.
+  // Return a std::future<T> with the eventual result.
+  //
+  // As a special case: if initialized with no threads, the function is
+  // executed synchronously.
+  template <class T>
+  std::future<T> ExecAsync(const std::function<T()> &f) {
+    std::promise<T> *p = new std::promise<T>();
+    std::future<T> future_result = p->get_future();
+    auto promise_fulfiller = [p, f]() {
+      try {
+        p->set_value(f());
+      } catch (...) {
+        p->set_exception(std::current_exception());
+      }
+      delete p;
+    };
+    EnqueueWork(promise_fulfiller);
+    return future_result;
+  }
+
+ private:
+  void Runner();
+  void CancelAllWork();
+  void EnqueueWork(const std::function<void()> &work);
+
+  std::vector<std::thread *> threads_;
+  std::mutex lock_;
+  std::condition_variable cv_;
+  std::deque<std::function<void()>> work_queue_;
+  bool exiting_ = false;
+};
+
+}  // namespace verible
+#endif  // VERIBLE_COMMON_UTIL_THREAD_POOL_H

--- a/common/util/thread_pool_test.cc
+++ b/common/util/thread_pool_test.cc
@@ -1,0 +1,90 @@
+// Copyright 2017-2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/util/thread_pool.h"
+
+#include <chrono>
+#include <vector>
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+
+using namespace std::chrono_literals;
+
+#include "gtest/gtest.h"
+
+namespace verible {
+namespace {
+
+// Use up some time to make it more likely to tickle the actual thread
+// exeuction.
+static void PretendWork(int ms) { absl::SleepFor(absl::Milliseconds(ms)); }
+
+TEST(ThreadPoolTest, SynchronousExecutionIfThreadCountZero) {
+  ThreadPool pool(0);
+  std::future<int> foo_ture = pool.ExecAsync<int>([]() -> int {
+    PretendWork(200);
+    return 42;
+  });
+
+  EXPECT_EQ(std::future_status::ready, foo_ture.wait_for(1ms))
+      << "Must be available immediately after return";
+  EXPECT_EQ(foo_ture.get(), 42);
+}
+
+TEST(ThreadPoolTest, WorkIsCompleted) {
+  constexpr int kLoops = 100;
+  ThreadPool pool(3);
+
+  std::vector<std::future<int>> results;
+  for (int i = 0; i < kLoops; ++i) {
+    results.emplace_back(pool.ExecAsync<int>([i]() -> int {
+      PretendWork(10);
+      return i;
+    }));
+  }
+
+  // Can't easily make a blackbox test that verifies that the functions are
+  // even executed in different threads, but at least let's verify that all
+  // of them finish with the expected result.
+  for (int i = 0; i < kLoops; ++i) {
+    EXPECT_EQ(results[i].get(), i);
+  }
+}
+
+TEST(ThreadPoolTest, ExceptionsArePropagated) {
+  constexpr int kLoops = 10;
+  ThreadPool pool(3);
+
+  std::vector<std::future<int>> results;
+  for (int i = 0; i < 10; ++i) {
+    results.emplace_back(pool.ExecAsync<int>([]() -> int {
+      throw 1;
+      return 0;
+    }));
+  }
+
+  int exception_count = 0;
+  for (int i = 0; i < kLoops; ++i) {
+    try {
+      results[i].get();
+    } catch (...) {
+      ++exception_count;
+    }
+  }
+  EXPECT_EQ(exception_count, kLoops);
+}
+
+}  // namespace
+}  // namespace verible


### PR DESCRIPTION
This is in preparation to using it for processing files in parallel, initially for large file-lists to symbolize in the language server.
