### PR TITLE
Reduce complexity and indentation: no else after return.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -44,7 +44,6 @@ Checks: >
   -readability-redundant-access-specifiers,
   -readability-simplify-boolean-expr,
   -readability-uppercase-literal-suffix,
-  -readability-convert-member-functions-to-static,
   -readability-use-anyofallof,
   google-*,
   -google-readability-casting,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,7 +33,6 @@ Checks: >
   readability-*,
   -readability-braces-around-statements,
   -readability-convert-member-functions-to-static,
-  -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -312,7 +312,8 @@ static absl::Status WaiveCommandHandler(
           if (line_start < 1) {
             return WaiveCommandError(token_pos, waive_file,
                                      "Invalid line number: ", val);
-          } else if (line_start > line_end) {
+          }
+          if (line_start > line_end) {
             return WaiveCommandError(token_pos, waive_file,
                                      "Invalid line range: ", val);
           }
@@ -472,9 +473,8 @@ absl::Status LintWaiverBuilder::ApplyExternalWaivers(
 
   if (all_commands_ok) {
     return absl::OkStatus();
-  } else {
-    return absl::InvalidArgumentError("Errors applying external waivers.");
   }
+  return absl::InvalidArgumentError("Errors applying external waivers.");
 }
 
 }  // namespace verible

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -493,16 +493,15 @@ std::ostream& operator<<(std::ostream& stream,
         const auto& cell = node.Value();
         if (cell.IsUnused()) {
           return {"", '.'};
-        } else {
-          const auto width_info = absl::StrCat("\t(", cell.left_border_width,
-                                               "+", cell.compact_width, ")\t");
-          if (cell.IsComposite()) {
-            return {absl::StrCat("/", width_info, "\\"), '`'};
-          }
-          std::ostringstream label;
-          label << "\t" << cell << "\t\n" << width_info;
-          return {label.str(), ' '};
         }
+        const auto width_info = absl::StrCat("\t(", cell.left_border_width, "+",
+                                             cell.compact_width, ")\t");
+        if (cell.IsComposite()) {
+          return {absl::StrCat("/", width_info, "\\"), '`'};
+        }
+        std::ostringstream label;
+        label << "\t" << cell << "\t\n" << width_info;
+        return {label.str(), ' '};
       });
   return stream;
 }

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -217,13 +217,12 @@ LayoutFunction LayoutFunctionFactory::Line(const UnwrappedLine& uwline) const {
         {style_.column_limit - span, std::move(layout), span, 0,
          style_.over_column_limit_penalty},
     };
-  } else {
-    return LayoutFunction{
-        {0, std::move(layout), span,
-         float((span - style_.column_limit) * style_.over_column_limit_penalty),
-         style_.over_column_limit_penalty},
-    };
   }
+  return LayoutFunction{
+      {0, std::move(layout), span,
+       float((span - style_.column_limit) * style_.over_column_limit_penalty),
+       style_.over_column_limit_penalty},
+  };
 }
 
 LayoutFunction LayoutFunctionFactory::Indent(const LayoutFunction& lf,
@@ -495,9 +494,8 @@ LayoutFunction TokenPartitionsLayoutOptimizer::CalculateOptimalLayout(
         node.Value().TokensRange().size() > 1 &&
         node.Value().TokensRange().size() < kWrapTokensLimit) {
       return factory_.WrappedLine(node.Value());
-    } else {
-      return factory_.Line(node.Value());
     }
+    return factory_.Line(node.Value());
   }
 
   // Traverse and calculate children layouts

--- a/common/formatting/state_node.cc
+++ b/common/formatting/state_node.cc
@@ -162,10 +162,9 @@ int StateNode::_UpdateColumnPosition() {
       // text up to the first newline.
       if (IsRootState()) {
         return first_newline_pos;
-      } else {
-        return prev_state->current_column +
-               current_format_token.before.spaces_required + first_newline_pos;
       }
+      return prev_state->current_column +
+             current_format_token.before.spaces_required + first_newline_pos;
     }
   }
 
@@ -328,12 +327,10 @@ std::shared_ptr<const StateNode> StateNode::AppendIfItFits(
       std::make_shared<StateNode>(current_state, style, SpacingDecision::Wrap);
   const auto appended = std::make_shared<StateNode>(current_state, style,
                                                     SpacingDecision::Append);
-  if (token.before.break_decision == SpacingOptions::MustWrap ||
-      appended->current_column > style.column_limit) {
-    return wrapped;
-  } else {
-    return appended;
-  }
+  return (token.before.break_decision == SpacingOptions::MustWrap ||
+          appended->current_column > style.column_limit)
+             ? wrapped
+             : appended;
 }
 
 std::shared_ptr<const StateNode> StateNode::QuickFinish(

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -570,11 +570,7 @@ class TokenPartitionTreeWrapper {
 
   // Return wrapped node value or concatenation of subnodes values
   const UnwrappedLine& Value() const {
-    if (node_) {
-      return node_->Value();
-    } else {
-      return *unwrapped_line_;
-    }
+    return node_ ? node_->Value() : *unwrapped_line_;
   }
 
   // Concatenate subnodes value with other node value

--- a/common/lsp/json-rpc-expect.cc
+++ b/common/lsp/json-rpc-expect.cc
@@ -89,7 +89,8 @@ static bool ValuesMatch(const json &expected, const json &received) {
   }
   if (expected.is_object()) {
     return CheckNested(expected, received);
-  } else if (expected.is_array()) {
+  }
+  if (expected.is_array()) {
     if (expected.size() != received.size()) {
       std::cerr << "array size mismatch. Expected: " << expected.size()
                 << "; got: " << received.size() << std::endl;
@@ -99,8 +100,8 @@ static bool ValuesMatch(const json &expected, const json &received) {
       if (!ValuesMatch(expected[i], received[i])) return false;
     }
     return true;
-
-  } else if (expected.is_string()) {
+  }
+  if (expected.is_string()) {
     return absl::StrContains(received.get<std::string>(),
                              expected.get<std::string>());
   }

--- a/common/lsp/lsp-text-buffer.cc
+++ b/common/lsp/lsp-text-buffer.cc
@@ -40,9 +40,8 @@ bool EditTextBuffer::ApplyChange(const TextDocumentContentChangeEvent &c) {
   if (c.range.start.line == c.range.end.line &&
       c.text.find_first_of('\n') == std::string::npos) {
     return LineEdit(c, lines_[c.range.start.line].get());  // simple case.
-  } else {
-    return MultiLineEdit(c);
   }
+  return MultiLineEdit(c);
 }
 
 /*static*/ EditTextBuffer::LineVector EditTextBuffer::GenerateLines(

--- a/common/parser/bison_parser_adapter.h
+++ b/common/parser/bison_parser_adapter.h
@@ -49,12 +49,12 @@ class BisonParserAdapter : public Parser {
     VLOG(3) << "max_used_stack_size : " << MaxUsedStackSize();
     if (result == 0 && param_.RecoveredSyntaxErrors().empty()) {
       return absl::OkStatus();
-    } else {
-      // We could potentially dump the parser's symbol stack from ParserParam.
-      // We could also print information about recovered errors.
-      return absl::InvalidArgumentError("Syntax error.");
-      // More detailed error information is stored inside param_.
     }
+
+    // We could potentially dump the parser's symbol stack from ParserParam.
+    // We could also print information about recovered errors.
+    return absl::InvalidArgumentError("Syntax error.");
+    // More detailed error information is stored inside param_.
   }
 
   const std::vector<TokenInfo>& RejectedTokens() const final {

--- a/common/strings/comment_utils.cc
+++ b/common/strings/comment_utils.cc
@@ -76,7 +76,8 @@ absl::string_view StripComment(absl::string_view text) {
   if (start == "//") {
     const auto ltrim = CountLeadingChars(text.substr(2), '/') + 2;
     return text.substr(ltrim);
-  } else if (start == "/*" && end == "*/") {
+  }
+  if (start == "/*" && end == "*/") {
     return StripBlockComment(text);
   }
   // else is not a well-formed comment

--- a/common/strings/obfuscator.cc
+++ b/common/strings/obfuscator.cc
@@ -35,11 +35,10 @@ absl::string_view Obfuscator::operator()(absl::string_view input) {
   if (decode_mode) {
     const auto* p = translator_.find_reverse(input);
     return (p != nullptr) ? *p : input;
-  } else {
-    const std::string* str = translator_.insert_using_value_generator(
-        std::string(input), [this, input]() { return generator_(input); });
-    return *str;
   }
+  const std::string* str = translator_.insert_using_value_generator(
+      std::string(input), [this, input]() { return generator_(input); });
+  return *str;
 }
 
 constexpr char kPairSeparator = ' ';

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -545,12 +545,12 @@ absl::Status FilePatch::Parse(const LineRange& lines) {
   if (line_iter == lines.end()) {
     return absl::InvalidArgumentError(
         "Expected a file marker starting with \"+++\", but did not find one.");
-  } else {
-    if (auto status = ParseSourceInfoWithMarker(&new_file_, *line_iter, "+++");
-        !status.ok()) {
-      return status;
-    }
   }
+  if (auto status = ParseSourceInfoWithMarker(&new_file_, *line_iter, "+++");
+      !status.ok()) {
+    return status;
+  }
+
   ++line_iter;
 
   // find hunk starts, and parse ranges of hunk texts

--- a/common/strings/split.h
+++ b/common/strings/split.h
@@ -77,15 +77,14 @@ class StringSpliterator {
       remainder_.remove_prefix(remainder_.length());  // empty
       end_ = true;
       return result;
-    } else {
-      // More text follows after the next occurrence of the delimiter.
-      // If the text ends with the delimiter, then the last string
-      // returned before the end() will be empty.
-      const absl::string_view result(remainder_.substr(0, pos));
-      // Skip over the delimiter.
-      remainder_.remove_prefix(pos + internal::DelimiterSize(delimiter));
-      return result;
     }
+    // More text follows after the next occurrence of the delimiter.
+    // If the text ends with the delimiter, then the last string
+    // returned before the end() will be empty.
+    const absl::string_view result(remainder_.substr(0, pos));
+    // Skip over the delimiter.
+    remainder_.remove_prefix(pos + internal::DelimiterSize(delimiter));
+    return result;
   }
 
   // Returns the un-scanned portion of text.

--- a/common/text/concrete_syntax_leaf.cc
+++ b/common/text/concrete_syntax_leaf.cc
@@ -31,9 +31,8 @@ bool SyntaxTreeLeaf::equals(const Symbol *symbol,
   if (symbol->Kind() == SymbolKind::kLeaf) {
     const auto *leaf = down_cast<const SyntaxTreeLeaf *>(symbol);
     return equals(leaf, compare_tokens);
-  } else {
-    return false;
   }
+  return false;
 }
 
 // Tests if this is equal to SyntaxTreeLeaf under compare_tokens function

--- a/common/text/concrete_syntax_tree.cc
+++ b/common/text/concrete_syntax_tree.cc
@@ -31,9 +31,8 @@ bool SyntaxTreeNode::equals(const Symbol* symbol,
   if (symbol->Kind() == SymbolKind::kNode) {
     const auto* node = down_cast<const SyntaxTreeNode*>(symbol);
     return equals(node, compare_tokens);
-  } else {
-    return false;
   }
+  return false;
 }
 
 // Checks if this is equal to a SyntaxTreeNode under compare_token function
@@ -43,13 +42,12 @@ bool SyntaxTreeNode::equals(const SyntaxTreeNode* node,
                             const TokenComparator& compare_tokens) const {
   if (children_.size() != node->children().size()) {
     return false;
-  } else {
-    int size = children_.size();
-    for (int i = 0; i < size; i++) {
-      if (!EqualTrees(children_[i].get(), node->children()[i].get(),
-                      compare_tokens)) {
-        return false;
-      }
+  }
+  int size = children_.size();
+  for (int i = 0; i < size; i++) {
+    if (!EqualTrees(children_[i].get(), node->children()[i].get(),
+                    compare_tokens)) {
+      return false;
     }
   }
   return true;

--- a/common/text/config_utils.cc
+++ b/common/text/config_utils.cc
@@ -140,12 +140,11 @@ ConfigValueSetter SetStringOneOf(std::string* value,
                return absl::InvalidArgumentError(
                    absl::StrCat("Value can only be '", allowed[0], "'; got '",
                                 v, "'"));
-             } else {
-               return absl::InvalidArgumentError(
-                   absl::StrCat("Value can only be one of ['",
-                                absl::StrJoin(allowed, "', '"),
-                                "']; got '", v, "'"));
              }
+             return absl::InvalidArgumentError(
+                 absl::StrCat("Value can only be one of ['",
+                              absl::StrJoin(allowed, "', '"),
+                              "']; got '", v, "'"));
            }
            value->assign(v.data(), v.length());
            return absl::OkStatus();

--- a/common/text/parser_verifier.cc
+++ b/common/text/parser_verifier.cc
@@ -35,11 +35,10 @@ void ParserVerifier::Visit(const SyntaxTreeLeaf& leaf) {
       // Found a matching token, continue to next leaf
       view_iterator_++;
       break;
-    } else {
-      // Failed to find a matching token.
-      unmatched_tokens_.push_back(view_token);
-      view_iterator_++;
     }
+    // Failed to find a matching token.
+    unmatched_tokens_.push_back(view_token);
+    view_iterator_++;
   } while (true);
 }
 

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -158,9 +158,8 @@ TokenRange TextStructureView::TokenRangeOnLine(size_t lineno) const {
   const auto& line_token_map = GetLineTokenMap();
   if (lineno + 1 < line_token_map.size()) {
     return make_range(line_token_map[lineno], line_token_map[lineno + 1]);
-  } else {
-    return make_range(tokens_.cend(), tokens_.cend());
   }
+  return make_range(tokens_.cend(), tokens_.cend());
 }
 
 TokenInfo TextStructureView::FindTokenAt(const LineColumn& pos) const {

--- a/common/text/tree_compare.cc
+++ b/common/text/tree_compare.cc
@@ -24,12 +24,12 @@ bool EqualTrees(const Symbol* lhs, const Symbol* rhs,
                 const TokenComparator& compare_tokens) {
   if (lhs == nullptr && rhs == nullptr) {
     return true;
-  } else if (lhs == nullptr || rhs == nullptr) {
-    return false;
-  } else {
-    const Symbol* rhs_pointer = rhs;
-    return lhs->equals(rhs_pointer, compare_tokens);
   }
+  if (lhs == nullptr || rhs == nullptr) {
+    return false;
+  }
+  const Symbol* rhs_pointer = rhs;
+  return lhs->equals(rhs_pointer, compare_tokens);
 }
 
 bool EqualTrees(const Symbol* lhs, const Symbol* rhs) {

--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -101,9 +101,8 @@ absl::string_view StringSpanOfSymbol(const Symbol& lsym, const Symbol& rsym) {
     const auto range_end = right->get().text().end();
     return absl::string_view(range_begin,
                              std::distance(range_begin, range_end));
-  } else {
-    return "";
   }
+  return "";
 }
 
 const SyntaxTreeNode& SymbolCastToNode(const Symbol& symbol) {

--- a/common/util/bijective_map.h
+++ b/common/util/bijective_map.h
@@ -98,16 +98,16 @@ class BijectiveMap {
       fwd_p.first->second = &rev_p.first->first;
       rev_p.first->second = &fwd_p.first->first;
       return true;
-    } else {  // either key or value already existed in respective set
-      // undo any insertions
-      if (fwd_p.second) {
-        forward_map.erase(fwd_p.first);
-      }
-      if (rev_p.second) {
-        reverse_map.erase(rev_p.first);
-      }
-      return false;
     }
+    // either key or value already existed in respective set
+    // undo any insertions
+    if (fwd_p.second) {
+      forward_map.erase(fwd_p.first);
+    }
+    if (rev_p.second) {
+      reverse_map.erase(rev_p.first);
+    }
+    return false;
   }
 
   // function f is a (lazy) value generator that is invoked only when the key

--- a/common/util/enum_flags.h
+++ b/common/util/enum_flags.h
@@ -130,12 +130,11 @@ class EnumNameMap {
     if (found_value != nullptr) {
       *enum_value = *found_value;
       return true;
-    } else {
-      errstream << "Invalid " << type_name << ": '" << text
-                << "'\nValid options are: ";
-      ListNames(errstream, ",");
-      return false;
     }
+    errstream << "Invalid " << type_name << ": '" << text
+              << "'\nValid options are: ";
+    ListNames(errstream, ",");
+    return false;
   }
 
   // Converts the name of an enum to its corresponding value.

--- a/common/util/expandable_tree_view.h
+++ b/common/util/expandable_tree_view.h
@@ -159,9 +159,8 @@ class ExpandableTreeView {
     if (info.IsExpanded() && !is_leaf(current)) {
       // Let compiler to tail-call optimize self-recursion.
       return first_unexpanded_child(current.Children().front());
-    } else {
-      return &current;
     }
+    return &current;
   }
 
   // Helper function for iterating to next node in sequence, which could be
@@ -172,27 +171,22 @@ class ExpandableTreeView {
   // \precondition this->parent_->expand_ is true (for all ancestors),
   //   otherwise we would have never reached this node.
   static const impl_type* next_sibling(const impl_type& current) {
-    if (current.Parent() != nullptr) {
-      // Find the next sibling, if there is one.
-      const size_t birth_rank = verible::BirthRank(current);
-      const size_t next_rank = birth_rank + 1;
-      if (next_rank == current.Parent()->Children().size()) {
-        // This is the last child of the group.
-        // Find the nearest parent that has a next child (ascending).
-        auto* next_ancestor = next_sibling(*current.Parent());
-        if (next_ancestor != nullptr) {
-          return first_unexpanded_child(*next_ancestor);
-        } else {
-          return nullptr;
-        }
-      } else {
-        // More children follow this one.
-        return first_unexpanded_child(current.Parent()->Children()[next_rank]);
+    if (current.Parent() == nullptr) return nullptr;
+
+    // Find the next sibling, if there is one.
+    const size_t birth_rank = verible::BirthRank(current);
+    const size_t next_rank = birth_rank + 1;
+    if (next_rank == current.Parent()->Children().size()) {
+      // This is the last child of the group.
+      // Find the nearest parent that has a next child (ascending).
+      auto* next_ancestor = next_sibling(*current.Parent());
+      if (next_ancestor != nullptr) {
+        return first_unexpanded_child(*next_ancestor);
       }
-    } else {
-      // Root node has no next sibling, this is the end().
       return nullptr;
     }
+    // More children follow this one.
+    return first_unexpanded_child(current.Parent()->Children()[next_rank]);
   }
 
  private:

--- a/common/util/expandable_tree_view.h
+++ b/common/util/expandable_tree_view.h
@@ -180,10 +180,7 @@ class ExpandableTreeView {
       // This is the last child of the group.
       // Find the nearest parent that has a next child (ascending).
       auto* next_ancestor = next_sibling(*current.Parent());
-      if (next_ancestor != nullptr) {
-        return first_unexpanded_child(*next_ancestor);
-      }
-      return nullptr;
+      return next_ancestor ? first_unexpanded_child(*next_ancestor) : nullptr;
     }
     // More children follow this one.
     return first_unexpanded_child(current.Parent()->Children()[next_rank]);

--- a/common/util/interval_map.h
+++ b/common/util/interval_map.h
@@ -91,13 +91,12 @@ static std::pair<typename M::iterator, bool> FindNonoverlappingEmplacePosition(
     // Can't use CHECK_LT because iterators are not printable (logging.h).
     CHECK(interval.first <= iter->first.first);
     return {iter, interval.second <= iter->first.first};
-  } else {
-    const auto prev = std::prev(iter);
-    CHECK(prev->first.first <= interval.first);
-    return {iter, prev->first.second <= interval.first &&
-                      (iter == intervals.end() ||
-                       interval.second <= iter->first.first)};
   }
+  const auto prev = std::prev(iter);
+  CHECK(prev->first.first <= interval.first);
+  return {iter, prev->first.second <= interval.first &&
+                    (iter == intervals.end() ||
+                     interval.second <= iter->first.first)};
 }
 
 }  // namespace internal

--- a/common/util/interval_set.h
+++ b/common/util/interval_set.h
@@ -121,12 +121,11 @@ class _IntervalSetImpl {
       // Can't use CHECK_LT because iterators are not printable (logging.h).
       CHECK(min <= iter->first);
       return {iter, max <= iter->first};
-    } else {
-      const auto prev = std::prev(iter);
-      CHECK(prev->first <= min);
-      return {iter, prev->second <= min &&
-                        (iter == intervals.end() || max <= iter->first)};
     }
+    const auto prev = std::prev(iter);
+    CHECK(prev->first <= min);
+    return {iter, prev->second <= min &&
+                      (iter == intervals.end() || max <= iter->first)};
   }
 };
 
@@ -325,7 +324,8 @@ class IntervalSet : private _IntervalSetImpl {
     const auto min_lb = LowerBound(min);
     if (min_lb == intervals_.end()) {
       return;  // interval is out of range of this set
-    } else if (AsInterval(*min_lb).contains(min)) {
+    }
+    if (AsInterval(*min_lb).contains(min)) {
       if (min_lb->first == min) {
         erase_begin = min_lb;  // erase starting at this interval
         replaced_lower_interval = {max, min_lb->second};

--- a/common/util/tree_operations.h
+++ b/common/util/tree_operations.h
@@ -923,10 +923,9 @@ TreeNodePair<LT, RT> DeepEqual(
                         const auto result = DeepEqual(l, r, comp);
                         if (result.left == nullptr) {
                           return true;
-                        } else {
-                          first_diff = result;  // Capture first difference.
-                          return false;
                         }
+                        first_diff = result;  // Capture first difference.
+                        return false;
                         // When this returns true, no further comparisons will
                         // be called, so the assignment to first_diff will
                         // contain the desired result.

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -47,15 +47,14 @@ char ReadCharFromUser(std::istream& input, std::ostream& output,
       return '\0';
     }
     return line.empty() ? '\n' : line.front();
-  } else {
-    // Input from a file or pipe: no prompt, read single character.
-    char c;
-    input.get(c);
-    if (input.eof() || input.fail()) {
-      return '\0';
-    }
-    return c;
   }
+  // Input from a file or pipe: no prompt, read single character.
+  char c;
+  input.get(c);
+  if (input.eof() || input.fail()) {
+    return '\0';
+  }
+  return c;
 }
 
 namespace term {

--- a/verilog/CST/parameters.cc
+++ b/verilog/CST/parameters.cc
@@ -159,7 +159,8 @@ const verible::SyntaxTreeNode* GetTypeAssignmentFromParamDeclaration(
   // Check which type of node it is.
   if (NodeEnum(assignment_tag.tag) == NodeEnum::kTypeAssignment) {
     return &verible::SymbolCastToNode(*assignment_symbol);
-  } else if (NodeEnum(assignment_tag.tag) == NodeEnum::kTypeAssignmentList) {
+  }
+  if (NodeEnum(assignment_tag.tag) == NodeEnum::kTypeAssignmentList) {
     const auto& type_symbol = verible::GetSubtreeAsNode(
         *assignment_symbol, NodeEnum::kTypeAssignmentList, 0,
         NodeEnum::kTypeAssignment);

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
@@ -75,13 +75,9 @@ static int digitBits(char digit, bool* is_lower_bound) {
     return 1;  // Minimum number of bits assumed
   }
   *is_lower_bound = false;
-  if (digit > '7') {
-    return 4;
-  } else if (digit > '3') {
-    return 3;
-  } else if (digit > '1') {
-    return 2;
-  }
+  if (digit > '7') return 4;
+  if (digit > '3') return 3;
+  if (digit > '1') return 2;
   return 1;
 }
 

--- a/verilog/analysis/flow_tree.cc
+++ b/verilog/analysis/flow_tree.cc
@@ -126,9 +126,8 @@ absl::Status FlowTree::MacroFollows(
   auto macro_iterator = conditional_iterator + 1;
   if (macro_iterator->token_enum() != PP_Identifier) {
     return absl::InvalidArgumentError("Expected identifier for macro name.");
-  } else {
-    return absl::OkStatus();
   }
+  return absl::OkStatus();
 }
 
 // Adds a conditional macro to conditional_macros_ if not added before,

--- a/verilog/analysis/lint_rule_registry.cc
+++ b/verilog/analysis/lint_rule_registry.cc
@@ -55,10 +55,7 @@ class LintRuleRegistry {
   // Returns nullptr if rule is not registered.
   static std::unique_ptr<RuleType> CreateLintRule(const LintRuleId& rule) {
     auto* create_func = FindOrNull(*GetLintRuleRegistry<RuleType>(), rule);
-    if (create_func == nullptr) {
-      return nullptr;
-    }
-    return (create_func->lint_rule_generator)();
+    return create_func ? (create_func->lint_rule_generator)() : nullptr;
   }
 
   // Returns true if registry holds a LintRule named rule.

--- a/verilog/analysis/lint_rule_registry.cc
+++ b/verilog/analysis/lint_rule_registry.cc
@@ -57,9 +57,8 @@ class LintRuleRegistry {
     auto* create_func = FindOrNull(*GetLintRuleRegistry<RuleType>(), rule);
     if (create_func == nullptr) {
       return nullptr;
-    } else {
-      return (create_func->lint_rule_generator)();
     }
+    return (create_func->lint_rule_generator)();
   }
 
   // Returns true if registry holds a LintRule named rule.

--- a/verilog/analysis/verilog_equivalence.cc
+++ b/verilog/analysis/verilog_equivalence.cc
@@ -212,7 +212,8 @@ DiffStatus LexicallyEquivalent(
     if (size_match) {
       // Lengths match, and end of both sequences reached without mismatch.
       return DiffStatus::kEquivalent;
-    } else if (l_size < r_size) {
+    }
+    if (l_size < r_size) {
       *errstream << "First excess token in right sequence: "
                  << *right_filtered[min_size] << std::endl;
     } else {  // r_size < l_size

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -138,11 +138,10 @@ bool RuleBundle::ParseConfiguration(absl::string_view text, char separator,
     if (rule_iter == rule_name_set.end()) {
       *error = absl::StrCat("invalid flag \"", rule_name, "\"");
       return false;
-    } else {
-      // Map keys must use canonical registered string_views for guaranteed
-      // lifetime, not just any string-equivalent copy.
-      rules[*rule_iter] = setting;
     }
+    // Map keys must use canonical registered string_views for guaranteed
+    // lifetime, not just any string-equivalent copy.
+    rules[*rule_iter] = setting;
   }
 
   return true;

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -191,12 +191,11 @@ static Status ReformatVerilog(absl::string_view original_text,
     // format whole file
     return FormatVerilog(formatted_text, filename, style, reformat_stream,
                          lines, convergence_control);
-  } else {
-    // reformat incrementally
-    return ReformatVerilogIncrementally(original_text, formatted_text, filename,
-                                        style, reformat_stream,
-                                        convergence_control);
   }
+  // reformat incrementally
+  return ReformatVerilogIncrementally(original_text, formatted_text, filename,
+                                      style, reformat_stream,
+                                      convergence_control);
 }
 
 static absl::StatusOr<std::unique_ptr<VerilogAnalyzer>> ParseWithStatus(

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -207,9 +207,10 @@ static WithReason<int> SpacesRequiredBetween(
   if (right_context.IsInsideFirst({NodeEnum::kStreamingConcatenation}, {})) {
     if (left.TokenEnum() == TK_LS || left.TokenEnum() == TK_RS) {
       return {0, "No space around streaming operators"};
-    } else if (left.format_token_enum == FormatTokenType::numeric_literal ||
-               left.format_token_enum == FormatTokenType::identifier ||
-               left.format_token_enum == FormatTokenType::keyword) {
+    }
+    if (left.format_token_enum == FormatTokenType::numeric_literal ||
+        left.format_token_enum == FormatTokenType::identifier ||
+        left.format_token_enum == FormatTokenType::keyword) {
       return {0, "No space around streaming operator slice size"};
     }
   }
@@ -511,9 +512,8 @@ static WithReason<int> SpacesRequiredBetween(
              NodeEnum::kExtendsList},
             {})) {
       return {0, "No space before # when direct parent is kUnqualifiedId."};
-    } else {
-      return {1, "Spaces before # in most other contexts."};
     }
+    return {1, "Spaces before # in most other contexts."};
   }
 
   if (right.format_token_enum == FormatTokenType::keyword) {
@@ -772,11 +772,10 @@ static WithReason<SpacingOptions> BreakDecisionBetween(
     if (std::count(text.begin(), text.end(), '\n') >= 2) {
       return {SpacingOptions::Preserve,
               "Preserve spacing before a multi-line macro definition body."};
-    } else {
-      return {SpacingOptions::MustAppend,
-              "Macro definition body must start on same line (but may be "
-              "line-continued)."};
     }
+    return {SpacingOptions::MustAppend,
+            "Macro definition body must start on same line (but may be "
+            "line-continued)."};
   }
 
   // Check for mandatory line breaks.

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1253,11 +1253,10 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
         VisitIndentedSection(node, indent,
                              PartitionPolicyEnum::kFitOnLineElseExpand);
         break;
-      } else {
-        // Default handling
-        TraverseChildren(node);
-        break;
       }
+      // Default handling
+      TraverseChildren(node);
+      break;
     }
 
     case NodeEnum::kPortList: {

--- a/verilog/formatting/verilog_token.cc
+++ b/verilog/formatting/verilog_token.cc
@@ -532,52 +532,51 @@ FTT GetFormatTokenType(verilog_tokentype e) {
   // token's enum value, where lower values are ASCII character values.
   if (e > 257) {
     return FindWithDefault(FormatTokenTypeMap(), e, FTT::unknown);
-  } else {
-    // single char tokens which use ASCII values as enum.
-    switch (static_cast<int>(e)) {
-      /* arithmetic */
-      case '+':
-      case '-':
-      case '*':
-      case '/':
-      case '%':
-      /* bitwise */
-      case '&':
-      case '|':
-      case '^':
-      /* relational */
-      case '<':
-      case '>':
-        return FTT::binary_operator;
-      case '?':
-        // Technically, ?: is a ternary operator, but nonetheless we
-        // space it the same way as a binary operator.
-        return FTT::binary_operator;
-      // TODO(fangism): handle the ':' separator, but use context-sensitivity
-      // to accommodate the cases where spacing is undesirable.
-      case '=':
-        // Though technically = is an assignment operator, and not an expression
-        // operator, we lump it with binary_operator for convenience.
-        // It is also used in contexts like default values.
-        // Make sure this stays consistent with nonblocking assignment '<=',
-        // which happens to be an overloaded TK_LE.
-        return FTT::binary_operator;
-      case '.':
-        // TODO(fangism): this is actually context-dependent.  .port(foo) in a
-        // port actual list, vs. a.b.c for a member reference.  distinguish
-        // these.
-        return FTT::hierarchy;
-      case '(':
-      case '[':
-      case '{':
-        return FTT::open_group;
-      case ')':
-      case ']':
-      case '}':
-        return FTT::close_group;
-      default:
-        return FTT::unknown;
-    }
+  }
+  // single char tokens which use ASCII values as enum.
+  switch (static_cast<int>(e)) {
+    /* arithmetic */
+    case '+':
+    case '-':
+    case '*':
+    case '/':
+    case '%':
+    /* bitwise */
+    case '&':
+    case '|':
+    case '^':
+    /* relational */
+    case '<':
+    case '>':
+      return FTT::binary_operator;
+    case '?':
+      // Technically, ?: is a ternary operator, but nonetheless we
+      // space it the same way as a binary operator.
+      return FTT::binary_operator;
+    // TODO(fangism): handle the ':' separator, but use context-sensitivity
+    // to accommodate the cases where spacing is undesirable.
+    case '=':
+      // Though technically = is an assignment operator, and not an expression
+      // operator, we lump it with binary_operator for convenience.
+      // It is also used in contexts like default values.
+      // Make sure this stays consistent with nonblocking assignment '<=',
+      // which happens to be an overloaded TK_LE.
+      return FTT::binary_operator;
+    case '.':
+      // TODO(fangism): this is actually context-dependent.  .port(foo) in a
+      // port actual list, vs. a.b.c for a member reference.  distinguish
+      // these.
+      return FTT::hierarchy;
+    case '(':
+    case '[':
+    case '{':
+      return FTT::open_group;
+    case ')':
+    case ']':
+    case '}':
+      return FTT::close_group;
+    default:
+      return FTT::unknown;
   }
 }
 

--- a/verilog/parser/verilog_lexical_context.cc
+++ b/verilog/parser/verilog_lexical_context.cc
@@ -653,13 +653,15 @@ int LexicalContext::_InterpretToken(int token_enum) const {
         //     x -> y;
         //   }
         return randomize_call_tracker_.InterpretToken(token_enum);
-      } else if (constraint_declaration_tracker_.IsActive()) {
+      }
+      if (constraint_declaration_tracker_.IsActive()) {
         // e.g.
         //   constraint c {
         //     x -> y;
         //   }
         return constraint_declaration_tracker_.InterpretToken(token_enum);
-      } else if (ExpectingStatement()) {
+      }
+      if (ExpectingStatement()) {
         // e.g.
         //   task foo();
         //     ...
@@ -667,16 +669,14 @@ int LexicalContext::_InterpretToken(int token_enum) const {
         //     ...
         //   endtask
         return TK_TRIGGER;
-      } else {
-        // Everywhere where right-arrow can appear should be interpreted
-        // as the 'implies' binary operator for expressions.
-        // e.g.
-        //   if (a -> b) ...
-        return TK_LOGICAL_IMPLIES;
       }
-      break;
-    }
-    // TODO(b/129204554): disambiguate '<='
+      // Everywhere where right-arrow can appear should be interpreted
+      // as the 'implies' binary operator for expressions.
+      // e.g.
+      //   if (a -> b) ...
+      return TK_LOGICAL_IMPLIES;
+    } break;
+      // TODO(b/129204554): disambiguate '<='
     default:
       break;
   }

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -256,15 +256,15 @@ absl::Status VerilogPreprocess::ConsumeAndParseMacroCall(
       }
       parameters_size--;
       continue;
-    } else if ((*token_iter)->text() == ",") {
+    }
+    if ((*token_iter)->text() == ",") {
       macro_call->positional_arguments.emplace_back(
           verible::DefaultTokenInfo());
       token_iter = GenerateBypassWhiteSpaces(generator);
       parameters_size--;
       continue;
-    } else if ((*token_iter)->text() == ")") {
-      break;
     }
+    if ((*token_iter)->text() == ")") break;
   }
   if (parameters_size > 0) {
     while (parameters_size--) {

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -264,7 +264,9 @@ absl::Status VerilogPreprocess::ConsumeAndParseMacroCall(
       parameters_size--;
       continue;
     }
-    if ((*token_iter)->text() == ")") break;
+    if ((*token_iter)->text() == ")") {
+      break;
+    }
   }
   if (parameters_size > 0) {
     while (parameters_size--) {


### PR DESCRIPTION
Applying the readability-else-after-return suggestions of clang-tidy.