### PR TITLE
Patch installer to not use unnecessary option -T on install binary

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,11 @@ http_archive(
 # 'make install' equivalent rule
 http_archive(
     name = "com_github_google_rules_install",
+    # The installer uses an option -T that is not available on MacOS, but
+    # it is benign to leave out.
+    # Upstream bug https://github.com/google/bazel_rules_install/issues/31
+    patch_args = ["-p1"],
+    patches = ["//bazel:installer.patch"],
     sha256 = "880217b21dbd40928bbe3bca3d97bd4de7d70d5383665ec007d7e1aac41d9739",
     strip_prefix = "bazel_rules_install-5ae7c2a8d22de2558098e3872fc7f3f7edc61fb4",
     urls = ["https://github.com/google/bazel_rules_install/archive/5ae7c2a8d22de2558098e3872fc7f3f7edc61fb4.zip"],

--- a/bazel/installer.patch
+++ b/bazel/installer.patch
@@ -1,0 +1,11 @@
+--- ./installer/installer.bash.template.orig	2023-02-01 13:10:18.224882680 -0800
++++ ./installer/installer.bash.template	2023-02-01 13:10:30.952848590 -0800
+@@ -104,7 +104,7 @@
+     $sudo mkdir --parents -- "${target_dir}"
+ 
+   $sudo install -m "${target_mode}" \
+-    -T -- "${source}" "${target_dir}/${target_name}"
++    -- "${source}" "${target_dir}/${target_name}"
+ }
+ 
+ function main() {


### PR DESCRIPTION
This option is not compatible with the `install` found on MacOS.

Issues #1404
