### PR TITLE
Don't clutter the CI logs with progress lines.

### DIFF
--- a/.github/settings.sh
+++ b/.github/settings.sh
@@ -28,8 +28,8 @@ export GIT_VERSION=${GIT_VERSION:-$(git describe --match=v*)}
 
 export BAZEL_CXXOPTS="-std=c++17"
 
-# Reduce the verbosity of progress output on CI
-export BAZEL_OPTS="-c opt --show_progress_rate_limit=10.0"
+# Progress output is just noisy in CI outputs.
+export BAZEL_OPTS="-c opt --noshow_progress"
 
 # Used to fetch the BAZEL version where needed.
 export BAZEL_VERSION=4.0.0

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -364,7 +364,7 @@ jobs:
         restore-keys: bazelcache_macos_
 
     - name: Tests
-      run: bazel test --test_output=errors --cxxopt=-Wno-range-loop-analysis //...
+      run: bazel test --noshow_progress --test_output=errors --cxxopt=-Wno-range-loop-analysis //...
 
   PrepareVSPlugin:
     container: ubuntu:jammy
@@ -423,10 +423,10 @@ jobs:
       run: bazel info
 
     - name: Run Tests
-      run: bazel test --test_output=errors //...
+      run: bazel test --noshow_progress --test_output=errors //...
 
     - name: Build Verible Binaries
-      run: bazel build -c opt :install-binaries
+      run: bazel build --noshow_progress -c opt :install-binaries
 
     - name: Prepare release
       run: |


### PR DESCRIPTION
Since the logs are no shell, the progress information does not happen 'in place' like in the terminal, but just fills the logs with clutter that might hide real information.