### PR TITLE
Reduce log chatter.

### DIFF
--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -451,6 +451,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/time",
     ],
 )
 

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -22,6 +22,8 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "common/strings/display_utils.h"
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/concrete_syntax_tree.h"
@@ -2007,8 +2009,10 @@ void SymbolTable::CheckIntegrity() const {
 }
 
 void SymbolTable::Resolve(std::vector<absl::Status>* diagnostics) {
+  const absl::Time start = absl::Now();
   symbol_table_root_.ApplyPreOrder(
       [=](SymbolTableNode& node) { node.Value().Resolve(node, diagnostics); });
+  VLOG(1) << "SymbolTable::Resolve took " << (absl::Now() - start);
 }
 
 void SymbolTable::ResolveLocallyOnly() {
@@ -2050,10 +2054,12 @@ static void ParseFileAndBuildSymbolTable(
 }
 
 void SymbolTable::Build(std::vector<absl::Status>* diagnostics) {
+  const absl::Time start = absl::Now();
   for (auto& translation_unit : *project_) {
     ParseFileAndBuildSymbolTable(translation_unit.second.get(), this, project_,
                                  diagnostics);
   }
+  VLOG(1) << "SymbolTable::Build() took " << (absl::Now() - start);
 }
 
 void SymbolTable::BuildSingleTranslationUnit(

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -105,6 +105,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
     ],
 )

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -39,8 +39,8 @@ ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
       uri_(uri),
       parser_(verilog::VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(
           content, uri)) {
-  LOG(INFO) << "Analyzed " << uri << " lex:" << parser_->LexStatus()
-            << "; parser:" << parser_->ParseStatus() << std::endl;
+  VLOG(1) << "Analyzed " << uri << " lex:" << parser_->LexStatus()
+          << "; parser:" << parser_->ParseStatus() << std::endl;
   // TODO(hzeller): we should use a filename not URI; strip prefix.
   if (auto lint_result = RunLinter(uri, *parser_); lint_result.ok()) {
     lint_statuses_ = std::move(lint_result.value());

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -176,7 +176,7 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
   } else if (!p.rootPath.empty()) {
     ConfigureProject(p.rootPath);
   } else {
-    LOG(WARNING) << "Could not configure Verilog Project root";
+    VLOG(1) << "No root URI given. Initialize with root='.'";
     ConfigureProject();
   }
   return GetCapabilities();
@@ -233,7 +233,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
   if (!buffer_tracker->last_good()) return;
   symbol_table_handler_.UpdateFileContent(
       path, &buffer_tracker->last_good()->parser().Data());
-  LOG(INFO) << "Updated file:  " << uri << " (" << path << ")";
+  VLOG(1) << "Updated file:  " << uri << " (" << path << ")";
 }
 
 };  // namespace verilog


### PR DESCRIPTION
Make it easier to see what tests are running and help concentrate on important messages.

bazel test --test_output=streamed  //verilog/tools/ls/...