### PR TITLE
Reduce logging noise in symbol table.

### DIFF
--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -184,7 +184,7 @@ VerilogLinter::VerilogLinter()
 
 absl::Status VerilogLinter::Configure(const LinterConfiguration& configuration,
                                       absl::string_view lintee_filename) {
-  if (VLOG_IS_ON(1)) {
+  if (VLOG_IS_ON(2)) {
     for (const auto& name : configuration.ActiveRuleIds()) {
       LOG(INFO) << "active rule: '" << name << '\'';
     }


### PR DESCRIPTION
Move the VLOG()-level requirements up one notch.
This makes it easier to see relevant logging if symbol table is used as a library.

Also, similar in verilog linter.