### PR TITLE
Rename VerilogSourceFile::State to ProcessingState

### DIFF
--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -46,7 +46,7 @@ VerilogSourceFile::VerilogSourceFile(absl::string_view referenced_path,
 
 absl::Status VerilogSourceFile::Open() {
   // Don't re-open.  analyzed_structure_ should be set/written once only.
-  if (state_ != State::kInitialized) return status_;
+  if (processing_state_ != ProcessingState::kInitialized) return status_;
 
   // Load file contents.
   auto content_status = verible::file::GetContentAsMemBlock(ResolvedPath());
@@ -54,7 +54,7 @@ absl::Status VerilogSourceFile::Open() {
   if (!status_.ok()) return status_;
 
   content_ = std::move(*content_status);
-  state_ = State::kOpened;
+  processing_state_ = ProcessingState::kOpened;
 
   return status_;  // status_ is Ok here.
 }
@@ -65,7 +65,7 @@ absl::string_view VerilogSourceFile::GetContent() const {
 
 absl::Status VerilogSourceFile::Parse() {
   // Parsed state is cached.
-  if (state_ == State::kParsed) return status_;
+  if (processing_state_ == ProcessingState::kParsed) return status_;
 
   // Open file and load contents if not already done.
   status_ = Open();
@@ -79,7 +79,7 @@ absl::Status VerilogSourceFile::Parse() {
   status_ = analyzed_structure_->Analyze();
   LOG(INFO) << "Analyzed " << ResolvedPath() << " in "
             << (absl::Now() - analyze_start);
-  state_ = State::kParsed;
+  processing_state_ = ProcessingState::kParsed;
   return status_;
 }
 
@@ -111,19 +111,19 @@ std::ostream& operator<<(std::ostream& stream,
 }
 
 absl::Status InMemoryVerilogSourceFile::Open() {
-  state_ = State::kOpened;
+  processing_state_ = ProcessingState::kOpened;
   status_ = absl::OkStatus();
   return status_;
 }
 
 absl::Status ParsedVerilogSourceFile::Open() {
-  state_ = State::kOpened;
+  processing_state_ = ProcessingState::kOpened;
   status_ = absl::OkStatus();
   return status_;
 }
 
 absl::Status ParsedVerilogSourceFile::Parse() {
-  state_ = State::kParsed;
+  processing_state_ = ProcessingState::kParsed;
   status_ = absl::OkStatus();
   return status_;
 }

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -116,7 +116,7 @@ class VerilogSourceFile {
  protected:
   // Tracking state for linear progression of analysis, which allows
   // prerequisite actions to be cached.
-  enum class State {
+  enum class ProcessingState {
     // Only the paths have been established.
     kInitialized,
 
@@ -142,8 +142,8 @@ class VerilogSourceFile {
   // github.com/chipsalliance/verible).
   const absl::string_view corpus_;
 
-  // State of this file.
-  State state_ = State::kInitialized;
+  // Linear progression of analysis.
+  ProcessingState processing_state_ = ProcessingState::kInitialized;
 
   // Holds any diagostics for problems encountered finding/reading this file.
   absl::Status status_;


### PR DESCRIPTION
This is to avoid confusion with absl::Status, as
state and status are close, linguistically.
