### PR TITLE
Update zlib to 1.2.13

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -208,11 +208,11 @@ maybe(
     http_archive,
     name = "zlib",
     build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-    sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
-    strip_prefix = "zlib-1.2.12",
+    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+    strip_prefix = "zlib-1.2.13",
     urls = [
-        "https://zlib.net/zlib-1.2.12.tar.gz",
-        "https://zlib.net/fossils/zlib-1.2.12.tar.gz",
+        "https://zlib.net/zlib-1.2.13.tar.gz",
+        "https://zlib.net/fossils/zlib-1.2.13.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Updated version, fixes CVE-2022-37434. The mentioned bug does _not_ affect our application, but it is good to stay at head nevertheless.