### PR TITLE
Some mostly mechanical cleanups.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,19 +15,27 @@
 #    a valid assertion. Running the check every now and then manually and
 #    fixing all the non-iterator cases is useful though. Off by default.
 #
+# misc-const-correctness: useful, but it seems to be overzealous at times.
+#
+# modernize-make-unique: mostly correct, but wants to also replace .reset()
+#                         which is a more readable way than assign.
 # NOTE: Below, there must be no comments, otherwise clang tidy silently ignores
 #       rules... (ask me how I know).
-##
+###
 Checks: >
-  clang-diagnostic-*,clang-analyzer-*,
+  clang-diagnostic-*,
+  -clang-diagnostic-unused-const-variable,
+  clang-analyzer-*,
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
-  -clang-diagnostic-unused-const-variable,
-  abseil-*,-abseil-no-namespace,
+  abseil-*,
+  -abseil-no-namespace,
   readability-*,
   -readability-braces-around-statements,
+  -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
+  -readability-identifier-length,
   -readability-implicit-bool-conversion,
   -readability-isolate-declaration,
   -readability-magic-numbers,
@@ -35,12 +43,13 @@ Checks: >
   -readability-named-parameter,
   -readability-qualified-auto,
   -readability-redundant-access-specifiers,
-  -readability-use-anyofallof,
-  -readability-identifier-length,
+  -readability-simplify-boolean-expr,
   -readability-uppercase-literal-suffix,
   -readability-convert-member-functions-to-static,
+  -readability-use-anyofallof,
   google-*,
   -google-readability-braces-around-statements,
+  -google-readability-casting,
   -google-readability-todo,
   performance-*,
   bugprone-*,
@@ -50,8 +59,20 @@ Checks: >
   -bugprone-move-forwarding-reference,
   -bugprone-narrowing-conversions,
   -bugprone-reserved-identifier,
-  modernize-use-override,
+  modernize-*,
+  -modernize-avoid-bind,
+  -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
+  -modernize-make-unique,
+  -modernize-pass-by-value,
+  -modernize-raw-string-literal,
+  -modernize-return-braced-init-list,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -modernize-use-transparent-functors,
   misc-*,
+  -misc-const-correctness,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,
@@ -59,5 +80,5 @@ Checks: >
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
+AnalyzeTemporaryDtors: true
 ...

--- a/common/analysis/command_file_lexer.cc
+++ b/common/analysis/command_file_lexer.cc
@@ -55,7 +55,7 @@ std::vector<TokenRange> CommandFileLexer::GetCommandsTokenRanges() {
   auto i = tokens_.cbegin();
   auto j = i;
 
-  while (1) {
+  for (;;) {
     // Note that empty lines or lines with whitespace only are skipped
     // by the lexer and do not have to be handled here
     j = std::find_if(i + 1, tokens_.cend(), [](TokenInfo t) {

--- a/common/analysis/file_analyzer.h
+++ b/common/analysis/file_analyzer.h
@@ -95,7 +95,7 @@ class FileAnalyzer {
   FileAnalyzer(absl::string_view contents, absl::string_view filename)
       : text_structure_(new TextStructure(contents)), filename_(filename) {}
 
-  virtual ~FileAnalyzer() {}
+  virtual ~FileAnalyzer() = default;
 
   virtual absl::Status Tokenize() = 0;
 

--- a/common/analysis/line_lint_rule.h
+++ b/common/analysis/line_lint_rule.h
@@ -28,7 +28,7 @@ namespace verible {
 
 class LineLintRule : public LintRule {
  public:
-  ~LineLintRule() override {}
+  ~LineLintRule() override = default;
 
   // Scans a single line during analysis.
   virtual void HandleLine(absl::string_view line) = 0;

--- a/common/analysis/lint_rule.h
+++ b/common/analysis/lint_rule.h
@@ -29,7 +29,7 @@ namespace verible {
 // LintRule is an abstract base class that represent a single linter rule.
 class LintRule {
  public:
-  virtual ~LintRule() {}
+  virtual ~LintRule() = default;
 
   // If there is a configuration string for this rule, it will be passed to this
   // rule before use. This is a single string and the rule is free to impose

--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -72,7 +72,7 @@ static TokenInfo SymbolToToken(const Symbol& root) {
   return TokenInfo::EOFToken();
 }
 
-LintViolation::LintViolation(const Symbol& root, const std::string& reason,
+LintViolation::LintViolation(const Symbol& root, absl::string_view reason,
                              const SyntaxTreeContext& context,
                              const std::vector<AutoFix>& autofixes)
     : root(&root),

--- a/common/analysis/lint_rule_status.h
+++ b/common/analysis/lint_rule_status.h
@@ -62,7 +62,7 @@ struct ReplacementEdit {
 // Collection of ReplacementEdits performing single violation fix.
 class AutoFix {
  public:
-  AutoFix() {}
+  AutoFix() = default;
   AutoFix(const AutoFix& other) = default;
   AutoFix(AutoFix&& other) = default;
 
@@ -91,30 +91,22 @@ class AutoFix {
 // LintViolation is a class that represents a single rule violation.
 struct LintViolation {
   // This construct records a token stream lint violation.
-  LintViolation(const TokenInfo& token, const std::string& reason,
+  LintViolation(const TokenInfo& token, absl::string_view reason,
                 const std::vector<AutoFix>& autofixes = {})
-      : root(nullptr),
-        token(token),
-        reason(reason),
-        context(),
-        autofixes(autofixes) {}
+      : token(token), reason(reason), context(), autofixes(autofixes) {}
 
   // This construct records a syntax tree lint violation.
   // Use this variation when the violation can be localized to a single token.
-  LintViolation(const TokenInfo& token, const std::string& reason,
+  LintViolation(const TokenInfo& token, absl::string_view reason,
                 const SyntaxTreeContext& context,
                 const std::vector<AutoFix>& autofixes = {})
-      : root(nullptr),
-        token(token),
-        reason(reason),
-        context(context),
-        autofixes(autofixes) {}
+      : token(token), reason(reason), context(context), autofixes(autofixes) {}
 
   // This construct records a syntax tree lint violation.
   // Use this variation when the range of violation is a subtree that spans
   // multiple tokens.  The violation will be reported at the location of
   // the left-most leaf of the subtree.
-  LintViolation(const Symbol& root, const std::string& reason,
+  LintViolation(const Symbol& root, absl::string_view reason,
                 const SyntaxTreeContext& context,
                 const std::vector<AutoFix>& autofixes = {});
 
@@ -144,7 +136,7 @@ struct LintViolation {
 
 // LintRuleStatus represents the result of running a single lint rule.
 struct LintRuleStatus {
-  LintRuleStatus() {}
+  LintRuleStatus() = default;
 
   LintRuleStatus(const std::set<LintViolation>& vs, absl::string_view rule_name,
                  const std::string& url)

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -419,8 +419,7 @@ absl::Status LintWaiverBuilder::ApplyExternalWaivers(
     absl::string_view lintee_filename, absl::string_view waiver_filename,
     absl::string_view waivers_config_content) {
   if (waivers_config_content.empty()) {
-    return absl::Status(absl::StatusCode::kInternal,
-                        "Broken waiver config handle");
+    return {absl::StatusCode::kInternal, "Broken waiver config handle"};
   }
 
   CommandFileLexer lexer(waivers_config_content);

--- a/common/analysis/lint_waiver.h
+++ b/common/analysis/lint_waiver.h
@@ -36,7 +36,7 @@ class LintWaiver {
   using RegexVector = std::vector<const std::regex*>;
 
  public:
-  LintWaiver() {}
+  LintWaiver() = default;
 
   // Construction either done in Builder function or LintWaiverBuilder class
   // defined below.

--- a/common/analysis/matcher/bound_symbol_manager.cc
+++ b/common/analysis/matcher/bound_symbol_manager.cc
@@ -31,11 +31,8 @@ bool BoundSymbolManager::ContainsSymbol(const std::string& id) const {
 }
 
 const Symbol* BoundSymbolManager::FindSymbol(const std::string& id) const {
-  auto result = FindOrNull(bound_symbols_, id);
-  if (result)
-    return *result;
-  else
-    return nullptr;
+  auto* result = FindOrNull(bound_symbols_, id);
+  return result ? *result : nullptr;
 }
 
 void BoundSymbolManager::BindSymbol(const std::string& id,

--- a/common/analysis/matcher/matcher.cc
+++ b/common/analysis/matcher/matcher.cc
@@ -45,9 +45,9 @@ bool Matcher::Matches(const Symbol& symbol, BoundSymbolManager* manager) const {
       if (!target_symbol) continue;
       bool inner_match_result =
           inner_match_handler_(*target_symbol, inner_matchers_, manager);
-      if (inner_match_result && manager && bind_id_)
+      if (inner_match_result && manager && bind_id_) {
         manager->BindSymbol(bind_id_.value(), target_symbol);
-
+      }
       any_target_matches |= inner_match_result;
     }
 

--- a/common/analysis/matcher/matcher_builders.h
+++ b/common/analysis/matcher/matcher_builders.h
@@ -134,7 +134,7 @@ constexpr PathMatchBuilder<N> MakePathMatcher(const SymbolTag (&path)[N]) {
 template <SymbolKind Kind, typename EnumType, EnumType Tag>
 class TagMatchBuilder {
  public:
-  constexpr TagMatchBuilder() {}
+  constexpr TagMatchBuilder() = default;
 
   template <typename... Args>
   BindableMatcher operator()(Args... args) const {

--- a/common/analysis/syntax_tree_lint_rule.h
+++ b/common/analysis/syntax_tree_lint_rule.h
@@ -38,7 +38,7 @@ namespace verible {
 // top of the stack/back of vector.
 class SyntaxTreeLintRule : public LintRule {
  public:
-  ~SyntaxTreeLintRule() override {}
+  ~SyntaxTreeLintRule() override = default;
 
   virtual void HandleLeaf(const SyntaxTreeLeaf& leaf,
                           const SyntaxTreeContext& context) {}

--- a/common/analysis/syntax_tree_linter.h
+++ b/common/analysis/syntax_tree_linter.h
@@ -49,7 +49,7 @@ namespace verible {
 //
 class SyntaxTreeLinter : public TreeContextVisitor {
  public:
-  SyntaxTreeLinter() {}
+  SyntaxTreeLinter() = default;
 
   void Visit(const SyntaxTreeLeaf& leaf) final;
   void Visit(const SyntaxTreeNode& node) final;

--- a/common/analysis/text_structure_lint_rule.h
+++ b/common/analysis/text_structure_lint_rule.h
@@ -38,7 +38,7 @@ namespace verible {
 
 class TextStructureLintRule : public LintRule {
  public:
-  ~TextStructureLintRule() override {}
+  ~TextStructureLintRule() override = default;
 
   // Analyze text structure for violations.
   virtual void Lint(const TextStructureView& text_structure,

--- a/common/analysis/token_stream_lint_rule.h
+++ b/common/analysis/token_stream_lint_rule.h
@@ -26,7 +26,7 @@ namespace verible {
 
 class TokenStreamLintRule : public LintRule {
  public:
-  ~TokenStreamLintRule() override {}
+  ~TokenStreamLintRule() override = default;
 
   // Scans a single token during analysis.
   virtual void HandleToken(const TokenInfo& token) = 0;

--- a/common/analysis/violation_handler.cc
+++ b/common/analysis/violation_handler.cc
@@ -153,8 +153,9 @@ void ViolationFixer::HandleViolation(
         rule_answers_[rule_name] = {AnswerChoice::kApply, answer.alternative};
         [[fallthrough]];
       case AnswerChoice::kApply:  // Apply fix chosen in the alternatative
-        if (answer.alternative >= violation.autofixes.size())
+        if (answer.alternative >= violation.autofixes.size()) {
           continue;  // ask again.
+        }
         if (!fix->AddEdits(violation.autofixes[answer.alternative].Edits())) {
           *message_stream_ << previous_fix_conflict;
         }
@@ -202,8 +203,9 @@ ViolationFixer::Answer ViolationFixer::InteractiveAnswerChooser(
     help_message =
         absl::StrCat("y - apply first fix\n[1-", fix_count,
                      "] - apply given alternative\n", fixed_help_message);
-    for (size_t i = 0; i < fix_count; ++i)
+    for (size_t i = 0; i < fix_count; ++i) {
       absl::StrAppend(&alternative_list, (i + 1), ",");
+    }
   } else {
     help_message = absl::StrCat("y - apply fix\n", fixed_help_message);
   }

--- a/common/analysis/violation_handler.h
+++ b/common/analysis/violation_handler.h
@@ -46,8 +46,7 @@ class ViolationHandler {
 // messages.
 class ViolationPrinter : public ViolationHandler {
  public:
-  explicit ViolationPrinter(std::ostream* stream)
-      : stream_(stream), formatter_(nullptr) {}
+  explicit ViolationPrinter(std::ostream* stream) : stream_(stream) {}
 
   void HandleViolations(
       const std::set<verible::LintViolationWithStatus>& violations,
@@ -55,7 +54,7 @@ class ViolationPrinter : public ViolationHandler {
 
  protected:
   std::ostream* const stream_;
-  verible::LintStatusFormatter* formatter_;
+  verible::LintStatusFormatter* formatter_ = nullptr;
 };
 
 // ViolationHandler that prints all violations in a format required by
@@ -64,9 +63,7 @@ class ViolationWaiverPrinter : public ViolationHandler {
  public:
   explicit ViolationWaiverPrinter(std::ostream* message_stream_,
                                   std::ostream* waiver_stream_)
-      : message_stream_(message_stream_),
-        waiver_stream_(waiver_stream_),
-        formatter_(nullptr) {}
+      : message_stream_(message_stream_), waiver_stream_(waiver_stream_) {}
 
   void HandleViolations(
       const std::set<verible::LintViolationWithStatus>& violations,
@@ -75,7 +72,7 @@ class ViolationWaiverPrinter : public ViolationHandler {
  protected:
   std::ostream* const message_stream_;
   std::ostream* const waiver_stream_;
-  verible::LintStatusFormatter* formatter_;
+  verible::LintStatusFormatter* formatter_ = nullptr;
 };
 
 // ViolationHandler that prints all violations and gives an option to fix those

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -111,7 +111,7 @@ struct AlignmentCell {
   int TotalWidth() const { return left_border_width + compact_width; }
 
   FormatTokenRange ConstTokensRange() const {
-    return FormatTokenRange(tokens.begin(), tokens.end());
+    return {tokens.begin(), tokens.end()};
   }
 
   void UpdateWidths() {
@@ -246,12 +246,13 @@ static void ColumnsTreeFormatter(
       const int padding_len = lines[level - 1].size() - lines[level].size() -
                               node.Parent()->Value().width;
       if (padding_len > 0) {
-        if (lines[level].empty())
+        if (lines[level].empty()) {
           lines[level].append(std::string(padding_len, ' '));
-        else if (padding_len > int(kCellSeparator.size()))
+        } else if (padding_len > int(kCellSeparator.size())) {
           lines[level].append(absl::StrCat(
               kCellSeparator,
               std::string(padding_len - kCellSeparator.size(), ' ')));
+        }
       }
     }
 
@@ -495,9 +496,9 @@ std::ostream& operator<<(std::ostream& stream,
         } else {
           const auto width_info = absl::StrCat("\t(", cell.left_border_width,
                                                "+", cell.compact_width, ")\t");
-          if (cell.IsComposite())
+          if (cell.IsComposite()) {
             return {absl::StrCat("/", width_info, "\\"), '`'};
-
+          }
           std::ostringstream label;
           label << "\t" << cell << "\t\n" << width_info;
           return {label.str(), ' '};
@@ -804,7 +805,7 @@ static FormatTokenRange EpilogRange(const TokenPartitionTree& partition,
   // spanned by 'row'.
   auto partition_end = partition.Value().TokensRange().end();
   auto row_end = last_subcol.Value().tokens.end();
-  return FormatTokenRange(row_end, partition_end);
+  return {row_end, partition_end};
 }
 
 // This width calculation accounts for the unaligned tokens in the tail position
@@ -957,8 +958,9 @@ AlignablePartitionGroup::CalculateAlignmentSpacings(
     }
     // Also check for length of unaligned trailing tokens.
     if (!AlignedRowsFitUnderColumnLimit(rows, result.matrix, total_column_width,
-                                        column_limit))
+                                        column_limit)) {
       return result;
+    }
   }
 
   // TODO(fangism): implement overflow mitigation fallback strategies.

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -264,8 +264,7 @@ class AlignablePartitionGroup {
   bool IsEmpty() const { return alignable_rows_.empty(); }
 
   TokenPartitionRange Range() const {
-    return TokenPartitionRange(alignable_rows_.front(),
-                               alignable_rows_.back() + 1);
+    return {alignable_rows_.front(), alignable_rows_.back() + 1};
   }
 
   // This executes alignment, depending on the alignment_policy.

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -67,8 +67,9 @@ void AdoptLayoutAndFlattenIfSameType(const LayoutTree& source,
     CHECK(src_item.SpacesBefore() == first_subitem.SpacesBefore());
     destination->Children().reserve(destination->Children().size() +
                                     source.Children().size());
-    for (const auto& sublayout : source.Children())
+    for (const auto& sublayout : source.Children()) {
       AdoptSubtree(*destination, sublayout);
+    }
   } else {
     AdoptSubtree(*destination, source);
   }
@@ -429,8 +430,9 @@ LayoutFunction LayoutFunctionFactory::Choice(
       const LayoutFunction::const_iterator min_cost_segment = *std::min_element(
           segments->begin(), segments->end(),
           [current_column](const auto& a, const auto& b) {
-            if (a->CostAt(current_column) != b->CostAt(current_column))
+            if (a->CostAt(current_column) != b->CostAt(current_column)) {
               return (a->CostAt(current_column) < b->CostAt(current_column));
+            }
             // Sort by gradient when cost is the same. Favor earlier
             // element when both gradients are equal.
             return (a->gradient < b->gradient);
@@ -601,8 +603,9 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
       }
       auto stack = factory_.Stack(layouts.begin(), layouts.end());
 
-      if (juxtaposition_allowed)
+      if (juxtaposition_allowed) {
         return factory_.Choice({std::move(juxtaposition), std::move(stack)});
+      }
       return stack;
     }
 
@@ -695,8 +698,9 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
         // TODO(mglb): add support for break_decision == Preserve
         if (layout.SpacesBefore() == tokens.front().before.spaces_required) {
           // No need for separate inline partition
-          if (!slices.empty())
+          if (!slices.empty()) {
             slices.back().Value().SpanUpToToken(tokens.end());
+          }
           return;
         }
 

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -257,17 +257,19 @@ class LayoutFunction {
   LayoutFunction& operator=(const LayoutFunction&) = default;
 
   void push_back(const LayoutFunctionSegment& segment) {
-    if (!segments_.empty())
+    if (!segments_.empty()) {
       CHECK_LT(segments_.back().column, segment.column);
-    else
+    } else {
       CHECK_EQ(segment.column, 0);
+    }
     segments_.push_back(segment);
   }
   void push_back(LayoutFunctionSegment&& segment) {
-    if (!segments_.empty())
+    if (!segments_.empty()) {
       CHECK_LT(segments_.back().column, segment.column);
-    else
+    } else {
       CHECK_EQ(segment.column, 0);
+    }
     segments_.push_back(segment);
   }
 
@@ -319,8 +321,9 @@ class LayoutFunction {
 
   // Sets whether to force line break just before this layout.
   void SetMustWrap(bool must_wrap) {
-    for (auto& segment : segments_)
+    for (auto& segment : segments_) {
       segment.layout.Value().SetMustWrap(must_wrap);
+    }
   }
 
  private:
@@ -533,7 +536,7 @@ class LayoutFunctionFactory {
                   "Iterator's value type must be LayoutFunction.");
     const auto lfs = make_container_range(begin, end);
 
-    if (lfs.empty()) return LayoutFunction();
+    if (lfs.empty()) return {};
     if (lfs.size() == 1) return lfs.front();
 
     // Create a segment iterator for each LayoutFunction.
@@ -580,7 +583,7 @@ class LayoutFunctionFactory {
 
     auto lfs_container = make_container_range(begin, end);
 
-    if (lfs_container.empty()) return LayoutFunction();
+    if (lfs_container.empty()) return {};
     if (lfs_container.size() == 1) return lfs_container.front();
 
     LayoutFunction incremental = lfs_container.front();
@@ -612,7 +615,7 @@ class LayoutFunctionFactory {
                   "Iterator's value type must be LayoutFunction.");
     const auto lfs = make_container_range(begin, end);
 
-    if (lfs.empty()) return LayoutFunction();
+    if (lfs.empty()) return {};
     if (lfs.size() == 1) return lfs.front();
 
     // Create a segment iterator for each LayoutFunction.
@@ -651,7 +654,7 @@ class LayoutFunctionFactory {
 
     const auto lfs = make_container_range(begin, end);
 
-    if (lfs.empty()) return LayoutFunction();
+    if (lfs.empty()) return {};
     if (lfs.size() == 1) return lfs.front();
 
     absl::FixedArray<LayoutFunction> results(lfs.size());
@@ -678,19 +681,21 @@ class LayoutFunctionFactory {
           const auto& first_token = first_line.TokensRange().front();
           const int token_break_penalty = first_token.before.break_penalty;
 
-          for (auto& segment : results_i[j - i])
+          for (auto& segment : results_i[j - i]) {
             segment.intercept += wrapping_penalty + token_break_penalty;
+          }
         }
 
-        if (next_element.MustWrap())
+        if (next_element.MustWrap()) {
           incremental = Stack({
               std::move(incremental),
               Indent(next_element, hanging_indentation),
           });
-        else
+        } else {
           // TODO(mglb): use Stack for invervals where lfs[j] is multiline (i.e.
           // has any stack sublayouts)
           incremental = Juxtaposition({std::move(incremental), next_element});
+        }
       }
       results_i.back() = std::move(incremental);
 

--- a/common/formatting/state_node.cc
+++ b/common/formatting/state_node.cc
@@ -33,7 +33,7 @@
 
 namespace verible {
 
-static const char kNotForAlignment[] =
+static absl::string_view kNotForAlignment =
     "Aligned tokens should never use line-wrap optimization!";
 
 static SpacingDecision FrontTokenSpacing(const FormatTokenRange range) {

--- a/common/formatting/state_node.h
+++ b/common/formatting/state_node.h
@@ -36,8 +36,8 @@ namespace verible {
 // is reached.  StateNode is language-agnostic.
 // StateNode is purely an implementation detail of line_wrap_searcher.cc.
 struct StateNode {
-  typedef std::vector<PreFormatToken> path_type;
-  typedef container_iterator_range<path_type::const_iterator> range_type;
+  using path_type = std::vector<PreFormatToken>;
+  using range_type = container_iterator_range<path_type::const_iterator>;
 
   // The StateNode that has an edge to this StateNode, to backtrack once a final
   // state is reached.

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -277,7 +277,7 @@ void AdjustIndentationAbsolute(TokenPartitionTree* tree, int amount) {
 }
 
 absl::string_view StringSpanOfTokenRange(const FormatTokenRange& range) {
-  if (range.empty()) return absl::string_view();
+  if (range.empty()) return {};
   return make_string_view_range(range.front().Text().begin(),
                                 range.back().Text().end());
 }
@@ -343,8 +343,9 @@ void ApplyAlreadyFormattedPartitionPropertiesToTokens(
 
   for (auto& token : make_range(mutable_tokens_begin, mutable_tokens_end)) {
     auto& decision = token.before.break_decision;
-    if (decision == verible::SpacingOptions::Undecided)
+    if (decision == verible::SpacingOptions::Undecided) {
       decision = verible::SpacingOptions::MustAppend;
+    }
   }
   // Children are no longer needed
   already_formatted_partition_node->Children().clear();
@@ -550,8 +551,7 @@ class TokenPartitionTreeWrapper {
   /* implicit */ TokenPartitionTreeWrapper(  // NOLINT
       const UnwrappedLine& unwrapped_line)
       : node_(nullptr) {
-    unwrapped_line_ =
-        std::unique_ptr<UnwrappedLine>(new UnwrappedLine(unwrapped_line));
+    unwrapped_line_ = std::make_unique<UnwrappedLine>(unwrapped_line);
   }
 
   // At least one of node_ or unwrapped_line_ should not be nullptr
@@ -564,8 +564,7 @@ class TokenPartitionTreeWrapper {
       node_ = other.node_;
     } else {
       node_ = nullptr;
-      unwrapped_line_ = std::unique_ptr<UnwrappedLine>(
-          new UnwrappedLine(*other.unwrapped_line_));
+      unwrapped_line_ = std::make_unique<UnwrappedLine>(*other.unwrapped_line_);
     }
   }
 

--- a/common/formatting/tree_unwrapper.h
+++ b/common/formatting/tree_unwrapper.h
@@ -39,7 +39,7 @@ namespace verible {
 // design documentation.
 class TreeUnwrapper : public TreeContextVisitor {
  protected:
-  typedef std::vector<verible::PreFormatToken> preformatted_tokens_type;
+  using preformatted_tokens_type = std::vector<verible::PreFormatToken>;
 
  public:
   explicit TreeUnwrapper(const TextStructureView& view,
@@ -52,7 +52,7 @@ class TreeUnwrapper : public TreeContextVisitor {
   TreeUnwrapper& operator=(const TreeUnwrapper&) = delete;
   TreeUnwrapper& operator=(TreeUnwrapper&&) = delete;
 
-  ~TreeUnwrapper() override {}
+  ~TreeUnwrapper() override = default;
 
   // Partitions the token stream (in text_structure_view_) into
   // unwrapped_lines_ by traversing the syntax tree representation.

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -110,7 +110,7 @@ std::ostream& operator<<(std::ostream&, PartitionPolicyEnum);
 // line wrap optimization. It consists of a lightweight const_iterator range
 // that can be easily grown without any copy-overhead.
 class UnwrappedLine {
-  typedef FormatTokenRange::const_iterator token_iterator;
+  using token_iterator = FormatTokenRange::const_iterator;
 
  public:
   enum {

--- a/common/lexer/lexer.h
+++ b/common/lexer/lexer.h
@@ -24,7 +24,7 @@ namespace verible {
 
 class Lexer {
  public:
-  virtual ~Lexer() {}
+  virtual ~Lexer() = default;
 
   Lexer(const Lexer&) = delete;
   Lexer& operator=(const Lexer&) = delete;
@@ -42,7 +42,7 @@ class Lexer {
   virtual bool TokenIsError(const TokenInfo&) const = 0;
 
  protected:
-  Lexer() {}
+  Lexer() = default;
 };
 
 }  // namespace verible

--- a/common/lsp/lsp-text-buffer.cc
+++ b/common/lsp/lsp-text-buffer.cc
@@ -143,8 +143,9 @@ void BufferCollection::didOpenEvent(const DidOpenTextDocumentParams &o) {
   if (inserted.second) {
     inserted.first->second.reset(new EditTextBuffer(o.textDocument.text));
     inserted.first->second->set_last_global_version(++global_version_);
-    if (change_listener_)
+    if (change_listener_) {
       change_listener_(o.textDocument.uri, inserted.first->second.get());
+    }
   }
 }
 

--- a/common/parser/parse.h
+++ b/common/parser/parse.h
@@ -37,12 +37,12 @@ class Parser {
   // Return the collection of rejected tokens from recovered syntax errors.
   virtual const std::vector<TokenInfo>& RejectedTokens() const = 0;
 
-  virtual ~Parser() {}
+  virtual ~Parser() = default;
 
  protected:
-  Parser() {}
+  Parser() = default;
 
- private:
+ public:                                      // Deleted should be public.
   Parser(const Parser&) = delete;             // disallow copy
   Parser& operator=(const Parser&) = delete;  // disallow assign
 };

--- a/common/parser/parser_param.cc
+++ b/common/parser/parser_param.cc
@@ -34,7 +34,7 @@ ParserParam::ParserParam(TokenGenerator* token_stream)
       last_token_(TokenInfo::EOFToken()),
       max_used_stack_size_(0) {}
 
-ParserParam::~ParserParam() {}
+ParserParam::~ParserParam() = default;
 
 const TokenInfo& ParserParam::FetchToken() {
   last_token_ = (*token_stream_)();

--- a/common/parser/parser_param.h
+++ b/common/parser/parser_param.h
@@ -99,6 +99,7 @@ class ParserParam {
   ValueStack value_stack_;
   size_t max_used_stack_size_;
 
+ public:  // deleted member functions: public.
   ParserParam(const ParserParam&) = delete;
   ParserParam& operator=(const ParserParam&) = delete;
 };

--- a/common/strings/diff.cc
+++ b/common/strings/diff.cc
@@ -178,9 +178,7 @@ void LineDiffsToUnifiedDiff(std::ostream& stream, const LineDiffs& linediffs,
     int chunk_before_lines_count = 0;
     int chunk_added_lines_count = 0;
 
-    for (size_t i = 0; i < chunk.size(); ++i) {
-      const auto& edit = chunk[i];
-
+    for (const auto& edit : chunk) {
       if (edit.operation == Operation::INSERT) {
         chunk_added_lines_count += edit.end - edit.start;
       } else if (edit.operation == Operation::DELETE) {

--- a/common/strings/display_utils.cc
+++ b/common/strings/display_utils.cc
@@ -65,11 +65,12 @@ std::ostream& operator<<(std::ostream& stream, const EscapeString& vis) {
         break;
 
       default:
-        if (c < 0x20 || c > 0x7E)
+        if (c < 0x20 || c > 0x7E) {
           stream << "\\x" << std::hex << std::setw(2) << std::setfill('0')
                  << static_cast<unsigned>(c);
-        else
+        } else {
           stream << c;
+        }
     }
   }
   return stream;

--- a/common/strings/mem_block.h
+++ b/common/strings/mem_block.h
@@ -26,13 +26,13 @@ namespace verible {
 // as std::shared_ptr<> if needed in multiple places.
 class MemBlock {
  public:
-  virtual ~MemBlock() {}
+  virtual ~MemBlock() = default;
   virtual absl::string_view AsStringView() const = 0;
 
  protected:
   MemBlock() = default;
 
- private:
+ public:
   MemBlock(const MemBlock&) = delete;
   MemBlock(MemBlock&&) = delete;
   MemBlock& operator=(const MemBlock&) = delete;
@@ -42,7 +42,7 @@ class MemBlock {
 // An implementation of MemBlock backed by a std::string
 class StringMemBlock final : public MemBlock {
  public:
-  StringMemBlock() {}
+  StringMemBlock() = default;
   explicit StringMemBlock(absl::string_view copy_from)
       : content_(copy_from.begin(), copy_from.end()) {}
 

--- a/common/strings/naming_utils.cc
+++ b/common/strings/naming_utils.cc
@@ -47,9 +47,9 @@ bool IsUpperCamelCaseWithDigits(absl::string_view text) {
 
   // Check for underscores followed by digits
   auto pos = text.find('_');
-  if (pos != absl::string_view::npos)
+  if (pos != absl::string_view::npos) {
     return AllUnderscoresFollowedByDigits(text.substr(pos));
-
+  }
   return true;
 }
 

--- a/common/strings/obfuscator.h
+++ b/common/strings/obfuscator.h
@@ -40,10 +40,9 @@ namespace verible {
 // substitutions written/read from a text file.
 class Obfuscator {
  public:
-  typedef std::function<std::string(absl::string_view)> generator_type;
-  typedef BijectiveMap<std::string, std::string, StringViewCompare,
-                       StringViewCompare>
-      translator_type;
+  using generator_type = std::function<std::string(absl::string_view)>;
+  using translator_type = BijectiveMap<std::string, std::string,
+                                       StringViewCompare, StringViewCompare>;
 
   explicit Obfuscator(const generator_type& g) : generator_(g) {}
 
@@ -86,7 +85,7 @@ class Obfuscator {
 };
 
 class IdentifierObfuscator : public Obfuscator {
-  typedef Obfuscator parent_type;
+  using parent_type = Obfuscator;
 
  public:
   // Tip for users of this: use something like RandomEqualLengthIdentifier,

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -251,7 +251,7 @@ std::vector<Hunk> Hunk::Split() const {
   std::vector<Hunk> sub_hunks;
 
   // Split after every group of changed lines.
-  typedef std::vector<MarkedLine>::const_iterator MarkedLineIterator;
+  using MarkedLineIterator = std::vector<MarkedLine>::const_iterator;
   std::vector<MarkedLineIterator> cut_points;
   verible::find_all(lines_.begin(), lines_.end(),
                     std::back_inserter(cut_points), HunkSplitter());
@@ -269,7 +269,7 @@ std::vector<Hunk> Hunk::Split() const {
   // cut_points always contains lines_.begin(), and .end()
 
   // convert cut points to sub-ranges
-  typedef container_iterator_range<MarkedLineIterator> MarkedLineRange;
+  using MarkedLineRange = container_iterator_range<MarkedLineIterator>;
   const std::vector<MarkedLineRange> ranges(
       IteratorsToRanges<MarkedLineRange>(cut_points));
 
@@ -325,7 +325,7 @@ absl::Status SourceInfo::Parse(absl::string_view text) {
   path.assign(token.begin(), token.end());
   if (path.empty()) {
     return absl::InvalidArgumentError(absl::StrCat(
-        "Expected \"path [timestamp]\" (tab-separated), but got: \"", text,
+        R"(Expected "path [timestamp]" (tab-separated), but got: ")", text,
         "\"."));
   }
 

--- a/common/strings/patch.h
+++ b/common/strings/patch.h
@@ -125,9 +125,7 @@ struct MarkedLine {
   bool IsAdded() const { return Marker() == '+'; }
   bool IsDeleted() const { return Marker() == '-'; }
 
-  absl::string_view Text() const {
-    return absl::string_view(&line[1], line.length() - 1);
-  }
+  absl::string_view Text() const { return {&line[1], line.length() - 1}; }
 
   // default equality operator
   bool operator==(const MarkedLine& other) const { return line == other.line; }

--- a/common/strings/position.h
+++ b/common/strings/position.h
@@ -34,7 +34,7 @@ int AdvancingTextNewColumnPosition(int old_column_position,
 // IntervalSet<int> to avoid potential confusion with other IntervalSet<int>.
 // Type safety will enforce intent of meaning.
 class ByteOffsetSet : public verible::IntervalSet<int> {
-  typedef verible::IntervalSet<int> impl_type;
+  using impl_type = verible::IntervalSet<int>;
 
  public:
   ByteOffsetSet() = default;
@@ -52,7 +52,7 @@ class ByteOffsetSet : public verible::IntervalSet<int> {
 // avoid potential confusion with other IntervalSet<int>.
 // Mismatches will be caught as type errors.
 class LineNumberSet : public verible::IntervalSet<int> {
-  typedef verible::IntervalSet<int> impl_type;
+  using impl_type = verible::IntervalSet<int>;
 
  public:
   LineNumberSet() = default;

--- a/common/strings/split.cc
+++ b/common/strings/split.cc
@@ -21,7 +21,7 @@
 namespace verible {
 
 std::vector<absl::string_view> SplitLines(absl::string_view text) {
-  if (text.empty()) return std::vector<absl::string_view>();
+  if (text.empty()) return {};
   std::vector<absl::string_view> lines(
       absl::StrSplit(text, absl::ByChar('\n')));
   // If text ends cleanly with a \n, omit the last blank split,
@@ -40,8 +40,9 @@ class AfterCharDelimiter {
 
   absl::string_view Find(absl::string_view text, size_t pos) const {
     const size_t found_pos = text.find(delimiter_, pos);
-    if (found_pos == absl::string_view::npos)
-      return absl::string_view(text.data() + text.size(), 0);
+    if (found_pos == absl::string_view::npos) {
+      return {text.data() + text.size(), 0};
+    }
     return text.substr(found_pos + 1, 0);
   }
 
@@ -51,7 +52,7 @@ class AfterCharDelimiter {
 
 std::vector<absl::string_view> SplitLinesKeepLineTerminator(
     absl::string_view text) {
-  if (text.empty()) return std::vector<absl::string_view>();
+  if (text.empty()) return {};
   return absl::StrSplit(text, AfterCharDelimiter('\n'));
 }
 

--- a/common/strings/string_memory_map.h
+++ b/common/strings/string_memory_map.h
@@ -40,13 +40,13 @@ string_view_to_pair(absl::string_view sv) {
 // any of the referenced memory -- the user is responsible for maintaining
 // proper string lifetime, owning strings must outlive these objects.
 class StringViewSuperRangeMap {
-  typedef DisjointIntervalSet<absl::string_view::const_iterator> impl_type;
+  using impl_type = DisjointIntervalSet<absl::string_view::const_iterator>;
 
  public:
   // This iterator dereferences to a std::pair of
   // absl::string_view::const_iterator, which can be constructed into a
   // string_view.
-  typedef impl_type::const_iterator const_iterator;
+  using const_iterator = impl_type::const_iterator;
 
   StringViewSuperRangeMap() = default;
 
@@ -68,7 +68,7 @@ class StringViewSuperRangeMap {
   // Similar to find(), but asserts that a superstring range is found,
   // and converts the result directly to a string_view.
   absl::string_view must_find(absl::string_view substring) const {
-    const const_iterator found(find(substring));
+    const auto found(find(substring));
     CHECK(found != string_map_.end());
     return make_string_view_range(found->first, found->second);  // superstring
   }
@@ -104,11 +104,11 @@ class StringViewSuperRangeMap {
 //
 template <class T, absl::string_view RangeOf(const T&)>
 class StringMemoryMap {
-  typedef absl::string_view::const_iterator key_type;
-  typedef DisjointIntervalMap<key_type, T> map_type;
+  using key_type = absl::string_view::const_iterator;
+  using map_type = DisjointIntervalMap<key_type, T>;
 
  public:
-  typedef typename map_type::iterator iterator;
+  using iterator = typename map_type::iterator;
 
   StringMemoryMap() = default;
 

--- a/common/strings/utf8.h
+++ b/common/strings/utf8.h
@@ -35,12 +35,13 @@ inline absl::string_view utf8_substr(absl::string_view str,
   size_t remaining = character_pos;
   absl::string_view::const_iterator it;
   for (it = str.begin(); remaining && it != str.end(); ++it, --remaining) {
-    if ((*it & 0xE0) == 0xC0)
+    if ((*it & 0xE0) == 0xC0) {
       remaining += 1;
-    else if ((*it & 0xF0) == 0xE0)
+    } else if ((*it & 0xF0) == 0xE0) {
       remaining += 2;
-    else if ((*it & 0xF8) == 0xF0)
+    } else if ((*it & 0xF8) == 0xF0) {
       remaining += 3;
+    }
   }
   return str.substr(it - str.begin());
 }

--- a/common/text/concrete_syntax_leaf.cc
+++ b/common/text/concrete_syntax_leaf.cc
@@ -29,7 +29,7 @@ namespace verible {
 bool SyntaxTreeLeaf::equals(const Symbol *symbol,
                             const TokenComparator &compare_tokens) const {
   if (symbol->Kind() == SymbolKind::kLeaf) {
-    const SyntaxTreeLeaf *leaf = down_cast<const SyntaxTreeLeaf *>(symbol);
+    const auto *leaf = down_cast<const SyntaxTreeLeaf *>(symbol);
     return equals(leaf, compare_tokens);
   } else {
     return false;

--- a/common/text/concrete_syntax_tree.cc
+++ b/common/text/concrete_syntax_tree.cc
@@ -29,7 +29,7 @@ namespace verible {
 bool SyntaxTreeNode::equals(const Symbol* symbol,
                             const TokenComparator& compare_tokens) const {
   if (symbol->Kind() == SymbolKind::kNode) {
-    const SyntaxTreeNode* node = down_cast<const SyntaxTreeNode*>(symbol);
+    const auto* node = down_cast<const SyntaxTreeNode*>(symbol);
     return equals(node, compare_tokens);
   } else {
     return false;
@@ -47,8 +47,9 @@ bool SyntaxTreeNode::equals(const SyntaxTreeNode* node,
     int size = children_.size();
     for (int i = 0; i < size; i++) {
       if (!EqualTrees(children_[i].get(), node->children()[i].get(),
-                      compare_tokens))
+                      compare_tokens)) {
         return false;
+      }
     }
   }
   return true;

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -150,7 +150,7 @@ class SyntaxTreeNode final : public Symbol {
     auto it = enums.begin();
     // Unroll OR expression. Right now, we never have more than 4.
     switch (enums.size()) {
-      case 4:
+      case 4:  // NOLINT(bugprone-branch-clone)
         if (*it++ == EnumType(tag_)) return true;
         ABSL_FALLTHROUGH_INTENDED;
       case 3:
@@ -189,7 +189,7 @@ class SyntaxTreeNode final : public Symbol {
 // Sample usage: $$ = MakeNode(TAG, $1, $2, $3);
 template <typename... Args>
 SymbolPtr MakeNode(Args&&... args) {
-  SyntaxTreeNode* node_pointer = new SyntaxTreeNode();
+  auto* const node_pointer = new SyntaxTreeNode();
   node_pointer->Append(std::forward<Args>(args)...);
   return SymbolPtr(node_pointer);
 }
@@ -201,7 +201,7 @@ SymbolPtr MakeNode(Args&&... args) {
 //   $$ = MakeTaggedNode(TAG, $1, $2, $3);
 template <typename Enum, typename... Args>
 SymbolPtr MakeTaggedNode(const Enum tag, Args&&... args) {
-  SyntaxTreeNode* node_pointer = new SyntaxTreeNode(static_cast<int>(tag));
+  auto* const node_pointer = new SyntaxTreeNode(static_cast<int>(tag));
   node_pointer->Append(std::forward<Args>(args)...);
   return SymbolPtr(node_pointer);
 }
@@ -220,7 +220,7 @@ SymbolPtr ExtendNode(T&& list_ptr, Args&&... args) {
 template <typename... Args>
 SymbolPtr _ExtendNodeMoved(SymbolPtr list_ptr, Args&&... args) {
   CHECK(list_ptr->Kind() == SymbolKind::kNode);
-  SyntaxTreeNode* node_pointer = down_cast<SyntaxTreeNode*>(list_ptr.get());
+  auto* const node_pointer = down_cast<SyntaxTreeNode*>(list_ptr.get());
   node_pointer->Append(std::forward<Args>(args)...);
   return list_ptr;
 }

--- a/common/text/macro_definition.h
+++ b/common/text/macro_definition.h
@@ -65,18 +65,18 @@ struct MacroCall {
   DefaultTokenInfo macro_name;
 
   // Distinguish between a definition without () vs. with empty ().
-  bool has_parameters;
+  bool has_parameters = false;
 
   // Positional arguments to macro call.
   std::vector<DefaultTokenInfo> positional_arguments;
 
-  MacroCall() : has_parameters(false) {}
+  MacroCall() = default;
 };
 
 class MacroDefinition {
  public:
   MacroDefinition(const TokenInfo& header, const TokenInfo& name)
-      : header_(header), name_(name), is_callable_(false) {}
+      : header_(header), name_(name) {}
 
   absl::string_view Name() const { return name_.text(); }
   const TokenInfo& NameToken() const { return name_; }
@@ -100,7 +100,7 @@ class MacroDefinition {
     return parameter_info_array_;
   }
 
-  typedef std::map<absl::string_view, DefaultTokenInfo> substitution_map_type;
+  using substitution_map_type = std::map<absl::string_view, DefaultTokenInfo>;
 
   // Create a text substitution map to be used for macro expansion.
   absl::Status PopulateSubstitutionMap(const std::vector<TokenInfo>&,
@@ -121,7 +121,7 @@ class MacroDefinition {
   TokenInfo name_;
 
   // Distinguish between a definition without () vs. with empty ().
-  bool is_callable_;
+  bool is_callable_ = false;
 
   // These form an ordered dictionary on macro parameters.
   std::vector<MacroParameterInfo> parameter_info_array_;

--- a/common/text/symbol.h
+++ b/common/text/symbol.h
@@ -60,7 +60,7 @@ inline constexpr SymbolTag LeafTag(int tag) { return {SymbolKind::kLeaf, tag}; }
 
 class Symbol {
  public:
-  virtual ~Symbol() {}
+  virtual ~Symbol() = default;
 
   virtual bool equals(const Symbol *symbol,
                       const TokenComparator &compare_tokens) const = 0;
@@ -80,7 +80,7 @@ class Symbol {
   virtual SymbolTag Tag() const = 0;
 
  protected:
-  Symbol() {}
+  Symbol() = default;
 };
 
 }  // namespace verible

--- a/common/text/syntax_tree_context.h
+++ b/common/text/syntax_tree_context.h
@@ -38,7 +38,7 @@ namespace verible {
 // that managed elements are non-nullptrs.
 class SyntaxTreeContext : public AutoPopStack<const SyntaxTreeNode*> {
  public:
-  typedef AutoPopStack<const SyntaxTreeNode*> base_type;
+  using base_type = AutoPopStack<const SyntaxTreeNode*>;
 
   // member class to handle push and pop of stack safely
   using AutoPop = base_type::AutoPop;

--- a/common/text/token_info.cc
+++ b/common/text/token_info.cc
@@ -30,11 +30,11 @@ namespace verible {
 
 TokenInfo TokenInfo::EOFToken() {
   static constexpr absl::string_view null_text;
-  return TokenInfo(TK_EOF, null_text);
+  return {TK_EOF, null_text};
 }
 
 TokenInfo TokenInfo::EOFToken(absl::string_view buffer) {
-  return TokenInfo(TK_EOF, absl::string_view(buffer.end(), 0));
+  return {TK_EOF, absl::string_view(buffer.end(), 0)};
 }
 
 bool TokenInfo::operator==(const TokenInfo& token) const {

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -110,10 +110,9 @@ const SyntaxTreeLeaf* MatchLeafEnumOrNull(const SyntaxTreeLeaf& leaf,
 namespace internal {
 template <typename S>
 void StaticAssertMustBeCSTSymbolOrNode(S&) {
-  typedef typename std::remove_const<S>::type base_type;
+  using base_type = typename std::remove_const<S>::type;
   static_assert(std::is_same<base_type, Symbol>::value ||
-                    std::is_same<base_type, SyntaxTreeNode>::value,
-                "");
+                std::is_same<base_type, SyntaxTreeNode>::value);
 }
 }  // namespace internal
 

--- a/common/text/visitors.h
+++ b/common/text/visitors.h
@@ -35,7 +35,7 @@ class SyntaxTreeNode;
 //
 class TreeVisitorRecursive {
  public:
-  virtual ~TreeVisitorRecursive() {}
+  virtual ~TreeVisitorRecursive() = default;
   virtual void Visit(const SyntaxTreeLeaf& leaf) = 0;
   virtual void Visit(const SyntaxTreeNode& node) = 0;
 };
@@ -50,7 +50,7 @@ class TreeVisitorRecursive {
 //
 class SymbolVisitor {
  public:
-  virtual ~SymbolVisitor() {}
+  virtual ~SymbolVisitor() = default;
   virtual void Visit(const SyntaxTreeLeaf& leaf) = 0;
   virtual void Visit(const SyntaxTreeNode& node) = 0;
 };
@@ -63,7 +63,7 @@ class SymbolVisitor {
 // delete or mutate syntax tree nodes.
 class MutableTreeVisitorRecursive {
  public:
-  virtual ~MutableTreeVisitorRecursive() {}
+  virtual ~MutableTreeVisitorRecursive() = default;
   virtual void Visit(const SyntaxTreeLeaf& leaf, SymbolPtr*) = 0;
   virtual void Visit(const SyntaxTreeNode& node, SymbolPtr*) = 0;
 };

--- a/common/util/auto_pop_stack.h
+++ b/common/util/auto_pop_stack.h
@@ -34,27 +34,25 @@ namespace verible {
 template <typename T>
 class AutoPopStack {
  public:
-  typedef T value_type;
-  typedef AutoPopStack<value_type> this_type;
+  using value_type = T;
+  using this_type = AutoPopStack<value_type>;
 
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
+  using reference = value_type&;
+  using const_reference = const value_type&;
 
-  typedef std::vector<value_type> stack_type;
-  typedef typename stack_type::iterator iterator;
-  typedef typename stack_type::const_iterator const_iterator;
-  typedef typename stack_type::const_reverse_iterator const_reverse_iterator;
+  using stack_type = std::vector<value_type>;
+  using iterator = typename stack_type::iterator;
+  using const_iterator = typename stack_type::const_iterator;
+  using const_reverse_iterator = typename stack_type::const_reverse_iterator;
 
   // member class which exclusively manages stack.
   // it's the only class that can modify number of elements in stack
   class AutoPop {
    public:
-    AutoPop(this_type* stack, value_type&& value) {
-      stack_ = stack;
+    AutoPop(this_type* stack, value_type&& value) : stack_(stack) {
       stack->Push(std::move(value));
     }
-    AutoPop(this_type* stack, const_reference value) {
-      stack_ = stack;
+    AutoPop(this_type* stack, const_reference value) : stack_(stack) {
       stack->Push(&value);
     }
     ~AutoPop() { stack_->Pop(); }

--- a/common/util/bijective_map.h
+++ b/common/util/bijective_map.h
@@ -36,11 +36,11 @@ class BijectiveMap {
   // Map of keys to values (by pointer).
   // Would really rather have value_type be a reverse_map_type::const_iterator
   // but cannot due to mutually recursive template type.
-  typedef std::map<K, const V*, KComp> forward_map_type;
+  using forward_map_type = std::map<K, const V*, KComp>;
   // Map of values to keys (by pointer).
   // Would really rather have value_type be a forward_map_type::const_iterator
   // but cannot due to mutually recursive template type.
-  typedef std::map<V, const K*, VComp> reverse_map_type;
+  using reverse_map_type = std::map<V, const K*, VComp>;
 
  public:
   BijectiveMap() = default;

--- a/common/util/container_iterator_range.h
+++ b/common/util/container_iterator_range.h
@@ -36,8 +36,8 @@ namespace verible {
 // invalidates these iterator ranges, e.g. vector::push_back().
 template <typename IT>
 class container_iterator_range : public iterator_range<IT> {
-  typedef container_iterator_range<IT> this_type;
-  typedef iterator_range<IT> range_type;
+  using this_type = container_iterator_range<IT>;
+  using range_type = iterator_range<IT>;
 
  public:
   using iterator = IT;

--- a/common/util/container_util.h
+++ b/common/util/container_util.h
@@ -33,7 +33,7 @@ struct ValueTypeFromKeyType;
 // Constructs a default-valued pair from a key-type, for map-like types.
 template <class KeyType, class MappedType>
 struct ValueTypeFromKeyType<KeyType, std::pair<const KeyType, MappedType>> {
-  typedef std::pair<const KeyType, MappedType> ValueType;
+  using ValueType = std::pair<const KeyType, MappedType>;
   ValueType operator()(const KeyType& k) const {
     return {k, MappedType{}};  // default-value mapped-type
   }
@@ -59,9 +59,8 @@ bool InsertOrUpdate(M* map, const typename M::key_type& k,
 
 template <typename M>
 typename M::mapped_type& InsertKeyOrDie(M* m, const typename M::key_type& k) {
-  typedef internal::ValueTypeFromKeyType<typename M::key_type,
-                                         typename M::value_type>
-      value_inserter;
+  using value_inserter = internal::ValueTypeFromKeyType<typename M::key_type,
+                                                        typename M::value_type>;
   auto res = m->insert(value_inserter()(k));
   CHECK(res.second) << "duplicate key: " << k;
   return res.first->second;

--- a/common/util/enum_flags.h
+++ b/common/util/enum_flags.h
@@ -95,13 +95,12 @@ class EnumNameMap {
   // Using a string_view is safe when the string-memory owned elsewhere is
   // guaranteed to outlive objects of this class.
   // String-literals are acceptable sources of string_views for this purpose.
-  typedef absl::string_view key_type;
+  using key_type = absl::string_view;
 
   // Storage type for mapping information.
   // StringViewCompare gives the benefit of copy-free heterogeneous lookup.
-  typedef BijectiveMap<key_type, EnumType, StringViewCompare,
-                       internal::EnumCompare>
-      map_type;
+  using map_type = BijectiveMap<key_type, EnumType, StringViewCompare,
+                                internal::EnumCompare>;
 
  public:
   // Pairs must contain unique keys or values, or this will result in a fatal

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -14,11 +14,10 @@
 
 #include "common/util/file_util.h"
 
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <algorithm>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -78,15 +77,15 @@ static absl::Status CreateErrorStatusFromSysError(const char *fallback_msg,
   switch (sys_error) {
     case EPERM:
     case EACCES:
-      return absl::Status(StatusCode::kPermissionDenied, system_msg);
+      return {StatusCode::kPermissionDenied, system_msg};
     case ENOENT:
-      return absl::Status(StatusCode::kNotFound, system_msg);
+      return {StatusCode::kNotFound, system_msg};
     case EEXIST:
-      return absl::Status(StatusCode::kAlreadyExists, system_msg);
+      return {StatusCode::kAlreadyExists, system_msg};
     case EINVAL:
-      return absl::Status(StatusCode::kInvalidArgument, system_msg);
+      return {StatusCode::kInvalidArgument, system_msg};
     default:
-      return absl::Status(StatusCode::kUnknown, system_msg);
+      return {StatusCode::kUnknown, system_msg};
   }
 }
 
@@ -194,9 +193,9 @@ static absl::StatusOr<std::unique_ptr<MemBlock>> AttemptMemMapFile(
   }
 
   const size_t file_size = s.st_size;
-  void *const buffer = mmap(NULL, file_size, PROT_READ, MAP_SHARED, fd, 0);
+  void *const buffer = mmap(nullptr, file_size, PROT_READ, MAP_SHARED, fd, 0);
   close(fd);
-  if (buffer == MAP_FAILED) {
+  if (buffer == MAP_FAILED) {  // NOLINT(performance-no-int-to-ptr)
     return CreateErrorStatusFromErrno("Can't mmap file");
   }
 

--- a/common/util/interval.h
+++ b/common/util/interval.h
@@ -28,8 +28,8 @@ namespace verible {
 // Currently intended for direct use in IntervalSet<>.
 template <typename T>
 struct Interval {
-  typedef T value_type;
-  typedef ForwardReferenceElseConstruct<Interval<T>> forwarder;
+  using value_type = T;
+  using forwarder = ForwardReferenceElseConstruct<Interval<T>>;
 
   // Allow direct access.  Use responsibly.  Check valid()-ity.
   T min = {};
@@ -76,10 +76,11 @@ struct Interval {
   std::ostream& FormatInclusive(std::ostream& stream, bool compact,
                                 char delim = '-') const {
     const T upper = max - 1;
-    if ((min == upper) && compact)
+    if ((min == upper) && compact) {
       stream << min;  // N instead of N-N
-    else
+    } else {
       stream << min << delim << upper;
+    }
     return stream;
   }
 };

--- a/common/util/interval_map.h
+++ b/common/util/interval_map.h
@@ -126,16 +126,16 @@ static std::pair<typename M::iterator, bool> FindNonoverlappingEmplacePosition(
 template <typename K, typename V>
 class DisjointIntervalMap {
   // Interpreted as the interval [i,j)
-  typedef std::pair<K, K> interval_key_type;
-  typedef internal::CompareFirst<K> comparator;
-  typedef std::map<interval_key_type, V, comparator> map_type;
+  using interval_key_type = std::pair<K, K>;
+  using comparator = internal::CompareFirst<K>;
+  using map_type = std::map<interval_key_type, V, comparator>;
 
  public:
-  typedef typename map_type::key_type key_type;
-  typedef typename map_type::mapped_type mapped_type;
-  typedef typename map_type::value_type value_type;
-  typedef typename map_type::iterator iterator;
-  typedef typename map_type::const_iterator const_iterator;
+  using key_type = typename map_type::key_type;
+  using mapped_type = typename map_type::mapped_type;
+  using value_type = typename map_type::value_type;
+  using iterator = typename map_type::iterator;
+  using const_iterator = typename map_type::const_iterator;
 
  public:
   DisjointIntervalMap() = default;

--- a/common/util/interval_set.h
+++ b/common/util/interval_set.h
@@ -37,7 +37,7 @@ namespace verible {
 // (like std::pair).
 template <class Iter>
 std::ostream& FormatIntervals(std::ostream& stream, Iter begin, Iter end) {
-  typedef typename std::iterator_traits<Iter>::value_type value_type;
+  using value_type = typename std::iterator_traits<Iter>::value_type;
   return stream << absl::StrJoin(
              begin, end, ", ",
              [](std::string* out, const value_type& interval) {
@@ -138,17 +138,17 @@ class _IntervalSetImpl {
 template <typename T>
 class IntervalSet : private _IntervalSetImpl {
  private:
-  typedef std::map<T, T> impl_type;
+  using impl_type = std::map<T, T>;
 
  protected:
-  typedef typename impl_type::iterator iterator;
-  typedef typename impl_type::reverse_iterator reverse_iterator;
+  using iterator = typename impl_type::iterator;
+  using reverse_iterator = typename impl_type::reverse_iterator;
 
  public:
-  typedef typename impl_type::value_type value_type;
-  typedef typename impl_type::const_iterator const_iterator;
-  typedef typename impl_type::const_reverse_iterator const_reverse_iterator;
-  typedef typename impl_type::size_type size_type;
+  using value_type = typename impl_type::value_type;
+  using const_iterator = typename impl_type::const_iterator;
+  using const_reverse_iterator = typename impl_type::const_reverse_iterator;
+  using size_type = typename impl_type::size_type;
 
  public:
   IntervalSet() = default;
@@ -168,21 +168,21 @@ class IntervalSet : private _IntervalSetImpl {
   IntervalSet<T>& operator=(IntervalSet<T>&&) noexcept = default;
 
  public:
-  const_iterator begin(void) const { return intervals_.begin(); }
+  const_iterator begin() const { return intervals_.begin(); }
 
-  const_iterator end(void) const { return intervals_.end(); }
+  const_iterator end() const { return intervals_.end(); }
 
   // Returns the number of disjoint intervals that compose this set.
-  size_type size(void) const { return intervals_.size(); }
+  size_type size() const { return intervals_.size(); }
 
   // Returns sum of sizes of all intervals.
-  size_type sum_of_sizes(void) const;
+  size_type sum_of_sizes() const;
 
   // Returns true if the set contains no intervals/values.
-  bool empty(void) const { return intervals_.empty(); }
+  bool empty() const { return intervals_.empty(); }
 
   // Remove all intervals from the set.
-  void clear(void) { intervals_.clear(); }
+  void clear() { intervals_.clear(); }
 
   void swap(IntervalSet<T>& other) { intervals_.swap(other.intervals_); }
 
@@ -463,8 +463,8 @@ class IntervalSet : private _IntervalSetImpl {
   }
 
   // Checks invariant properties described in class description.
-  void CheckIntegrity(void) const {
-    typedef Interval<T> interval_type;
+  void CheckIntegrity() const {
+    using interval_type = Interval<T>;
     if (intervals_.empty()) return;
 
     // Check front outside of loop.
@@ -571,15 +571,15 @@ template <typename T>
 class DisjointIntervalSet : private _IntervalSetImpl {
  private:
   // This makes the value_type an immutable std::pair<const T, const T>.
-  typedef std::map<T, const T> impl_type;
+  using impl_type = std::map<T, const T>;
 
  public:
-  typedef typename impl_type::key_type key_type;
-  typedef typename impl_type::value_type value_type;
-  typedef typename impl_type::mapped_type mapped_type;
-  typedef typename impl_type::const_iterator const_iterator;
-  typedef typename impl_type::const_reverse_iterator const_reverse_iterator;
-  typedef typename impl_type::size_type size_type;
+  using key_type = typename impl_type::key_type;
+  using value_type = typename impl_type::value_type;
+  using mapped_type = typename impl_type::mapped_type;
+  using const_iterator = typename impl_type::const_iterator;
+  using const_reverse_iterator = typename impl_type::const_reverse_iterator;
+  using size_type = typename impl_type::size_type;
 
  public:
   DisjointIntervalSet() = default;

--- a/common/util/map_tree.h
+++ b/common/util/map_tree.h
@@ -73,20 +73,20 @@ namespace verible {
 //
 template <typename K, typename V, typename KeyComp = std::less<K>>
 class MapTree {
-  typedef MapTree<K, V, KeyComp> this_type;
+  using this_type = MapTree<K, V, KeyComp>;
 
   // Self-recursive type that holds subtrees.
   // A std::map is chosen for key-value co-location and iterator stability.
   // We chose std::map over std::set to allow values to be mutable, while keys
   // remain const.
-  typedef std::map<K, this_type, KeyComp> subtrees_type;
+  using subtrees_type = std::map<K, this_type, KeyComp>;
 
  public:
-  typedef K key_type;
-  typedef V node_value_type;
-  typedef typename subtrees_type::value_type key_value_type;  // pair
-  typedef typename subtrees_type::iterator iterator;
-  typedef typename subtrees_type::const_iterator const_iterator;
+  using key_type = K;
+  using node_value_type = V;
+  using key_value_type = typename subtrees_type::value_type;  // pair
+  using iterator = typename subtrees_type::iterator;
+  using const_iterator = typename subtrees_type::const_iterator;
 
   MapTree() = default;
 

--- a/common/util/thread_pool.h
+++ b/common/util/thread_pool.h
@@ -45,7 +45,7 @@ class ThreadPool {
   // executed synchronously.
   template <class T>
   std::future<T> ExecAsync(const std::function<T()> &f) {
-    std::promise<T> *p = new std::promise<T>();
+    auto *p = new std::promise<T>();
     std::future<T> future_result = p->get_future();
     auto promise_fulfiller = [p, f]() {
       try {

--- a/common/util/top_n.h
+++ b/common/util/top_n.h
@@ -30,7 +30,7 @@ namespace verible {
 template <typename T, typename Comp = std::greater<T>>
 class TopN {
  public:
-  typedef T value_type;
+  using value_type = T;
 
   explicit TopN(size_t limit) : max_size_(limit) {}
 
@@ -80,7 +80,7 @@ class TopN {
 
   // For simplicity, use existing priority_queue internally, which implements
   // the desired ordering.
-  typedef std::priority_queue<T, std::vector<T>, Comp> impl_type;
+  using impl_type = std::priority_queue<T, std::vector<T>, Comp>;
 
   // Internal storage of elements.
   impl_type elements_;

--- a/common/util/tree_operations.h
+++ b/common/util/tree_operations.h
@@ -873,7 +873,7 @@ template <typename LT, typename RT,
           std::enable_if_t<TreeNodeTraits<LT>::available &&
                            TreeNodeTraits<RT>::available>* = nullptr>
 struct TreeNodePair {
-  TreeNodePair() {}
+  TreeNodePair() = default;
   TreeNodePair(const LT* l, const RT* r) : left(l), right(r) {}
   const LT* left = nullptr;
   const RT* right = nullptr;

--- a/common/util/vector_tree.h
+++ b/common/util/vector_tree.h
@@ -65,15 +65,15 @@ namespace verible {
 // parent.
 template <typename T>
 class VectorTree {
-  typedef VectorTree<T> this_type;
+  using this_type = VectorTree<T>;
 
   // Forward declaration
   class ChildrenList;
 
  public:
   // Self-recursive type that represents children in an expanded view.
-  typedef std::vector<this_type> subnodes_type;
-  typedef T value_type;
+  using subnodes_type = std::vector<this_type>;
+  using value_type = T;
 
   VectorTree() : children_(*this) {}
 
@@ -224,9 +224,6 @@ class VectorTree {
 
     explicit ChildrenList(VectorTree& node) : node_(node) {}
 
-    // Construction requires parent node reference.
-    ChildrenList(const ChildrenList&) = delete;
-
     ChildrenList(VectorTree& node, const ChildrenList& other)
         : node_(node), container_(other.container_) {
       LinkChildrenToParent(container_);
@@ -237,9 +234,6 @@ class VectorTree {
       LinkChildrenToParent(container_);
       return *this;
     }
-
-    // Construction requires parent node reference.
-    ChildrenList(ChildrenList&&) = delete;
 
     ChildrenList(VectorTree& node, ChildrenList&& other) noexcept
         : node_(node), container_(std::move(other.container_)) {
@@ -266,6 +260,13 @@ class VectorTree {
 
     // Actual data container where the nodes are stored.
     subnodes_type container_;
+
+   public:  // deleted members need to be public.
+    // Construction requires parent node reference.
+    ChildrenList(const ChildrenList&) = delete;
+
+    // Construction requires parent node reference.
+    ChildrenList(ChildrenList&&) = delete;
   };
 
   // Singular value stored at this node.

--- a/verilog/CST/numbers.cc
+++ b/verilog/CST/numbers.cc
@@ -14,9 +14,8 @@
 
 #include "verilog/CST/numbers.h"
 
-#include <ctype.h>
-
 #include <algorithm>
+#include <cctype>
 #include <iterator>
 #include <string>
 

--- a/verilog/analysis/checkers/always_comb_rule.cc
+++ b/verilog/analysis/checkers/always_comb_rule.cc
@@ -39,7 +39,8 @@ using verible::matcher::Matcher;
 // Register AlwaysCombRule
 VERILOG_REGISTER_LINT_RULE(AlwaysCombRule);
 
-static const char kMessage[] = "Use \'always_comb\' instead of \'always @*\'.";
+static constexpr absl::string_view kMessage =
+    "Use 'always_comb' instead of 'always @*'.";
 
 const LintRuleDescriptor& AlwaysCombRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/endif_comment_rule.h
+++ b/verilog/analysis/checkers/endif_comment_rule.h
@@ -50,7 +50,7 @@ class EndifCommentRule : public verible::TokenStreamLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  EndifCommentRule() : state_(State::kNormal) {}
+  EndifCommentRule() = default;
 
   void HandleToken(const verible::TokenInfo& token) final;
 
@@ -65,7 +65,7 @@ class EndifCommentRule : public verible::TokenStreamLintRule {
   };
 
   // Internal lexical analysis state.
-  State state_;
+  State state_ = State::kNormal;
 
   // Token information for the last seen `endif.
   verible::TokenInfo last_endif_ = verible::TokenInfo::EOFToken();

--- a/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.h
+++ b/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.h
@@ -36,7 +36,7 @@ class ForbidConsecutiveNullStatementsRule : public verible::SyntaxTreeLintRule {
  public:
   using rule_type = verible::SyntaxTreeLintRule;
 
-  ForbidConsecutiveNullStatementsRule() : state_(State::kNormal) {}
+  ForbidConsecutiveNullStatementsRule() = default;
 
   static const LintRuleDescriptor& GetDescriptor();
 
@@ -53,7 +53,7 @@ class ForbidConsecutiveNullStatementsRule : public verible::SyntaxTreeLintRule {
   };
 
   // Internal analysis state.
-  State state_;
+  State state_ = State::kNormal;
 
   std::set<verible::LintViolation> violations_;
 };

--- a/verilog/analysis/checkers/line_length_rule.h
+++ b/verilog/analysis/checkers/line_length_rule.h
@@ -45,7 +45,7 @@ class LineLengthRule : public verible::TextStructureLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  LineLengthRule() {}
+  LineLengthRule() = default;
 
   absl::Status Configure(absl::string_view configuration) final;
 

--- a/verilog/analysis/checkers/macro_name_style_rule.h
+++ b/verilog/analysis/checkers/macro_name_style_rule.h
@@ -34,7 +34,7 @@ class MacroNameStyleRule : public verible::TokenStreamLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  MacroNameStyleRule() : state_(State::kNormal) {}
+  MacroNameStyleRule() = default;
 
   void HandleToken(const verible::TokenInfo& token) final;
 
@@ -48,7 +48,7 @@ class MacroNameStyleRule : public verible::TokenStreamLintRule {
   };
 
   // Internal lexical analysis state.
-  State state_;
+  State state_ = State::kNormal;
 
   std::set<verible::LintViolation> violations_;
 };

--- a/verilog/analysis/checkers/macro_string_concatenation_rule.h
+++ b/verilog/analysis/checkers/macro_string_concatenation_rule.h
@@ -33,7 +33,7 @@ class MacroStringConcatenationRule : public verible::TokenStreamLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  MacroStringConcatenationRule() : state_(State::kNormal) {}
+  MacroStringConcatenationRule() = default;
 
   void HandleToken(const verible::TokenInfo& token) final;
 
@@ -47,7 +47,7 @@ class MacroStringConcatenationRule : public verible::TokenStreamLintRule {
   };
 
   // Internal lexical analysis state.
-  State state_;
+  State state_ = State::kNormal;
 
   std::set<verible::LintViolation> violations_;
 };

--- a/verilog/analysis/checkers/module_filename_rule.h
+++ b/verilog/analysis/checkers/module_filename_rule.h
@@ -34,7 +34,7 @@ class ModuleFilenameRule : public verible::TextStructureLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  ModuleFilenameRule() {}
+  ModuleFilenameRule() = default;
 
   absl::Status Configure(absl::string_view configuration) final;
   void Lint(const verible::TextStructureView&, absl::string_view) final;

--- a/verilog/analysis/checkers/no_tabs_rule.h
+++ b/verilog/analysis/checkers/no_tabs_rule.h
@@ -15,8 +15,7 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TABS_RULE_H_
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TABS_RULE_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <set>
 #include <string>
 
@@ -35,7 +34,7 @@ class NoTabsRule : public verible::LineLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  NoTabsRule() {}
+  NoTabsRule() = default;
 
   void HandleLine(absl::string_view line) final;
 

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.cc
@@ -14,10 +14,9 @@
 
 #include "verilog/analysis/checkers/no_trailing_spaces_rule.h"
 
-#include <stddef.h>
-
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <iterator>
 #include <set>
 #include <string>

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.h
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.h
@@ -15,8 +15,7 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TRAILING_SPACES_RULE_H_
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_NO_TRAILING_SPACES_RULE_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <set>
 #include <string>
 
@@ -35,7 +34,7 @@ class NoTrailingSpacesRule : public verible::LineLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  NoTrailingSpacesRule() {}
+  NoTrailingSpacesRule() = default;
 
   void HandleLine(absl::string_view line) final;
 

--- a/verilog/analysis/checkers/numeric_format_string_style_rule.h
+++ b/verilog/analysis/checkers/numeric_format_string_style_rule.h
@@ -34,7 +34,7 @@ class NumericFormatStringStyleRule : public verible::TokenStreamLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  NumericFormatStringStyleRule() {}
+  NumericFormatStringStyleRule() = default;
 
   void HandleToken(const verible::TokenInfo& token) final;
 

--- a/verilog/analysis/checkers/one_module_per_file_rule.h
+++ b/verilog/analysis/checkers/one_module_per_file_rule.h
@@ -34,7 +34,7 @@ class OneModulePerFileRule : public verible::TextStructureLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  OneModulePerFileRule() {}
+  OneModulePerFileRule() = default;
 
   void Lint(const verible::TextStructureView&, absl::string_view) final;
 

--- a/verilog/analysis/checkers/package_filename_rule.h
+++ b/verilog/analysis/checkers/package_filename_rule.h
@@ -35,7 +35,7 @@ class PackageFilenameRule : public verible::TextStructureLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  PackageFilenameRule() {}
+  PackageFilenameRule() = default;
 
   absl::Status Configure(absl::string_view configuration) final;
   void Lint(const verible::TextStructureView&, absl::string_view) final;

--- a/verilog/analysis/checkers/posix_eof_rule.h
+++ b/verilog/analysis/checkers/posix_eof_rule.h
@@ -41,7 +41,7 @@ class PosixEOFRule : public verible::TextStructureLintRule {
 
   static const LintRuleDescriptor& GetDescriptor();
 
-  PosixEOFRule() {}
+  PosixEOFRule() = default;
 
   void Lint(const verible::TextStructureView&, absl::string_view) final;
 

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule.h
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule.h
@@ -43,7 +43,7 @@ class UvmMacroSemicolonRule : public verible::SyntaxTreeLintRule {
  public:
   using rule_type = verible::SyntaxTreeLintRule;
 
-  UvmMacroSemicolonRule() : state_(State::kNormal) {}
+  UvmMacroSemicolonRule() = default;
 
   // Returns the description of the rule implemented
   static const LintRuleDescriptor& GetDescriptor();
@@ -61,7 +61,7 @@ class UvmMacroSemicolonRule : public verible::SyntaxTreeLintRule {
   };
 
   // Internal analysis state
-  State state_;
+  State state_ = State::kNormal;
 
   // Save the matching macro and include it in diagnostic message
   verible::TokenInfo macro_id_ = verible::TokenInfo::EOFToken();

--- a/verilog/analysis/flow_tree.h
+++ b/verilog/analysis/flow_tree.h
@@ -141,7 +141,7 @@ class FlowTree {
 
   // A flag that determines if the VariantReceiver returned 'false'.
   // By default: it assumes VariantReceiver wants more variants.
-  bool wants_more_ = 1;
+  bool wants_more_ = true;
 
   // Mapping each conditional macro to an integer ID,
   // to use it later as a bit offset.

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -374,11 +374,12 @@ struct SymbolInfo {
     }
   };
 
-  typedef std::set<const DependentReferences*, StringAddressCompare>
-      address_ordered_set_type;
-  typedef std::map<absl::string_view, address_ordered_set_type,
-                   verible::StringViewCompare>
-      references_map_view_type;
+  using address_ordered_set_type =
+      std::set<const DependentReferences*, StringAddressCompare>;
+
+  using references_map_view_type =
+      std::map<absl::string_view, address_ordered_set_type,
+               verible::StringViewCompare>;
 
   // For testing only, quickly find reference candidates by name, and positional
   // occurence.  The outer map is ordered by string contents, and the inner

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -216,14 +216,14 @@ VerilogAnalyzer::AnalyzeAutomaticPreprocessFallback(absl::string_view text,
                                                     absl::string_view name) {
   std::unique_ptr<verilog::VerilogAnalyzer> parser;
   for (bool preprocess_expand_macros : {false, true}) {
-    bool expand_macro_status = 0;
+    bool expand_macro_status = false;
     for (bool preprocess_filter_branches : {false, true}) {
       parser = verilog::VerilogAnalyzer::AnalyzeAutomaticMode(
           text, name,
           {.filter_branches = preprocess_filter_branches,
            .expand_macros = preprocess_expand_macros});
       if (parser && parser->LexStatus().ok() && parser->ParseStatus().ok()) {
-        expand_macro_status = 1;
+        expand_macro_status = true;
         break;
       }
       VLOG(1) << "Retry parsing with filter branches enabled";

--- a/verilog/analysis/verilog_filelist.cc
+++ b/verilog/analysis/verilog_filelist.cc
@@ -32,7 +32,8 @@ absl::Status AppendFileListFromContent(absl::string_view file_list_path,
                                        FileList* append_to) {
   // TODO(hzeller): parse +define+ and stash into preprocessing configuration.
   constexpr absl::string_view kIncludeDirPrefix = "+incdir+";
-  append_to->preprocessing.include_dirs.push_back(".");  // Should we do that?
+  append_to->preprocessing.include_dirs.emplace_back(
+      ".");  // Should we do that?
   std::string file_path;
   std::istringstream stream(file_list_content);
   while (std::getline(stream, file_path)) {

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -166,7 +166,7 @@ struct LinterOptions {
 class LinterConfiguration {
  public:
   // Constructor has no rules enabled by default;
-  LinterConfiguration() {}
+  LinterConfiguration() = default;
 
   // This is copy-able.
   LinterConfiguration(const LinterConfiguration&) = default;

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -236,13 +236,13 @@ class ParsedVerilogSourceFile final : public VerilogSourceFile {
 class VerilogProject {
   // Collection of per-file metadata and analyzer objects
   // key: referenced file name (as opposed to resolved filename)
-  typedef std::map<std::string, std::unique_ptr<VerilogSourceFile>,
-                   VerilogSourceFile::Less>
-      file_set_type;
+  using file_set_type =
+      std::map<std::string, std::unique_ptr<VerilogSourceFile>,
+               VerilogSourceFile::Less>;
 
  public:
-  typedef file_set_type::iterator iterator;
-  typedef file_set_type::const_iterator const_iterator;
+  using iterator = file_set_type::iterator;
+  using const_iterator = file_set_type::const_iterator;
 
   // Constructor. Note that `populate_string_maps` (populating internal string
   // view maps) fragments the class's usage. Enabling it prevents removing files

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -71,7 +71,7 @@ using verible::UnwrappedLine;
 using verible::VectorTree;
 using verible::VectorTreeLeavesIterator;
 
-typedef VectorTree<TreeViewNodeInfo<TokenPartitionTree>> partition_node_type;
+using partition_node_type = VectorTree<TreeViewNodeInfo<TokenPartitionTree>>;
 
 // Takes a TextStructureView and FormatStyle, and formats UnwrappedLines.
 class Formatter {

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -183,7 +183,7 @@ static WithReason<int> SpacesRequiredBetween(
   }
 
   if (left.TokenEnum() == TK_SCOPE_RES) {
-    return {0, "Prefer \"::id\" over \":: id\", \"::*\" over \":: *\""};
+    return {0, R"(Prefer "::id" over ":: id", \"::*" over ":: *")"};
   }
 
   // Delimiters, list separators

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -208,7 +208,7 @@ class TreeUnwrapper::TokenScanner {
   }
 
  protected:
-  typedef TokenScannerState State;
+  using State = TokenScannerState;
 
   // The current state of the TokenScanner.
   State current_state_ = kStart;
@@ -314,7 +314,7 @@ TreeUnwrapper::TreeUnwrapper(const verible::TextStructureView& view,
   CHECK(back.text().empty());
 }
 
-TreeUnwrapper::~TreeUnwrapper() {}
+TreeUnwrapper::~TreeUnwrapper() = default;
 
 static bool IsPreprocessorClause(NodeEnum e) {
   switch (e) {

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -72,7 +72,7 @@ class TreeUnwrapper final : public verible::TreeUnwrapper {
   using verible::TreeUnwrapper::Unwrap;
 
  private:
-  typedef std::vector<verible::PreFormatToken> preformatted_tokens_type;
+  using preformatted_tokens_type = std::vector<verible::PreFormatToken>;
 
   // Private implementation type for handling tokens between syntax tree leaves.
   class TokenScanner;

--- a/verilog/parser/verilog_lexical_context.cc
+++ b/verilog/parser/verilog_lexical_context.cc
@@ -581,7 +581,7 @@ void LexicalContext::_UpdateState(const TokenInfo& token) {
     case TK_case:   // fall-through
     case TK_casex:  // fall-through
     case TK_casez:
-      flow_control_stack_.push_back(FlowControlState(&token));
+      flow_control_stack_.emplace_back(&token);
       break;
 
     // Procedural control blocks:

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -56,7 +56,7 @@ using verilog::formatter::FormatVerilog;
 //   --flag x --flag y yields [x, y]
 struct LineRanges {
   // need to copy string, cannot just use string_view
-  typedef std::vector<std::string> storage_type;
+  using storage_type = std::vector<std::string>;
   static storage_type values;
 };
 
@@ -69,9 +69,9 @@ bool AbslParseFlag(absl::string_view flag_arg, LineRanges* /* unused */,
   // equivalent.
   const std::vector<absl::string_view> tokens = absl::StrSplit(flag_arg, ',');
   values.reserve(values.size() + tokens.size());
-  for (const auto& token : tokens) {
+  for (const absl::string_view& token : tokens) {
     // need to copy string, cannot just use string_view
-    values.push_back(std::string(token.begin(), token.end()));
+    values.emplace_back(token.begin(), token.end());
   }
   // Range validation done later.
   return true;

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -92,7 +92,7 @@ static absl::Status PreprocessSingleFile(
   verilog::VerilogPreprocess::Config config;
   config.filter_branches = true;
   config.include_files = true;
-  config.expand_macros = 1;
+  config.expand_macros = true;
 
   verilog::VerilogProject project(".", preprocessing_info.include_dirs);
 
@@ -143,7 +143,7 @@ static absl::Status MultipleCU(const SubcommandArgsRange& args, std::istream&,
 
   // TODO(karimtera): allow including files with absolute paths.
   // This is a hacky solution for now.
-  preprocessing_info.include_dirs.push_back("/");
+  preprocessing_info.include_dirs.emplace_back("/");
 
   if (files.empty()) {
     return absl::InvalidArgumentError("ERROR: Missing file argument.");


### PR DESCRIPTION
Following reasonable modernize-* clang tidy suggestions. Enabling all of them, then disabling the ones that produce overzealous or possibly less readable results.

Also, fix some of google-readability-braces-around-statements suggestions, but there are more.

A lot based on clang-tidy suggestions.