### PR TITLE
Fix broken clang-tidy config; fix new warnings showing up.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,9 @@
 #    returns; however since the iterator is implementation defined, this is not
 #    a valid assertion. Running the check every now and then manually and
 #    fixing all the non-iterator cases is useful though. Off by default.
+#
+# NOTE: Below, there must be no comments, otherwise clang tidy silently ignores
+#       rules... (ask me how I know).
 ##
 Checks: >
   clang-diagnostic-*,clang-analyzer-*,
@@ -35,7 +38,7 @@ Checks: >
   -readability-use-anyofallof,
   -readability-identifier-length,
   -readability-uppercase-literal-suffix,
-  -readability-convert-member-functions-to-static,  # creates false positive ?
+  -readability-convert-member-functions-to-static,
   google-*,
   -google-readability-braces-around-statements,
   -google-readability-todo,

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -90,7 +90,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          /tmp/clang-tidy-hashes.cache
+          /tmp/verible-clang-tidy-hashes.cache
           /root/.cache/bazel
         key: clang-tidy-${{ steps.cache_timestamp.outputs.time }}
         restore-keys: clang-tidy-

--- a/common/strings/mem_block.h
+++ b/common/strings/mem_block.h
@@ -35,7 +35,7 @@ class MemBlock {
  private:
   MemBlock(const MemBlock&) = delete;
   MemBlock(MemBlock&&) = delete;
-  MemBlock& operator=(MemBlock&) = delete;
+  MemBlock& operator=(const MemBlock&) = delete;
   MemBlock& operator=(MemBlock&&) = delete;
 };
 

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -200,7 +200,8 @@ static absl::StatusOr<std::unique_ptr<MemBlock>> AttemptMemMapFile(
     return CreateErrorStatusFromErrno("Can't mmap file");
   }
 
-  return std::make_unique<MemMapBlock>((char *)buffer, file_size);
+  return std::make_unique<MemMapBlock>(reinterpret_cast<char *>(buffer),
+                                       file_size);
 #else
   // TODO: implement some memory mapping on Windows.
   return absl::UnimplementedError("No windows mmap implementation yet.");

--- a/common/util/thread_pool.h
+++ b/common/util/thread_pool.h
@@ -33,7 +33,7 @@ class ThreadPool {
  public:
   // Create thread pool with "thread_count" threads.
   // If that count is zero, functions will be executed synchronously.
-  ThreadPool(int thread_count);
+  explicit ThreadPool(int thread_count);
 
   // Exit ASAP and leave remaining work in queue unfinished.
   ~ThreadPool();

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -323,9 +323,10 @@ struct SymbolInfo {
 
  public:  // methods
   SymbolInfo() = default;
-  SymbolInfo(SymbolMetaType metatype, const VerilogSourceFile* file_origin = {},
-             const verible::Symbol* syntax_origin = {},
-             DeclarationTypeInfo declared_type = {})
+  explicit SymbolInfo(SymbolMetaType metatype,
+                      const VerilogSourceFile* file_origin = {},
+                      const verible::Symbol* syntax_origin = {},
+                      DeclarationTypeInfo declared_type = {})
       : metatype(metatype),
         file_origin(file_origin),
         syntax_origin(syntax_origin),

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -35,7 +35,7 @@ class VerilogLanguageServer {
   using WriteFun = verible::lsp::JsonRpcDispatcher::WriteFun;
 
   // Constructor preparing the callbacks for Language Server requests
-  VerilogLanguageServer(const WriteFun &write_fun);
+  explicit VerilogLanguageServer(const WriteFun &write_fun);
 
   // Reads single request and responds to it
   absl::Status Step(const ReadFun &read_fun);


### PR DESCRIPTION
  * TIL that a #-comment in the .clang-tidy configuration silently messes up the config, resulting in ignored rules.
  * Remove the comment in our clang tidy config. It has been there since 065904fa4ac24858a96fbf055d595ee5ac34c879
  * Harden the run-clang-tidy.sh script to make sure such comments are not added.
  * Fix the fall-out of not having complete clang-tidy rules active for a few months.