### PR TITLE
Convert the remaining static constexpr -> inline constexpr in headers.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,6 @@
 ###
 Checks: >
   clang-diagnostic-*,
-  -clang-diagnostic-unused-const-variable,
   clang-analyzer-*,
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-cplusplus.NewDeleteLeaks,

--- a/common/text/constants.h
+++ b/common/text/constants.h
@@ -21,7 +21,7 @@ namespace verible {
 
 // This is the value of EOF token from all Flex-generated lexers.
 // This is also the value expected by Bison-generated parsers for $end.
-constexpr int TK_EOF = 0;
+inline constexpr int TK_EOF = 0;
 
 // Language-specific tags for various nonterminals should be nonzero.
 enum NodeEnum {

--- a/verilog/analysis/default_rules.h
+++ b/verilog/analysis/default_rules.h
@@ -22,7 +22,7 @@ namespace analysis {
 // Use --ruleset default
 // clang-format off
 // LINT.IfChange
-constexpr const char* kDefaultRuleSet[] = {
+inline constexpr const char* kDefaultRuleSet[] = {
     "invalid-system-task-function",
     "module-begin-block",
     "module-parameter",

--- a/verilog/analysis/verilog_linter_constants.h
+++ b/verilog/analysis/verilog_linter_constants.h
@@ -20,15 +20,16 @@
 namespace verilog {
 
 // This is the leading string that makes a comment a lint waiver.
-static constexpr absl::string_view kLinterTrigger = "verilog_lint:";
+inline constexpr absl::string_view kLinterTrigger = "verilog_lint:";
 
 // This command says to waive one line (this or next applicable).
-static constexpr absl::string_view kLinterWaiveLineCommand = "waive";
+inline constexpr absl::string_view kLinterWaiveLineCommand = "waive";
 
 // This command says to start waiving a rule from this line...
-static constexpr absl::string_view kLinterWaiveStartCommand = "waive-start";
+inline constexpr absl::string_view kLinterWaiveStartCommand = "waive-start";
+
 // ... and stop waiving at this line.
-static constexpr absl::string_view kLinterWaiveStopCommand = "waive-stop";
+inline constexpr absl::string_view kLinterWaiveStopCommand = "waive-stop";
 
 }  // namespace verilog
 


### PR DESCRIPTION
That way, we don't use up multiple storage if not needed.