### PR TITLE
Given that zlib.h is imported in WORKSPACE, it is a project header.

### DIFF
--- a/common/util/simple_zip.cc
+++ b/common/util/simple_zip.cc
@@ -14,8 +14,6 @@
 
 #include "common/util/simple_zip.h"
 
-#include <zlib.h>
-
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -24,6 +22,7 @@
 
 #include "absl/strings/string_view.h"
 #include "third_party/portable_endian/portable_endian.h"
+#include "zlib.h"  // WORKSPACE imported project header
 
 namespace verible {
 namespace zip {


### PR DESCRIPTION
This way we emphasize that this is a local header and that the system <zlib.h> shall not be considered.