### PR TITLE
Changed VSCode plugin language capabilities

### DIFF
--- a/verilog/tools/ls/vscode/package.json
+++ b/verilog/tools/ls/vscode/package.json
@@ -15,14 +15,14 @@
   "contributes": {
     "languages": [
       {
-        "id": "system-verilog",
+        "id": "systemverilog",
         "extensions": [
           ".sv",
           ".v"
         ],
         "aliases": [
           "System Verilog",
-          "systemverilog",
+          "system-verilog",
           "verilog"
         ]
       }
@@ -41,7 +41,7 @@
     }
   },
   "activationEvents": [
-    "onLanguage:system-verilog",
+    "onLanguage:systemverilog",
     "onLanguage:verilog"
   ],
   "categories": [

--- a/verilog/tools/ls/vscode/src/extension.ts
+++ b/verilog/tools/ls/vscode/src/extension.ts
@@ -17,7 +17,7 @@ function initLanguageClient() {
     // Options to control the language client
     const clientOptions: vscodelc.LanguageClientOptions = {
         // Register the server for (System)Verilog documents
-        documentSelector: [{ scheme: 'file', language: 'system-verilog' },
+        documentSelector: [{ scheme: 'file', language: 'systemverilog' },
                            { scheme: 'file', language: 'verilog' }]
     };
 


### PR DESCRIPTION
This PR changes how SystemVerilog capability is being communicated to VSCode, from `system-verilog` to just `systemverilog` - it is the default way, otherwise it produces conflicts with other packages and does not load the plugin alongside them.

Fixes #1666 
