### PR TITLE
clang-tidy script: Reformulate file exclusion processing using sed.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt -qqy update
-        apt -qq -y install clang-tidy-11 build-essential git wget gawk
+        apt -qq -y install clang-tidy-11 build-essential git wget
         source ./.github/settings.sh
         ./.github/bin/install-bazel.sh
         echo "TMPDIR=/tmp" >> $GITHUB_ENV

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,5 @@ pkgs.mkShell {
       lcov              # coverage html generation.
       clang-tools_11    # clang-format, clang-tidy
       bazel-buildtools  # buildifier
-      gawk              # clang-tidy script.
     ];
 }


### PR DESCRIPTION
Thus not needing the specialized gnu awk.