### PR TITLE
Add loading linter rules from .rules.verible_lint

### DIFF
--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/flags/declare.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
@@ -33,6 +34,10 @@
 #include "common/text/text_structure.h"
 #include "verilog/analysis/lint_rule_registry.h"
 #include "verilog/analysis/verilog_linter_configuration.h"
+
+// Flag is declared for testing purposes (used e.g. in
+// verilog/tools/ls/verilog-language-server_test.cc)
+ABSL_DECLARE_FLAG(bool, rules_config_search);
 
 namespace verilog {
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -44,6 +44,7 @@ cc_library(
     srcs = ["lsp-parse-buffer.cc"],
     hdrs = ["lsp-parse-buffer.h"],
     deps = [
+        ":lsp-file-utils",
         "//common/lsp:lsp-text-buffer",
         "//common/util:logging",
         "//verilog/analysis:verilog_analyzer",
@@ -98,6 +99,7 @@ cc_library(
     hdrs = ["symbol-table-handler.h"],
     deps = [
         ":lsp-parse-buffer",
+        ":lsp-file-utils",
         "//common/lsp:lsp-protocol",
         "//common/strings:line_column_map",
         "//common/util:file_util",
@@ -110,6 +112,16 @@ cc_library(
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
     ],
+)
+
+cc_library(
+    name = "lsp-file-utils",
+    srcs = ["lsp-file-utils.cc"],
+    hdrs = ["lsp-file-utils.h"],
+    deps = [
+        "//common/util:file_util",
+        "@com_google_absl//absl/strings"
+    ]
 )
 
 cc_test(

--- a/verilog/tools/ls/lsp-file-utils.cc
+++ b/verilog/tools/ls/lsp-file-utils.cc
@@ -1,0 +1,38 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "verilog/tools/ls/lsp-file-utils.h"
+
+#include <filesystem>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+
+namespace verilog {
+
+static constexpr absl::string_view kFileSchemePrefix = "file://";
+
+absl::string_view LSPUriToPath(absl::string_view uri) {
+  if (!absl::StartsWith(uri, kFileSchemePrefix)) return "";
+  return uri.substr(kFileSchemePrefix.size());
+}
+
+std::string PathToLSPUri(absl::string_view path) {
+  std::filesystem::path p(path.begin(), path.end());
+  return absl::StrCat(kFileSchemePrefix, std::filesystem::absolute(p).string());
+}
+
+}  // namespace verilog

--- a/verilog/tools/ls/lsp-file-utils.h
+++ b/verilog/tools/ls/lsp-file-utils.h
@@ -1,0 +1,32 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef VERILOG_TOOLS_LS_LSP_FILE_UTILS_H
+#define VERILOG_TOOLS_LS_LSP_FILE_UTILS_H
+
+#include "absl/strings/string_view.h"
+
+namespace verilog {
+// Converts file:// scheme entries to actual system paths.
+// If other scheme is provided, method returns empty string_view.
+// TODO (glatosinski) current resolving of LSP URIs is very naive
+// and supports only narrow use cases of file:// specifier.
+absl::string_view LSPUriToPath(absl::string_view uri);
+
+// Converts filesystem paths to file:// scheme entries.
+std::string PathToLSPUri(absl::string_view path);
+}  // namespace verilog
+
+#endif  // VERILOG_TOOLS_LS_LSP_FILE_UTILS_H

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -17,6 +17,7 @@
 
 #include "absl/status/status.h"
 #include "common/util/logging.h"
+#include "verilog/tools/ls/lsp-file-utils.h"
 
 namespace verilog {
 static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
@@ -24,7 +25,9 @@ static absl::StatusOr<std::vector<verible::LintRuleStatus>> RunLinter(
   const auto &text_structure = parser.Data();
 
   verilog::LinterConfiguration config;
-  if (auto from_flags = LinterConfigurationFromFlags(); from_flags.ok()) {
+  absl::string_view file_path = verilog::LSPUriToPath(filename);
+  if (auto from_flags = LinterConfigurationFromFlags(file_path);
+      from_flags.ok()) {
     config = *from_flags;
   } else {
     LOG(ERROR) << from_flags.status().message() << std::endl;

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -23,13 +23,12 @@
 #include "common/strings/line_column_map.h"
 #include "common/util/file_util.h"
 #include "verilog/analysis/verilog_filelist.h"
+#include "verilog/tools/ls/lsp-file-utils.h"
 
 ABSL_FLAG(std::string, file_list_path, "verible.filelist",
           "Name of the file with Verible FileList for the project");
 
 namespace verilog {
-
-static constexpr absl::string_view kFileSchemePrefix = "file://";
 
 // If vlog(2), output all non-ok messages, with vlog(1) just the first few,
 // else: none
@@ -46,16 +45,6 @@ static void LogFullIfVLog(const std::vector<absl::Status> &statuses) {
       }
     }
   }
-}
-
-absl::string_view LSPUriToPath(absl::string_view uri) {
-  if (!absl::StartsWith(uri, kFileSchemePrefix)) return "";
-  return uri.substr(kFileSchemePrefix.size());
-}
-
-std::string PathToLSPUri(absl::string_view path) {
-  std::filesystem::path p(path.begin(), path.end());
-  return absl::StrCat(kFileSchemePrefix, std::filesystem::absolute(p).string());
 }
 
 std::string FindFileList(absl::string_view current_dir) {

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -30,15 +30,6 @@
 
 namespace verilog {
 
-// Converts file:// scheme entries to actual system paths.
-// If other scheme is provided, method returns empty string_view.
-// TODO (glatosinski) current resolving of LSP URIs is very naive
-// and supports only narrow use cases of file:// specifier.
-absl::string_view LSPUriToPath(absl::string_view uri);
-
-// Converts filesystem paths to file:// scheme entries.
-std::string PathToLSPUri(absl::string_view path);
-
 // Looks for FileList file for SymbolTableHandler
 std::string FindFileList(absl::string_view current_dir);
 

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -21,6 +21,7 @@
 #include "common/lsp/lsp-protocol.h"
 #include "common/util/file_util.h"
 #include "common/util/init_command_line.h"
+#include "verilog/tools/ls/lsp-file-utils.h"
 #include "verilog/tools/ls/verible-lsp-adapter.h"
 
 namespace verilog {


### PR DESCRIPTION
This PR:

* Moves conversions of LSP URI to paths and vice versa to a separate library
* Enables checking `.rules.verible_lint` by default
* Adds mechanism in parsed buffers to check for `.rules.verible_lint` up in directory hierarchy, starting from linted file, to load linter rules
* Adds tests for verifying reactions of `VerilogLanguageServer` for `.rules.verible_lint` file

@hzeller - I am not sure about changing the default value of the `--rules-config-search` to `true`. This flag is available from the level of `verible-verilog-ls` - not sure whether I should change the flag value to `true` via `SetFlag` in a function delivered with `VerilogLanguageServer`, or change this default value directly in `verilog_linter`.