### PR TITLE
Make constexpr in headers inline.

### DIFF
--- a/verilog/tools/kythe/kythe_schema_constants.h
+++ b/verilog/tools/kythe/kythe_schema_constants.h
@@ -21,42 +21,44 @@ namespace verilog {
 namespace kythe {
 
 // Kythe Nodes.
-constexpr absl::string_view kNodeAnchor = "anchor";
-constexpr absl::string_view kNodeRecord = "record";
-constexpr absl::string_view kNodeInterface = "interface";
-constexpr absl::string_view kNodePackage = "package";
-constexpr absl::string_view kNodeMacro = "macro";
-constexpr absl::string_view kNodeConstant = "constant";
-constexpr absl::string_view kNodeFile = "file";
-constexpr absl::string_view kNodeBuiltin = "tbuiltin";
-constexpr absl::string_view kSubkindModule = "module";
-constexpr absl::string_view kSubkindConstructor = "constructor";
-constexpr absl::string_view kSubkindProgram = "program";
-constexpr absl::string_view kCompleteDefinition = "definition";
-constexpr absl::string_view kInComplete = "incomplete";
-constexpr absl::string_view kNodeVariable = "variable";
-constexpr absl::string_view kNodeFunction = "function";
-constexpr absl::string_view kNodeTAlias = "talias";
+inline constexpr absl::string_view kNodeAnchor = "anchor";
+inline constexpr absl::string_view kNodeRecord = "record";
+inline constexpr absl::string_view kNodeInterface = "interface";
+inline constexpr absl::string_view kNodePackage = "package";
+inline constexpr absl::string_view kNodeMacro = "macro";
+inline constexpr absl::string_view kNodeConstant = "constant";
+inline constexpr absl::string_view kNodeFile = "file";
+inline constexpr absl::string_view kNodeBuiltin = "tbuiltin";
+inline constexpr absl::string_view kSubkindModule = "module";
+inline constexpr absl::string_view kSubkindConstructor = "constructor";
+inline constexpr absl::string_view kSubkindProgram = "program";
+inline constexpr absl::string_view kCompleteDefinition = "definition";
+inline constexpr absl::string_view kInComplete = "incomplete";
+inline constexpr absl::string_view kNodeVariable = "variable";
+inline constexpr absl::string_view kNodeFunction = "function";
+inline constexpr absl::string_view kNodeTAlias = "talias";
 
 // Facts for kythe.
-constexpr absl::string_view kFactText = "/kythe/text";
-constexpr absl::string_view kFactNodeKind = "/kythe/node/kind";
-constexpr absl::string_view kFactSubkind = "/kythe/subkind";
-constexpr absl::string_view kFactComplete = "/kythe/complete";
-constexpr absl::string_view kFactAnchorEnd = "/kythe/loc/end";
-constexpr absl::string_view kFactAnchorStart = "/kythe/loc/start";
+inline constexpr absl::string_view kFactText = "/kythe/text";
+inline constexpr absl::string_view kFactNodeKind = "/kythe/node/kind";
+inline constexpr absl::string_view kFactSubkind = "/kythe/subkind";
+inline constexpr absl::string_view kFactComplete = "/kythe/complete";
+inline constexpr absl::string_view kFactAnchorEnd = "/kythe/loc/end";
+inline constexpr absl::string_view kFactAnchorStart = "/kythe/loc/start";
 
 // Edges for kythe.
-constexpr absl::string_view kEdgeDefinesBinding = "/kythe/edge/defines/binding";
-constexpr absl::string_view kEdgeChildOf = "/kythe/edge/childof";
-constexpr absl::string_view kEdgeRef = "/kythe/edge/ref";
-constexpr absl::string_view kEdgeRefExpands = "/kythe/edge/ref/expands";
-constexpr absl::string_view kEdgeRefCall = "/kythe/edge/ref/call";
-constexpr absl::string_view kEdgeRefImports = "/kythe/edge/ref/imports";
-constexpr absl::string_view kEdgeExtends = "/kythe/edge/extends";
-constexpr absl::string_view kEdgeRefIncludes = "/kythe/edge/ref/includes";
-constexpr absl::string_view kEdgeTyped = "/kythe/edge/typed";
-constexpr absl::string_view kEdgeOverrides = "/kythe/edge/overrides";
+inline constexpr absl::string_view kEdgeDefinesBinding =
+    "/kythe/edge/defines/binding";
+inline constexpr absl::string_view kEdgeChildOf = "/kythe/edge/childof";
+inline constexpr absl::string_view kEdgeRef = "/kythe/edge/ref";
+inline constexpr absl::string_view kEdgeRefExpands = "/kythe/edge/ref/expands";
+inline constexpr absl::string_view kEdgeRefCall = "/kythe/edge/ref/call";
+inline constexpr absl::string_view kEdgeRefImports = "/kythe/edge/ref/imports";
+inline constexpr absl::string_view kEdgeExtends = "/kythe/edge/extends";
+inline constexpr absl::string_view kEdgeRefIncludes =
+    "/kythe/edge/ref/includes";
+inline constexpr absl::string_view kEdgeTyped = "/kythe/edge/typed";
+inline constexpr absl::string_view kEdgeOverrides = "/kythe/edge/overrides";
 
 }  // namespace kythe
 }  // namespace verilog


### PR DESCRIPTION
Thus the compiler won't be bothered that there is a unused constant variable.