### PR TITLE
If no bash is needed, simplify to use /bin/sh

### DIFF
--- a/common/parser/move_yacc_stack_symbols.sh
+++ b/common/parser/move_yacc_stack_symbols.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/common/parser/record_syntax_error.sh
+++ b/common/parser/record_syntax_error.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Copyright 2017-2020 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
These are scripts critical for the build, so keep the system requirements as barebones as possible.

Issues #1669

Signed-off-by: Henner Zeller <hzeller@google.com>