### PR TITLE
Invoke grail compilation db script directly.

### DIFF
--- a/.github/bin/make-compilation-db.sh
+++ b/.github/bin/make-compilation-db.sh
@@ -15,16 +15,11 @@
 
 set -u
 set -e
-set -o pipefail
 
-readonly OUTPUT_BASE=$(bazel info output_base)
+bazel fetch ...  # no double-slash: seems to problematic on Windows
 
-# First, build the compilation database baseline with placeholders for exec-root
-bazel build :compdb > /dev/null 2>&1
+readonly OUTPUT_BASE="$(bazel info output_base)"
+python3 "${OUTPUT_BASE}/external/com_grail_bazel_compdb/generate.py"
 
-# Fix up the __OUTPUT_BASE__ to the path used by bazel and put the resulting
-# db with the expected name in the root directory of the project.
-cat bazel-bin/compile_commands.json \
-  | sed "s|__OUTPUT_BASE__|$OUTPUT_BASE|g" \
-  | sed 's/-fno-canonical-system-headers//g' \
-        > compile_commands.json
+# Remove a gcc compiler flag that clang-tidy doesn't understand.
+sed -i -e 's/-fno-canonical-system-headers//g' compile_commands.json

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -22,7 +22,7 @@ readonly NAME_PREFIX=verible-clang-tidy  # Make files easy to tab-complete-find
 readonly CLANG_TIDY_CONFIG_MSG=${TMPDIR}/${NAME_PREFIX}-config.msg
 
 readonly PARALLEL_COUNT=$(nproc)
-readonly FILES_PER_INVOCATION=5
+readonly FILES_PER_INVOCATION=1
 
 readonly CLANG_TIDY_SEEN_CACHE=${TMPDIR}/${NAME_PREFIX}-hashes.cache
 touch ${CLANG_TIDY_SEEN_CACHE}  # Just in case it is not there yet

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -382,6 +382,11 @@ jobs:
         key: bazelcache_macos_${{ steps.cache_timestamp.outputs.time }}
         restore-keys: bazelcache_macos_
 
+    - name: Test compilation DB creation
+      run: |
+        .github/bin/make-compilation-db.sh
+        wc -l compile_commands.json
+
     - name: Tests
       run: bazel test --noshow_progress --test_output=errors --cxxopt=-Wno-range-loop-analysis //...
 

--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,6 @@
 #  bazel test ...
 
 load("@com_github_google_rules_install//installer:def.bzl", "installer")
-load("@com_grail_bazel_compdb//:defs.bzl", "compilation_database")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -72,12 +71,3 @@ action_listener(
     visibility = ["//visibility:public"],
 )
 
-compilation_database(
-    name = "compdb",
-    targets = [
-        ":install-binaries",
-        "//common/lsp:dummy-ls",
-    ],
-    # TODO: is there a way to essentially specify //... so that all tests
-    # are included as well ?
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -195,12 +195,15 @@ http_archive(
     ],
 )
 
+# 2022-09-19
 http_archive(
     name = "com_grail_bazel_compdb",
     sha256 = "a3ff6fe238eec8202270dff75580cba3d604edafb8c3408711e82633c153efa8",
     strip_prefix = "bazel-compilation-database-940cedacdb8a1acbce42093bf67f3a5ca8b265f7",
     urls = ["https://github.com/grailbio/bazel-compilation-database/archive/940cedacdb8a1acbce42093bf67f3a5ca8b265f7.tar.gz"],
 )
+load("@com_grail_bazel_compdb//:deps.bzl", "bazel_compdb_deps")
+bazel_compdb_deps()
 
 # zlib is imported through protobuf. Make the dependency explicit considering
 # it's used outside protobuf.


### PR DESCRIPTION
Creating the compilation DB from within bazel has
its issues, e.g. we can't include the test targets.

In the project for creating a compilation database for baze l(https://github.com/grailbio/bazel-compilation-database), there is also an alternative way: a script that can be used to create a compilation DB for all targets by invoking bazel
with some aspects enabled.

Let's use that instead: with that, we get all targets, including test targets into the compilation database.

To avoid having to download the script manually, hash-sum check  and set up some temporary place on the users' workstation to host the script and the files it needs, we let bazel download it in the WORKSPACE file and then call into it.

While this assumes a certain layout of the bazel directory structure, this does seem to work fine with bazel 4, 5, and 6.