### PR TITLE
Exclude 'suspicious comma' clang-tidy warning.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,6 +56,7 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-move-forwarding-reference,
   -bugprone-narrowing-conversions,
+  -bugprone-suspicious-missing-comma,
   modernize-*,
   -modernize-avoid-bind,
   -modernize-avoid-c-arrays,


### PR DESCRIPTION
This is emitted when there are c-strings concatenated in sequence, an often occurence in test file. The warning wants to point out that there are somtimes commas to separate.

Might be useful to address (and some already are), but given that all these instances are in tests, this is somewhat lower prio.