### PR TITLE
Provide a fallback git date and version.

### DIFF
--- a/bazel/build-version.py
+++ b/bazel/build-version.py
@@ -39,10 +39,16 @@ def main():
     version = ""
 
   if not date:
-    date = os.environ["GIT_DATE"]
+    try:
+      date = os.environ["GIT_DATE"]
+    except:
+      date = "<unknown-git-date>"
 
   if not version:
-    version = os.environ["GIT_VERSION"]
+    try:
+      version = os.environ["GIT_VERSION"]
+    except:
+      version = "<unknown-git-version>"
 
   print("GIT_DATE", '"{}"'.format(date))
   print("GIT_DESCRIBE", '"{}"'.format(version))


### PR DESCRIPTION
If git is not available and the GIT_DATE and GIT_VERSION environment variables are not set, fall back to a
generic string.

Fixes #1658
