### PR TITLE
Use absl::string_views for lint messages.

### DIFF
--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -230,6 +230,9 @@ cc_library(
 cc_library(
     name = "verilog_linter_constants",
     hdrs = ["verilog_linter_constants.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
 )
 
 cc_library(

--- a/verilog/analysis/checkers/always_comb_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_comb_blocking_rule.cc
@@ -43,7 +43,7 @@ using verible::matcher::Matcher;
 // Register AlwaysCombBlockingRule
 VERILOG_REGISTER_LINT_RULE(AlwaysCombBlockingRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Use only blocking assignments in \'always_comb\' combinational blocks.";
 
 const LintRuleDescriptor& AlwaysCombBlockingRule::GetDescriptor() {

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
@@ -44,7 +44,7 @@ using verible::matcher::Matcher;
 // Register AlwaysFFNonBlockingRule
 VERILOG_REGISTER_LINT_RULE(AlwaysFFNonBlockingRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Use blocking assignments, at most, for locals inside "
     "'always_ff' sequential blocks.";
 

--- a/verilog/analysis/checkers/banned_declared_name_patterns_rule.cc
+++ b/verilog/analysis/checkers/banned_declared_name_patterns_rule.cc
@@ -37,7 +37,8 @@ VERILOG_REGISTER_LINT_RULE(BannedDeclaredNamePatternsRule);
 using verible::LintRuleStatus;
 using verible::LintViolation;
 
-static const char kMessage[] = "Check banned declared name patterns";
+static constexpr absl::string_view kMessage =
+    "Check banned declared name patterns";
 
 const LintRuleDescriptor& BannedDeclaredNamePatternsRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/case_missing_default_rule.cc
+++ b/verilog/analysis/checkers/case_missing_default_rule.cc
@@ -39,7 +39,7 @@ using verible::matcher::Matcher;
 // Register CaseMissingDefaultRule
 VERILOG_REGISTER_LINT_RULE(CaseMissingDefaultRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Explicitly define a default case for every case statement.";
 
 const LintRuleDescriptor& CaseMissingDefaultRule::GetDescriptor() {

--- a/verilog/analysis/checkers/constraint_name_style_rule.cc
+++ b/verilog/analysis/checkers/constraint_name_style_rule.cc
@@ -44,7 +44,7 @@ using verible::matcher::Matcher;
 // Register ConstraintNameStyleRule.
 VERILOG_REGISTER_LINT_RULE(ConstraintNameStyleRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Constraint names must by styled with lower_snake_case and end with _c.";
 
 const LintRuleDescriptor& ConstraintNameStyleRule::GetDescriptor() {

--- a/verilog/analysis/checkers/disable_statement_rule.cc
+++ b/verilog/analysis/checkers/disable_statement_rule.cc
@@ -41,10 +41,10 @@ using verible::matcher::Matcher;
 
 VERILOG_REGISTER_LINT_RULE(DisableStatementNoLabelsRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Invalid usage of disable statement. Preferred construction is: disable "
     "fork;";
-static const char kMessageSeqBlock[] =
+static constexpr absl::string_view kMessageSeqBlock =
     "Invalid usage of disable statement. Preferred construction is: disable "
     "label_of_seq_block;";
 
@@ -72,7 +72,7 @@ void DisableStatementNoLabelsRule::HandleSymbol(
   if (!DisableMatcher().Matches(symbol, &manager)) {
     return;
   }
-  const char* kMessageFinal = kMessage;
+  absl::string_view message_final = kMessage;
   // if no kDisable label, return, nothing to be checked
   const auto& disableLabels = FindAllSymbolIdentifierLeafs(symbol);
   if (disableLabels.empty()) {
@@ -104,7 +104,7 @@ void DisableStatementNoLabelsRule::HandleSymbol(
       if (ptag == static_cast<int>(NodeEnum::kInitialStatement) ||
           ptag == static_cast<int>(NodeEnum::kFinalStatement) ||
           ptag == static_cast<int>(NodeEnum::kAlwaysStatement)) {
-        kMessageFinal = kMessageSeqBlock;
+        message_final = kMessageSeqBlock;
         break;
       }
       const auto& beginLabel = SymbolCastToLeaf(*beginLabels[0].match);
@@ -114,7 +114,7 @@ void DisableStatementNoLabelsRule::HandleSymbol(
       }
     }
   }
-  violations_.insert(LintViolation(symbol, kMessageFinal, context));
+  violations_.insert(LintViolation(symbol, message_final, context));
 }
 
 LintRuleStatus DisableStatementNoLabelsRule::Report() const {

--- a/verilog/analysis/checkers/endif_comment_rule.cc
+++ b/verilog/analysis/checkers/endif_comment_rule.cc
@@ -41,7 +41,7 @@ using verible::TokenStreamLintRule;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(EndifCommentRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "`endif should be followed on the same line by a comment that matches the "
     "opening `ifdef/`ifndef.";
 

--- a/verilog/analysis/checkers/enum_name_style_rule.cc
+++ b/verilog/analysis/checkers/enum_name_style_rule.cc
@@ -39,7 +39,7 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Enum names must use lower_snake_case naming convention "
     "and end with _t or _e.";
 

--- a/verilog/analysis/checkers/explicit_function_lifetime_rule.cc
+++ b/verilog/analysis/checkers/explicit_function_lifetime_rule.cc
@@ -42,7 +42,7 @@ using Matcher = verible::matcher::Matcher;
 // Register ExplicitFunctionLifetimeRule
 VERILOG_REGISTER_LINT_RULE(ExplicitFunctionLifetimeRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Explicitly define static or automatic lifetime for non-class functions";
 
 const LintRuleDescriptor& ExplicitFunctionLifetimeRule::GetDescriptor() {

--- a/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_function_task_parameter_type_rule.cc
@@ -42,7 +42,7 @@ using Matcher = verible::matcher::Matcher;
 // Register ExplicitFunctionTaskParameterTypeRule
 VERILOG_REGISTER_LINT_RULE(ExplicitFunctionTaskParameterTypeRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Explicitly define a storage type for every function parameter.";
 
 const LintRuleDescriptor&

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
@@ -42,7 +42,7 @@ using Matcher = verible::matcher::Matcher;
 // Register ExplicitParameterStorageTypeRule
 VERILOG_REGISTER_LINT_RULE(ExplicitParameterStorageTypeRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Explicitly define a storage type for every parameter and localparam, ";
 
 const LintRuleDescriptor& ExplicitParameterStorageTypeRule::GetDescriptor() {

--- a/verilog/analysis/checkers/explicit_task_lifetime_rule.cc
+++ b/verilog/analysis/checkers/explicit_task_lifetime_rule.cc
@@ -42,7 +42,7 @@ using Matcher = verible::matcher::Matcher;
 // Register ExplicitTaskLifetimeRule
 VERILOG_REGISTER_LINT_RULE(ExplicitTaskLifetimeRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Explicitly define static or automatic lifetime for non-class tasks";
 
 const LintRuleDescriptor& ExplicitTaskLifetimeRule::GetDescriptor() {

--- a/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.cc
+++ b/verilog/analysis/checkers/forbid_consecutive_null_statements_rule.cc
@@ -37,7 +37,7 @@ using verible::SyntaxTreeContext;
 // Register ForbidConsecutiveNullStatementsRule
 VERILOG_REGISTER_LINT_RULE(ForbidConsecutiveNullStatementsRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Do not use consecutive null statements like \';;\'.";
 
 const LintRuleDescriptor& ForbidConsecutiveNullStatementsRule::GetDescriptor() {

--- a/verilog/analysis/checkers/forbid_defparam_rule.cc
+++ b/verilog/analysis/checkers/forbid_defparam_rule.cc
@@ -35,7 +35,7 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(ForbidDefparamRule);
 
-static const char kMessage[] = "Do not use defparam.";
+static constexpr absl::string_view kMessage = "Do not use defparam.";
 
 const LintRuleDescriptor& ForbidDefparamRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/forbidden_anonymous_enums_rule.cc
+++ b/verilog/analysis/checkers/forbidden_anonymous_enums_rule.cc
@@ -37,7 +37,7 @@ using Matcher = verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(ForbiddenAnonymousEnumsRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "enum types always should be named using typedef.";
 
 const LintRuleDescriptor& ForbiddenAnonymousEnumsRule::GetDescriptor() {

--- a/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.cc
+++ b/verilog/analysis/checkers/forbidden_anonymous_structs_unions_rule.cc
@@ -39,9 +39,9 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(ForbiddenAnonymousStructsUnionsRule);
 
-static const char kMessageStruct[] =
+static constexpr absl::string_view kMessageStruct =
     "struct definitions always should be named using typedef.";
-static const char kMessageUnion[] =
+static constexpr absl::string_view kMessageUnion =
     "union definitions always should be named using typedef.";
 
 const LintRuleDescriptor& ForbiddenAnonymousStructsUnionsRule::GetDescriptor() {

--- a/verilog/analysis/checkers/generate_label_prefix_rule.cc
+++ b/verilog/analysis/checkers/generate_label_prefix_rule.cc
@@ -38,7 +38,7 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(GenerateLabelPrefixRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "All generate block labels must start with g_ or gen_";
 
 // TODO(fangism): and be lower_snake_case?

--- a/verilog/analysis/checkers/generate_label_rule.cc
+++ b/verilog/analysis/checkers/generate_label_rule.cc
@@ -36,7 +36,7 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(GenerateLabelRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "All generate block statements must have a label";
 
 const LintRuleDescriptor& GenerateLabelRule::GetDescriptor() {

--- a/verilog/analysis/checkers/interface_name_style_rule.cc
+++ b/verilog/analysis/checkers/interface_name_style_rule.cc
@@ -40,7 +40,7 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Interface names must use lower_snake_case naming convention "
     "and end with _if.";
 

--- a/verilog/analysis/checkers/legacy_generate_region_rule.cc
+++ b/verilog/analysis/checkers/legacy_generate_region_rule.cc
@@ -38,7 +38,7 @@ using verible::LintRuleStatus;
 using verible::LintViolation;
 using verible::matcher::EqualTagPredicate;
 
-static const char kMessage[] = "Do not use generate regions.";
+static constexpr absl::string_view kMessage = "Do not use generate regions.";
 
 const LintRuleDescriptor& LegacyGenerateRegionRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/legacy_genvar_declaration_rule.cc
+++ b/verilog/analysis/checkers/legacy_genvar_declaration_rule.cc
@@ -37,7 +37,8 @@ VERILOG_REGISTER_LINT_RULE(LegacyGenvarDeclarationRule);
 using verible::LintRuleStatus;
 using verible::LintViolation;
 
-static const char kMessage[] = "Do not use separate genvar declaration.";
+static constexpr absl::string_view kMessage =
+    "Do not use separate genvar declaration.";
 
 const LintRuleDescriptor& LegacyGenvarDeclarationRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/line_length_rule.cc
+++ b/verilog/analysis/checkers/line_length_rule.cc
@@ -52,7 +52,7 @@ using verible::TokenSequence;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(LineLengthRule);
 
-static const char kMessage[] = "Line length exceeds max: ";
+static constexpr absl::string_view kMessage = "Line length exceeds max: ";
 
 #if 0  // See comment below about comment-reflowing being implemented
 static bool ContainsAnyWhitespace(absl::string_view s) {

--- a/verilog/analysis/checkers/macro_name_style_rule.cc
+++ b/verilog/analysis/checkers/macro_name_style_rule.cc
@@ -40,7 +40,7 @@ using verible::TokenStreamLintRule;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(MacroNameStyleRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Macro names must contain only CAPITALS, underscores, and digits.  "
     "Exception: UVM-like macros.";
 

--- a/verilog/analysis/checkers/macro_string_concatenation_rule.cc
+++ b/verilog/analysis/checkers/macro_string_concatenation_rule.cc
@@ -35,7 +35,7 @@ using verible::TokenInfo;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(MacroStringConcatenationRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Token concatenation (``) used inside plain string literal.";
 
 const LintRuleDescriptor& MacroStringConcatenationRule::GetDescriptor() {

--- a/verilog/analysis/checkers/mismatched_labels_rule.cc
+++ b/verilog/analysis/checkers/mismatched_labels_rule.cc
@@ -40,8 +40,10 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(MismatchedLabelsRule);
 
-static const char kMessageMismatch[] = "Begin/end block labels must match.";
-static const char kMessageMissing[] = "Matching begin label is missing.";
+static constexpr absl::string_view kMessageMismatch =
+    "Begin/end block labels must match.";
+static constexpr absl::string_view kMessageMissing =
+    "Matching begin label is missing.";
 
 const LintRuleDescriptor& MismatchedLabelsRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/module_begin_block_rule.cc
+++ b/verilog/analysis/checkers/module_begin_block_rule.cc
@@ -35,7 +35,7 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(ModuleBeginBlockRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Module-level begin-end blocks are not LRM-valid syntax.";
 
 const LintRuleDescriptor& ModuleBeginBlockRule::GetDescriptor() {

--- a/verilog/analysis/checkers/module_filename_rule.cc
+++ b/verilog/analysis/checkers/module_filename_rule.cc
@@ -45,7 +45,7 @@ using verible::TextStructureView;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(ModuleFilenameRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Declared module does not match the first dot-delimited component "
     "of file name: ";
 

--- a/verilog/analysis/checkers/module_instantiation_rules.cc
+++ b/verilog/analysis/checkers/module_instantiation_rules.cc
@@ -114,7 +114,7 @@ static bool IsAnyPort(const verible::Symbol* symbol) {
 
 void ModuleParameterRule::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
-  static const char kMessage[] =
+  static constexpr absl::string_view kMessage =
       "Pass named parameters for parameterized module instantiations with "
       "more than one parameter";
 
@@ -152,7 +152,7 @@ verible::LintRuleStatus ModuleParameterRule::Report() const {
 
 void ModulePortRule::HandleSymbol(const verible::Symbol& symbol,
                                   const verible::SyntaxTreeContext& context) {
-  static const char kMessage[] =
+  static constexpr absl::string_view kMessage =
       "Use named ports for module instantiation with "
       "more than one port";
 

--- a/verilog/analysis/checkers/no_tabs_rule.cc
+++ b/verilog/analysis/checkers/no_tabs_rule.cc
@@ -36,7 +36,7 @@ using verible::TokenInfo;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(NoTabsRule);
 
-static const char kMessage[] = "Use spaces, not tabs.";
+static constexpr absl::string_view kMessage = "Use spaces, not tabs.";
 
 const LintRuleDescriptor& NoTabsRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/no_trailing_spaces_rule.cc
+++ b/verilog/analysis/checkers/no_trailing_spaces_rule.cc
@@ -41,7 +41,7 @@ using verible::TokenInfo;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(NoTrailingSpacesRule);
 
-static const char kMessage[] = "Remove trailing spaces.";
+static constexpr absl::string_view kMessage = "Remove trailing spaces.";
 
 const LintRuleDescriptor& NoTrailingSpacesRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/numeric_format_string_style_rule.cc
+++ b/verilog/analysis/checkers/numeric_format_string_style_rule.cc
@@ -41,7 +41,7 @@ using verible::TokenStreamLintRule;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(NumericFormatStringStyleRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Formatting string must contain proper style-compilant numeric specifiers.";
 
 const LintRuleDescriptor& NumericFormatStringStyleRule::GetDescriptor() {

--- a/verilog/analysis/checkers/one_module_per_file_rule.cc
+++ b/verilog/analysis/checkers/one_module_per_file_rule.cc
@@ -44,7 +44,7 @@ using verible::TextStructureView;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(OneModulePerFileRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Each file should have only one module declaration. Found: ";
 
 const LintRuleDescriptor& OneModulePerFileRule::GetDescriptor() {

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -42,9 +42,9 @@ using verible::TextStructureView;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(PackageFilenameRule);
 
-static const char optional_suffix[] = "_pkg";
+static constexpr absl::string_view optional_suffix = "_pkg";
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Package declaration name must match the file name "
     "(ignoring optional \"_pkg\" file name suffix).  ";
 

--- a/verilog/analysis/checkers/packed_dimensions_rule.cc
+++ b/verilog/analysis/checkers/packed_dimensions_rule.cc
@@ -43,7 +43,7 @@ using verible::matcher::Matcher;
 
 VERILOG_REGISTER_LINT_RULE(PackedDimensionsRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Declare packed dimension range in little-endian (decreasing) order, "
     "e.g. [N-1:0].";
 

--- a/verilog/analysis/checkers/parameter_type_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_type_name_style_rule.cc
@@ -44,7 +44,7 @@ using verible::matcher::Matcher;
 // Register ParameterTypeNameStyleRule.
 VERILOG_REGISTER_LINT_RULE(ParameterTypeNameStyleRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Parameter type names must use the lower_snake_case naming convention"
     " and end with _t.";
 

--- a/verilog/analysis/checkers/plusarg_assignment_rule.cc
+++ b/verilog/analysis/checkers/plusarg_assignment_rule.cc
@@ -37,8 +37,8 @@ using verible::matcher::Matcher;
 
 VERILOG_REGISTER_LINT_RULE(PlusargAssignmentRule);
 
-static const char kForbiddenFunctionName[] = "$test$plusargs";
-static const char kCorrectFunctionName[] = "$value$plusargs";
+static constexpr absl::string_view kForbiddenFunctionName = "$test$plusargs";
+static constexpr absl::string_view kCorrectFunctionName = "$value$plusargs";
 
 const LintRuleDescriptor& PlusargAssignmentRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/port_name_suffix_rule.cc
+++ b/verilog/analysis/checkers/port_name_suffix_rule.cc
@@ -48,11 +48,11 @@ using verible::matcher::Matcher;
 // Register PortNameSuffixRule.
 VERILOG_REGISTER_LINT_RULE(PortNameSuffixRule);
 
-static const char kMessageIn[] =
+static constexpr absl::string_view kMessageIn =
     "input port names must end with _i, _ni or _pi";
-static const char kMessageOut[] =
+static constexpr absl::string_view kMessageOut =
     "output port names must end with _o, _no, or _po";
-static const char kMessageInOut[] =
+static constexpr absl::string_view kMessageInOut =
     "inout port names must end with _io, _nio or _pio";
 
 const LintRuleDescriptor& PortNameSuffixRule::GetDescriptor() {

--- a/verilog/analysis/checkers/positive_meaning_parameter_name_rule.cc
+++ b/verilog/analysis/checkers/positive_meaning_parameter_name_rule.cc
@@ -44,7 +44,7 @@ using verible::matcher::Matcher;
 // Register PositiveMeaningParameterNameRule.
 VERILOG_REGISTER_LINT_RULE(PositiveMeaningParameterNameRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Use positive naming for parameters, start the name with 'enable' instead.";
 
 const LintRuleDescriptor& PositiveMeaningParameterNameRule::GetDescriptor() {

--- a/verilog/analysis/checkers/posix_eof_rule.cc
+++ b/verilog/analysis/checkers/posix_eof_rule.cc
@@ -38,7 +38,7 @@ using verible::TokenInfo;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(PosixEOFRule);
 
-static const char kMessage[] = "File must end with a newline.";
+static constexpr absl::string_view kMessage = "File must end with a newline.";
 
 const LintRuleDescriptor& PosixEOFRule::GetDescriptor() {
   static const LintRuleDescriptor d{

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule.cc
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule.cc
@@ -41,10 +41,10 @@ using verible::matcher::Matcher;
 // Register ProperParameterDeclarationRule
 VERILOG_REGISTER_LINT_RULE(ProperParameterDeclarationRule);
 
-static const char kParameterMessage[] =
+static constexpr absl::string_view kParameterMessage =
     "\'parameter\' declarations should only be within packages or in the "
     "formal parameter list of modules/classes.";
-static const char kLocalParamMessage[] =
+static constexpr absl::string_view kLocalParamMessage =
     "\'localparam\' declarations should only be within modules\' or classes\' "
     "definition bodies.";
 

--- a/verilog/analysis/checkers/signal_name_style_rule.cc
+++ b/verilog/analysis/checkers/signal_name_style_rule.cc
@@ -45,7 +45,7 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Signal names must use lower_snake_case naming convention.";
 
 const LintRuleDescriptor& SignalNameStyleRule::GetDescriptor() {

--- a/verilog/analysis/checkers/struct_union_name_style_rule.cc
+++ b/verilog/analysis/checkers/struct_union_name_style_rule.cc
@@ -42,8 +42,8 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-static const char kMessageStruct[] = "Struct names";
-static const char kMessageUnion[] = "Union names";
+static constexpr absl::string_view kMessageStruct = "Struct names";
+static constexpr absl::string_view kMessageUnion = "Union names";
 
 const LintRuleDescriptor& StructUnionNameStyleRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -72,7 +72,7 @@ void StructUnionNameStyleRule::HandleSymbol(const verible::Symbol& symbol,
     // have consistent shape for all kTypeDeclaration nodes.
     const bool is_struct = !FindAllStructTypes(symbol).empty();
     if (!is_struct && FindAllUnionTypes(symbol).empty()) return;
-    const char* const msg = is_struct ? kMessageStruct : kMessageUnion;
+    const absl::string_view msg = is_struct ? kMessageStruct : kMessageUnion;
 
     const auto* identifier_leaf = GetIdentifierFromTypeDeclaration(symbol);
     const auto name = ABSL_DIE_IF_NULL(identifier_leaf)->get().text();

--- a/verilog/analysis/checkers/suggest_parentheses_rule.cc
+++ b/verilog/analysis/checkers/suggest_parentheses_rule.cc
@@ -28,7 +28,7 @@ using verible::AutoFix;
 using verible::LintRuleStatus;
 using verible::LintViolation;
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Parenthesize condition expressions that appear in the true-clause of "
     "another condition expression.";
 

--- a/verilog/analysis/checkers/token_stream_lint_rule.cc
+++ b/verilog/analysis/checkers/token_stream_lint_rule.cc
@@ -41,7 +41,7 @@ using verible::matcher::Matcher;
 // Register TokenStreamLintRule
 VERILOG_REGISTER_LINT_RULE(TokenStreamLintRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "The lines can't be continued with \'\\\', use concatenation operator with "
     "braces";
 

--- a/verilog/analysis/checkers/unpacked_dimensions_rule.cc
+++ b/verilog/analysis/checkers/unpacked_dimensions_rule.cc
@@ -41,13 +41,13 @@ using verible::matcher::Matcher;
 
 VERILOG_REGISTER_LINT_RULE(UnpackedDimensionsRule);
 
-static const char kMessageScalarInOrder[] =
+static constexpr absl::string_view kMessageScalarInOrder =
     "When an unpacked dimension range is zero-based ([0:N-1]), "
     "declare size as [N] instead.";
-static const char kMessageScalarReversed[] =
+static constexpr absl::string_view kMessageScalarReversed =
     "Unpacked dimension range must be declared in big-endian ([0:N-1]) order.  "
     "Declare zero-based big-endian unpacked dimensions sized as [N].";
-static const char kMessageReorder[] =
+static constexpr absl::string_view kMessageReorder =
     "Declare unpacked dimension range in big-endian (increasing) order, "
     "e.g. [N:N+M].";
 

--- a/verilog/analysis/checkers/v2001_generate_begin_rule.cc
+++ b/verilog/analysis/checkers/v2001_generate_begin_rule.cc
@@ -39,7 +39,7 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(V2001GenerateBeginRule);
 
-static const char kMessage[] =
+static constexpr absl::string_view kMessage =
     "Do not begin a generate block inside a generate region.";
 
 const LintRuleDescriptor& V2001GenerateBeginRule::GetDescriptor() {

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -55,8 +55,6 @@ using verible::TokenInfo;
 using verible::TokenSequence;
 using verible::container::InsertKeyOrDie;
 
-const char VerilogAnalyzer::kParseDirectiveName[] = "verilog_syntax:";
-
 absl::Status VerilogAnalyzer::Tokenize() {
   if (!tokenized_) {
     VerilogLexer lexer{Data().Contents()};

--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -107,7 +107,7 @@ class VerilogAnalyzer : public verible::FileAnalyzer {
       const verible::TokenSequence& raw_tokens);
 
   // Special string inside a comment that triggers setting parsing mode.
-  static const char kParseDirectiveName[];
+  static constexpr absl::string_view kParseDirectiveName = "verilog_syntax:";
 
  private:
   // Attempt to parse all macro arguments as expressions.  Where parsing as an

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -162,7 +162,7 @@ class FakeTextStructureView : public TextStructureView {
 static const verible::LineColumnMap dummy_map("");
 
 // Don't care about file name for these tests.
-static const char filename[] = "";
+static constexpr absl::string_view filename = "";
 
 TEST(ProjectPolicyTest, MatchesAnyPath) {
   struct TestCase {

--- a/verilog/analysis/verilog_linter_constants.h
+++ b/verilog/analysis/verilog_linter_constants.h
@@ -15,18 +15,20 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_VERILOG_LINTER_CONSTANTS_H_
 #define VERIBLE_VERILOG_ANALYSIS_VERILOG_LINTER_CONSTANTS_H_
 
+#include "absl/strings/string_view.h"
+
 namespace verilog {
 
 // This is the leading string that makes a comment a lint waiver.
-static constexpr char kLinterTrigger[] = "verilog_lint:";
+static constexpr absl::string_view kLinterTrigger = "verilog_lint:";
 
 // This command says to waive one line (this or next applicable).
-static constexpr char kLinterWaiveLineCommand[] = "waive";
+static constexpr absl::string_view kLinterWaiveLineCommand = "waive";
 
 // This command says to start waiving a rule from this line...
-static constexpr char kLinterWaiveStartCommand[] = "waive-start";
+static constexpr absl::string_view kLinterWaiveStartCommand = "waive-start";
 // ... and stop waiving at this line.
-static constexpr char kLinterWaiveStopCommand[] = "waive-stop";
+static constexpr absl::string_view kLinterWaiveStopCommand = "waive-stop";
 
 }  // namespace verilog
 


### PR DESCRIPTION
LintViolation() recently had its constructor changed to accept an absl::string_view instead of a std::string; so let's use these natively when definiting the messages.