### PR TITLE
Work around an overload that becomes ambiguous with C++20

### DIFF
--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -29,12 +29,12 @@ using verible::lsp::TextEdit;
 
 // Generate text edits using the given function and test if they had the desired
 // effect
-void TestTextEdits(const std::function<std::vector<TextEdit>(
-                       SymbolTableHandler*, BufferTracker*)>& edit_fun,
-                   const std::vector<absl::string_view>& project_file_contents,
-                   const absl::string_view text_before,
-                   const absl::string_view text_golden,
-                   const bool repeat = true) {
+void TestTextEditsWithProject(
+    const std::function<std::vector<TextEdit>(SymbolTableHandler*,
+                                              BufferTracker*)>& edit_fun,
+    const std::vector<absl::string_view>& project_file_contents,
+    const absl::string_view text_before, const absl::string_view text_golden,
+    const bool repeat = true) {
   static const char* TESTED_FILENAME = "<<tested-file>>";
   // Init a text buffer which we need for the autoepxand functions
   EditTextBuffer buffer(text_before);
@@ -78,8 +78,8 @@ void TestTextEdits(const std::function<std::vector<TextEdit>(
   buffer.RequestContent([&](const absl::string_view text_after) {
     EXPECT_EQ(text_after, text_golden);
     if (repeat) {
-      TestTextEdits(edit_fun, project_file_contents, text_golden, text_golden,
-                    false);
+      TestTextEditsWithProject(edit_fun, project_file_contents, text_golden,
+                               text_golden, false);
     }
   });
 }
@@ -90,7 +90,7 @@ void TestTextEdits(const std::function<std::vector<TextEdit>(
                    const absl::string_view text_before,
                    const absl::string_view text_golden,
                    const bool repeat = true) {
-  TestTextEdits(edit_fun, {}, text_before, text_golden, repeat);
+  TestTextEditsWithProject(edit_fun, {}, text_before, text_golden, repeat);
 }
 
 // Generate a specific code action and extract text edits from it
@@ -482,28 +482,28 @@ endmodule
 }
 
 TEST(Autoexpand, AUTOINST_MultipleFiles) {
-  TestTextEdits(GenerateAutoExpandTextEdits,
-                {R"(
+  TestTextEditsWithProject(GenerateAutoExpandTextEdits,
+                           {R"(
 module bar(input i1, output o1);
   input i2;
   inout io;
   output o2;
 endmodule
     )",
-                 R"(
+                            R"(
 module qux;
   input i1;
   inout io;
   output o2;
 endmodule
    )"},
-                R"(
+                           R"(
 module foo;
   bar b(/*AUTOINST*/);
   qux q(/*AUTOINST*/);
 endmodule
 )",
-                R"(
+                           R"(
 module foo;
   bar b(/*AUTOINST*/
     // Inputs


### PR DESCRIPTION
Starting with c++20, there is a new constructor #5 for string_view in town:
https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view

Together with concepts the initailization with {} can be ambiguous for either a std::vector<std::string_view> or a std::string_view{} initialization with two parameters that conceptually allow iterating.

Both functions would match, in the latter case the last string would be interpreted as the optional boolean ...

Unfortunately, I could not reproduce this in the CI (#1706 was for that), I suspect this only shows up with libstdc++ (which we're not using in the CI).

Long story short: dismbiguiated it by renaming the functions. An alternative would be to just remove one of the functions.
