### PR TITLE
Re-enable asan-clang compile.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -120,6 +120,7 @@ jobs:
         - smoke-test
         - smoke-test-analyzer
         - asan
+        - asan-clang
         - compile
         - compile-clang
         - coverage
@@ -162,7 +163,7 @@ jobs:
         apt -qq -y install build-essential wget git python3 python-is-python3 default-jdk cmake python3-pip
         apt -qq -y install gcc-10 g++-10
         apt -qq -y install gcc-11 g++-11
-        apt -qq -y install clang-11  # clang always a particular version.
+        apt -qq -y install clang-12  # clang always a particular version.
         source ./.github/settings.sh
         # Use newer compiler for c++23 compilation
         ./.github/bin/set-compiler.sh $([ "$MODE" == "test-c++23" ] && echo 11 || echo 10)


### PR DESCRIPTION
This was briefly broken after changing the virtual machine image; possibly due to caching old paths.
