### PR TITLE
Apply some automated clang fixes on tests.

### DIFF
--- a/common/analysis/line_linter_test.cc
+++ b/common/analysis/line_linter_test.cc
@@ -35,7 +35,7 @@ using testing::SizeIs;
 // Blank lines are considered bad for demonstration purposes.
 class BlankLineRule : public LineLintRule {
  public:
-  BlankLineRule() {}
+  BlankLineRule() = default;
 
   void HandleLine(absl::string_view line) final {
     if (line.empty()) {
@@ -90,7 +90,7 @@ TEST(LineLinterTest, OneRuleRejectsLine) {
 // Mock rule that rejects empty files.
 class EmptyFileRule : public LineLintRule {
  public:
-  EmptyFileRule() {}
+  EmptyFileRule() = default;
 
   void HandleLine(absl::string_view line) final { ++lines_; }
 

--- a/common/analysis/line_linter_test_utils.h
+++ b/common/analysis/line_linter_test_utils.h
@@ -31,7 +31,7 @@ namespace verible {
 template <>
 class LintRunner<LineLintRule> {
  public:
-  explicit LintRunner(std::unique_ptr<LineLintRule> rule) : linter_() {
+  explicit LintRunner(std::unique_ptr<LineLintRule> rule) {
     linter_.AddRule(std::move(rule));
   }
 

--- a/common/analysis/matcher/matcher_test.cc
+++ b/common/analysis/matcher/matcher_test.cc
@@ -156,12 +156,8 @@ TEST(MatcherTest, BindMatcherNested) {
 static std::vector<const Symbol*> GetFirstChild(const Symbol& symbol) {
   if (symbol.Kind() == SymbolKind::kNode) {
     const auto& node = down_cast<const SyntaxTreeNode&>(symbol);
-
-    if (node.children().empty()) {
-      return {};
-    } else {
-      return {node.children()[0].get()};
-    }
+    if (node.children().empty()) return {};
+    return {node.children()[0].get()};
   }
 
   return {};

--- a/common/analysis/syntax_tree_linter_test_utils.h
+++ b/common/analysis/syntax_tree_linter_test_utils.h
@@ -33,7 +33,7 @@ namespace verible {
 template <>
 class LintRunner<SyntaxTreeLintRule> {
  public:
-  explicit LintRunner(std::unique_ptr<SyntaxTreeLintRule> rule) : linter_() {
+  explicit LintRunner(std::unique_ptr<SyntaxTreeLintRule> rule) {
     linter_.AddRule(std::move(rule));
   }
 

--- a/common/analysis/text_structure_linter_test.cc
+++ b/common/analysis/text_structure_linter_test.cc
@@ -35,7 +35,7 @@ using testing::SizeIs;
 // Example lint rule that uses raw contents and lines array.
 class RequireHelloRule : public TextStructureLintRule {
  public:
-  RequireHelloRule() {}
+  RequireHelloRule() = default;
 
   void Lint(const TextStructureView& text_structure,
             absl::string_view filename) final {

--- a/common/analysis/text_structure_linter_test_utils.h
+++ b/common/analysis/text_structure_linter_test_utils.h
@@ -32,7 +32,7 @@ namespace verible {
 template <>
 class LintRunner<TextStructureLintRule> {
  public:
-  explicit LintRunner(std::unique_ptr<TextStructureLintRule> rule) : linter_() {
+  explicit LintRunner(std::unique_ptr<TextStructureLintRule> rule) {
     linter_.AddRule(std::move(rule));
   }
 

--- a/common/analysis/token_stream_linter_test_utils.h
+++ b/common/analysis/token_stream_linter_test_utils.h
@@ -32,7 +32,7 @@ namespace verible {
 template <>
 class LintRunner<TokenStreamLintRule> {
  public:
-  explicit LintRunner(std::unique_ptr<TokenStreamLintRule> rule) : linter_() {
+  explicit LintRunner(std::unique_ptr<TokenStreamLintRule> rule) {
     linter_.AddRule(std::move(rule));
   }
 

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -701,7 +701,8 @@ class GetPartitionAlignmentSubrangesTestFixture : public AlignmentTestFixture {
         partition.Value().TokensRange().front().Text();
     if (text == "match") {
       return AlignmentGroupAction::kMatch;
-    } else if (text == "nomatch") {
+    }
+    if (text == "nomatch") {
       return AlignmentGroupAction::kNoMatch;
     } else {
       return AlignmentGroupAction::kIgnore;
@@ -804,7 +805,8 @@ class GetPartitionAlignmentSubrangesSubtypedTestFixture
       absl::string_view last = *std::next(toks.begin());
       // Use the first character after the : as the subtype, so 'X', 'Y', 'Z'.
       return {AlignmentGroupAction::kMatch, static_cast<int>(last.front())};
-    } else if (text == "nomatch") {
+    }
+    if (text == "nomatch") {
       return {AlignmentGroupAction::kNoMatch};
     } else {
       return {AlignmentGroupAction::kIgnore};
@@ -995,10 +997,11 @@ class SyntaxTreeColumnizer : public ColumnSchemaScanner {
 
   void Visit(const SyntaxTreeNode& node) final {
     ColumnPositionTree* column;
-    if (!current_column_)
+    if (!current_column_) {
       column = ReserveNewColumn(node, props);
-    else
+    } else {
       column = ReserveNewColumn(current_column_, node, props);
+    }
 
     ValueSaver<ColumnPositionTree*> current_column_saver(&current_column_,
                                                          column);
@@ -1008,10 +1011,11 @@ class SyntaxTreeColumnizer : public ColumnSchemaScanner {
     AlignmentColumnProperties local_props = props;
     if (leaf.get().text() == ",") local_props.contains_delimiter = true;
 
-    if (!current_column_)
+    if (!current_column_) {
       ReserveNewColumn(leaf, local_props);
-    else
+    } else {
       ReserveNewColumn(current_column_, leaf, local_props);
+    }
   }
 
  private:
@@ -1093,7 +1097,8 @@ class SubcolumnsTreeAlignmentTest : public MatrixTreeAlignmentTestFixture {
       SymbolPtr rp = Leaf(1, (*it)->Text());
       ++*it;
       return TNode(1, std::move(lp), std::move(list), std::move(rp));
-    } else if ((*it)->Text() == ")") {
+    }
+    if ((*it)->Text() == ")") {
       return SymbolPtr(nullptr);
     } else {
       SymbolPtr leaf = Leaf(0, (*it)->Text());
@@ -1448,11 +1453,13 @@ class OutsideCharPairs {
   absl::string_view Find(absl::string_view text, size_t pos) const {
     if (text[pos] == start_) {
       const size_t stop_pos = text.find(stop_, pos + 1);
-      if (stop_pos == absl::string_view::npos)
+      if (stop_pos == absl::string_view::npos) {
         return absl::string_view(text.data() + text.size(), 0);
+      }
       const size_t start_pos = text.find(start_, stop_pos + 1);
-      if (start_pos == absl::string_view::npos)
+      if (start_pos == absl::string_view::npos) {
         return text.substr(stop_pos + 1);
+      }
       return text.substr(stop_pos + 1, start_pos - stop_pos - 1);
     }
     const size_t start_pos = text.find(start_, pos);

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -2387,27 +2387,26 @@ class TokenPartitionsLayoutOptimizerTest : public ::testing::Test,
         style_(CreateStyle()),
         factory_(LayoutFunctionFactory(style_)) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     CreateTokenInfosExternalStringBuffer(ftokens_);
     ConnectPreFormatTokensPreservedSpaceStarts(sample_.data(),
                                                &pre_format_tokens_);
 
     // Set token properties
-    for (auto token_it = pre_format_tokens_.begin();
-         token_it != pre_format_tokens_.end(); ++token_it) {
-      const auto leading_spaces = token_it->OriginalLeadingSpaces();
+    for (auto& token : pre_format_tokens_) {
+      const auto leading_spaces = token.OriginalLeadingSpaces();
 
       // First token in a line
       if (absl::StrContains(leading_spaces, '\n')) {
-        token_it->before.break_decision = SpacingOptions::MustWrap;
+        token.before.break_decision = SpacingOptions::MustWrap;
         auto last_non_space_offset = leading_spaces.find_last_not_of(' ');
         if (last_non_space_offset != absl::string_view::npos) {
-          token_it->before.spaces_required =
+          token.before.spaces_required =
               leading_spaces.size() - 1 - last_non_space_offset;
         }
       } else {
-        token_it->before.spaces_required = leading_spaces.size();
+        token.before.spaces_required = leading_spaces.size();
       }
     }
     pre_format_tokens_.front().before.break_decision = SpacingOptions::MustWrap;

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -45,8 +45,9 @@ std::string ToString(const T& value) {
 
 std::ostream& PrintIndented(std::ostream& stream, absl::string_view str,
                             int indentation) {
-  for (const auto& line : verible::SplitLinesKeepLineTerminator(str))
+  for (const auto& line : verible::SplitLinesKeepLineTerminator(str)) {
     stream << verible::Spacer(indentation) << line;
+  }
   return stream;
 }
 
@@ -103,8 +104,9 @@ void ExpectLayoutFunctionsEqual(const LayoutFunction& actual,
                                *layout_diff.left, *layout_diff.right, 2, true);
     }
 
-    if (auto str = segment_msg.str(); !str.empty())
+    if (auto str = segment_msg.str(); !str.empty()) {
       msg << "segment[" << i << "]:\n" << str << "\n";
+    }
   }
 
   if (const auto str = msg.str(); !str.empty()) {
@@ -718,8 +720,9 @@ class LayoutFunctionFactoryTest : public ::testing::Test,
 
       // First token in a line
       if (absl::StrContains(leading_spaces, '\n')) {
-        if (first_on_line_must_wrap)
+        if (first_on_line_must_wrap) {
           token->before.break_decision = SpacingOptions::MustWrap;
+        }
         uwlines->back().SpanUpToToken(token);
         uwlines->emplace_back(0, token);
       }

--- a/common/lexer/lexer_test_util.h
+++ b/common/lexer/lexer_test_util.h
@@ -39,7 +39,7 @@ namespace verible {
 // Modeled after the Lexer base class.
 class FakeLexer {
  protected:
-  explicit FakeLexer() {}
+  explicit FakeLexer() = default;
 
   void SetTokensData(const std::vector<TokenInfo>& tokens);
 

--- a/common/strings/diff_test.cc
+++ b/common/strings/diff_test.cc
@@ -42,7 +42,7 @@ std::ostream& operator<<(std::ostream& out, const diff::Edit& edit) {
 
 std::ostream& operator<<(std::ostream& out, const Edits& edits) {
   out << "Edits{";
-  std::string outer_delim = "";
+  std::string outer_delim;
   for (auto& edit : edits) {
     out << outer_delim << edit;
     outer_delim = ",";

--- a/common/strings/rebase_test.cc
+++ b/common/strings/rebase_test.cc
@@ -28,7 +28,7 @@ namespace {
 
 // Test that empty string token rebases correctly.
 TEST(RebaseStringViewTest, EmptyStringsZeroOffset) {
-  const std::string text = "";
+  const std::string text;
   // We want another empty string, but we need to trick too smart compilers
   // to give us a different memory address.
   std::string substr = "foo";

--- a/common/text/token_info_test.cc
+++ b/common/text/token_info_test.cc
@@ -215,7 +215,7 @@ TEST(TokenWithContextTest, StreamOutput) {
 
 // Test that empty string token rebases correctly.
 TEST(RebaseStringViewTest, EmptyStringsZeroOffset) {
-  const std::string text = "";
+  const std::string text;
   // We want another empty string, but we need to trick too smart compilers
   // to give us a different memory address.
   std::string substr = "foo";

--- a/common/text/token_stream_view_test.cc
+++ b/common/text/token_stream_view_test.cc
@@ -28,7 +28,7 @@ namespace verible {
 
 class TokenStreamViewTest : public testing::Test {
  protected:
-  TokenStreamViewTest() : tokens_() {
+  TokenStreamViewTest() {
     // Generate with bogus token enums, with 0 at the end.
     for (int i = 0; i < 10; ++i) {
       tokens_.push_back(TokenInfo(i + 2, "moo"));

--- a/common/util/container_proxy_test.cc
+++ b/common/util/container_proxy_test.cc
@@ -238,7 +238,7 @@ class ContainerProxy
 template <class Proxy>
 class ContainerProxyTest : public ::testing::Test {
  public:
-  ContainerProxyTest() {}
+  ContainerProxyTest() = default;
 
   using Container = typename Proxy::container_type;
   Container container = {"zero", "one", "two"};

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -57,7 +57,7 @@ testing::AssertionResult VerifyTree(const T& actual, const T& expected,
     }
     return err;
   }
-  if (actual.Children().size() != 0) {
+  if (!actual.Children().empty()) {
     auto actual_child = actual.Children().begin();
     auto expected_child = expected.Children().begin();
     auto child_path = path;

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -211,7 +211,7 @@ class NodeWithParentAndValue
 // trees.
 class IntNode {
  public:
-  IntNode() {}
+  IntNode() = default;
   explicit IntNode(int value, std::initializer_list<IntNode> children = {})
       : value_(value), children_(children) {}
 
@@ -254,7 +254,7 @@ class IntNode {
 template <class Node>
 class TreeTest : public ::testing::Test {
  public:
-  TreeTest() {}
+  TreeTest() = default;
 
   using N = Node;
   N root = N("root", {N("0"),                                          //

--- a/external_libs/editscript_test.cc
+++ b/external_libs/editscript_test.cc
@@ -47,7 +47,7 @@ std::ostream &operator<<(std::ostream &out, const Edit &edit) {
 
 std::ostream &operator<<(std::ostream &out, const Edits &edits) {
   out << "Edits{";
-  std::string outer_delim = "";
+  std::string outer_delim;
   for (auto &edit : edits) {
     out << outer_delim << edit;
     outer_delim = ",";

--- a/verilog/CST/verilog_matchers_test.cc
+++ b/verilog/CST/verilog_matchers_test.cc
@@ -35,8 +35,9 @@ TEST(VerilogMatchers, SystemTFIdentifierLeafTests) {
       {SystemTFIdentifierLeaf(), EmbedInClass(""), 0},
       {SystemTFIdentifierLeaf(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for MacroCallIdLeaf matching
@@ -52,8 +53,9 @@ TEST(VerilogMatchers, MacroCallIdLeafTests) {
       {MacroCallIdLeaf(), EmbedInClassMethod("uvm_foo(\"foo\");"), 0},
       {MacroCallIdLeaf(), EmbedInClassMethod("$uvm_foo(\"foo\");"), 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for SymbolIdentifierLeaf matching
@@ -66,8 +68,9 @@ TEST(VerilogMatchers, SymbolIdentifierLeaf) {
       {SymbolIdentifierLeaf(), EmbedInClassMethod("uvm_foo(\"foo\");"), 3},
       {SymbolIdentifierLeaf(), "parameter foo = 32'hDEADBEEF;", 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NodekVoidcast matching
@@ -78,8 +81,9 @@ TEST(VerilogMatchers, VoidCastNodeTests) {
       {NodekVoidcast(), EmbedInClass(""), 0},
       {NodekVoidcast(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NodekExpression matching
@@ -90,8 +94,9 @@ TEST(VerilogMatchers, ExpressionNodeTests) {
       {NodekExpression(), EmbedInClass(""), 0},
       {NodekExpression(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for ExpressionHasFunctionCall matching
@@ -111,8 +116,9 @@ TEST(VerilogMatchers, ExpressionHasFunctionCallTests) {
       {ExpressionHasFunctionCall(), EmbedInClassMethod("bar.foo();"), 0},
       {ExpressionHasFunctionCall(), EmbedInClassMethod("x = bar.foo();"), 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for ExpressionHasRandomizeCallExtension matching
@@ -126,8 +132,9 @@ TEST(VerilogMatchers, ExpressionHasRandomizeCallExtensionTests) {
       {ExpressionHasRandomizeCallExtension(), EmbedInClass(""), 0},
       {ExpressionHasRandomizeCallExtension(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for ExpressionHasRandomizeFunction matching
@@ -139,8 +146,9 @@ TEST(VerilogMatchers, ExpressionHasRandomizeFunctionTests) {
       {ExpressionHasRandomizeFunction(), EmbedInClass(""), 0},
       {ExpressionHasRandomizeFunction(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for FunctionCallHasId matching
@@ -148,8 +156,9 @@ TEST(VerilogMatchers, FunctionCallHasIdTests) {
   const RawMatcherTestCase tests[] = {
       {FunctionCallHasId(), EmbedInClassMethod("foo();"), 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NumberHasConstantWidth matching
@@ -161,8 +170,9 @@ TEST(VerilogMatchers, NumberHasConstantWidthTests) {
       {NumberHasConstantWidth(), "localparam x = 8'b0000_1111;", 1},
       {NumberHasConstantWidth(), "localparam x = `WIDTH'bx;", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NumberHasBasedLiteral matching
@@ -184,8 +194,9 @@ TEST(VerilogMatchers, NumberHasBasedLiteralTests) {
       {NumberHasBasedLiteral(), "localparam x = 32'h 0000_4321;", 1},
       {NumberHasBasedLiteral(), "localparam x = 64'H aaaa_bbbb_cccc_dddd;", 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NumberIsBinary matching
@@ -208,8 +219,9 @@ TEST(VerilogMatchers, NumberIsBinaryTests) {
       {NumberIsBinary(), "localparam x = 32'h 0000_4321;", 0},
       {NumberIsBinary(), "localparam x = 64'H aaaa_bbbb_cccc_dddd;", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NumberHasBInaryDigits matching
@@ -232,8 +244,9 @@ TEST(VerilogMatchers, NumberHasBinaryDigitsTests) {
       {NumberHasBinaryDigits(), "localparam x = 32'h 0000_4321;", 0},
       {NumberHasBinaryDigits(), "localparam x = 64'H aaaa_bbbb_cccc_dddd;", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NodekActualParameterList matching
@@ -246,8 +259,9 @@ TEST(VerilogMatchers, ActualParameterListNodeTests) {
       {NodekActualParameterList(), EmbedInModule(""), 0},
       {NodekActualParameterList(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for ActualParameterListHasPositionalParameterList matching
@@ -260,8 +274,9 @@ TEST(VerilogMatchers, ActualParameterListHasPositionalParameterListTests) {
       {ActualParameterListHasPositionalParameterList(), EmbedInModule(""), 0},
       {ActualParameterListHasPositionalParameterList(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NodekGateInstance matching
@@ -273,8 +288,9 @@ TEST(VerilogMatchers, GateInstanceNodeTests) {
       {NodekGateInstance(), EmbedInModule(""), 0},
       {NodekGateInstance(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for GateInstanceHasPortList matching
@@ -285,8 +301,9 @@ TEST(VerilogMatchers, GateInstanceHasPortListTests) {
       {GateInstanceHasPortList(), EmbedInModule(""), 0},
       {GateInstanceHasPortList(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NodekGenerateBlock matching
@@ -306,8 +323,9 @@ TEST(VerilogMatchers, GenerateBlockNodeTests) {
       {NodekGenerateBlock(), EmbedInModule(""), 0},
       {NodekGenerateBlock(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for GenerateRegionNode matching
@@ -328,8 +346,9 @@ TEST(VerilogMatchers, GenerateRegionNodeTests) {
       {NodekGenerateRegion(), EmbedInModule(""), 0},
       {NodekGenerateRegion(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for HasBeginLabel matching
@@ -352,8 +371,9 @@ TEST(VerilogMatchers, HasBeginLabelTests) {
       {HasBeginLabel(), EmbedInModule(""), 0},
       {HasBeginLabel(), "", 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for HasGenerateBlock matching
@@ -390,8 +410,9 @@ TEST(VerilogMatchers, HasGenerateBlockTests) {
                      "endgenerate"),
        0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for integration between NodekGenerateBlock and HasBeginLabel
@@ -412,8 +433,9 @@ TEST(VerilogMatchers, GenerateBlockHasBeginLabelTests) {
                      "endgenerate"),
        0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for NodekAlwaysStatement matching
@@ -434,8 +456,9 @@ TEST(VerilogMatchers, AlwaysStatementNodeTests) {
                      "always_comb begin a = b; end"),
        2},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for AlwaysKeyword matching
@@ -454,8 +477,9 @@ TEST(VerilogMatchers, AlwaysKeywordTests) {
                      "always_comb begin a = b; end"),
        0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for AlwaysCombKeyword matching
@@ -474,8 +498,9 @@ TEST(VerilogMatchers, AlwaysCombKeywordTests) {
                      "always_comb begin a = b; end"),
        1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for AlwaysFFKeyword matching
@@ -494,8 +519,9 @@ TEST(VerilogMatchers, AlwaysFFKeywordTests) {
                      "always_comb begin a = b; end"),
        1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for AlwaysStatementHasEventControlStar matching
@@ -517,8 +543,9 @@ TEST(VerilogMatchers, AlwaysStatementHasEventControlStarTests) {
                      "always_comb begin a = b; end"),
        0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 TEST(VerilogMatchers, AlwaysStatementHasEventControlStarAndParentheses) {
@@ -534,8 +561,9 @@ TEST(VerilogMatchers, AlwaysStatementHasEventControlStarAndParentheses) {
       {AlwaysStatementHasEventControlStarAndParentheses(),
        EmbedInModule("always @( * ) begin a = b; end"), 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for AlwaysStatementHasParentheses matching
@@ -554,8 +582,9 @@ TEST(VerilogMatchers, AlwaysStatementHasParentheses) {
       {AlwaysStatementHasParentheses(),
        EmbedInModule("always @(posedge foo) begin a <= b; end"), 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests that matcher finds left-hand-sides of assignments.
@@ -576,8 +605,9 @@ TEST(VerilogMatchers, PathkLPValueTests) {
       {PathkLPValue(), EmbedInClassMethod("forever x = y;"), 1},
       {PathkLPValue(), EmbedInClassMethod("x = 1;\ny = two();"), 2},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests that matcher finds assignments values that are function calls.
@@ -597,8 +627,9 @@ TEST(VerilogMatchers, RValueIsFunctionCallTest) {
       {RValueIsFunctionCall(), EmbedInClassMethod("x = bar::foo() -12;"), 0},
       {RValueIsFunctionCall(), EmbedInClassMethod("x = a + bar::foo();"), 0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests that qualified function calls are found.
@@ -619,8 +650,9 @@ TEST(VerilogMatchers, FunctionCallIsQualifiedTest) {
       {FunctionCallIsQualified(), EmbedInClassMethod("x = bar::foo() -12;"), 1},
       {FunctionCallIsQualified(), EmbedInClassMethod("x = a + bar::foo();"), 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests that assignments to qualified function calls are found.
@@ -666,8 +698,9 @@ TEST(VerilogMatchers, RValueFunctionCallIsQualifiedTest) {
       {RValueIsFunctionCall(FunctionCallIsQualified()),
        EmbedInClassMethod("x = a + bar::foo();"), 0},  // outermost rvalue is +
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests that function call arguments are matched.
@@ -687,8 +720,9 @@ TEST(VerilogMatchers, FunctionCallArgumentsTest) {
       {FunctionCallArguments(), EmbedInClassMethod("x = foobar();"), 0},
       {FunctionCallArguments(), EmbedInClassMethod("f.g.h = foobar(g);"), 1},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests that ranged dimensions are matched.
@@ -706,8 +740,9 @@ TEST(VerilogMatchers, DeclarationDimensionsHasRanges) {
       {DeclarationDimensionsHasRanges(), EmbedInModule("wire [1:2] w [1:0];"),
        2},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 // Tests for HasDefaultCase matching.
@@ -733,8 +768,9 @@ TEST(VerilogMatchers, HasDefaultCaseTests) {
        )",
        0},
   };
-  for (const auto& test : tests)
+  for (const auto& test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
 }
 
 }  // namespace

--- a/verilog/analysis/checkers/module_filename_rule_test.cc
+++ b/verilog/analysis/checkers/module_filename_rule_test.cc
@@ -42,7 +42,7 @@ TEST(ModuleFilenameRuleTest, BlankFilename) {
       {"module m; endmodule"},
       {"class c; endclass"},
   };
-  const std::string filename = "";
+  const std::string filename;
   RunLintTestCases<VerilogAnalyzer, ModuleFilenameRule>(kTestCases, filename);
 }
 

--- a/verilog/analysis/checkers/package_filename_rule_test.cc
+++ b/verilog/analysis/checkers/package_filename_rule_test.cc
@@ -40,7 +40,7 @@ TEST(PackageFilenameRuleTest, BlankFilename) {
       {"package m; endpackage"},
       {"class c; endclass"},
   };
-  const std::string filename = "";
+  const std::string filename;
   RunLintTestCases<VerilogAnalyzer, PackageFilenameRule>(kTestCases, filename);
 }
 

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
@@ -162,6 +162,7 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        {kToken, ";"},
        "`uvm_analysis_imp_decl(_TX)",
        {kToken, ";"}},
+
       {"`uvm_info_begin(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_message_add_tag(\"my_color\", \"red\")",
@@ -176,7 +177,7 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "endfunction\n"},
-      {"function void f();"
+      {"function void f();",
        "`uvm_info_begin(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_message_add_tag(\"my_color\", \"red\")",
@@ -186,7 +187,8 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        "`uvm_info_end",
        {kToken, ";"},
        "endfunction\n"},
-      {"function void f();"
+
+      {"function void f();",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_warning(\"msg_id\",\"message\")",
@@ -196,11 +198,13 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        "`uvm_fatal(\"msg_id\",\"message\")",
        {kToken, ";"},
        "endfunction\n"},
+
       {"task t();"
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "endtask\n"},
-      {"task t();"
+
+      {"task t();",
        "`uvm_info_begin(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_message_add_tag(\"my_color\", \"red\")",
@@ -210,7 +214,8 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        "`uvm_info_end",
        {kToken, ";"},
        "endtask\n"},
-      {"task t();"
+
+      {"task t();",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_warning(\"msg_id\",\"message\")",
@@ -233,11 +238,11 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
       {"class c extends uvm_object;",
        "`uvm_object_utils_begin(c)",
        {kToken, ";"},
-       "\n"
+       "\n",
        "`uvm_object_utils_end\n",
        "endclass\n"},
-      {"class c extends uvm_object;"
-       "function void f();"
+      {"class c extends uvm_object;",
+       "function void f();",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_warning(\"msg_id\",\"message\")",
@@ -246,11 +251,11 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        {kToken, ";"},
        "`uvm_fatal(\"msg_id\",\"message\")",
        {kToken, ";"},
-       "endfunction\n"
+       "endfunction\n",
        "endclass\n"},
 
       // Module scope
-      {"module top;"
+      {"module top;",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_warning(\"msg_id\",\"message\")",
@@ -262,22 +267,22 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        "endmodule\n"},
 
       // Block scope
-      {"function void f();"
-       "if(1)\n"
+      {"function void f();",
+       "if(1)\n",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
-       "if(1)\n"
+       "if(1)\n",
        "`uvm_warning(\"msg_id\",\"message\")",
        {kToken, ";"},
-       "if(1)\n"
+       "if(1)\n",
        "`uvm_error(\"msg_id\",\"message\")",
        {kToken, ";"},
-       "if(1)\n"
+       "if(1)\n",
        "`uvm_fatal(\"msg_id\",\"message\")",
        {kToken, ";"},
        "endfunction"},
-      {"function void f();"
-       "if(1) begin\n"
+      {"function void f();",
+       "if(1) begin\n",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_warning(\"msg_id\",\"message\")",
@@ -286,24 +291,25 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        {kToken, ";"},
        "`uvm_fatal(\"msg_id\",\"message\")",
        {kToken, ";"},
-       "end\n"
+       "end\n",
        "endfunction\n"},
-      {"task t();"
-       "for(int i=0;i<10;i++)"
+      {"task t();",
+       "for(int i=0;i<10;i++)",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
-       "for(int i=0;i<10;i++)"
+       "for(int i=0;i<10;i++)",
        "`uvm_warning(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
-       "for(int i=0;i<10;i++)"
+       "for(int i=0;i<10;i++)",
        "`uvm_error(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
-       "for(int i=0;i<10;i++)"
+       "for(int i=0;i<10;i++)",
        "`uvm_fatal(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "endtask\n"},
-      {"task t();"
-       "for(int i=0;i<10;i++) begin"
+
+      {"task t();",
+       "for(int i=0;i<10;i++) begin",
        "`uvm_info(\"msg_id\",\"message\", UVM_LOW)",
        {kToken, ";"},
        "`uvm_warning(\"msg_id\",\"message\")",
@@ -312,7 +318,7 @@ TEST(UvmMacroSemicolonRule, WrongUvmMacroTest) {
        {kToken, ";"},
        "`uvm_fatal(\"msg_id\",\"message\")",
        {kToken, ";"},
-       "end\n"
+       "end\n",
        "endtask\n"}};
   RunLintTestCases<VerilogAnalyzer, UvmMacroSemicolonRule>(kTestCases);
 }

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -554,9 +554,9 @@ TEST(RuleSetTest, ParseRuleSetSuccess) {
   std::string all_text = "all";
   std::string default_text = "default";
 
-  std::string none_error = "";
-  std::string all_error = "";
-  std::string default_error = "";
+  std::string none_error;
+  std::string all_error;
+  std::string default_error;
 
   RuleSet none_destination, all_destination, default_destination;
 
@@ -580,7 +580,7 @@ TEST(RuleSetTest, ParseRuleSetSuccess) {
 
 TEST(RuleSetTest, ParseRuleSetError) {
   std::string bad_text = "fdsfdfds";
-  std::string error = "";
+  std::string error;
 
   RuleSet rule_result;
   bool result = AbslParseFlag(bad_text, &rule_result, &error);
@@ -635,7 +635,7 @@ TEST(RuleBundleTest, UnparseRuleBundleSeveralConfiguration) {
 
 TEST(RuleBundleTest, UnparseRuleBundleEmpty) {
   RuleBundle bundle = {};
-  std::string expected = "";
+  std::string expected;
 
   std::string result_comma = bundle.UnparseConfiguration(',');
   EXPECT_EQ(result_comma, expected);

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -55,9 +55,7 @@ using verible::file::testing::ScopedTestFile;
 class DefaultLinterConfigTestFixture {
  public:
   // Test code using the default rule set.
-  DefaultLinterConfigTestFixture() : config_() {
-    config_.UseRuleSet(RuleSet::kDefault);
-  }
+  DefaultLinterConfigTestFixture() { config_.UseRuleSet(RuleSet::kDefault); }
 
  protected:
   LinterConfiguration config_;
@@ -438,7 +436,7 @@ TEST(VerilogLinterDocumentationTest, AllRulesMarkdown) {
 
 class ViolationFixerTest : public testing::Test {
  public:
-  ViolationFixerTest() : config_() {
+  ViolationFixerTest() {
     config_.UseRuleSet(RuleSet::kNone);
     config_.TurnOn("forbid-consecutive-null-statements");
     config_.TurnOn("no-trailing-spaces");

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -18435,8 +18435,8 @@ std::string NLCountAndfirstWord(absl::string_view str) {
   result.append(1,
                 static_cast<char>(newline_count + '0'));  // single digit itoa
   const char* end_str = begin;
-  for (/**/; end_str < str.end() && !isspace(*end_str); ++end_str)
-    ;
+  for (/**/; end_str < str.end() && !isspace(*end_str); ++end_str) {
+  }
   result.append(begin, end_str);
   return result;
 }
@@ -18453,8 +18453,8 @@ std::string lastWordAndNLCount(absl::string_view str) {
   }
 
   const char* start_str = back;
-  for (/**/; start_str >= str.begin() && !isspace(*start_str); --start_str)
-    ;
+  for (/**/; start_str >= str.begin() && !isspace(*start_str); --start_str) {
+  }
   result.append(start_str + 1, back - start_str);
   // Emit number of newlines seen following last token.
   result.append(1,

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -130,8 +130,9 @@ std::ostream& operator<<(
     std::ostream& stream,
     const AnnotateFormattingInformationTestCase& test_case) {
   stream << '[';
-  for (const auto& token : test_case.input_tokens)
+  for (const auto& token : test_case.input_tokens) {
     stream << ' ' << token.text();
+  }
   return stream << " ]";
 }
 

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -53,7 +53,7 @@ struct ExpectedUnwrappedLine {
   int indentation_spaces;
   std::vector<absl::string_view> tokens;  // includes comments
 
-  explicit ExpectedUnwrappedLine(int s) : indentation_spaces(s), tokens() {}
+  explicit ExpectedUnwrappedLine(int s) : indentation_spaces(s) {}
 
   ExpectedUnwrappedLine(
       int s, std::initializer_list<absl::string_view> expected_tokens)

--- a/verilog/parser/verilog_lexical_context_test.cc
+++ b/verilog/parser/verilog_lexical_context_test.cc
@@ -1153,7 +1153,7 @@ TEST_F(RandomizeCallStateMachineTest,
 // Class for testing some internal methods of LexicalContext.
 class LexicalContextTest : public ::testing::Test, public LexicalContext {
  protected:
-  LexicalContextTest() {}
+  LexicalContextTest() = default;
 
   void CheckInitialState() const {
     EXPECT_EQ(previous_token_, nullptr);

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -42,11 +42,11 @@ using ParserTestCaseArray = std::initializer_list<const char*>;
 static constexpr VerilogPreprocess::Config kDefaultPreprocess;
 
 // No syntax tree expected from these inputs.
-static const ParserTestCaseArray kEmptyTests = {
+static constexpr ParserTestCaseArray kEmptyTests = {
     "", "    ", "\t\t\t", "\n\n", "// comment\n", "/* comment */\n",
 };
 
-static const ParserTestCaseArray kPreprocessorTests = {
+static constexpr ParserTestCaseArray kPreprocessorTests = {
     "`define TRUTH\n",        // definition without value
     "`define FOO BAR-1\n",    // definition with value
     "`include \"foo.svh\"\n"  // include directive
@@ -108,17 +108,17 @@ static const ParserTestCaseArray kPreprocessorTests = {
 };
 
 // Make sure line continuations, newlines and spaces get filtered out
-static const ParserTestCaseArray kLexerFilterTests = {
+static constexpr ParserTestCaseArray kLexerFilterTests = {
     "parameter \tfoo =\t\t0;",
     "parameter\n\nfoo =\n 0;",
     "parameter \\\nfoo =\\\n 0;",
     "//comment with line-continuation\\\n",
-    "//comment1 with line-continuation\\\n"
-    "//comment2 with line-continuation\\\n",
+    ("//comment1 with line-continuation\\\n"
+     "//comment2 with line-continuation\\\n"),
 };
 
 // Numbers are parsed as ([width], [signed]base, digits)
-static const ParserTestCaseArray kNumberTests = {
+static constexpr ParserTestCaseArray kNumberTests = {
     "parameter foo = 0;",
     "parameter int foo = 0;",
     "parameter int foo = '0;",
@@ -204,7 +204,7 @@ static const ParserTestCaseArray kNumberTests = {
 };
 
 // classes are a System Verilog construct
-static const ParserTestCaseArray kClassTests = {
+static constexpr ParserTestCaseArray kClassTests = {
     "class semicolon_classy; ; ;;; ; ; ;endclass",
     "class Foo; endclass",
     "class static Foo; endclass",
@@ -504,7 +504,7 @@ static const ParserTestCaseArray kClassTests = {
     "endclass",
 };
 
-static const ParserTestCaseArray kFunctionTests = {
+static constexpr ParserTestCaseArray kFunctionTests = {
     "function integer add;\n"
     "input a, b;\n"
     "begin\n"
@@ -887,7 +887,7 @@ static const ParserTestCaseArray kFunctionTests = {
     "endfunction\n",
 };
 
-static const ParserTestCaseArray kTaskTests = {
+static constexpr ParserTestCaseArray kTaskTests = {
     "task task_a;\n"
     "endtask",
     "task static task_a;\n"
@@ -1332,7 +1332,7 @@ static const ParserTestCaseArray kTaskTests = {
     "endtask\n",
 };
 
-static const ParserTestCaseArray kModuleTests = {
+static constexpr ParserTestCaseArray kModuleTests = {
     "module modular_thing;\n"
     "endmodule",
     "module semicolon_madness;;;;;\n"
@@ -3495,7 +3495,7 @@ static const ParserTestCaseArray kModuleTests = {
     "endmodule",
 };
 
-static const ParserTestCaseArray kModuleInstanceTests = {
+static constexpr ParserTestCaseArray kModuleInstanceTests = {
     "module tryme;\n"
     "logic lol;\n"   // is a data_declaration
     "wire money;\n"  // is a net_declaration
@@ -3544,7 +3544,7 @@ static const ParserTestCaseArray kModuleInstanceTests = {
     "endmodule",
 };
 
-static const ParserTestCaseArray kInterfaceTests = {
+static constexpr ParserTestCaseArray kInterfaceTests = {
     "interface Face;\n"
     "endinterface",
     "interface Face;\n"
@@ -3682,7 +3682,7 @@ endinterface : conduit_if
     "endinterface",
 };
 
-static const ParserTestCaseArray kTypedefTests = {
+static constexpr ParserTestCaseArray kTypedefTests = {
     "typedef i_am_a_type_really;",
     "typedef reg[3:0] quartet;",
     "typedef reg quartet[3:0];",
@@ -3764,7 +3764,7 @@ static const ParserTestCaseArray kTypedefTests = {
 };
 
 // typedefs as forward declarations
-static const ParserTestCaseArray kStructTests = {
+static constexpr ParserTestCaseArray kStructTests = {
     "typedef struct mystruct_fwd;",
     // anonymous structs:
     "struct { int i; bit b; } foo;",
@@ -3773,11 +3773,11 @@ static const ParserTestCaseArray kStructTests = {
     "struct packed unsigned { int i; bit b; } foo;",
 };
 
-static const ParserTestCaseArray kEnumTests = {
+static constexpr ParserTestCaseArray kEnumTests = {
     "typedef enum myenum_fwd;",
 };
 
-static const ParserTestCaseArray kUnionTests = {
+static constexpr ParserTestCaseArray kUnionTests = {
     "typedef union myunion_fwd;",
     // anonymous unions:
     "union { int i; bit b; } foo;",
@@ -3793,7 +3793,7 @@ static const ParserTestCaseArray kUnionTests = {
 // TODO(fangism): implement and test ENUM_CONSTANT
 
 // packages
-static const ParserTestCaseArray kPackageTests = {
+static constexpr ParserTestCaseArray kPackageTests = {
     "package mypkg;\n"
     "endpackage",
     "package automatic mypkg;\n"
@@ -4041,7 +4041,7 @@ static const ParserTestCaseArray kPackageTests = {
     "endpackage\n",
 };
 
-static const ParserTestCaseArray kDescriptionTests = {
+static constexpr ParserTestCaseArray kDescriptionTests = {
     // preprocessor balanced top-level description items
     "`ifdef DEBUGGER\n"  // empty
     "`endif\n",
@@ -4139,7 +4139,7 @@ static const ParserTestCaseArray kDescriptionTests = {
     "`endif\n",
 };
 
-static const ParserTestCaseArray kSequenceTests = {
+static constexpr ParserTestCaseArray kSequenceTests = {
     "sequence myseq;\n"
     "  a != b\n"
     "endsequence\n",
@@ -4183,7 +4183,7 @@ static const ParserTestCaseArray kSequenceTests = {
     "endsequence\n",
 };
 
-static const ParserTestCaseArray kPropertyTests = {
+static constexpr ParserTestCaseArray kPropertyTests = {
     "property ready_follows_valid_bounded_P;\n"
     "  @(posedge clk) disable iff (reset)\n"
     "  valid |-> eventually [0:Bound] (ready);\n"
@@ -4348,7 +4348,7 @@ static const ParserTestCaseArray kPropertyTests = {
     "endproperty\n",
 };
 
-static const ParserTestCaseArray kModuleMemberTests = {
+static constexpr ParserTestCaseArray kModuleMemberTests = {
     "module mymodule;\n"
     "task subtask;\n"
     "endtask\n"
@@ -4673,7 +4673,7 @@ static const ParserTestCaseArray kModuleMemberTests = {
     "endgroup",
 };
 
-static const ParserTestCaseArray kClassMemberTests = {
+static constexpr ParserTestCaseArray kClassMemberTests = {
     // member tasks
     "class myclass;\n"
     "task subtask;\n"
@@ -5001,7 +5001,7 @@ static const ParserTestCaseArray kClassMemberTests = {
     "endclass\n",
 };
 
-static const ParserTestCaseArray kInterfaceClassTests = {
+static constexpr ParserTestCaseArray kInterfaceClassTests = {
     "interface class base_ic;\n"
     "endclass",
     "interface class base_ic;\n"
@@ -5046,7 +5046,7 @@ static const ParserTestCaseArray kInterfaceClassTests = {
     "endclass",
 };
 
-static const ParserTestCaseArray kConstraintTests = {
+static constexpr ParserTestCaseArray kConstraintTests = {
     "constraint solve_this {\n"
     "  solve x.z before y.x;\n"
     "}",
@@ -5200,7 +5200,7 @@ static const ParserTestCaseArray kConstraintTests = {
     "}",
 };
 
-static const ParserTestCaseArray kConfigTests = {
+static constexpr ParserTestCaseArray kConfigTests = {
     "config cfg;\n"
     "  design foo.bar;\n"  // library-qualified cell-id
     "endconfig",
@@ -5427,7 +5427,7 @@ static const ParserTestCaseArray kConfigTests = {
     "endconfig",
 };
 
-static const ParserTestCaseArray kPrimitiveTests = {
+static constexpr ParserTestCaseArray kPrimitiveTests = {
     "primitive ape (output out, input in1, input in2);\n"
     "  table\n"
     "    0:0:0;\n"  // sequential entry
@@ -5500,7 +5500,7 @@ static const ParserTestCaseArray kPrimitiveTests = {
     "endprimitive",
 };
 
-static const ParserTestCaseArray kDisciplineTests = {
+static constexpr ParserTestCaseArray kDisciplineTests = {
     "discipline d;\n"
     "enddiscipline\n",
     "discipline d \n"  // no ';'
@@ -5519,7 +5519,7 @@ static const ParserTestCaseArray kDisciplineTests = {
     "enddiscipline\n",
 };
 
-static const ParserTestCaseArray kMultiBlockTests = {
+static constexpr ParserTestCaseArray kMultiBlockTests = {
     // check for correct scope switching around timescale and module
     "module modular_thing1;\n"
     "endmodule\n"
@@ -5555,7 +5555,7 @@ static const ParserTestCaseArray kMultiBlockTests = {
     "  endtask\n"
     "endclass\n"};
 
-static const ParserTestCaseArray kRandSequenceTests = {
+static constexpr ParserTestCaseArray kRandSequenceTests = {
     // randsequence inside initial block
     "module foo();\n"
     "initial begin\n"
@@ -5711,7 +5711,7 @@ static const ParserTestCaseArray kRandSequenceTests = {
     "endtask\n",
 };
 
-static const ParserTestCaseArray kNetAliasTests = {
+static constexpr ParserTestCaseArray kNetAliasTests = {
     "module byte_swap (inout wire [31:0] A, inout wire [31:0] B);\n"
     "  alias {A[7:0],A[15:8],A[23:16],A[31:24]} = B;\n"
     "endmodule\n",
@@ -5744,7 +5744,7 @@ static const ParserTestCaseArray kNetAliasTests = {
 };
 
 // These tests target LRM Ch. 33
-static const ParserTestCaseArray kLibraryTests = {
+static constexpr ParserTestCaseArray kLibraryTests = {
     ";\n",
     "library foolib bar;\n",
     "library foolib *.bar;\n",


### PR DESCRIPTION
Result of

```
.github/bin/run-clang-tidy.sh --checks="-*,modernize-use-equals-default,readability-redundant-string-init,google-readability-braces-around-statements,readability-redundant-member-init,readability-else-after-return" --fix
```