### PR TITLE
Don't search for .clang-tidy, provide it directly in command line.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,3 @@
----
 # Disabled some clang-analyzer static checks, need some more investigation.
 # TODO(hzeller) fix and re-enable clang-analyzer checks.
 # TODO(hzeller) Looking over magic numbers might be good, but probably
@@ -42,9 +41,11 @@ Checks: >
   -readability-qualified-auto,
   -readability-redundant-access-specifiers,
   -readability-simplify-boolean-expr,
+  -readability-static-definition-in-anonymous-namespace,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,
   google-*,
+  -google-readability-avoid-underscore-in-googletest-name,
   -google-readability-casting,
   -google-readability-todo,
   performance-*,
@@ -76,5 +77,3 @@ Checks: >
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: true
-...


### PR DESCRIPTION
If the configuration is not provided in the command line, clang-tidy will attempt to search for every *.cc file it checks to go up the directory chain to look for .clang-tidy. That of course might fail if this is a generated file that lives in a symbolic-linked bazel-out/ of sorts.

clang-tidy versions 12 and up have a convenient --config-file option, but clang-tidy 11 only knows --config, so we use that.