### PR TITLE
[LSP] textDocument/definition: Going to ports and module definitions

### DIFF
--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -224,6 +224,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
       case NodeEnum::kPortList:
         DeclarePorts(node);
         break;
+      case NodeEnum::kModulePortDeclaration:
       case NodeEnum::kPortItem:           // fall-through
                                           // for function/task parameters
       case NodeEnum::kPortDeclaration:    // fall-through
@@ -607,7 +608,18 @@ class SymbolTable::Builder : public TreeContextVisitor {
         Context().DirectParentsAre(
             {NodeEnum::kUnqualifiedId,
              NodeEnum::kDataTypeImplicitBasicIdDimensions,
-             NodeEnum::kPortItem})) {
+             NodeEnum::kPortItem}) ||
+        Context().DirectParentsAre(
+            {NodeEnum::kUnqualifiedId, NodeEnum::kModulePortDeclaration}) ||
+        Context().DirectParentsAre(
+            {NodeEnum::kUnqualifiedId, NodeEnum::kIdentifierUnpackedDimensions,
+             NodeEnum::kIdentifierList, NodeEnum::kModulePortDeclaration}) ||
+        Context().DirectParentsAre({NodeEnum::kIdentifierUnpackedDimensions,
+                                    NodeEnum::kIdentifierUnpackedDimensionsList,
+                                    NodeEnum::kModulePortDeclaration}) ||
+        Context().DirectParentsAre({NodeEnum::kPortIdentifier,
+                                    NodeEnum::kPortIdentifierList,
+                                    NodeEnum::kModulePortDeclaration})) {
       // This identifier declares a (non-parameter) port (of a module,
       // function, task).
       EmplaceTypedElementInCurrentScope(

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -618,6 +618,9 @@ class SymbolTable::Builder : public TreeContextVisitor {
             {NodeEnum::kUnqualifiedId, NodeEnum::kIdentifierUnpackedDimensions,
              NodeEnum::kIdentifierList, NodeEnum::kModulePortDeclaration}) ||
         Context().DirectParentsAre({NodeEnum::kIdentifierUnpackedDimensions,
+                                    NodeEnum::kIdentifierList,
+                                    NodeEnum::kModulePortDeclaration}) ||
+        Context().DirectParentsAre({NodeEnum::kIdentifierUnpackedDimensions,
                                     NodeEnum::kIdentifierUnpackedDimensionsList,
                                     NodeEnum::kModulePortDeclaration}) ||
         Context().DirectParentsAre({NodeEnum::kPortIdentifier,
@@ -1056,8 +1059,9 @@ class SymbolTable::Builder : public TreeContextVisitor {
       // then we assume it is a different type on both sides (hence the
       // conflict)
       if (!(is_first_direction || is_second_direction || is_first_sign ||
-            is_second_sign))
+            is_second_sign)) {
         return true;
+      }
     }
     if (second->Kind() == verible::SymbolKind::kNode) {
       const SyntaxTreeNode* second_node =

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -231,7 +231,12 @@ struct DeclarationTypeInfo {
   // which can be recovered by StringSpanOfSymbol(const verible::Symbol&).
   const verible::Symbol* syntax_origin = nullptr;
 
+  // holds optional string_view describing direction of the port
   absl::string_view direction = "";
+
+  // holds additional type specifications, used mostly in multiline definitions
+  // of ports
+  std::vector<const verible::Symbol*> type_specifications;
 
   // Pointer to the reference node that represents a user-defined type, if
   // applicable.

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -280,6 +280,15 @@ struct SymbolInfo {
   // Reminder: Parts of the syntax tree may originate from included files.
   const verible::Symbol* syntax_origin = nullptr;
 
+  // vector to additional definition entries, e.g. for port definitions
+  // TODO (glatosinski): I guess we should include more information here rather
+  // than just string_view pointing to the symbol, or add string_view pointing
+  // to the symbol in the Symbol class
+  std::vector<absl::string_view> supplement_definitions;
+
+  // bool telling if the given symbol is a port identifier
+  bool is_port_identifier = false;
+
   // What is the type associated with this symbol?
   // Only applicable to typed elements: variables, nets, instances,
   // typedefs, etc.

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -346,7 +346,7 @@ struct SymbolInfo {
       : metatype(metatype),
         file_origin(file_origin),
         syntax_origin(syntax_origin),
-        declared_type(declared_type) {}
+        declared_type(std::move(declared_type)) {}
 
   // move-only
   SymbolInfo(const SymbolInfo&) = delete;

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -231,6 +231,8 @@ struct DeclarationTypeInfo {
   // which can be recovered by StringSpanOfSymbol(const verible::Symbol&).
   const verible::Symbol* syntax_origin = nullptr;
 
+  absl::string_view direction = "";
+
   // Pointer to the reference node that represents a user-defined type, if
   // applicable.
   // For built-in and primitive types, this is left as nullptr.

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -9138,6 +9138,91 @@ TEST(BuildSymbolTableTest,
   }
 }
 
+TEST(BuildSymbolTableTest,
+     ModulePortDeclarationTypeMultilineCorrectSignPlacements) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m(a, b, c, d);\n"
+                            "  input signed [10:0] a;\n"
+                            "  output unsigned [10:0] b;\n"
+                            "  input [10:0] c;\n"
+                            "  output [10:0] d;\n"
+                            "  wire [10:0] a;\n"
+                            "  logic [10:0] b;\n"
+                            "  logic unsigned [10:0] c;\n"
+                            "  wire signed [10:0] d;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+}
+
+TEST(BuildSymbolTableTest,
+     ModulePortDeclarationTypeMultilineWithMismatchingSigns) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m(mport);\n"
+                            "  input unsigned [10:0] mport;\n"
+                            "  reg signed [10:0] mport;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode& root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  EXPECT_EQ(module_node_info.metatype, SymbolMetaType::kModule);
+  EXPECT_EQ(module_node_info.file_origin, &src);
+  EXPECT_EQ(module_node_info.declared_type.syntax_origin,
+            nullptr);  // there is no module meta-type
+
+  ASSIGN_MUST_HAVE_UNIQUE(err_status, build_diagnostics);
+  EXPECT_EQ(err_status.code(), absl::StatusCode::kAlreadyExists);
+  EXPECT_THAT(err_status.message(),
+              HasSubstr("\"mport\" is already defined in the $root::m scope"));
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);  // nothing to resolve
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
+TEST(BuildSymbolTableTest, ModulePortDeclarationTypeMultilineWithPortList) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m(a, b, c);\n"
+                            "  input a, b;\n"
+                            "  output b, c;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode& root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  EXPECT_EQ(module_node_info.metatype, SymbolMetaType::kModule);
+  EXPECT_EQ(module_node_info.file_origin, &src);
+  EXPECT_EQ(module_node_info.declared_type.syntax_origin,
+            nullptr);  // there is no module meta-type
+
+  ASSIGN_MUST_HAVE_UNIQUE(err_status, build_diagnostics);
+  EXPECT_EQ(err_status.code(), absl::StatusCode::kAlreadyExists);
+  EXPECT_THAT(err_status.message(),
+              HasSubstr("\"b\" is already defined in the $root::m scope"));
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);  // nothing to resolve
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
 struct FileListTestCase {
   absl::string_view contents;
   std::vector<absl::string_view> expected_files;

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -9091,6 +9091,53 @@ TEST(BuildSymbolTableTest, ModulePortDeclarationTypeRedefinition) {
   }
 }
 
+TEST(BuildSymbolTableTest, ModulePortDeclarationTypeMultilineWithDimensions) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m(mport);\n"
+                            "  input [10:0] mport;\n"
+                            "  reg [10:0] mport;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+}
+
+TEST(BuildSymbolTableTest,
+     ModulePortDeclarationTypeMultilineWithMismatchingDimensions) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m(mport);\n"
+                            "  input [10:0] mport;\n"
+                            "  reg [8:0] mport;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode& root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  EXPECT_EQ(module_node_info.metatype, SymbolMetaType::kModule);
+  EXPECT_EQ(module_node_info.file_origin, &src);
+  EXPECT_EQ(module_node_info.declared_type.syntax_origin,
+            nullptr);  // there is no module meta-type
+
+  ASSIGN_MUST_HAVE_UNIQUE(err_status, build_diagnostics);
+  EXPECT_EQ(err_status.code(), absl::StatusCode::kAlreadyExists);
+  EXPECT_THAT(err_status.message(),
+              HasSubstr("\"mport\" is already defined in the $root::m scope"));
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);  // nothing to resolve
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
 struct FileListTestCase {
   absl::string_view contents;
   std::vector<absl::string_view> expected_files;

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5588,36 +5588,36 @@ module_port_declaration
    */
   : port_direction signed_unsigned_opt qualified_id decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, MakeDataType($3,
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, MakeDataType($2, $3,
                           MakePackedDimensionsNode($4)),
                           $5, $6); }
   | port_direction signed_unsigned_opt unqualified_id decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, MakeDataType($3,
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, MakeDataType($2, $3,
                           MakePackedDimensionsNode($4)),
                           $5, $6); }
   | port_direction signed_unsigned_opt decl_dimensions delay3_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2,
-                          MakeDataType(nullptr, nullptr, $4, MakePackedDimensionsNode($3)),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1,
+                          MakeDataType($2, nullptr, $4, MakePackedDimensionsNode($3)),
                           $5, $6);}
     /* implicit type */
   | port_direction signed_unsigned_opt delay3
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, MakeDataType(nullptr, nullptr, $3, nullptr), $4, $5); }
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, MakeDataType($2, nullptr, $3, nullptr), $4, $5); }
     /* implicit type */
   | port_direction signed_unsigned_opt list_of_module_item_identifiers ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3, MakeDataType(nullptr), $4);}
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, MakeDataType($2, nullptr, nullptr), $3, $4);}
     /* implicit type */
   | port_direction port_net_type signed_unsigned_opt decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $3,
-                          MakeDataType(ForwardChildren($2), MakePackedDimensionsNode($4)),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1,
+                          MakeDataType($3, ForwardChildren($2), MakePackedDimensionsNode($4)),
                           $5, $6); }
   | dir var_type signed_unsigned_opt decl_dimensions_opt
     list_of_port_identifiers ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $3,
-                          MakeDataType(ForwardChildren($2), MakePackedDimensionsNode($4)),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1,
+                          MakeDataType($3, ForwardChildren($2), MakePackedDimensionsNode($4)),
                           $5, $6); }
   ;
 

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5582,36 +5582,36 @@ module_port_declaration
    */
   : port_direction signed_unsigned_opt qualified_id decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3,
-                          MakePackedDimensionsNode($4),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, MakeDataType($3,
+                          MakePackedDimensionsNode($4)),
                           $5, $6); }
   | port_direction signed_unsigned_opt unqualified_id decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3,
-                          MakePackedDimensionsNode($4),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, MakeDataType($3,
+                          MakePackedDimensionsNode($4)),
                           $5, $6); }
   | port_direction signed_unsigned_opt decl_dimensions delay3_opt
     list_of_identifiers_unpacked_dimensions ';'
     { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2,
-                          MakePackedDimensionsNode($3), $4,
+                          MakeDataType(nullptr, nullptr, $4, MakePackedDimensionsNode($3)),
                           $5, $6);}
     /* implicit type */
   | port_direction signed_unsigned_opt delay3
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3, $4, $5); }
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, MakeDataType(nullptr, nullptr, $3, nullptr), $4, $5); }
     /* implicit type */
   | port_direction signed_unsigned_opt list_of_module_item_identifiers ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3, $4);}
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3, MakeDataType(nullptr), $4);}
     /* implicit type */
   | port_direction port_net_type signed_unsigned_opt decl_dimensions_opt
     list_of_identifiers_unpacked_dimensions ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3,
-                          MakePackedDimensionsNode($4),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $3,
+                          MakeDataType(ForwardChildren($2), MakePackedDimensionsNode($4)),
                           $5, $6); }
   | dir var_type signed_unsigned_opt decl_dimensions_opt
     list_of_port_identifiers ';'
-    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $2, $3,
-                          MakePackedDimensionsNode($4),
+    { $$ = MakeTaggedNode(N::kModulePortDeclaration, $1, $3,
+                          MakeDataType(ForwardChildren($2), MakePackedDimensionsNode($4)),
                           $5, $6); }
   ;
 

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5572,11 +5572,11 @@ net_declaration
   //   trailing_assign_opt ',' net_decl_assigns ';'
   // | net_type data_type_or_implicit drive_strength net_decl_assigns ';'
   | TK_trireg charge_strength_opt decl_dimensions_opt delay3_opt list_of_identifiers ';'
-    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), $2,
+    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType(nullptr, $1, $4, nullptr), $2,
                           MakePackedDimensionsNode($3),
-                          $4, $5, $6); }
+                          $5, $6); }
   | net_type delay3 net_variable_or_decl_assigns ';'
-  { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), nullptr, nullptr, $2, $3, $4); }
+  { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType(nullptr, $1, $2, nullptr), nullptr, nullptr, $3, $4); }
   /* TODO(fangism): net_type_identifer [ delay_control ] list_of_net_decl_assignments */
   /* TODO(fangism): TK_interconnect ... */
   ;

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5549,11 +5549,17 @@ module_parameter_port_list_item_last
     { $$ = MakeTaggedNode(N::kFormalParameterList, $1); }
   ;
 
+// TODO (glatosinski) MakeDataType is introduced here to mark
+// all tokens responsible for data creation for a given net
+// declaration.
+// Additional information, such as dimensions should be possibly
+// included too, for type comparison purposes (for multiline port
+// declaration)
 net_declaration
   : net_type net_variable_or_decl_assigns ';'
-    { $$ = MakeTaggedNode(N::kNetDeclaration, $1, nullptr, $2, $3); }
+    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), nullptr, $2, $3); }
   | net_type data_type_or_implicit net_variable_or_decl_assigns ';'
-    { $$ = MakeTaggedNode(N::kNetDeclaration, $1, $2, $3, $4); }
+    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), $2, $3, $4); }
     /* TODO(fangism): support drive_strength and charge_strength */
   // : net_type data_type_or_implicit delay3_opt net_variable_list ';'
   // : net_type data_type_or_implicit delay3 net_variable_list ';'
@@ -5566,11 +5572,11 @@ net_declaration
   //   trailing_assign_opt ',' net_decl_assigns ';'
   // | net_type data_type_or_implicit drive_strength net_decl_assigns ';'
   | TK_trireg charge_strength_opt decl_dimensions_opt delay3_opt list_of_identifiers ';'
-    { $$ = MakeTaggedNode(N::kNetDeclaration, $1, $2,
+    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), $2,
                           MakePackedDimensionsNode($3),
                           $4, $5, $6); }
   | net_type delay3 net_variable_or_decl_assigns ';'
-  { $$ = MakeTaggedNode(N::kNetDeclaration, $1, nullptr, nullptr, $2, $3, $4); }
+  { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), nullptr, nullptr, $2, $3, $4); }
   /* TODO(fangism): net_type_identifer [ delay_control ] list_of_net_decl_assignments */
   /* TODO(fangism): TK_interconnect ... */
   ;

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -200,9 +200,8 @@ const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
   if (context->Key() && verible::IsSubRange(*context->Key(), symbol)) {
     return context;
   }
-  for (const auto &supplement_definition :
-       context->Value().supplement_definitions) {
-    if (verible::IsSubRange(supplement_definition, symbol)) {
+  for (const auto &sdef : context->Value().supplement_definitions) {
+    if (verible::IsSubRange(sdef, symbol)) {
       return context;
     }
   }
@@ -294,14 +293,12 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinitionLocation(
   // Symbol not found
   if (!node) return {};
   std::vector<verible::lsp::Location> locations;
-  std::optional<verible::lsp::Location> location =
+  const std::optional<verible::lsp::Location> location =
       GetLocationFromSymbolName(*node->Key(), node->Value().file_origin);
   if (!location) return {};
   locations.push_back(*location);
-  for (const auto &supplement_definition :
-       node->Value().supplement_definitions) {
-    std::optional<verible::lsp::Location> loc = GetLocationFromSymbolName(
-        supplement_definition, node->Value().file_origin);
+  for (const auto &sdef : node->Value().supplement_definitions) {
+    const auto loc = GetLocationFromSymbolName(sdef, node->Value().file_origin);
     if (loc) locations.push_back(*loc);
   }
   return locations;
@@ -322,7 +319,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindReferencesLocations(
     const verible::lsp::ReferenceParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
   Prepare();
-  absl::string_view symbol =
+  const absl::string_view symbol =
       GetTokenAtTextDocumentPosition(params, parsed_buffers);
   const SymbolTableNode &root = symbol_table_->Root();
   const SymbolTableNode *node = ScanSymbolTreeForDefinition(&root, symbol);
@@ -339,8 +336,8 @@ void SymbolTableHandler::CollectReferencesReferenceComponents(
     const SymbolTableNode *definition_node,
     std::vector<verible::lsp::Location> *references) {
   if (ref->Value().resolved_symbol == definition_node) {
-    std::optional<verible::lsp::Location> loc = GetLocationFromSymbolName(
-        ref->Value().identifier, ref_origin->Value().file_origin);
+    const auto loc = GetLocationFromSymbolName(ref->Value().identifier,
+                                               ref_origin->Value().file_origin);
     if (loc) references->push_back(*loc);
   }
   for (const auto &childref : ref->Children()) {

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -287,10 +287,18 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinitionLocation(
   const SymbolTableNode *node = ScanSymbolTreeForDefinition(&root, symbol);
   // Symbol not found
   if (!node) return {};
+  std::vector<verible::lsp::Location> locations;
   std::optional<verible::lsp::Location> location =
       GetLocationFromSymbolName(*node->Key(), node->Value().file_origin);
   if (!location) return {};
-  return {*location};
+  locations.push_back(*location);
+  for (const auto &supplement_definition :
+       node->Value().supplement_definitions) {
+    std::optional<verible::lsp::Location> loc = GetLocationFromSymbolName(
+        supplement_definition, node->Value().file_origin);
+    if (loc) locations.push_back(*loc);
+  }
+  return locations;
 }
 
 const verible::Symbol *SymbolTableHandler::FindDefinitionSymbol(

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -200,6 +200,12 @@ const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
   if (context->Key() && verible::IsSubRange(*context->Key(), symbol)) {
     return context;
   }
+  for (const auto &supplement_definition :
+       context->Value().supplement_definitions) {
+    if (verible::IsSubRange(supplement_definition, symbol)) {
+      return context;
+    }
+  }
   for (const auto &ref : context->Value().local_references_to_bind) {
     if (ref.Empty()) continue;
     const SymbolTableNode *resolved =

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -197,6 +197,9 @@ const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
   }
   // TODO (glatosinski): reduce searched scope by utilizing information from
   // syntax tree?
+  if (context->Key() && verible::IsSubRange(*context->Key(), symbol)) {
+    return context;
+  }
   for (const auto &ref : context->Value().local_references_to_bind) {
     if (ref.Empty()) continue;
     const SymbolTableNode *resolved =

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include "verilog/tools/ls/verilog-language-server.h"
 
 #include <filesystem>
@@ -489,7 +488,7 @@ TEST_F(VerilogLanguageServerTest, RangeFormattingTest) {
        0}};
 
   for (const auto &params : formatting_params) {
-    std::string request = FormattingRequest("file://fmt.sv", params);
+    const std::string request = FormattingRequest("file://fmt.sv", params);
     ASSERT_OK(SendRequest(request));
 
     const json response = json::parse(GetResponse());
@@ -662,7 +661,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestTest) {
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(module_a_uri, 2, 2, 16);
+  const std::string definition_request =
+      DefinitionRequest(module_a_uri, 2, 2, 16);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -741,7 +741,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable in b.sv file
-  std::string definition_request = DefinitionRequest(module_b_uri, 2, 4, 14);
+  const std::string definition_request =
+      DefinitionRequest(module_b_uri, 2, 4, 14);
 
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
@@ -773,7 +774,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable in b.sv file
-  std::string definition_request = DefinitionRequest(module_b_uri, 2, 4, 14);
+  const std::string definition_request =
+      DefinitionRequest(module_b_uri, 2, 4, 14);
 
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
@@ -820,7 +822,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable of a module in b.sv file
-  std::string definition_request = DefinitionRequest(module_b_uri, 2, 4, 14);
+  const std::string definition_request =
+      DefinitionRequest(module_b_uri, 2, 4, 14);
 
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
@@ -869,7 +872,8 @@ endmodule
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(module_a_uri, 2, 2, 16);
+  const std::string definition_request =
+      DefinitionRequest(module_a_uri, 2, 2, 16);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -910,7 +914,8 @@ endmodule
   GetResponse();
 
   // find definition for "var1" variable of a module in b.sv file
-  std::string definition_request = DefinitionRequest(module_b_uri, 2, 4, 15);
+  const std::string definition_request =
+      DefinitionRequest(module_b_uri, 2, 4, 15);
 
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
@@ -939,7 +944,7 @@ TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestUnsupportedURI) {
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(
+  const std::string definition_request = DefinitionRequest(
       absl::StrReplaceAll(module_a_uri, {{"file://", "https://"}}), 2, 2, 16);
 
   ASSERT_OK(SendRequest(definition_request));
@@ -968,7 +973,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(module_a_uri, 2, 1, 10);
+  const std::string definition_request =
+      DefinitionRequest(module_a_uri, 2, 1, 10);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -996,7 +1002,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(module_a_uri, 2, 1, 0);
+  const std::string definition_request =
+      DefinitionRequest(module_a_uri, 2, 1, 0);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -1024,7 +1031,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(module_b_uri, 2, 3, 2);
+  const std::string definition_request =
+      DefinitionRequest(module_b_uri, 2, 3, 2);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -1048,7 +1056,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestNoFileList) {
   GetResponse();
 
   // find definition for "var1" variable in a.sv file
-  std::string definition_request = DefinitionRequest(module_a_uri, 2, 2, 16);
+  const std::string definition_request =
+      DefinitionRequest(module_a_uri, 2, 2, 16);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -1080,7 +1089,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   GetResponse();
 
   // find definition for "var1" variable in b.sv file
-  std::string definition_request = DefinitionRequest(module_b_uri, 2, 4, 14);
+  const std::string definition_request =
+      DefinitionRequest(module_b_uri, 2, 4, 14);
 
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
@@ -1128,7 +1138,8 @@ endmodule
   GetResponse();
 
   // find definition for "bar" type
-  std::string definition_request = DefinitionRequest(module_foo_uri, 2, 1, 3);
+  const std::string definition_request =
+      DefinitionRequest(module_foo_uri, 2, 1, 3);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
@@ -1450,21 +1461,23 @@ endmodule
   const verible::file::testing::ScopedTestFile module_instmodule(
       root_dir, instmodule, "instmodule.sv");
 
+  const std::string module_instmodule_uri =
+      PathToLSPUri(module_instmodule.filename());
   const std::string foo_open_request =
-      DidOpenRequest("file://" + module_instmodule.filename(), instmodule);
+      DidOpenRequest(module_instmodule_uri, instmodule);
   ASSERT_OK(SendRequest(foo_open_request));
 
   GetResponse();
 
   // find definition for "InstModule"
-  std::string definition_request =
-      DefinitionRequest("file://" + module_instmodule.filename(), 2, 17, 3);
+  const std::string definition_request =
+      DefinitionRequest(module_instmodule_uri, 2, 17, 3);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(
-      response, 2, 0, 7, 0, 17, "file://" + module_instmodule.filename());
+  CheckDefinitionResponseSingleDefinition(response, 2, 0, 7, 0, 17,
+                                          module_instmodule_uri);
 }
 
 // Checks the go-to definition when pointing to the definition of the symbol
@@ -1495,21 +1508,23 @@ endmodule
   const verible::file::testing::ScopedTestFile module_instmodule(
       root_dir, instmodule, "instmodule.sv");
 
+  const std::string module_instmodule_uri =
+      PathToLSPUri(module_instmodule.filename());
   const std::string foo_open_request =
-      DidOpenRequest("file://" + module_instmodule.filename(), instmodule);
+      DidOpenRequest(module_instmodule_uri, instmodule);
   ASSERT_OK(SendRequest(foo_open_request));
 
   GetResponse();
 
   // find definition for "InstModule"
-  std::string definition_request =
-      DefinitionRequest("file://" + module_instmodule.filename(), 2, 0, 8);
+  const std::string definition_request =
+      DefinitionRequest(module_instmodule_uri, 2, 0, 8);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(
-      response, 2, 0, 7, 0, 17, "file://" + module_instmodule.filename());
+  CheckDefinitionResponseSingleDefinition(response, 2, 0, 7, 0, 17,
+                                          module_instmodule_uri);
 }
 
 // Checks the definition request for module port
@@ -1528,19 +1543,21 @@ endmodule
   const verible::file::testing::ScopedTestFile module_instmodule(
       root_dir, instmodule, "instmodule.sv");
 
+  const std::string module_instmodule_uri =
+      PathToLSPUri(module_instmodule.filename());
   const std::string foo_open_request =
-      DidOpenRequest("file://" + module_instmodule.filename(), instmodule);
+      DidOpenRequest(module_instmodule_uri, instmodule);
   ASSERT_OK(SendRequest(foo_open_request));
 
   GetResponse();
 
   // find definition for "i"
   std::string definition_request =
-      DefinitionRequest("file://" + module_instmodule.filename(), 2, 4, 22);
+      DefinitionRequest(module_instmodule_uri, 2, 4, 22);
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
-  CheckDefinitionResponseSingleDefinition(
-      response, 2, 2, 16, 2, 17, "file://" + module_instmodule.filename());
+  CheckDefinitionResponseSingleDefinition(response, 2, 2, 16, 2, 17,
+                                          module_instmodule_uri);
 }
 
 // Checks the definition request for module port
@@ -1561,20 +1578,22 @@ endmodule
   const verible::file::testing::ScopedTestFile module_instmodule(
       root_dir, instmodule, "instmodule.sv");
 
+  const std::string module_instmodule_uri =
+      PathToLSPUri(module_instmodule.filename());
   const std::string foo_open_request =
-      DidOpenRequest("file://" + module_instmodule.filename(), instmodule);
+      DidOpenRequest(module_instmodule_uri, instmodule);
   ASSERT_OK(SendRequest(foo_open_request));
 
   GetResponse();
 
   // find definition for "bar" type
-  std::string definition_request =
-      DefinitionRequest("file://" + module_instmodule.filename(), 2, 6, 22);
+  const std::string definition_request =
+      DefinitionRequest(module_instmodule_uri, 2, 6, 22);
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
-  CheckDefinitionResponseSingleDefinition(
-      response, 2, 5, 14, 5, 15, "file://" + module_instmodule.filename());
+  CheckDefinitionResponseSingleDefinition(response, 2, 5, 14, 5, 15,
+                                          module_instmodule_uri);
 }
 
 // Tests correctness of Language Server shutdown request

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -616,6 +616,23 @@ std::string ReferencesRequest(absl::string_view file, int id, int line,
                                           line, character);
 }
 
+// Performs assertions on textDocument/definition responses where single
+// definition is expected
+void CheckDefinitionResponseSingleDefinition(const json &response, int id,
+                                             int start_line,
+                                             int start_character, int end_line,
+                                             int end_character,
+                                             const std::string &file_uri) {
+  ASSERT_EQ(response["id"], id);
+  ASSERT_EQ(response["result"].size(), 1);
+  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], start_line);
+  ASSERT_EQ(response["result"][0]["range"]["start"]["character"],
+            start_character);
+  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], end_line);
+  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], end_character);
+  ASSERT_EQ(response["result"][0]["uri"], file_uri);
+}
+
 // Performs simple textDocument/definition request with no VerilogProject set
 TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestNoProjectTest) {
   std::string definition_request = DefinitionRequest("file://b.sv", 2, 3, 18);
@@ -649,13 +666,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestTest) {
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  ASSERT_EQ(response["id"], 2);
-  ASSERT_EQ(response["result"].size(), 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition request when there are two symbols of the same
@@ -689,13 +701,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  ASSERT_EQ(response_b["id"], 2);
-  ASSERT_EQ(response_b["result"].size(), 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_b["result"][0]["uri"], module_b_uri);
+  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
+                                          module_b_uri);
 
   // find definition for "var1" variable in a.sv file
   definition_request = DefinitionRequest(module_a_uri, 3, 2, 16);
@@ -703,13 +710,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_a = json::parse(GetResponse());
 
-  ASSERT_EQ(response_a["id"], 3);
-  ASSERT_EQ(response_a["result"].size(), 1);
-  ASSERT_EQ(response_a["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_a["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_a["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_a["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_a["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response_a, 3, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -743,13 +745,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  ASSERT_EQ(response_b["id"], 2);
-  ASSERT_EQ(response_b["result"].size(), 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_b["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -780,13 +777,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  ASSERT_EQ(response_b["id"], 2);
-  ASSERT_EQ(response_b["result"].size(), 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_b["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -832,25 +824,15 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  ASSERT_EQ(response_b["id"], 2);
-  ASSERT_EQ(response_b["result"].size(), 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_b["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 
   // perform double check
   ASSERT_OK(SendRequest(definition_request));
   response_b = json::parse(GetResponse());
 
-  ASSERT_EQ(response_b["id"], 2);
-  ASSERT_EQ(response_b["result"].size(), 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_b["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -891,13 +873,8 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  ASSERT_EQ(response["id"], 2);
-  ASSERT_EQ(response["result"].size(), 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -995,13 +972,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  ASSERT_EQ(response["id"], 2);
-  ASSERT_EQ(response["result"].size(), 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 // Check textDocument/definition when the cursor points at nothing
@@ -1112,13 +1084,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  ASSERT_EQ(response_b["id"], 2);
-  ASSERT_EQ(response_b["result"].size(), 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["start"]["character"], 9);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["line"], 1);
-  ASSERT_EQ(response_b["result"][0]["range"]["end"]["character"], 13);
-  ASSERT_EQ(response_b["result"][0]["uri"], module_a_uri);
+  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
+                                          module_a_uri);
 }
 
 TEST_F(VerilogLanguageServerSymbolTableTest, MultipleDefinitionsOfSameSymbol) {
@@ -1165,13 +1132,8 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  ASSERT_EQ(response["id"], 2);
-  ASSERT_EQ(response["result"].size(), 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], 0);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["character"], 7);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], 0);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], 10);
-  ASSERT_EQ(response["result"][0]["uri"], module_bar_1_uri);
+  CheckDefinitionResponseSingleDefinition(response, 2, 0, 7, 0, 10,
+                                          module_bar_1_uri);
 }
 
 // Sample of badly styled modle

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -619,17 +619,15 @@ std::string ReferencesRequest(absl::string_view file, int id, int line,
 // Performs assertions on textDocument/definition responses where single
 // definition is expected
 void CheckDefinitionResponseSingleDefinition(const json &response, int id,
-                                             int start_line,
-                                             int start_character, int end_line,
-                                             int end_character,
+                                             verible::LineColumn start,
+                                             verible::LineColumn end,
                                              const std::string &file_uri) {
   ASSERT_EQ(response["id"], id);
   ASSERT_EQ(response["result"].size(), 1);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], start_line);
-  ASSERT_EQ(response["result"][0]["range"]["start"]["character"],
-            start_character);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], end_line);
-  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], end_character);
+  ASSERT_EQ(response["result"][0]["range"]["start"]["line"], start.line);
+  ASSERT_EQ(response["result"][0]["range"]["start"]["character"], start.column);
+  ASSERT_EQ(response["result"][0]["range"]["end"]["line"], end.line);
+  ASSERT_EQ(response["result"][0]["range"]["end"]["character"], end.column);
   ASSERT_EQ(response["result"][0]["uri"], file_uri);
 }
 
@@ -667,7 +665,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest, DefinitionRequestTest) {
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response, 2, 1, 9, 1, 13,
+  CheckDefinitionResponseSingleDefinition(response, 2, {.line = 1, .column = 9},
+                                          {.line = 1, .column = 13},
                                           module_a_uri);
 }
 
@@ -702,17 +701,20 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
-                                          module_b_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_b, 2, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_b_uri);
 
   // find definition for "var1" variable in a.sv file
-  definition_request = DefinitionRequest(module_a_uri, 3, 2, 16);
+  const std::string definition_request2 =
+      DefinitionRequest(module_a_uri, 3, 2, 16);
 
-  ASSERT_OK(SendRequest(definition_request));
+  ASSERT_OK(SendRequest(definition_request2));
   json response_a = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_a, 3, 1, 9, 1, 13,
-                                          module_a_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_a, 3, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -747,8 +749,9 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
-                                          module_a_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_b, 2, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -780,8 +783,9 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
-                                          module_a_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_b, 2, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -828,15 +832,17 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
-                                          module_a_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_b, 2, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_a_uri);
 
   // perform double check
   ASSERT_OK(SendRequest(definition_request));
   response_b = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
-                                          module_a_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_b, 2, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_a_uri);
 }
 
 // Check textDocument/definition request where we want definition of a symbol
@@ -878,7 +884,8 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response, 2, 1, 9, 1, 13,
+  CheckDefinitionResponseSingleDefinition(response, 2, {.line = 1, .column = 9},
+                                          {.line = 1, .column = 13},
                                           module_a_uri);
 }
 
@@ -979,7 +986,8 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response, 2, 1, 9, 1, 13,
+  CheckDefinitionResponseSingleDefinition(response, 2, {.line = 1, .column = 9},
+                                          {.line = 1, .column = 13},
                                           module_a_uri);
 }
 
@@ -1095,8 +1103,9 @@ TEST_F(VerilogLanguageServerSymbolTableTest,
   ASSERT_OK(SendRequest(definition_request));
   json response_b = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response_b, 2, 1, 9, 1, 13,
-                                          module_a_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response_b, 2, {.line = 1, .column = 9}, {.line = 1, .column = 13},
+      module_a_uri);
 }
 
 TEST_F(VerilogLanguageServerSymbolTableTest, MultipleDefinitionsOfSameSymbol) {
@@ -1144,7 +1153,8 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response, 2, 0, 7, 0, 10,
+  CheckDefinitionResponseSingleDefinition(response, 2, {.line = 0, .column = 7},
+                                          {.line = 0, .column = 10},
                                           module_bar_1_uri);
 }
 
@@ -1476,8 +1486,9 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response, 2, 0, 7, 0, 17,
-                                          module_instmodule_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response, 2, {.line = 0, .column = 7}, {.line = 0, .column = 17},
+      module_instmodule_uri);
 }
 
 // Checks the go-to definition when pointing to the definition of the symbol
@@ -1523,8 +1534,9 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(response, 2, 0, 7, 0, 17,
-                                          module_instmodule_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response, 2, {.line = 0, .column = 7}, {.line = 0, .column = 17},
+      module_instmodule_uri);
 }
 
 // Checks the definition request for module port
@@ -1556,8 +1568,9 @@ endmodule
       DefinitionRequest(module_instmodule_uri, 2, 4, 22);
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
-  CheckDefinitionResponseSingleDefinition(response, 2, 2, 16, 2, 17,
-                                          module_instmodule_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response, 2, {.line = 2, .column = 16}, {.line = 2, .column = 17},
+      module_instmodule_uri);
 }
 
 // Checks the definition request for module port
@@ -1592,8 +1605,9 @@ endmodule
 
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
-  CheckDefinitionResponseSingleDefinition(response, 2, 5, 14, 5, 15,
-                                          module_instmodule_uri);
+  CheckDefinitionResponseSingleDefinition(
+      response, 2, {.line = 5, .column = 14}, {.line = 5, .column = 15},
+      module_instmodule_uri);
 }
 
 // Tests correctness of Language Server shutdown request

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -1492,9 +1492,9 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(
-      response, 2, {.line = 0, .column = 7}, {.line = 0, .column = 17},
-      module_instmodule_uri);
+  CheckDefinitionResponseSingleDefinition(response, 2, {.line = 0, .column = 7},
+                                          {.line = 0, .column = 17},
+                                          module_instmodule_uri);
 }
 
 // Checks the go-to definition when pointing to the definition of the symbol
@@ -1540,9 +1540,9 @@ endmodule
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
-  CheckDefinitionResponseSingleDefinition(
-      response, 2, {.line = 0, .column = 7}, {.line = 0, .column = 17},
-      module_instmodule_uri);
+  CheckDefinitionResponseSingleDefinition(response, 2, {.line = 0, .column = 7},
+                                          {.line = 0, .column = 17},
+                                          module_instmodule_uri);
 }
 
 // Checks the definition request for module port
@@ -1643,56 +1643,54 @@ endmodule)");
   const verible::file::testing::ScopedTestFile module_port_identifier(
       root_dir, port_identifier, "port_identifier.sv");
 
-  const std::string foo_open_request = DidOpenRequest(
-      "file://" + module_port_identifier.filename(), port_identifier);
+  const std::string module_port_identifier_uri =
+      PathToLSPUri(module_port_identifier.filename());
+  const std::string foo_open_request =
+      DidOpenRequest(module_port_identifier_uri, port_identifier);
   ASSERT_OK(SendRequest(foo_open_request));
 
   GetResponse();
 
   // find definition for "a"
-  std::string definition_request = DefinitionRequest(
-      "file://" + module_port_identifier.filename(), 2, 11, 24);
+  std::string definition_request =
+      DefinitionRequest(module_port_identifier_uri, 2, 11, 24);
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
   CheckDefinitionResponseSingleDefinition(
       response, 2, {.line = 1, .column = 23}, {.line = 1, .column = 24},
-      "file://" + module_port_identifier.filename());
+      module_port_identifier_uri);
 
   // find definition for "clk"
-  definition_request = DefinitionRequest(
-      "file://" + module_port_identifier.filename(), 3, 6, 22);
+  definition_request = DefinitionRequest(module_port_identifier_uri, 3, 6, 22);
   ASSERT_OK(SendRequest(definition_request));
   response = json::parse(GetResponse());
   CheckDefinitionResponseSingleDefinition(
       response, 3, {.line = 3, .column = 16}, {.line = 3, .column = 19},
-      "file://" + module_port_identifier.filename());
+      module_port_identifier_uri);
 
   // find definition for "rst"
-  definition_request = DefinitionRequest(
-      "file://" + module_port_identifier.filename(), 4, 6, 22);
+  definition_request = DefinitionRequest(module_port_identifier_uri, 4, 6, 22);
   ASSERT_OK(SendRequest(definition_request));
   response = json::parse(GetResponse());
   CheckDefinitionResponseSingleDefinition(
       response, 4, {.line = 3, .column = 16}, {.line = 3, .column = 19},
-      "file://" + module_port_identifier.filename());
+      module_port_identifier_uri);
 
   // find first definition for "out"
-  definition_request = DefinitionRequest(
-      "file://" + module_port_identifier.filename(), 5, 8, 13);
+  definition_request = DefinitionRequest(module_port_identifier_uri, 5, 8, 13);
   ASSERT_OK(SendRequest(definition_request));
   response = json::parse(GetResponse());
   CheckDefinitionResponseSingleDefinition(
       response, 5, {.line = 4, .column = 22}, {.line = 4, .column = 25},
-      "file://" + module_port_identifier.filename());
+      module_port_identifier_uri);
 
   // find second definition for "out"
-  definition_request = DefinitionRequest(
-      "file://" + module_port_identifier.filename(), 6, 11, 18);
+  definition_request = DefinitionRequest(module_port_identifier_uri, 6, 11, 18);
   ASSERT_OK(SendRequest(definition_request));
   response = json::parse(GetResponse());
   CheckDefinitionResponseSingleDefinition(
       response, 6, {.line = 4, .column = 22}, {.line = 4, .column = 25},
-      "file://" + module_port_identifier.filename());
+      module_port_identifier_uri);
 }
 
 // Verifies the work of the go-to definition request when the
@@ -1716,19 +1714,20 @@ endmodule
   const verible::file::testing::ScopedTestFile module_port_identifier(
       root_dir, port_identifier, "port_identifier.sv");
 
-  const std::string foo_open_request = DidOpenRequest(
-      "file://" + module_port_identifier.filename(), port_identifier);
+  const std::string module_port_identifier_uri =
+      PathToLSPUri(module_port_identifier.filename());
+  const std::string foo_open_request =
+      DidOpenRequest(module_port_identifier_uri, port_identifier);
   ASSERT_OK(SendRequest(foo_open_request));
 
   json diagnostics = json::parse(GetResponse());
   ASSERT_EQ(diagnostics["method"], "textDocument/publishDiagnostics");
-  ASSERT_EQ(diagnostics["params"]["uri"],
-            "file://" + module_port_identifier.filename());
+  ASSERT_EQ(diagnostics["params"]["uri"], module_port_identifier_uri);
   ASSERT_EQ(diagnostics["params"]["diagnostics"].size(), 0);
 
   // find definition for "i"
-  std::string definition_request = DefinitionRequest(
-      "file://" + module_port_identifier.filename(), 2, 9, 15);
+  std::string definition_request =
+      DefinitionRequest(module_port_identifier_uri, 2, 9, 15);
   ASSERT_OK(SendRequest(definition_request));
   json response = json::parse(GetResponse());
 
@@ -1740,11 +1739,59 @@ endmodule
       [](const json &a, const json &b) -> bool { return a.dump() < b.dump(); });
 
   CheckDefinitionEntry(response["result"][0], {.line = 5, .column = 13},
-                       {.line = 5, .column = 14},
-                       "file://" + module_port_identifier.filename());
+                       {.line = 5, .column = 14}, module_port_identifier_uri);
   CheckDefinitionEntry(response["result"][1], {.line = 2, .column = 8},
-                       {.line = 2, .column = 9},
-                       "file://" + module_port_identifier.filename());
+                       {.line = 2, .column = 9}, module_port_identifier_uri);
+}
+
+// Verifies the work of the go-to definition request when
+// definition of the symbol later in the definition list is requested
+TEST_F(VerilogLanguageServerSymbolTableTest, MultilinePortDefinitionsWithList) {
+  static constexpr absl::string_view  //
+      port_identifier(
+          R"(module port_identifier(a, b, o, trigger);
+  input trigger;
+  input a, b;
+  output o;
+
+  reg [31:0] a, b;
+  wire [31:0] o;
+
+  always @(posedge clock)
+    assign o = a + b;
+endmodule
+)");
+  const verible::file::testing::ScopedTestFile module_port_identifier(
+      root_dir, port_identifier, "port_identifier.sv");
+
+  const std::string module_port_identifier_uri =
+      PathToLSPUri(module_port_identifier.filename());
+  const std::string foo_open_request =
+      DidOpenRequest(module_port_identifier_uri, port_identifier);
+  ASSERT_OK(SendRequest(foo_open_request));
+
+  json diagnostics = json::parse(GetResponse());
+  ASSERT_EQ(diagnostics["method"], "textDocument/publishDiagnostics");
+  ASSERT_EQ(diagnostics["params"]["uri"], module_port_identifier_uri);
+  ASSERT_EQ(diagnostics["params"]["diagnostics"].size(), 0);
+
+  // find definition for "i"
+  std::string definition_request =
+      DefinitionRequest(module_port_identifier_uri, 2, 5, 16);
+  ASSERT_OK(SendRequest(definition_request));
+  json response = json::parse(GetResponse());
+
+  ASSERT_EQ(response["id"], 2);
+  ASSERT_EQ(response["result"].size(), 2);
+
+  std::sort(
+      response["result"].begin(), response["result"].end(),
+      [](const json &a, const json &b) -> bool { return a.dump() < b.dump(); });
+
+  CheckDefinitionEntry(response["result"][0], {.line = 2, .column = 11},
+                       {.line = 2, .column = 12}, module_port_identifier_uri);
+  CheckDefinitionEntry(response["result"][1], {.line = 5, .column = 16},
+                       {.line = 5, .column = 17}, module_port_identifier_uri);
 }
 
 // Tests correctness of Language Server shutdown request


### PR DESCRIPTION
Fixes #1673
Fixes #1668
Fixes #1783

This PR:

- [X] Adds fix for finding definition of the module when cursor points at symbol definition
- [X] Adds fix for finding definition of ports for module - initial tests added, the solution seems to work.
- [X] Fixes the smoke tests which fail on "redefined" symbols, when symbol definition is fragmented.
- [X] Adds initial multiline goto-definition support to the LanguageServer
- [x] Implements tests for multiline goto-definition
- [x] Implements type checking for split definitions of a single symbol
- [X] Fixes adding symbols to symbol table that were listed in K&R-style definitions, e.g. `input a, b, c;` (symbols after comma were not handled)
- [X] Improves handling DataTypes in net and port declarations