### PR TITLE
Reduce logging noise: Only aggregate to LOG(INFO), file-level VLOG(1).

### DIFF
--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -77,7 +77,12 @@ absl::Status VerilogSourceFile::Parse() {
 
   const absl::Time start = absl::Now();
   status_ = analyzed_structure_->Analyze();
-  VLOG(1) << "Analyzed " << ResolvedPath() << " in " << (absl::Now() - start);
+  const absl::Duration analyze_time = absl::Now() - start;
+  if (analyze_time > absl::Milliseconds(500)) {
+    LOG(WARNING) << "Slow Parse " << ResolvedPath() << " took " << analyze_time;
+  } else {
+    VLOG(1) << "Parse " << ResolvedPath() << " in " << analyze_time;
+  }
 
   processing_state_ = ProcessingState::kParsed;
   return status_;

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -75,10 +75,10 @@ absl::Status VerilogSourceFile::Parse() {
   analyzed_structure_ = std::make_unique<VerilogAnalyzer>(
       content_, ResolvedPath(), kPreprocessConfig);
 
-  const absl::Time analyze_start = absl::Now();
+  const absl::Time start = absl::Now();
   status_ = analyzed_structure_->Analyze();
-  LOG(INFO) << "Analyzed " << ResolvedPath() << " in "
-            << (absl::Now() - analyze_start);
+  VLOG(1) << "Analyzed " << ResolvedPath() << " in " << (absl::Now() - start);
+
   processing_state_ = ProcessingState::kParsed;
   return status_;
 }

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -68,6 +68,12 @@ class VerilogSourceFile {
   // Depending on context, not all files are suitable for standalone parsing.
   virtual absl::Status Parse();
 
+  // Return if Parse() has been called and content has been parsed.
+  // (see Status() if it was actually successful).
+  bool is_parsed() const {
+    return processing_state_ >= ProcessingState::kParsed;
+  }
+
   // After Parse(), text structure may contain other analyzed structural forms.
   // Before successful Parse(), this is not initialized and returns nullptr.
   virtual const verible::TextStructureView* GetTextStructure() const;

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -90,6 +90,9 @@ class SymbolTableHandler {
   // It is meant to be executed once per VerilogProject setup
   bool LoadProjectFileList(absl::string_view current_dir);
 
+  // Parse all the files in the project.
+  void ParseProjectFiles();
+
   // Path to the filelist file for the project
   std::string filelist_path_;
 

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -49,7 +49,7 @@ std::string FindFileList(absl::string_view current_dir);
 // The provided information is in LSP-friendly format.
 class SymbolTableHandler {
  public:
-  SymbolTableHandler(){};
+  SymbolTableHandler() = default;
 
   // Sets the project for the symbol table.
   // VerilogProject requires root, include_paths and corpus to
@@ -57,21 +57,8 @@ class SymbolTableHandler {
   // Once the project's root is set, a new SymbolTable is created.
   void SetProject(const std::shared_ptr<VerilogProject> &project);
 
-  // Returns the current project.
-  std::shared_ptr<VerilogProject> mutable_project() { return curr_project_; }
-
-  // Creates a new symbol table given the VerilogProject in setProject
-  // method.
-  void ResetSymbolTable();
-
-  // Fills the symbol table for a given verilog source file.
-  std::vector<absl::Status> BuildSymbolTableFor(const VerilogSourceFile &file);
-
-  // Creates a symbol table for entire project
-  std::vector<absl::Status> BuildProjectSymbolTable();
-
-  // Finds the location of the definition for a symbol provided in the
-  // DefinitionParams message delivered i.e. in textDocument/definition message.
+  // Finds the definition for a symbol provided in the DefinitionParams
+  // message delivered i.e. in textDocument/definition message.
   // Provides a list of locations with symbol's definitions.
   std::vector<verible::lsp::Location> FindDefinitionLocation(
       const verible::lsp::DefinitionParams &params,
@@ -80,10 +67,19 @@ class SymbolTableHandler {
   // Finds the symbol of the definition for the given identifier.
   const verible::Symbol *FindDefinitionSymbol(absl::string_view symbol);
 
+  // Provide new parsed content for the given path. If "content" is nullptr,
+  // opens the given file instead.
   void UpdateFileContent(absl::string_view path,
                          const verible::TextStructureView *content);
 
+  // Creates a symbol table for entire project (public: needed in unit-test)
+  std::vector<absl::Status> BuildProjectSymbolTable();
+
  private:
+  // Creates a new symbol table given the VerilogProject in setProject
+  // method.
+  void ResetSymbolTable();
+
   // Scans the symbol table tree to find a given symbol.
   // returns pointer to table node with the symbol on success, else nullptr.
   const SymbolTableNode *ScanSymbolTreeForDefinition(


### PR DESCRIPTION
For projects with many files, this filled the logs with all kinds of LOG(WARNING) that are not really relevant unless debugging. So moved all these to VLOG(1). Keep aggregate logs ("3000 files took 20 seconds to process") as LOG(INFO).

While at it:
 * Don't call BuildSymbolTable() while in LoadProjectFileList().
   It is confusing as it doesn't do anything, because it requires
   the file to be analyzed first. So just do what is needed to
   open the files into memory.
 * Remove methods only needed internally to the private section
   oof SymbolTableHandler header. Also remove unused method.
  * Separate out parsing from symbol table building to log timing independently.
  
These changes are improving timing information needed to make relevant implementation decisions in #1682.
