### PR TITLE
Simplify endless loops.

### DIFF
--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -1050,7 +1050,7 @@ class SubcolumnsTreeAlignmentTest : public MatrixTreeAlignmentTestFixture {
     partition_ = TokenPartitionTree{all};
 
     auto token_iter = pre_format_tokens_.begin();
-    while (true) {
+    for (;;) {
       UnwrappedLine uwline(0, token_iter);
       SymbolPtr item = ParseItem(&token_iter, pre_format_tokens_.end());
       if (!item) {

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -236,7 +236,7 @@ LayoutFunction LayoutFunctionFactory::Indent(const LayoutFunction& lf,
   auto column = indent;
   auto segment = lf.AtOrToTheLeftOf(column);
 
-  while (true) {
+  for (;;) {
     auto columns_over_limit = column - style_.column_limit;
 
     const float new_intercept =
@@ -288,7 +288,7 @@ LayoutFunction LayoutFunctionFactory::Juxtaposition(
   auto column_r = segment_l->span + segment_r->layout.Value().SpacesBefore();
   segment_r = right.AtOrToTheLeftOf(column_r);
 
-  while (true) {
+  for (;;) {
     const int columns_over_limit = column_r - style_.column_limit;
 
     const float new_intercept =

--- a/common/text/parser_verifier.cc
+++ b/common/text/parser_verifier.cc
@@ -26,7 +26,7 @@
 namespace verible {
 
 void ParserVerifier::Visit(const SyntaxTreeLeaf& leaf) {
-  do {
+  for (;;) {
     // Check to stop if reached end of stream or end of file
     if (view_iterator_ == view_.end() || (**view_iterator_).isEOF()) return;
 
@@ -34,12 +34,12 @@ void ParserVerifier::Visit(const SyntaxTreeLeaf& leaf) {
     if (token_comparator_(view_token, leaf.get())) {
       // Found a matching token, continue to next leaf
       view_iterator_++;
-      break;
+      return;
     }
     // Failed to find a matching token.
     unmatched_tokens_.push_back(view_token);
     view_iterator_++;
-  } while (true);
+  }
 }
 
 std::vector<TokenInfo> ParserVerifier::Verify() {

--- a/verilog/parser/verilog_lexer.cc
+++ b/verilog/parser/verilog_lexer.cc
@@ -55,7 +55,7 @@ bool VerilogLexer::KeepSyntaxTreeTokens(const TokenInfo& t) {
 void RecursiveLexText(absl::string_view text,
                       const std::function<void(const TokenInfo&)>& func) {
   VerilogLexer lexer(text);
-  while (true) {
+  for (;;) {
     const TokenInfo& subtoken(lexer.DoNextToken());
     if (subtoken.isEOF()) break;
     func(subtoken);

--- a/verilog/transform/obfuscate.cc
+++ b/verilog/transform/obfuscate.cc
@@ -53,7 +53,7 @@ static void ObfuscateVerilogCodeInternal(absl::string_view content,
                                          IdentifierObfuscator* subst) {
   VLOG(1) << __FUNCTION__;
   verilog::VerilogLexer lexer(content);
-  while (true) {
+  for (;;) {
     const verible::TokenInfo& token(lexer.DoNextToken());
     if (token.isEOF()) break;
     switch (token.token_enum()) {

--- a/verilog/transform/strip_comments.cc
+++ b/verilog/transform/strip_comments.cc
@@ -57,7 +57,7 @@ void StripVerilogComments(absl::string_view content, std::ostream* output,
     stream << verilog_symbol_name(e);
   });
 
-  while (true) {
+  for (;;) {
     const verible::TokenInfo& token(lexer.DoNextToken());
     if (token.isEOF()) break;
 


### PR DESCRIPTION
I prefer for (;;) over while (true). The latter slows down reading as the reader has to parse the condition.