### PR TITLE
Address a few clang-tidy concerns.

### DIFF
--- a/common/formatting/state_node_test.cc
+++ b/common/formatting/state_node_test.cc
@@ -93,7 +93,7 @@ TEST_F(StateNodeTestFixture, ConstructionWithEmptyFormatTokens) {
 // Tests that root StateNode of search can initialize to an array
 // of FormatTokens.
 TEST_F(StateNodeTestFixture, ConstructionWithOneFormatToken) {
-  static const int kInitialIndent = 1;
+  constexpr size_t kInitialIndent = 1;
   const std::vector<TokenInfo> tokens = {{0, "token1"}};
   Initialize(kInitialIndent, tokens);
   StateNode s(*uwline, style);

--- a/common/strings/obfuscator_test.cc
+++ b/common/strings/obfuscator_test.cc
@@ -24,12 +24,9 @@ namespace verible {
 namespace {
 
 static char Rot13(char c) {
-  if ((c >= 'a' && c <= 'm') || (c >= 'A' && c <= 'M'))
-    return c + 13;
-  else if ((c >= 'n' && c <= 'z') || (c >= 'N' && c <= 'Z'))
-    return c - 13;
-  else
-    return c;
+  if ((c >= 'a' && c <= 'm') || (c >= 'A' && c <= 'M')) return c + 13;
+  if ((c >= 'n' && c <= 'z') || (c >= 'N' && c <= 'Z')) return c - 13;
+  return c;
 }
 
 // Non-random generator, just for the sake of testing.

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -30,13 +30,13 @@ using testing::HasSubstr;
 #undef EXPECT_OK
 #define EXPECT_OK(value)      \
   {                           \
-    auto s = (value);         \
+    const auto& s = (value);  \
     EXPECT_TRUE(s.ok()) << s; \
   }
 #undef ASSERT_OK
 #define ASSERT_OK(value)      \
   {                           \
-    auto s = (value);         \
+    const auto& s = (value);  \
     ASSERT_TRUE(s.ok()) << s; \
   }
 

--- a/common/util/map_tree_test.cc
+++ b/common/util/map_tree_test.cc
@@ -285,7 +285,10 @@ TEST(MapTreeTest, InitializeTwoGenerationsDeepCopy) {
   check(m);
 
   {
-    const MapTreeTestType mcopy(m);  // deep copy
+    // specificially testing deep copy.
+    // clang-format off
+    const MapTreeTestType mcopy(m);  // NOLINT(performance-unnecessary-copy-initialization)
+    // clang-format on
     check(mcopy);
     check(m);
   }

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -144,7 +144,7 @@ class SimpleNode {
   }
 
  protected:
-  void PrintRecursively(std::ostream& stream, int depth = 0) const {
+  void PrintRecursively(std::ostream& stream, size_t depth = 0) const {
     stream << verible::Spacer(4 * depth)
            << absl::StreamFormat("@%p (%s; parent=%p)\n",
                                  static_cast<const ThisType*>(this), id_,
@@ -237,7 +237,7 @@ class IntNode {
   }
 
  private:
-  void PrintRecursively(std::ostream& stream, int depth = 0) const {
+  void PrintRecursively(std::ostream& stream, size_t depth = 0) const {
     stream << verible::Spacer(4 * depth)
            << absl::StreamFormat("@%p (%d)\n", this, value_);
     for (const auto& child : Children()) {

--- a/common/util/user_interaction_test.cc
+++ b/common/util/user_interaction_test.cc
@@ -28,8 +28,8 @@ TEST(ReadCharFromUserTest, NonTerminalInput) {
   std::ostringstream output;
   char characters[6];
 
-  for (unsigned i = 0; i < 6; ++i) {
-    characters[i] = ReadCharFromUser(input, output, false, "A prompt.");
+  for (char& c : characters) {
+    c = ReadCharFromUser(input, output, false, "A prompt.");
   }
 
   EXPECT_EQ(characters[0], 'a');
@@ -46,10 +46,10 @@ TEST(ReadCharFromUserTest, TerminalInput) {
   std::ostringstream output;
   char characters[4];
 
-  for (unsigned i = 0; i < 4; ++i) {
+  for (char& c : characters) {
     output.str("");
     output.clear();
-    characters[i] = ReadCharFromUser(input, output, true, "A prompt.");
+    c = ReadCharFromUser(input, output, true, "A prompt.");
     EXPECT_TRUE(absl::StrContains(output.str(), "A prompt."))
         << "Actual value: " << output.str();
   }

--- a/common/util/vector_tree_test.cc
+++ b/common/util/vector_tree_test.cc
@@ -149,7 +149,10 @@ TEST(VectorTreeTest, CopyInitializeEmpty) {
   using tree_type = VectorTree<int>;
   const tree_type tree(1);  // Root only tree.
   const tree_type expected(1);
-  tree_type tree2 = tree;
+  // Specifically testing copy here.
+  // clang-format off
+  tree_type tree2 = tree;  // NOLINT(performance-unnecessary-copy-initialization)
+  // clang-format on
   {
     const auto result_pair = DeepEqual(tree2, expected);
     EXPECT_EQ(result_pair.left, nullptr) << *result_pair.left;
@@ -168,7 +171,10 @@ TEST(VectorTreeTest, CopyInitializeDeep) {
                        tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
   const tree_type expected(
       1, tree_type(2, tree_type(3, tree_type(4, tree_type(5)))));
-  tree_type tree2 = tree;
+  // Specifically testing copy here.
+  // clang-format off
+  tree_type tree2 = tree;  // NOLINT(performance-unnecessary-copy-initialization)
+  // clang-format on
   {
     const auto result_pair = DeepEqual(tree2, expected);
     EXPECT_EQ(result_pair.left, nullptr) << *result_pair.left;
@@ -680,7 +686,10 @@ TEST(VectorTreeTest, FamilyTreeMembers) {
 // Tests internal consistency and properties of copied tree.
 TEST(VectorTreeTest, FamilyTreeCopiedMembers) {
   const auto orig_tree = verible::testing::MakeExampleFamilyTree();
-  const auto tree(orig_tree);  // copied
+  // Specifically testing copy here.
+  // clang-format off
+  const auto tree(orig_tree);  // NOLINT(performance-unnecessary-copy-initialization)
+  // clang-format on
   VerifyFamilyTree(orig_tree);
   VerifyFamilyTree(tree);
 

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -23,10 +23,10 @@
 #include "gtest/gtest.h"
 
 #undef ASSERT_OK
-#define ASSERT_OK(value)                      \
-  if (auto status__ = (value); status__.ok()) \
-    ;                                         \
-  else                                        \
+#define ASSERT_OK(value)                             \
+  if (const auto &status__ = (value); status__.ok()) \
+    ;                                                \
+  else                                               \
     EXPECT_TRUE(status__.ok()) << status__
 
 namespace verilog {


### PR DESCRIPTION
Either fixing it with (don't copy a value) or acknowledging it as explicitly wanted (when testing deep copies).