### PR TITLE
Document the gcc bug that genreates a spurious warning.

### DIFF
--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -115,7 +115,7 @@ case "$MODE" in
   test-c++20|test-c++20-clang)
     # Compile with C++ 20 to make sure to be compatible with the next version.
     if [[ ${MODE} == "test-c++20" ]]; then
-       # gcc complaint in protobuf
+       # Assignment of 1-char strings: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
        BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-restrict"
     fi
     bazel test --keep_going --test_output=errors $BAZEL_OPTS --cxxopt=-std=c++20 -- ${CHOSEN_TARGETS}
@@ -124,7 +124,7 @@ case "$MODE" in
   test-c++23|test-c++23-clang)
     # Same; c++23
     if [[ ${MODE} == "test-c++23" ]]; then
-       # gcc complaint in protobuf
+       # Assignment of 1-char strings: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
        BAZEL_OPTS="${BAZEL_OPTS} --cxxopt=-Wno-restrict"
     fi
     bazel test --keep_going --test_output=errors $BAZEL_OPTS --cxxopt=-std=c++2b -- ${CHOSEN_TARGETS}


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329

Is triggering issues in single-char string assignments to strings:

here:
https://github.com/chipsalliance/verible/blob/c730042f4a0ac27e7d936baaf801df225d9352cc/verilog/tools/ls/verilog-language-server.cc#L190

and here:
https://github.com/protocolbuffers/protobuf/blob/9c2211be08af10dd5964cf8b65364afaef001fdf/src/google/protobuf/io/tokenizer.cc#L588

This is a spurious warning in gcc 12.2, with c++20 and optimizations enabled and is safe to ignore. So just document why we enable -Wno-restrict.
