### PR TITLE
Add severity to language server's diagnostics

### DIFF
--- a/common/lsp/lsp-protocol-enums.h
+++ b/common/lsp/lsp-protocol-enums.h
@@ -19,15 +19,22 @@
 // done separately here.
 namespace verible {
 namespace lsp {
+// Deliberately no enum class as this enum is used as set of integer constants
+// in the context of the Language Server Protocol, so static_cast<int>-ing
+// them would be needed every time.
+enum DiagnosticSeverity {
+  Error = 1,
+  Warning = 2,
+  Info = 3,
+  Hint = 4,
+};
+
 // These are the SymbolKinds defined by the LSP specifcation
 // https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#symbolKind
 // Interesting is, that not all of them are actually supported by all
 // editors (playing around with Kate (https://kate-editor.org/)). So maybe
 // these editors need to be made understanding.
-//
-// Deliberately no enum class as this enum is used as set of integer constants
-// in the context of the Language Server Protocol, so static_cast<int>-ing
-// them would be needed every time.
+// As above, deliberately not enum class
 enum SymbolKind {
   File = 1,
   Module = 2,     // SV module. Kate does not seem to support that ?

--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -86,6 +86,7 @@ DidCloseTextDocumentParams:     # textDocument/didClose
 # -- textDocument/publishDiagnostics
 Diagnostic:
   range: Range
+  severity?: integer   # DiagnosticSeverity enum
   source: string = "verible"
   message: string
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -50,6 +50,7 @@ cc_library(
         ":document-symbol-filler",
         ":lsp-parse-buffer",
         "//common/lsp:lsp-protocol",
+        "//common/lsp:lsp-protocol-enums",
         "//common/lsp:lsp-protocol-operators",
         "//common/text:text_structure",
         "//verilog/analysis:verilog_analyzer",

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -15,6 +15,7 @@
 
 #include "verilog/tools/ls/verible-lsp-adapter.h"
 
+#include "common/lsp/lsp-protocol-enums.h"
 #include "common/lsp/lsp-protocol-operators.h"
 #include "common/lsp/lsp-protocol.h"
 #include "common/text/text_structure.h"
@@ -43,6 +44,8 @@ static verible::lsp::Diagnostic ViolationToDiagnostic(
                         .character = range.start.column},
               .end = {.line = range.end.line, .character = range.end.column},
           },
+      .severity = verible::lsp::DiagnosticSeverity::Warning,
+      .has_severity = true,
       .message = absl::StrCat(violation.reason, " ", v.status->url, "[",
                               v.status->lint_rule_name, "]", fix_msg),
   };
@@ -95,12 +98,15 @@ std::vector<verible::lsp::Diagnostic> CreateDiagnostics(
           if (!msg.empty()) {  // Note: msg is often empty and not useful.
             absl::StrAppend(&message, " ", msg);
           }
-          // TODO(hzeller): Add severity into lsp::Diagnostic json.
           result.emplace_back(verible::lsp::Diagnostic{
               .range{.start{.line = range.start.line,
                             .character = range.start.column},
                      .end{.line = range.end.line,  //
                           .character = range.end.column}},
+              .severity = severity == verible::ErrorSeverity::kError
+                              ? verible::lsp::DiagnosticSeverity::Error
+                              : verible::lsp::DiagnosticSeverity::Warning,
+              .has_severity = true,
               .message = message,
           });
         });


### PR DESCRIPTION
Adds support for diagnostic severity in the language server.

Before:
![before](https://user-images.githubusercontent.com/9216518/216355734-84e5b49e-b699-4645-93a1-def1294fdd59.png)

After:
![after](https://user-images.githubusercontent.com/9216518/216355761-d7556b9f-02e6-49ae-aef5-f2b357e7d0aa.png)


Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>