### PR TITLE
Some clang-tidy auto-fixes for tests.

### DIFF
--- a/common/analysis/linter_test_utils.h
+++ b/common/analysis/linter_test_utils.h
@@ -93,7 +93,7 @@ template <class AnalyzerType, class RuleClass>
 void RunConfiguredLintTestCases(
     std::initializer_list<LintTestCase> tests, absl::string_view configuration,
     absl::string_view filename = "<<inline-test>>") {
-  typedef typename RuleClass::rule_type rule_type;
+  using rule_type = typename RuleClass::rule_type;
   auto rule_generator = [&configuration]() -> std::unique_ptr<rule_type> {
     std::unique_ptr<rule_type> instance(new RuleClass());
     absl::Status config_status = instance->Configure(configuration);
@@ -143,7 +143,7 @@ void RunLintAutoFixCase(const AutoFixInOut& test,
 template <class AnalyzerType, class RuleClass>
 void RunApplyFixCases(std::initializer_list<AutoFixInOut> tests,
                       absl::string_view configuration) {
-  typedef typename RuleClass::rule_type rule_type;
+  using rule_type = typename RuleClass::rule_type;
   auto rule_generator = [&configuration]() -> std::unique_ptr<rule_type> {
     std::unique_ptr<rule_type> instance(new RuleClass());
     absl::Status config_status = instance->Configure(configuration);

--- a/common/analysis/syntax_tree_search_test_utils.cc
+++ b/common/analysis/syntax_tree_search_test_utils.cc
@@ -58,7 +58,7 @@ struct LessStringRanges {
   }
 };
 
-typedef std::set<absl::string_view, LessStringRanges> StringRangeSet;
+using StringRangeSet = std::set<absl::string_view, LessStringRanges>;
 
 // This function helps find symmetric differences between two sets
 // of findings (actual vs. expected) based on locations.

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -155,7 +155,7 @@ TEST_F(TabularAlignTokenTest, EmptyPartitionRange) {
 
 class MatrixTreeAlignmentTestFixture : public AlignmentTestFixture {
  public:
-  MatrixTreeAlignmentTestFixture(absl::string_view text)
+  explicit MatrixTreeAlignmentTestFixture(absl::string_view text)
       : AlignmentTestFixture(text),
         syntax_tree_(nullptr),  // for subclasses to initialize
         partition_(/* temporary */ UnwrappedLine()) {}
@@ -183,7 +183,7 @@ class MatrixTreeAlignmentTestFixture : public AlignmentTestFixture {
 
 class Sparse3x3MatrixAlignmentTest : public MatrixTreeAlignmentTestFixture {
  public:
-  Sparse3x3MatrixAlignmentTest(
+  explicit Sparse3x3MatrixAlignmentTest(
       absl::string_view text = "one two three four five six")
       : MatrixTreeAlignmentTestFixture(text) {
     // From the sample_ text, each pair of tokens will span a subpartition.
@@ -843,7 +843,8 @@ TEST_F(GetPartitionAlignmentSubrangesSubtypedTestFixture, VariousRanges) {
 
 class Dense2x2MatrixAlignmentTest : public MatrixTreeAlignmentTestFixture {
  public:
-  Dense2x2MatrixAlignmentTest(absl::string_view text = "one two three four")
+  explicit Dense2x2MatrixAlignmentTest(
+      absl::string_view text = "one two three four")
       : MatrixTreeAlignmentTestFixture(text) {
     CHECK_EQ(tokens_.size(), 4);
 
@@ -1019,12 +1020,13 @@ class SyntaxTreeColumnizer : public ColumnSchemaScanner {
 
 class SubcolumnsTreeAlignmentTest : public MatrixTreeAlignmentTestFixture {
  public:
-  SubcolumnsTreeAlignmentTest(absl::string_view text =
-                                  "zero\n"
-                                  "( one two three )\n"
-                                  "( four ( five six ) seven )\n"
-                                  "( eight ( ( nine ) ten ) )\n"
-                                  "( eleven nineteen-ninety-nine 2k )\n")
+  explicit SubcolumnsTreeAlignmentTest(
+      absl::string_view text =
+          "zero\n"
+          "( one two three )\n"
+          "( four ( five six ) seven )\n"
+          "( eight ( ( nine ) ten ) )\n"
+          "( eleven nineteen-ninety-nine 2k )\n")
       : MatrixTreeAlignmentTestFixture(text) {
     //  Columns tree:
     //
@@ -1249,13 +1251,14 @@ TEST_F(SubcolumnsTreeAlignmentTest,
 
 class MultiSubcolumnsTreeAlignmentTest : public SubcolumnsTreeAlignmentTest {
  public:
-  MultiSubcolumnsTreeAlignmentTest(absl::string_view text =
-                                       "zero\n"
-                                       "( one two three )\n"
-                                       "( four ( five six ) seven )\n"
-                                       "\n"
-                                       "( eight ( ( nine ) ten ) )\n"
-                                       "( eleven nineteen-ninety-nine 2k )\n")
+  explicit MultiSubcolumnsTreeAlignmentTest(
+      absl::string_view text =
+          "zero\n"
+          "( one two three )\n"
+          "( four ( five six ) seven )\n"
+          "\n"
+          "( eight ( ( nine ) ten ) )\n"
+          "( eleven nineteen-ninety-nine 2k )\n")
       : SubcolumnsTreeAlignmentTest(text) {}
 
   std::string Render() {
@@ -1302,7 +1305,7 @@ TEST_F(MultiSubcolumnsTreeAlignmentTest, BlankLineSeparatedGroups) {
 
 class InferSubcolumnsTreeAlignmentTest : public SubcolumnsTreeAlignmentTest {
  public:
-  InferSubcolumnsTreeAlignmentTest(
+  explicit InferSubcolumnsTreeAlignmentTest(
       absl::string_view text =
           "zero\n"
           "( one     two                   three )\n"
@@ -1344,12 +1347,12 @@ TEST_F(InferSubcolumnsTreeAlignmentTest, InferUserIntent) {
 
 class SubcolumnsTreeWithDelimitersTest : public SubcolumnsTreeAlignmentTest {
  public:
-  SubcolumnsTreeWithDelimitersTest(absl::string_view text =
-                                       "( One Two , )\n"
-                                       "( Three Four )\n"
-                                       "\n"
-                                       "( Seven Eight , )\n"
-                                       "( Five Six )\n")
+  explicit SubcolumnsTreeWithDelimitersTest(absl::string_view text =
+                                                "( One Two , )\n"
+                                                "( Three Four )\n"
+                                                "\n"
+                                                "( Seven Eight , )\n"
+                                                "( Five Six )\n")
       : SubcolumnsTreeAlignmentTest(text) {}
 };
 

--- a/common/formatting/token_partition_tree_test_utils.h
+++ b/common/formatting/token_partition_tree_test_utils.h
@@ -83,7 +83,7 @@ class TokenPartitionTreeBuilder {
       std::initializer_list<TokenPartitionTreeBuilder> children)
       : policy_(policy), children_(children) {}
 
-  explicit TokenPartitionTreeBuilder(
+  TokenPartitionTreeBuilder(
       std::initializer_list<TokenPartitionTreeBuilder> children)
       : children_(children) {}
 

--- a/common/lsp/message-stream-splitter_test.cc
+++ b/common/lsp/message-stream-splitter_test.cc
@@ -38,7 +38,7 @@ TEST(MessageStreamSplitterTest, NotRegisteredMessageProcessor) {
 // simulate partial reads.
 class DataStreamSimulator {
  public:
-  DataStreamSimulator(absl::string_view content, int max_chunk = -1)
+  explicit DataStreamSimulator(absl::string_view content, int max_chunk = -1)
       : content_(content), max_chunk_(max_chunk) {}
 
   int read(char *buf, int size) {

--- a/common/strings/diff_test.cc
+++ b/common/strings/diff_test.cc
@@ -351,7 +351,7 @@ struct DiffEditsToPatchHunksTestCase {
 };
 
 TEST(DiffEditsToPatchHunksTest, Various) {
-  typedef std::initializer_list<RelativeEdit> RelEdits;
+  using RelEdits = std::initializer_list<RelativeEdit>;
   const DiffEditsToPatchHunksTestCase kTestCases[] = {
       {
           .whole_edits = MakeDiffEdits(RelEdits{{Operation::EQUALS, 2}}),

--- a/common/strings/display_utils_test.cc
+++ b/common/strings/display_utils_test.cc
@@ -104,7 +104,7 @@ TEST(EscapeStringTest, Various) {
   }
 }
 
-typedef std::vector<int> IntVector;
+using IntVector = std::vector<int>;
 
 // Normally a definition like the following would appear in a header
 // to be shared.

--- a/common/strings/patch_test.cc
+++ b/common/strings/patch_test.cc
@@ -2187,7 +2187,7 @@ TEST(PatchSetAddedLinesMapTest, NewAndExistingFile) {
   const auto status = patch_set.Parse(patch_contents);
   ASSERT_TRUE(status.ok()) << status.message();
 
-  typedef FileLineNumbersMap::value_type P;
+  using P = FileLineNumbersMap::value_type;
   EXPECT_THAT(patch_set.AddedLinesMap(false),
               ElementsAre(P{"/path/to/file1.txt", {}},
                           P{"/path/to/file2.txt", {{54, 56}}}));

--- a/common/strings/range_test.cc
+++ b/common/strings/range_test.cc
@@ -38,7 +38,7 @@ TEST(MakeStringViewRangeTest, BadRange) {
   EXPECT_DEATH(make_string_view_range(text.end(), text.begin()), "Malformed");
 }
 
-typedef std::pair<int, int> IntPair;
+using IntPair = std::pair<int, int>;
 
 TEST(ByteOffsetRangeTest, EmptyInEmpty) {
   const absl::string_view superstring("");

--- a/common/strings/string_memory_map_test.cc
+++ b/common/strings/string_memory_map_test.cc
@@ -111,8 +111,8 @@ static absl::string_view StringViewKey(
   return absl::string_view(*ABSL_DIE_IF_NULL(owned));
 }
 
-typedef StringMemoryMap<std::unique_ptr<const std::string>, StringViewKey>
-    StringSet;
+using StringSet =
+    StringMemoryMap<std::unique_ptr<const std::string>, StringViewKey>;
 
 TEST(StringMemoryMapTest, EmptyOwnsNothing) {
   const StringSet sset;

--- a/common/util/auto_pop_stack_test.cc
+++ b/common/util/auto_pop_stack_test.cc
@@ -23,7 +23,7 @@ namespace {
 
 using ::testing::ElementsAre;
 
-typedef AutoPopStack<int> IntStack;
+using IntStack = AutoPopStack<int>;
 
 // Test that AutoPop properly pushes and pops nodes on and off the stack
 TEST(AutoPopStackTest, PushPopTest) {

--- a/common/util/interval_map_test.cc
+++ b/common/util/interval_map_test.cc
@@ -27,9 +27,9 @@
 namespace verible {
 namespace {
 
-typedef DisjointIntervalMap<int, std::unique_ptr<int>> IntIntervalMap;
-typedef DisjointIntervalMap<int, std::unique_ptr<std::string>>
-    StringIntervalMap;
+using IntIntervalMap = DisjointIntervalMap<int, std::unique_ptr<int>>;
+using StringIntervalMap =
+    DisjointIntervalMap<int, std::unique_ptr<std::string>>;
 
 TEST(DisjointIntervalMapTest, DefaultCtor) {
   const IntIntervalMap imap;
@@ -275,8 +275,8 @@ TEST(DisjointIntervalMapTest, BeginEndRangeConstIterators) {
 
 // std::vector is moveable and guaranteed to transfer ownership over its
 // internal array, i.e. no small/inline-vector optimization.
-typedef DisjointIntervalMap<std::vector<int>::const_iterator, std::vector<int>>
-    VectorIntervalMap;
+using VectorIntervalMap =
+    DisjointIntervalMap<std::vector<int>::const_iterator, std::vector<int>>;
 
 static VectorIntervalMap::iterator AllocateVectorBlock(VectorIntervalMap* vmap,
                                                        int min, int max) {

--- a/common/util/interval_set_test.cc
+++ b/common/util/interval_set_test.cc
@@ -117,7 +117,7 @@ TEST(IntervalSetTest, EqualityDifferentAsymmetricOverlapRight) {
   EXPECT_NE(iset2, iset1);
 }
 
-typedef std::map<int, int>::value_type pair_t;
+using pair_t = std::map<int, int>::value_type;
 
 TEST(IntervalSetTest, ConstructionWithInitializerOneInterval) {
   const interval_set_type iset{{2, 4}};
@@ -239,14 +239,18 @@ TEST(IntervalSetTest, Assign) {
 
 TEST(IntervalSetTest, CopyConstruct) {
   UnsafeIntervalSet iset{{2, 5}, {10, 11}};
-  const interval_set_type copy(iset);
+  // clang-format off
+  const interval_set_type copy(iset);  // NOLINT(performance-unnecessary-copy-initialization)
+  // clang-format on
   EXPECT_THAT(iset, ElementsAre(pair_t{2, 5}, pair_t{10, 11}));
   EXPECT_THAT(copy, ElementsAre(pair_t{2, 5}, pair_t{10, 11}));
 }
 
 TEST(IntervalSetTest, CopyAssign) {
   UnsafeIntervalSet iset{{2, 5}, {10, 11}};
-  const interval_set_type copy = iset;
+  // clang-format off
+  const interval_set_type copy = iset;  // NOLINT(performance-unnecessary-copy-initialization)
+  // clang-format on
   EXPECT_THAT(iset, ElementsAre(pair_t{2, 5}, pair_t{10, 11}));
   EXPECT_THAT(copy, ElementsAre(pair_t{2, 5}, pair_t{10, 11}));
 }
@@ -474,7 +478,7 @@ TEST(IntervalSetTest, AddInvalidInterval) {
   EXPECT_DEATH((iset.Add({2, 1})), "");
 }
 
-typedef AddIntervalTestData DifferenceIntervalTestData;
+using DifferenceIntervalTestData = AddIntervalTestData;
 
 TEST(IntervalSetTest, DifferenceInvalidInterval) {
   UnsafeIntervalSet iset{};
@@ -498,7 +502,7 @@ TEST(IntervalSetTest, DifferenceEmptyIntervalFromNonEmptySet) {
   }
 }
 
-typedef AddSingleValueTestData DifferenceSingleValueTestData;
+using DifferenceSingleValueTestData = AddSingleValueTestData;
 
 TEST(IntervalSetTest, DifferenceSingleValue) {
   const UnsafeIntervalSet init{{10, 20}, {30, 40}};
@@ -673,7 +677,7 @@ TEST(IntervalSetTest, SetUnions) {
   }
 }
 
-typedef AddIntervalTestData ComplementTestData;
+using ComplementTestData = AddIntervalTestData;
 
 TEST(IntervalSetTest, ComplementEmptyInitial) {
   const interval_type kTestCases[] = {
@@ -948,8 +952,8 @@ TEST(UniformRandomGeneratorTest, MultiRanges) {
 
 // DisjointIntervalSet tests
 
-typedef DisjointIntervalSet<int> IntIntervalSet;
-typedef DisjointIntervalSet<std::vector<int>::const_iterator> VectorIntervalSet;
+using IntIntervalSet = DisjointIntervalSet<int>;
+using VectorIntervalSet = DisjointIntervalSet<std::vector<int>::const_iterator>;
 
 // Make sure values interior to a range point back to the entire range.
 template <typename M>

--- a/common/util/map_tree_test.cc
+++ b/common/util/map_tree_test.cc
@@ -126,7 +126,7 @@ TEST(MapTreeTest, EmplaceOneChild) {
 struct NonCopyable {
   absl::string_view text;
 
-  NonCopyable(absl::string_view text) : text(text) {}
+  explicit NonCopyable(absl::string_view text) : text(text) {}
 
   // move-only, no copy
   NonCopyable(const NonCopyable&) = delete;

--- a/common/util/range_test.cc
+++ b/common/util/range_test.cc
@@ -167,7 +167,7 @@ TEST(BoundsEqualTest, DerivedSubStringView) {
   EXPECT_FALSE(BoundsEqual(str.substr(3, 4), str.substr(1, 4)));  // partial
 }
 
-typedef std::pair<int, int> IntPair;
+using IntPair = std::pair<int, int>;
 
 TEST(SubRangeIndicesTest, Empty) {
   const std::vector<int> v;

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -105,7 +105,7 @@ class SimpleNode {
  public:
   using ChildrenType = Container<ThisType>;
 
-  SimpleNode(absl::string_view id, ChildrenType&& children = {})
+  explicit SimpleNode(absl::string_view id, ChildrenType&& children = {})
       : children_(std::move(children)), id_(id) {
     Relink();
   }
@@ -212,7 +212,7 @@ class NodeWithParentAndValue
 class IntNode {
  public:
   IntNode() {}
-  IntNode(int value, std::initializer_list<IntNode> children = {})
+  explicit IntNode(int value, std::initializer_list<IntNode> children = {})
       : value_(value), children_(children) {}
 
   const int& Value() const { return value_; }

--- a/common/util/vector_tree_test.cc
+++ b/common/util/vector_tree_test.cc
@@ -108,7 +108,7 @@ TEST(VectorTreeTest, RootOnlySiblingIteration) {
 }
 
 TEST(VectorTreeTest, CopyAssignEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree(1);  // Root only tree.
   const tree_type expected(1);
   tree_type tree2(5);
@@ -126,7 +126,7 @@ TEST(VectorTreeTest, CopyAssignEmpty) {
 }
 
 TEST(VectorTreeTest, CopyAssignDeep) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree(1,
                        tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   const tree_type expected(
@@ -146,7 +146,7 @@ TEST(VectorTreeTest, CopyAssignDeep) {
 }
 
 TEST(VectorTreeTest, CopyInitializeEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree(1);  // Root only tree.
   const tree_type expected(1);
   tree_type tree2 = tree;
@@ -163,7 +163,7 @@ TEST(VectorTreeTest, CopyInitializeEmpty) {
 }
 
 TEST(VectorTreeTest, CopyInitializeDeep) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree(1,
                        tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   const tree_type expected(
@@ -182,7 +182,7 @@ TEST(VectorTreeTest, CopyInitializeDeep) {
 }
 
 TEST(VectorTreeTest, MoveInitializeEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1);  // Root only tree.
   const tree_type expected(1);
   tree_type tree2 = std::move(tree);
@@ -192,7 +192,7 @@ TEST(VectorTreeTest, MoveInitializeEmpty) {
 }
 
 TEST(VectorTreeTest, MoveInitializeDeep) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   const tree_type expected(
       1, tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
@@ -203,7 +203,7 @@ TEST(VectorTreeTest, MoveInitializeDeep) {
 }
 
 TEST(VectorTreeTest, MoveAssignEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1);  // Root only tree.
   const tree_type expected(1);
   tree_type tree2(2);
@@ -216,7 +216,7 @@ TEST(VectorTreeTest, MoveAssignEmpty) {
 }
 
 TEST(VectorTreeTest, MoveAssignDeep) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   tree_type tree2(7, tree_type(8, tree_type(9)));
   tree2 = std::move(tree);
@@ -228,7 +228,7 @@ TEST(VectorTreeTest, MoveAssignDeep) {
 }
 
 TEST(VectorTreeTest, SwapUnrelatedRoots) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   tree_type tree2(7, tree_type(8, tree_type(9)));
   const tree_type t1_expected(tree2);  // deep-copy
@@ -247,7 +247,7 @@ TEST(VectorTreeTest, SwapUnrelatedRoots) {
 }
 
 TEST(VectorTreeTest, SwapUnrelatedSubtrees) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   tree_type tree2(7, tree_type(8, tree_type(9, tree_type(10))));
   swap(tree.Children()[0], tree2.Children()[0]);
@@ -267,7 +267,7 @@ TEST(VectorTreeTest, SwapUnrelatedSubtrees) {
 }
 
 TEST(VectorTreeTest, SwapSiblings) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,  //
                  tree_type(0),
                  tree_type(2, tree_type(3, tree_type(4, tree_type(5)))),
@@ -284,7 +284,7 @@ TEST(VectorTreeTest, SwapSiblings) {
 }
 
 TEST(VectorTreeTest, SwapDistantCousins) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,  //
                  tree_type(0),
                  tree_type(2, tree_type(3, tree_type(4, tree_type(5)))),
@@ -981,35 +981,35 @@ TEST(VectorTreeTest, FamilyTreeMembersDeepEqualCustomComparator) {
 }
 
 TEST(VectorTreeTest, NearestCommonAncestorNoneMutable) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree1{0}, tree2{0};
   EXPECT_EQ(NearestCommonAncestor(tree1, tree2), nullptr);
   EXPECT_EQ(NearestCommonAncestor(tree2, tree1), nullptr);
 }
 
 TEST(VectorTreeTest, NearestCommonAncestorNoneConst) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree1{0}, tree2{0};
   EXPECT_EQ(NearestCommonAncestor(tree1, tree2), nullptr);
   EXPECT_EQ(NearestCommonAncestor(tree2, tree1), nullptr);
 }
 
 TEST(VectorTreeTest, NearestCommonAncestorSameMutable) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree{0};
   EXPECT_EQ(NearestCommonAncestor(tree, tree), &tree);
   EXPECT_EQ(NearestCommonAncestor(tree, tree), &tree);
 }
 
 TEST(VectorTreeTest, NearestCommonAncestorSameConst) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree{0};
   EXPECT_EQ(NearestCommonAncestor(tree, tree), &tree);
   EXPECT_EQ(NearestCommonAncestor(tree, tree), &tree);
 }
 
 TEST(VectorTreeTest, NearestCommonAncestorOneIsRootConst) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree(1,            //
                        tree_type(2,  //
                                  tree_type(4), tree_type(5)),
@@ -1033,7 +1033,7 @@ TEST(VectorTreeTest, NearestCommonAncestorOneIsRootConst) {
 }
 
 TEST(VectorTreeTest, NearestCommonAncestorNeitherIsRootConst) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   const tree_type tree(1,            //
                        tree_type(2,  //
                                  tree_type(4), tree_type(5)),
@@ -1417,7 +1417,7 @@ static std::vector<typename T::value_type> NodeValues(const T& node) {
 }
 
 TEST(VectorTreeTest, AdoptSubtreesFromEmptyToEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree1(1), tree2(2);  // no subtrees
   EXPECT_TRUE(is_leaf(tree1));
   EXPECT_TRUE(is_leaf(tree2));
@@ -1428,7 +1428,7 @@ TEST(VectorTreeTest, AdoptSubtreesFromEmptyToEmpty) {
 }
 
 TEST(VectorTreeTest, AdoptSubtreesFromEmptyToNonempty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree1(1, tree_type(4)), tree2(2);
   EXPECT_THAT(NodeValues(tree1), ElementsAre(4));
   EXPECT_THAT(NodeValues(tree2), ElementsAre());
@@ -1439,7 +1439,7 @@ TEST(VectorTreeTest, AdoptSubtreesFromEmptyToNonempty) {
 }
 
 TEST(VectorTreeTest, AdoptSubtreesFromNonemptyToEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree1(1), tree2(2, tree_type(5));
   EXPECT_THAT(NodeValues(tree1), ElementsAre());
   EXPECT_THAT(NodeValues(tree2), ElementsAre(5));
@@ -1450,7 +1450,7 @@ TEST(VectorTreeTest, AdoptSubtreesFromNonemptyToEmpty) {
 }
 
 TEST(VectorTreeTest, AdoptSubtreesFromNonemptyToNonempty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree1(1, tree_type(3), tree_type(6)),
       tree2(2, tree_type(5), tree_type(8));
   EXPECT_THAT(NodeValues(tree1), ElementsAre(3, 6));
@@ -1462,7 +1462,7 @@ TEST(VectorTreeTest, AdoptSubtreesFromNonemptyToNonempty) {
 }
 
 TEST(VectorTreeTest, MergeConsecutiveSiblingsTooFewElements) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2));
   auto adder = [](int* left, const int& right) { *left += right; };
   EXPECT_THAT(NodeValues(tree), ElementsAre(2));
@@ -1470,7 +1470,7 @@ TEST(VectorTreeTest, MergeConsecutiveSiblingsTooFewElements) {
 }
 
 TEST(VectorTreeTest, MergeConsecutiveSiblingsOutOfBounds) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2), tree_type(3));
   auto adder = [](int* left, const int& right) { *left += right; };
   EXPECT_THAT(NodeValues(tree), ElementsAre(2, 3));
@@ -1478,7 +1478,7 @@ TEST(VectorTreeTest, MergeConsecutiveSiblingsOutOfBounds) {
 }
 
 TEST(VectorTreeTest, MergeConsecutiveSiblingsAddLeaves) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2), tree_type(3), tree_type(4), tree_type(5));
   auto adder = [](int* left, const int& right) { *left += right; };
   EXPECT_THAT(NodeValues(tree), ElementsAre(2, 3, 4, 5));
@@ -1499,7 +1499,7 @@ TEST(VectorTreeTest, MergeConsecutiveSiblingsAddLeaves) {
 }
 
 TEST(VectorTreeTest, MergeConsecutiveSiblingsConcatenateSubtreesOnce) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),
@@ -1518,7 +1518,7 @@ TEST(VectorTreeTest, MergeConsecutiveSiblingsConcatenateSubtreesOnce) {
 }
 
 TEST(VectorTreeTest, MergeConsecutiveSiblingsConcatenateSubtrees) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),
@@ -1546,13 +1546,13 @@ TEST(VectorTreeTest, MergeConsecutiveSiblingsConcatenateSubtrees) {
 }
 
 TEST(VectorTreeTest, RemoveSelfFromParentRoot) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1);
   EXPECT_DEATH(RemoveSelfFromParent(tree), "");
 }
 
 TEST(VectorTreeTest, RemoveSelfFromParentFirstChild) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,             //
                  tree_type(2),  // no grandchildren
                  tree_type(3,   //
@@ -1576,7 +1576,7 @@ TEST(VectorTreeTest, RemoveSelfFromParentFirstChild) {
 }
 
 TEST(VectorTreeTest, RemoveSelfFromParentMiddleChildWithGrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,             //
                  tree_type(2),  // no grandchildren
                  tree_type(3,   //
@@ -1600,7 +1600,7 @@ TEST(VectorTreeTest, RemoveSelfFromParentMiddleChildWithGrandchildren) {
 }
 
 TEST(VectorTreeTest, RemoveSelfFromParentMiddleChildWithoutGrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,             //
                  tree_type(2),  // no grandchildren
                  tree_type(3,   //
@@ -1624,7 +1624,7 @@ TEST(VectorTreeTest, RemoveSelfFromParentMiddleChildWithoutGrandchildren) {
 }
 
 TEST(VectorTreeTest, RemoveSelfFromParentLastChild) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,             //
                  tree_type(2),  // no grandchildren
                  tree_type(3,   //
@@ -1649,7 +1649,7 @@ TEST(VectorTreeTest, RemoveSelfFromParentLastChild) {
 }
 
 TEST(VectorTreeTest, FlattenOnceNoChildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1);
   EXPECT_THAT(NodeValues(tree), ElementsAre());
 
@@ -1661,7 +1661,7 @@ TEST(VectorTreeTest, FlattenOnceNoChildren) {
 }
 
 TEST(VectorTreeTest, FlattenOnceNoGrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,  // no grandchildren
                  tree_type(2), tree_type(3), tree_type(4), tree_type(5));
   EXPECT_THAT(NodeValues(tree), ElementsAre(2, 3, 4, 5));
@@ -1674,7 +1674,7 @@ TEST(VectorTreeTest, FlattenOnceNoGrandchildren) {
 }
 
 TEST(VectorTreeTest, FlattenOnceOneGrandchild) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3)));
   EXPECT_THAT(NodeValues(tree), ElementsAre(2));
 
@@ -1686,7 +1686,7 @@ TEST(VectorTreeTest, FlattenOnceOneGrandchild) {
 }
 
 TEST(VectorTreeTest, FlattenOnceMixed) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,             //
                  tree_type(2),  // no grandchildren
                  tree_type(3,   //
@@ -1706,7 +1706,7 @@ TEST(VectorTreeTest, FlattenOnceMixed) {
 }
 
 TEST(VectorTreeTest, FlattenOnceAllNonempty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),
@@ -1729,7 +1729,7 @@ TEST(VectorTreeTest, FlattenOnceAllNonempty) {
 }
 
 TEST(VectorTreeTest, FlattenOnceGreatgrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,                      //
                  tree_type(2,            //
                            tree_type(6,  //
@@ -1761,7 +1761,7 @@ TEST(VectorTreeTest, FlattenOnceGreatgrandchildren) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenNoChildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1);
   EXPECT_THAT(NodeValues(tree), ElementsAre());
 
@@ -1775,7 +1775,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenNoChildren) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenNoChildrenNoOffsets) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1);
   EXPECT_THAT(NodeValues(tree), ElementsAre());
 
@@ -1787,7 +1787,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenNoChildrenNoOffsets) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenNoGrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,  // no grandchildren
                  tree_type(2), tree_type(3), tree_type(4), tree_type(5));
   EXPECT_THAT(NodeValues(tree), ElementsAre(2, 3, 4, 5));
@@ -1804,7 +1804,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenNoGrandchildren) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenOneGrandchild) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3)));
   EXPECT_THAT(NodeValues(tree), ElementsAre(2));
 
@@ -1818,7 +1818,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenOneGrandchild) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenOneGrandchildNoOffsets) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3)));
   EXPECT_THAT(NodeValues(tree), ElementsAre(2));
 
@@ -1830,7 +1830,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenOneGrandchildNoOffsets) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenTwoGrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1, tree_type(2, tree_type(3), tree_type(7)));
   EXPECT_THAT(NodeValues(tree), ElementsAre(2));
 
@@ -1844,7 +1844,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenTwoGrandchildren) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenMixed) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,             //
                  tree_type(2),  // no grandchildren
                  tree_type(3,   //
@@ -1868,7 +1868,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenMixed) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenAllNonempty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),
@@ -1893,7 +1893,7 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenAllNonempty) {
 }
 
 TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenGreatgrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,                      //
                  tree_type(2,            //
                            tree_type(6,  //
@@ -1927,13 +1927,13 @@ TEST(VectorTreeTest, FlattenOnlyChildrenWithChildrenGreatgrandchildren) {
 }
 
 TEST(VectorTreeTest, FlattenOneChildEmpty) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(4);  // no children
   EXPECT_DEATH(FlattenOneChild(tree, 0), "");
 }
 
 TEST(VectorTreeTest, FlattenOneChildOnlyChildNoGrandchildren) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(4, tree_type(2));  // no grandchildren
   const tree_type expect_tree(4);
   FlattenOneChild(tree, 0);
@@ -1943,7 +1943,7 @@ TEST(VectorTreeTest, FlattenOneChildOnlyChildNoGrandchildren) {
 }
 
 TEST(VectorTreeTest, FlattenOneChildOnlyChildOneGrandchild) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(4, tree_type(2, tree_type(11)));  // with grandchild
   const tree_type expect_tree(4, tree_type(11));
   FlattenOneChild(tree, 0);
@@ -1953,7 +1953,7 @@ TEST(VectorTreeTest, FlattenOneChildOnlyChildOneGrandchild) {
 }
 
 TEST(VectorTreeTest, FlattenOneChildFirstChildInFamilyTree) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),
@@ -1979,7 +1979,7 @@ TEST(VectorTreeTest, FlattenOneChildFirstChildInFamilyTree) {
 }
 
 TEST(VectorTreeTest, FlattenOneChildMiddleChildInFamilyTree) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),
@@ -2005,7 +2005,7 @@ TEST(VectorTreeTest, FlattenOneChildMiddleChildInFamilyTree) {
 }
 
 TEST(VectorTreeTest, FlattenOneChildLastChildInFamilyTree) {
-  typedef VectorTree<int> tree_type;
+  using tree_type = VectorTree<int>;
   tree_type tree(1,            //
                  tree_type(2,  //
                            tree_type(6), tree_type(7)),

--- a/common/util/vector_tree_test_util.cc
+++ b/common/util/vector_tree_test_util.cc
@@ -33,7 +33,7 @@ using VectorTreeTestType = VectorTree<NamedInterval>;
 // Convenient type alias for constructing test trees.
 // Calling this like a function actually invokes the recursive constructor
 // and builds entire trees using recursive initializer lists.
-typedef VectorTreeTestType MakeTree;
+using MakeTree = VectorTreeTestType;
 
 VectorTreeTestType MakeRootOnlyExampleTree() {
   return MakeTree({0, 2, "root"});

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -124,7 +124,7 @@ TEST(SymbolMetaTypePrintTest, Print) {
 }
 
 TEST(SymbolTableNodeFullPathTest, Print) {
-  typedef SymbolTableNode::key_value_type KV;
+  using KV = SymbolTableNode::key_value_type;
   const SymbolTableNode root(
       SymbolInfo{},
       KV("AA", SymbolTableNode(SymbolInfo{}, KV("BB", SymbolTableNode{}))));
@@ -211,8 +211,8 @@ TEST(ReferenceComponentTest, MatchesMetatypeTest) {
 }
 
 TEST(ReferenceNodeFullPathTest, Print) {
-  typedef ReferenceComponentNode Node;
-  typedef ReferenceComponent Data;
+  using Node = ReferenceComponentNode;
+  using Data = ReferenceComponent;
   const Node root(
       Data{.identifier = "xx",
            .ref_type = ReferenceType::kUnqualified,
@@ -257,7 +257,7 @@ TEST(DependentReferencesTest, PrintOnlyRootNodeUnresolved) {
 
 TEST(DependentReferencesTest, PrintNonRootResolved) {
   // Synthesize a symbol table.
-  typedef SymbolTableNode::key_value_type KV;
+  using KV = SymbolTableNode::key_value_type;
   SymbolTableNode root(
       SymbolInfo{SymbolMetaType::kRoot},
       KV{"p_pkg",

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -36,7 +36,7 @@ using verible::file::testing::ScopedTestFile;
 
 class TempDirFile : public ScopedTestFile {
  public:
-  TempDirFile(absl::string_view content)
+  explicit TempDirFile(absl::string_view content)
       : ScopedTestFile(::testing::TempDir(), content) {}
 };
 

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -85,7 +85,7 @@ std::ostream& operator<<(std::ostream& stream,
 }
 
 // This tree type will be 'diff-ed' against a VectorTree<UnwrappedLine>.
-typedef verible::VectorTree<ExpectedUnwrappedLine> ExpectedUnwrappedLineTree;
+using ExpectedUnwrappedLineTree = verible::VectorTree<ExpectedUnwrappedLine>;
 
 void ValidateExpectedTreeNode(const ExpectedUnwrappedLineTree& etree) {
   // At each tree node, there should either be expected tokens in the node's

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -45,7 +45,7 @@ using FileOpener = VerilogPreprocess::FileOpener;
 
 class LexerTester {
  public:
-  LexerTester(absl::string_view text) : lexer_(text) {
+  explicit LexerTester(absl::string_view text) : lexer_(text) {
     for (lexer_.DoNextToken(); !lexer_.GetLastToken().isEOF();
          lexer_.DoNextToken()) {
       lexed_sequence_.push_back(lexer_.GetLastToken());


### PR DESCRIPTION
Auto fix application of redundant-string-init, google-explicit-constructor, and modernize-use-using.

We currently don't have compilation db support for tests, this is why they are not clang-tidy clean yet.

(Currently experimenting with a different implementation of compilation database locally, which made this possible)