### PR TITLE
Some mechanical code-quality fixes.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
   clang-analyzer-*,
   -clang-analyzer-core.NonNullParamChecker,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
+  -clang-analyzer-optin.performance.Padding,
   abseil-*,
   -abseil-no-namespace,
   readability-*,

--- a/common/analysis/matcher/matcher_test_utils.cc
+++ b/common/analysis/matcher/matcher_test_utils.cc
@@ -56,8 +56,7 @@ void RunMatcherTestCase(const MatcherTestCase& test) {
 
 class MatchCounter : public TreeVisitorRecursive {
  public:
-  explicit MatchCounter(const Matcher& matcher)
-      : matcher_(matcher), num_matches_(0) {}
+  explicit MatchCounter(const Matcher& matcher) : matcher_(matcher) {}
 
   int Count(const Symbol& symbol) {
     num_matches_ = 0;
@@ -69,7 +68,7 @@ class MatchCounter : public TreeVisitorRecursive {
   void Visit(const SyntaxTreeNode& node) final { TestSymbol(node); }
 
  private:
-  Matcher matcher_;
+  const Matcher matcher_;
   int num_matches_ = 0;
 
   void TestSymbol(const Symbol& symbol) {

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -704,9 +704,8 @@ class GetPartitionAlignmentSubrangesTestFixture : public AlignmentTestFixture {
     }
     if (text == "nomatch") {
       return AlignmentGroupAction::kNoMatch;
-    } else {
-      return AlignmentGroupAction::kIgnore;
     }
+    return AlignmentGroupAction::kIgnore;
   }
 
  protected:
@@ -730,6 +729,7 @@ TEST_F(GetPartitionAlignmentSubrangesTestFixture, VariousRanges) {
 
   using P = std::pair<int, int>;
   std::vector<P> range_indices;
+  range_indices.reserve(ranges.size());
   for (const auto& range : ranges) {
     range_indices.push_back(SubRangeIndices(range.range, children));
   }
@@ -808,9 +808,8 @@ class GetPartitionAlignmentSubrangesSubtypedTestFixture
     }
     if (text == "nomatch") {
       return {AlignmentGroupAction::kNoMatch};
-    } else {
-      return {AlignmentGroupAction::kIgnore};
     }
+    return {AlignmentGroupAction::kIgnore};
   }
 
  protected:
@@ -830,6 +829,7 @@ TEST_F(GetPartitionAlignmentSubrangesSubtypedTestFixture, VariousRanges) {
 
   using P = std::pair<int, int>;
   std::vector<P> range_indices;
+  range_indices.reserve(ranges.size());
   for (const auto& range : ranges) {
     range_indices.push_back(SubRangeIndices(range.range, children));
   }
@@ -1064,7 +1064,7 @@ class SubcolumnsTreeAlignmentTest : public MatrixTreeAlignmentTestFixture {
       }
       uwline.SpanUpToToken(token_iter);
       uwline.SetOrigin(item.get());
-      partition_.Children().emplace_back(std::move(uwline));
+      partition_.Children().emplace_back(uwline);
       SymbolCastToNode(*syntax_tree_).AppendChild(std::move(item));
     }
   }
@@ -1100,11 +1100,10 @@ class SubcolumnsTreeAlignmentTest : public MatrixTreeAlignmentTestFixture {
     }
     if ((*it)->Text() == ")") {
       return SymbolPtr(nullptr);
-    } else {
-      SymbolPtr leaf = Leaf(0, (*it)->Text());
-      ++*it;
-      return leaf;
     }
+    SymbolPtr leaf = Leaf(0, (*it)->Text());
+    ++*it;
+    return leaf;
   }
 };
 
@@ -1498,7 +1497,7 @@ class FormatUsingOriginalSpacingTest : public ::testing::Test,
 
  protected:
   void RunTestCase(TokenPartitionTree actual,
-                   const TokenPartitionTree expected) {
+                   const TokenPartitionTree& expected) {
     TokenPartitionTree::subnodes_type nodes;
     nodes.push_back(std::move(actual));
     FormatUsingOriginalSpacing(TokenPartitionRange(nodes.begin(), nodes.end()));

--- a/common/lexer/lexer_test_util.h
+++ b/common/lexer/lexer_test_util.h
@@ -179,9 +179,9 @@ struct SynthesizedLexerTestData : public TokenInfoTestData {
 
 // These types and objects help dispatch the right overload of TestLexer.
 struct IgnoredText {};
-static const IgnoredText Ignored{};
+inline constexpr IgnoredText Ignored{};
 struct SingleCharTok {};
-static const SingleCharTok SingleChar{};
+inline constexpr SingleCharTok SingleChar{};
 
 // Test for ignored tokens.
 template <class Lexer>

--- a/common/strings/patch_test.cc
+++ b/common/strings/patch_test.cc
@@ -37,6 +37,7 @@ namespace {
 static std::vector<MarkedLine> MakeMarkedLines(
     const std::vector<absl::string_view>& lines) {
   std::vector<MarkedLine> result;
+  result.reserve(lines.size());
   for (const auto& line : lines) {
     result.emplace_back(line);
   }
@@ -555,6 +556,7 @@ static std::vector<Hunk> MakeExpectedHunks(
     const Hunk& original, const std::vector<ExpectedHunk>& hunk_infos) {
   const auto& marked_lines = original.MarkedLines();
   std::vector<Hunk> results;
+  results.reserve(hunk_infos.size());
   for (const auto& hunk_info : hunk_infos) {
     results.emplace_back(
         hunk_info.old_starting_line, hunk_info.new_starting_line,
@@ -886,8 +888,8 @@ TEST(FilePatchParseAndPrintTest, ValidInputs) {
       },
       {
           // one line of file metadata
-          "==== //depot/p4/style/path/to/file.txt#4 - local/path/to/file.txt "
-          "====",
+          ("==== //depot/p4/style/path/to/file.txt#4 - local/path/to/file.txt "
+           "===="),
           "--- /path/to/file.txt\t2020-03-30",
           "+++ /path/to/file.txt\t2020-03-30",
           "@@ -12,1 +13,1 @@",

--- a/common/strings/split_test.cc
+++ b/common/strings/split_test.cc
@@ -24,9 +24,10 @@ namespace {
 
 using ::testing::ElementsAre;
 
-static void AcceptFunctionChar(std::function<absl::string_view(char)> func) {}
+static void AcceptFunctionChar(
+    const std::function<absl::string_view(char)>& func) {}
 static void AcceptFunctionStringView(
-    std::function<absl::string_view(absl::string_view)> func) {}
+    const std::function<absl::string_view(absl::string_view)>& func) {}
 
 // This tests that StringSpliterator can be passed to a std::function.
 TEST(StringSpliteratorTest, CompileTimeAsFunction) {

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -84,12 +84,12 @@ void MultiTokenTextStructureViewNoTree(TextStructureView* view) {
   CHECK_GE(contents.length(), 5);
   auto& stream = view->MutableTokenStream();
   for (int i = 0; i < 5; ++i) {  // Populate with 5 single-char tokens.
-    stream.push_back(TokenInfo(i + 1, contents.substr(i, 1)));
+    stream.emplace_back(i + 1, contents.substr(i, 1));
   }
   auto& stream_view = view->MutableTokenStreamView();
   // Populate view with 2 tokens.
-  stream_view.push_back(stream.begin() + 1);
-  stream_view.push_back(stream.begin() + 3);
+  stream_view.emplace_back(stream.begin() + 1);
+  stream_view.emplace_back(stream.begin() + 3);
 }
 
 // Test that filtering can keep tokens.

--- a/common/util/algorithm_test.cc
+++ b/common/util/algorithm_test.cc
@@ -305,10 +305,10 @@ TEST(FindAllTest, StrSplitAtEqual) {
 TEST(FindAllTest, StrSplitAfterEqual) {
   const absl::string_view seq("aa=b=cd");
   std::vector<absl::string_view::const_iterator> bounds;
-  int prev = -1;
+  char prev = 0;
   find_all(seq.begin(), seq.end(), std::back_inserter(bounds), [&](char i) {
     // Split *after* each '='.
-    const bool p = prev == '=';
+    const bool p = (prev == '=');
     prev = i;
     return p;
   });

--- a/common/util/auto_iterator_test.cc
+++ b/common/util/auto_iterator_test.cc
@@ -27,34 +27,26 @@ namespace {
 
 TEST(AutoIteratorSelectorTest, NonConst) {
   static_assert(std::is_same<auto_iterator_selector<std::list<int>>::type,
-                             std::list<int>::iterator>::value,
-                "");
+                             std::list<int>::iterator>::value);
   static_assert(std::is_same<auto_iterator_selector<std::map<int, char>>::type,
-                             std::map<int, char>::iterator>::value,
-                "");
+                             std::map<int, char>::iterator>::value);
   static_assert(std::is_same<auto_iterator_selector<std::set<int>>::type,
-                             std::set<int>::iterator>::value,
-                "");
+                             std::set<int>::iterator>::value);
   static_assert(std::is_same<auto_iterator_selector<std::vector<int>>::type,
-                             std::vector<int>::iterator>::value,
-                "");
+                             std::vector<int>::iterator>::value);
 }
 
 TEST(AutoIteratorSelectorTest, Const) {
   static_assert(std::is_same<auto_iterator_selector<const std::list<int>>::type,
-                             std::list<int>::const_iterator>::value,
-                "");
+                             std::list<int>::const_iterator>::value);
   static_assert(
       std::is_same<auto_iterator_selector<const std::map<int, char>>::type,
-                   std::map<int, char>::const_iterator>::value,
-      "");
+                   std::map<int, char>::const_iterator>::value);
   static_assert(std::is_same<auto_iterator_selector<const std::set<int>>::type,
-                             std::set<int>::const_iterator>::value,
-                "");
+                             std::set<int>::const_iterator>::value);
   static_assert(
       std::is_same<auto_iterator_selector<const std::vector<int>>::type,
-                   std::vector<int>::const_iterator>::value,
-      "");
+                   std::vector<int>::const_iterator>::value);
 }
 
 }  // namespace

--- a/common/util/enum_flags_test.cc
+++ b/common/util/enum_flags_test.cc
@@ -75,7 +75,7 @@ std::string AbslUnparseFlag(const MyFakeEnum& mode) {
 
 TEST_F(EnumNameMapTest, ParseFlagValueValues) {
   for (const auto& p : enum_name_map_.forward_view()) {
-    MyFakeEnum e;
+    MyFakeEnum e = MyFakeEnum::kValue1;
     std::string error;
     EXPECT_TRUE(AbslParseFlag(p.first, &e, &error)) << " parsing " << p.first;
     EXPECT_EQ(e, *p.second) << " from " << p.first;

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -204,7 +204,7 @@ TEST(FileUtil, ScopedTestFileEmplace) {
     std::vector<ScopedTestFile> files;
     for (size_t i = 0; i < 10; ++i) {
       files.emplace_back(::testing::TempDir(), "zzz");
-      names.push_back(std::string(files.back().filename()));
+      names.emplace_back(files.back().filename());
     }
     for (const auto& name : names) {
       EXPECT_TRUE(file::FileExists(name).ok());

--- a/common/util/thread_pool_test.cc
+++ b/common/util/thread_pool_test.cc
@@ -48,6 +48,7 @@ TEST(ThreadPoolTest, WorkIsCompleted) {
   ThreadPool pool(3);
 
   std::vector<std::future<int>> results;
+  results.reserve(kLoops);
   for (int i = 0; i < kLoops; ++i) {
     results.emplace_back(pool.ExecAsync<int>([i]() -> int {
       PretendWork(10);
@@ -68,6 +69,7 @@ TEST(ThreadPoolTest, ExceptionsArePropagated) {
   ThreadPool pool(3);
 
   std::vector<std::future<int>> results;
+  results.reserve(10);
   for (int i = 0; i < 10; ++i) {
     results.emplace_back(pool.ExecAsync<int>([]() -> int {
       throw 1;

--- a/common/util/type_traits_test.cc
+++ b/common/util/type_traits_test.cc
@@ -21,17 +21,15 @@ namespace verible {
 namespace {
 
 TEST(MatchConst, NonConst) {
-  static_assert(std::is_same<match_const<int, char>::type, int>::value, "");
-  static_assert(std::is_same<match_const<const int, char>::type, int>::value,
-                "");
+  static_assert(std::is_same<match_const<int, char>::type, int>::value);
+  static_assert(std::is_same<match_const<const int, char>::type, int>::value);
 }
 
 TEST(MatchConst, Const) {
   static_assert(
-      std::is_same<match_const<int, const char>::type, const int>::value, "");
+      std::is_same<match_const<int, const char>::type, const int>::value);
   static_assert(
-      std::is_same<match_const<const int, const char>::type, const int>::value,
-      "");
+      std::is_same<match_const<const int, const char>::type, const int>::value);
 }
 
 }  // namespace

--- a/verilog/CST/DPI_test.cc
+++ b/verilog/CST/DPI_test.cc
@@ -118,6 +118,7 @@ TEST(GetDPIImportPrototypeTest, Various) {
 
           const auto dpi_imports = FindAllDPIImports(*ABSL_DIE_IF_NULL(root));
           std::vector<TreeSearchMatch> prototypes;
+          prototypes.reserve(dpi_imports.size());
           for (const auto& dpi_import : dpi_imports) {
             prototypes.push_back(TreeSearchMatch{
                 GetDPIImportPrototype(*dpi_import.match), /* no context */});

--- a/verilog/CST/declaration_test.cc
+++ b/verilog/CST/declaration_test.cc
@@ -259,7 +259,7 @@ TEST(GetQualifiersOfDataDeclarationTest, NoQualifiers) {
     TestVerilogSyntaxRangeMatches(
         __FUNCTION__, test, [](const TextStructureView& text_structure) {
           const auto& root = text_structure.SyntaxTree();
-          const auto decls = FindAllDataDeclarations(*ABSL_DIE_IF_NULL(root));
+          auto decls = FindAllDataDeclarations(*ABSL_DIE_IF_NULL(root));
 
           // Verify that quals is either nullptr or empty or contains only
           // nullptrs.
@@ -293,6 +293,7 @@ TEST(GetTypeOfDataDeclarationTest, ExplicitTypes) {
       {"static ", {kTag, "foo"}, " bar;\n"},
       {"var static ", {kTag, "foo"}, " bar;\n"},
       {"automatic ", {kTag, "foo"}, " bar;\n"},
+
       {"class c;\n",
        {kTag, "int"},
        " foo;\n"
@@ -302,6 +303,7 @@ TEST(GetTypeOfDataDeclarationTest, ExplicitTypes) {
        {kTag, "int"},
        " foo;\n"
        "endclass\n"},
+
       {"class c;\n"
        "function f;\n"
        "const ",
@@ -309,27 +311,29 @@ TEST(GetTypeOfDataDeclarationTest, ExplicitTypes) {
        " foo;\n"
        "endfunction\n"
        "endclass\n"},
-      {"class c;\n"
-       "function f;\n"
+
+      {"class c;\n",
+       "function f;\n",
        "const ",
        {kTag, "int"},
        " foo;\n",
        {kTag, "bit"},
-       " bar;\n"
-       "endfunction\n"
+       " bar;\n",
+       "endfunction\n",
        "endclass\n"},
-      {"class c;\n"
-       "function f;\n"
+
+      {"class c;\n",
+       "function f;\n",
        "const ",
        {kTag, "int"},
        " foo;\n",
-       "endfunction\n"
-       "endclass\n"
-       "class d;\n"
+       "endfunction\n",
+       "endclass\n",
+       "class d;\n",
        "function g;\n",
        {kTag, "bit"},
-       " bar;\n"
-       "endfunction\n"
+       " bar;\n",
+       "endfunction\n",
        "endclass\n"},
   };
   for (const auto& test : kTestCases) {

--- a/verilog/CST/dimensions_test.cc
+++ b/verilog/CST/dimensions_test.cc
@@ -14,9 +14,8 @@
 
 #include "verilog/CST/dimensions.h"
 
-#include <stddef.h>
-
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <vector>
 

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -172,7 +172,7 @@ TEST(AssociativeBinaryExpressionsTest, ThreeFlatOperands) {
     TestVerilogSyntaxRangeMatches(
         __FUNCTION__, test, [](const TextStructureView& text_structure) {
           const auto& root = text_structure.SyntaxTree();
-          const auto matches = FindAllBinaryOperations(*ABSL_DIE_IF_NULL(root));
+          auto matches = FindAllBinaryOperations(*ABSL_DIE_IF_NULL(root));
           for (const auto& match : matches) {
             // "A op B op C" is 5 sibling tokens, due to flattening
             EXPECT_EQ(verible::SymbolCastToNode(*ABSL_DIE_IF_NULL(match.match))

--- a/verilog/CST/functions_test.cc
+++ b/verilog/CST/functions_test.cc
@@ -167,6 +167,7 @@ TEST(FindAllFunctionPrototypesTest, Various) {
           const auto& root = text_structure.SyntaxTree();
           const auto protos(FindAllFunctionPrototypes(*ABSL_DIE_IF_NULL(root)));
           std::vector<TreeSearchMatch> headers;
+          headers.reserve(protos.size());
           for (const auto& proto : protos) {
             headers.push_back(TreeSearchMatch{
                 GetFunctionPrototypeHeader(*proto.match), /* no context */});

--- a/verilog/CST/identifier_test.cc
+++ b/verilog/CST/identifier_test.cc
@@ -228,6 +228,7 @@ TEST(FindAllSymbolIdentifierTest, VariousIds) {
           const auto& root = text_structure.SyntaxTree();
           const auto symb_ids = FindAllSymbolIdentifierLeafs(*root);
           std::vector<TreeSearchMatch> identifiers;
+          identifiers.reserve(symb_ids.size());
           for (const auto& symb_id : symb_ids) {
             identifiers.push_back(
                 TreeSearchMatch{symb_id.match, {/* ignored context */}});

--- a/verilog/CST/macro_test.cc
+++ b/verilog/CST/macro_test.cc
@@ -100,6 +100,7 @@ TEST(GetMacroCallIdsTest, Various) {
     const auto& root = analyzer.Data().SyntaxTree();
     const auto macro_calls = FindAllMacroCalls(*ABSL_DIE_IF_NULL(root));
     std::vector<absl::string_view> found_names;
+    found_names.reserve(macro_calls.size());
     for (const auto& match : macro_calls) {
       found_names.push_back(GetMacroCallId(*match.match)->text());
     }

--- a/verilog/CST/type_test.cc
+++ b/verilog/CST/type_test.cc
@@ -275,6 +275,7 @@ TEST(GetIdentifierFromTypeDeclarationTest, TypedefNames) {
           const auto& root = text_structure.SyntaxTree();
           const auto type_declarations = FindAllTypeDeclarations(*root);
           std::vector<TreeSearchMatch> ids;
+          ids.reserve(type_declarations.size());
           for (const auto& decl : type_declarations) {
             ids.push_back(TreeSearchMatch{
                 GetIdentifierFromTypeDeclaration(*decl.match),

--- a/verilog/analysis/checkers/numeric_format_string_style_rule_test.cc
+++ b/verilog/analysis/checkers/numeric_format_string_style_rule_test.cc
@@ -137,67 +137,73 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
        "\", dec); endmodule"},
 
       // Multiple violations
-      {"module test;"
+      {"module test;\n",
        "  initial $display(\"Value: 0x%0x ",
        {kToken, "%0x"},
        " ",
        {kToken, "%0x"},
-       "\", hex1, hex2, hex3);"
+       "\", hex1, hex2, hex3);",
        "endmodule"},
-      {"module test;"
+
+      {"module test;\n",
        "  initial $display(\"Value: ",
        {kToken, "%0x"},
        " 'h%0h ",
        {kToken, "%0x"},
-       "\", hex1, hex2, hex3);"
+       "\", hex1, hex2, hex3);",
        "endmodule"},
-      {"module test;"
+
+      {"module test;\n",
        "  initial $display(\"Value: ",
        {kToken, "%0x"},
        " ",
        {kToken, "%0x"},
        " ",
        {kToken, "%0x"},
-       "\", hex1, hex2, hex3);"
+       "\", hex1, hex2, hex3);",
        "endmodule"},
 
-      {"module test;"
+      {"module test;\n",
        "  initial $display(\"Value: 0b%0b ",
        {kToken, "%0b"},
        " ",
        {kToken, "%0b"},
-       "\", bin1, bin2, bin3);"
+       "\", bin1, bin2, bin3);",
        "endmodule"},
-      {"module test;"
+
+      {"module test;\n",
        "  initial $display(\"Value: ",
        {kToken, "%0b"},
        " 'b%0b ",
        {kToken, "%0b"},
-       "\", bin1, bin2, bin3);"
+       "\", bin1, bin2, bin3);",
        "endmodule"},
-      {"module test;"
+
+      {"module test;\n",
        "  initial $display(\"Value: ",
        {kToken, "%0b"},
        " ",
        {kToken, "%0b"},
        " ",
        {kToken, "%0b"},
-       "\",  bin1, bin2, bin3);"
+       "\",  bin1, bin2, bin3);",
        "endmodule"},
 
-      {"module test;"
+      {"module test;\n",
        "  initial $display(\"Value: ",
        {kToken, "0d%0d"},
        {kToken, "'D%0d"},
-       " %0d\", dec1, dec2, dec3);"
+       " %0d\", dec1, dec2, dec3);",
        "endmodule"},
-      {"module test;"
+
+      {"module test;\n",
        "  initial $display(\"Value: %0d ",
        {kToken, "0D%0d"},
        " ",
        {kToken, "'d%0d"},
-       "\", dec1, dec2, dec3);"
+       "\", dec1, dec2, dec3);",
        "endmodule"},
+
       {"module test;"
        "  initial $display(\"Value: %0d %0d %0d\", dec1, dec2, dec3);"
        "endmodule"},
@@ -205,13 +211,16 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
       {"module test;"
        "  initial $display(\"0x%0x, %d\", hex, dec);"
        "endmodule"},
+
       {"module test;"
        "  initial $display(\"0x%0x, 'b%0b\", hex, bin);"
        "endmodule"},
+
       {"module test;"
        "  initial $display(\"Value: 0x%0x (bin: 'b%b, dec: %d)\", hex, bin, "
        "dec);"
        "endmodule"},
+
       {"module test;"
        "  initial $display(\"Value: 0x%0x (bin: ",
        {kToken, "%b"},
@@ -221,6 +230,7 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
       {"module test;"
        "  parameter string fmt = \"Interrupts: %d\";"
        "endmodule"},
+
       {"module test;"
        "  parameter string fmt = \"Interrupts: ",
        {kToken, "'d%d"},
@@ -230,6 +240,7 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
       {"module test;"
        "  parameter string fmt = \"Interrupts: %d (flags: 0x%0x)\";"
        "endmodule"},
+
       {"module test;"
        "  parameter string fmt = \"Interrupts: ",
        {kToken, "'d%d"},
@@ -240,6 +251,7 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
        "  string s;"
        "  initial $sformat(s, \"misc: 0x%0x\", some_hex_value);"
        "endmodule"},
+
       {"module test;"
        "  string s;"
        "  initial $sformat(s, \"misc: ",
@@ -251,6 +263,7 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
        "  string s;"
        "  initial $sformat(s, \"misc: 0b%0b\", some_hex_value);"
        "endmodule"},
+
       {"module test;"
        "  string s;"
        "  initial $sformat(s, \"misc: ",
@@ -262,6 +275,7 @@ TEST(NumericFormatStringStyleRuleTest, BasicTests) {
        "  string s;"
        "  initial $sformat(s, \"counter: %d\", some_dec_value);"
        "endmodule"},
+
       {"module test;"
        "  string s;"
        "  initial $sformat(s, \"counter: ",

--- a/verilog/analysis/lint_rule_registry_test.cc
+++ b/verilog/analysis/lint_rule_registry_test.cc
@@ -14,8 +14,7 @@
 
 #include "verilog/analysis/lint_rule_registry.h"
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -394,12 +394,12 @@ TEST(BuildSymbolTableTest, IntegrityCheckResolvedSymbol) {
     // mind the destruction ordering here:
     // symbol_table1 will outlive symbol_table_2, so give symbol_table_2 a
     // pointer to symbol_table_1.
-    root2.Value().local_references_to_bind.push_back(DependentReferences{
+    root2.Value().local_references_to_bind.emplace_back(
         std::make_unique<ReferenceComponentNode>(ReferenceComponent{
             .identifier = "foo",
             .ref_type = ReferenceType::kUnqualified,
             .required_metatype = SymbolMetaType::kUnspecified,
-            .resolved_symbol = &root1})});
+            .resolved_symbol = &root1}));
     // CheckIntegrity() will fail on destruction of symbol_table_2.
   };
   EXPECT_DEATH(test_func(),
@@ -416,12 +416,12 @@ TEST(BuildSymbolTableTest, IntegrityCheckDeclaredType) {
     // mind the destruction ordering here:
     // symbol_table1 will outlive symbol_table_2, so give symbol_table_2 a
     // pointer to symbol_table_1.
-    root1.Value().local_references_to_bind.push_back(DependentReferences{
+    root1.Value().local_references_to_bind.emplace_back(
         std::make_unique<ReferenceComponentNode>(ReferenceComponent{
             .identifier = "foo",
             .ref_type = ReferenceType::kUnqualified,
             .required_metatype = SymbolMetaType::kUnspecified,
-            .resolved_symbol = &root1})});
+            .resolved_symbol = &root1}));
     root2.Value().declared_type.user_defined_type =
         root1.Value().local_references_to_bind.front().components.get();
     // CheckIntegrity() will fail on destruction of symbol_table_2.

--- a/verilog/analysis/verilog_equivalence_test.cc
+++ b/verilog/analysis/verilog_equivalence_test.cc
@@ -62,9 +62,8 @@ static DiffStatus FlipStatus(DiffStatus status) {
 }
 
 static void ExpectCompareWithErrstream(
-    std::function<DiffStatus(absl::string_view, absl::string_view,
-                             std::ostream*)>
-        func,
+    const std::function<DiffStatus(absl::string_view, absl::string_view,
+                                   std::ostream*)>& func,
     DiffStatus expect_compare, absl::string_view left, absl::string_view right,
     std::ostream* errstream = &std::cout) {
   EXPECT_EQ(func(left, right, errstream), expect_compare)

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -447,7 +447,7 @@ class ViolationFixerTest : public testing::Test {
   LinterConfiguration config_;
 
   absl::Status LintAnalyzeFixText(absl::string_view content,
-                                  ViolationFixer& violation_fixer,
+                                  ViolationFixer* violation_fixer,
                                   std::string* fixed_content) const {
     const ScopedTestFile temp_file(testing::TempDir(), content);
 
@@ -463,8 +463,8 @@ class ViolationFixerTest : public testing::Test {
 
     const std::set<verible::LintViolationWithStatus> violations =
         GetSortedViolations(lint_result.value());
-    violation_fixer.HandleViolations(violations, text_structure.Contents(),
-                                     temp_file.filename());
+    violation_fixer->HandleViolations(violations, text_structure.Contents(),
+                                      temp_file.filename());
 
     const auto ok = GetContents(temp_file.filename(), fixed_content);
     return lint_result.status();
@@ -526,7 +526,7 @@ class ViolationFixerTest : public testing::Test {
         std::string& fixed_source = fixed_sources[i];
 
         const absl::Status status =
-            LintAnalyzeFixText(input_source, violation_fixer, &fixed_source);
+            LintAnalyzeFixText(input_source, &violation_fixer, &fixed_source);
         EXPECT_TRUE(status.ok());
       }
 
@@ -556,7 +556,7 @@ class ViolationFixerTest : public testing::Test {
         std::string& fixed_source = fixed_sources[i];
 
         const absl::Status status =
-            LintAnalyzeFixText(input_source, violation_fixer, &fixed_source);
+            LintAnalyzeFixText(input_source, &violation_fixer, &fixed_source);
         EXPECT_TRUE(status.ok());
       }
 


### PR DESCRIPTION
Mostly
```
.github/bin/run-clang-tidy.sh --checks="-*,performance-inefficient-vector-operation,modernize-use-emplace,performance-unnecessary-value-param,readability-else-after-return,performance-move-const-arg" --fix
```
... but also a few manual changes.