### PR TITLE
clang-tidy: content-addressable results in config-dependent dir

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -13,60 +13,79 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Script to run clang-tidy on files in a bazel project while caching the
+# results as clang-tidy can be pretty slow. The clang-tidy output messages
+# are content-addressed in a hash(cc-file-content) cache file.
+
 set -u
+
+readonly PROJECT_NAME=verible           # Prefix for directory in ${TMPDIR}
+readonly EXIT_CODE_ON_WARNINGS=1        # Should fail on warnings found ?
+readonly CLANG_CONFIG_FILE=.clang-tidy  # config file used
 
 if [ ! -f WORKSPACE ]; then
   echo "This script needs to be invoked in the root of the bazel project"
   exit 1
 fi
 
-# The caller can supply additional clang-tidy flags that are passed
-# to it as-is.
+# The caller can supply additional clang-tidy flags that are passed as-is
 # Example:
-# .github/bin/run-clang-tidy.sh --checks="-*,modernize-use-equals-default" --fix
-readonly ADDITIONAL_TIDY_OPTIONS=("$@")
+#   run-clang-tidy.sh --checks="-*,modernize-use-equals-default" --fix
+readonly ADDITIONAL_TIDY_OPTIONS="$@"
+readonly PARALLEL_COUNT="$(nproc)"
 
-readonly CLANG_CONFIG_FILE=.clang-tidy
+# clang-tidy binary name can be provided in CLANG_TIDY environment variable.
+# If not set, try to auto-determine. Prefer clang-tidy-11 in that
+# case as it is the last that supports google-runtime-references.
+CLANG_TIDY="${CLANG_TIDY:-empty_env}"
+if [ "${CLANG_TIDY}" == "empty_env" ]; then
+  # fallback search to what is found in $PATH, with version priority
+  CLANG_TIDY=clang-tidy
+  for version in 11 12 13 14 15; do
+    if command -v "clang-tidy-${version}"; then
+      CLANG_TIDY="clang-tidy-${version}"
+      break
+    fi
+  done
+fi
+
+hash "${CLANG_TIDY}" || exit 2  # make sure it is installed.
 
 TMPDIR="${TMPDIR:-/tmp}"
-readonly NAME_PREFIX=verible-clang-tidy  # Make files easy to tab-complete-find
-readonly CLANG_TIDY_CONFIG_MSG=${TMPDIR}/${NAME_PREFIX}-config.msg
+EXIT_CODE=0
 
-readonly PARALLEL_COUNT=$(nproc)
-readonly FILES_PER_INVOCATION=1
+# Assemble unique name depending on the configuration. This allows to play with
+# various clang-tidy versions and have outputs cached in separate directories.
+readonly CLANG_SHORT_VERSION="$(${CLANG_TIDY} --version | sed 's/.*version \([0-9]\+\).*/\1/p;d')"
+readonly CONFIG_NAME="v${CLANG_SHORT_VERSION}_$((${CLANG_TIDY} --version; cat ${CLANG_CONFIG_FILE} WORKSPACE; echo ${ADDITIONAL_TIDY_OPTIONS}) | md5sum | cut -b1-8)"
 
-readonly CLANG_TIDY_SEEN_CACHE=${TMPDIR}/${NAME_PREFIX}-hashes.cache
-touch ${CLANG_TIDY_SEEN_CACHE}  # Just in case it is not there yet
+readonly BASE_DIR="${TMPDIR}/${PROJECT_NAME}-clang-tidy-${CONFIG_NAME}"
+readonly BASE_DIR_TMP="${BASE_DIR}/tmp"
+readonly CONTENT_DIR="${BASE_DIR}/contents"
+mkdir -p "${BASE_DIR}" "${BASE_DIR_TMP}" "${CONTENT_DIR}"
+echo "Cache directory: ${BASE_DIR}/"
 
-readonly FILES_TO_PROCESS=${TMPDIR}/${NAME_PREFIX}-files.list
-readonly TIDY_OUT=${TMPDIR}/${NAME_PREFIX}.out
+readonly CLANG_TIDY_CONFIG_MSG="${BASE_DIR_TMP}/config.msg"
+readonly INCLUDE_REPLACE="${BASE_DIR_TMP}/include-replace.expression"
+readonly FILES_OF_INTEREST="${BASE_DIR_TMP}/files.all"
+readonly HASHES_OF_INTEREST="${BASE_DIR_TMP}/hashes.interest"
+readonly FILE_HASHES_TO_PROCESS="${BASE_DIR_TMP}/files-hash.process"
+trap 'rm -rf -- "${BASE_DIR_TMP}"' EXIT
 
-# Use clang-tidy-11 if available as it still checks for
-# google-runtime-references, non-const references - which is the
-# preferred style in this project.
-# If not, increase version until we find some that is available.
-# (from old to new, as newer ones might have warnings not yet
-# anticipated in the clang-tidy configuration).
-CLANG_TIDY=clang-tidy
-for version in 11 12 13 14 ; do
-  if command -v clang-tidy-${version}; then
-    CLANG_TIDY=clang-tidy-${version}
-    break
-  fi
-done
-hash ${CLANG_TIDY} || exit 2  # make sure it is installed.
+readonly TIDY_OUT="${BASE_DIR}/tidy.out"
+readonly CURRENT_TIDY_OUT="${TMPDIR}/${PROJECT_NAME}-clang-tidy-current.out"
 
 # Explicitly test the configuration, otherwise clang-tidy will silently
 # fall back to some minimal default config.
 
 # A particular annoying thing: if there is a comment in the configuration,
-# things break. Silently.
+# checks are ignored. Silently.
 awk '
 BEGIN      { in_rules = 0; }
 /^Checks:/ { in_rules = 1; }
 /#/        { if (in_rules)  { printf("Comment found %s\n", $0); exit(1); } }
-END        { if (!in_rules) { printf("Never seen Checks: >\n"); exit(2); } }' \
-      < ${CLANG_CONFIG_FILE}
+END        { if (!in_rules) { printf("Never seen Checks: >\n"); exit(2); } }
+'  < "${CLANG_CONFIG_FILE}"
 
 if [ $? -ne 0 ]; then
   echo "::error:: config not valid: clang-tidy can't deal with comments."
@@ -76,96 +95,106 @@ fi
 # If there is an issue with the configuration, clang tidy will
 # not exit with a non-zero exit code (at least clang-tidy-11)
 # But at least there will be an error message to stderr.
-${CLANG_TIDY} --config="$(cat ${CLANG_CONFIG_FILE})" --dump-config \
-  > /dev/null 2> ${CLANG_TIDY_CONFIG_MSG}
-if [ -s ${CLANG_TIDY_CONFIG_MSG} ]; then
-  cat ${CLANG_TIDY_CONFIG_MSG}
+"${CLANG_TIDY}" --config="$(cat ${CLANG_CONFIG_FILE})" --dump-config \
+  > /dev/null 2> "${CLANG_TIDY_CONFIG_MSG}"
+if [ -s "${CLANG_TIDY_CONFIG_MSG}" ]; then
+  cat "${CLANG_TIDY_CONFIG_MSG}"
   exit 1
 fi
 
-echo ::group::Build compilation database
+: > "${HASHES_OF_INTEREST}"      # truncate if exists; we'll re-create below
+: > "${FILE_HASHES_TO_PROCESS}"
+: > "${INCLUDE_REPLACE}"
 
-time $(dirname $0)/make-compilation-db.sh
+# All the files we want to run clang-tidy on: *.cc and *.h
+find . -name "*.cc" -or -name "*.h" \
+  | grep -v "verilog/tools/ls/vscode" \
+  | sed 's|^\./||' > "${FILES_OF_INTEREST}"
 
-# The files might be reported with various absolute prefixes that
-# we remove to canonicalize and report as relative paths from project
-# root.
-readonly EXEC_ROOT="$(bazel info execution_root)"
-readonly CURRENT_DIR="$(pwd)"
-readonly CANONICALIZE_SOURCE_PATH_REGEX="^\(${EXEC_ROOT}\|${CURRENT_DIR}\|\.\)/"
+# Changing a header should also process all files depending on it.
+# We can't do full C-preprocessing as we don't have all -I available, so
+# we simply replace references to headers with hashes of their content.
+# If content of these files change, the hashes of the includers will change.
+#   #include "foo/bar/baz.h" -> #include "a46b89dd7a7f8f108b836b50762fb6e1"
+# Ideally loop until no changes in hashes, but one level good enough.
 
-# We create a hash of each file content to only have to look at new files.
-# (TODO: could the tidy result be different if an include content changes ?
-#  Then we have to do g++ -E (using compilation database knowing about -I etc.)
-#  or combine hashes of all mentioned #includes that are also in our list)
-# Make need to re-run file dependent on clang-tidy configuration, WORKSPACE
-# and of course file content.
-for f in $(find . -name "*.cc" -or -name "*.h" \
-             | grep -v "verilog/tools/ls/vscode" \
-           )
-do
-  (${CLANG_TIDY} --version; cat ${CLANG_CONFIG_FILE} WORKSPACE $f) \
-    | md5sum | sed -e "s|-|$f|g"
-done | sort > "${CLANG_TIDY_SEEN_CACHE}".new
+# Create a sed expression that replaces header filenames with content hash.
+for f in $(cat ${FILES_OF_INTEREST}); do
+  if [ "${f##*.}" == "h" ]; then     # only headers expected to be relevant
+    c_hash="$(cat $f | md5sum | awk '{print $1}')"
+    echo "s|$f|$c_hash|g" | sed 's|\.|\\.|g' >> "${INCLUDE_REPLACE}"
+  fi
+done
 
-# Only the files with different hashes are the ones we want to process.
-join -v2 "${CLANG_TIDY_SEEN_CACHE}" "${CLANG_TIDY_SEEN_CACHE}".new \
-  | awk '{print $2}' | sort > "${FILES_TO_PROCESS}"
+# Create a content hash of each file, first changing include filenames with
+# their content-hash as described above.
+# Make a list of all files we don't have hashes for yet.
+for f in $(cat ${FILES_OF_INTEREST}); do
+  c_hash="$(sed -f "${INCLUDE_REPLACE}" < $f | md5sum | awk '{print $1}')"
+  echo "${c_hash}" >> "${HASHES_OF_INTEREST}"
+  if [ ! -r "${CONTENT_DIR}/${c_hash}" ]; then  # don't have, need to create
+    echo "${c_hash} ${f}" >> "${FILE_HASHES_TO_PROCESS}"
+  else
+    touch "${CONTENT_DIR}/${c_hash}"  # keep current to prevent garbage collect
+  fi
+done
 
-echo "::group::$(wc -l < ${FILES_TO_PROCESS}) files to process"
-cat "${FILES_TO_PROCESS}"
-echo "::endgroup::"
+echo "$(wc -l < ${HASHES_OF_INTEREST}) files of interest."
 
-EXIT_CODE=0
-if [ -s ${FILES_TO_PROCESS} ]; then
-  echo "::group::Run ${PARALLEL_COUNT} parallel invocations of ${CLANG_TIDY} in chunks of ${FILES_PER_INVOCATION} files."
-
-  cat ${FILES_TO_PROCESS} \
-    | xargs -P${PARALLEL_COUNT} -n ${FILES_PER_INVOCATION} -- \
-      ${CLANG_TIDY} --config="$(cat ${CLANG_CONFIG_FILE})" --quiet "${ADDITIONAL_TIDY_OPTIONS[@]}" 2>/dev/null \
-    | sed -e "s@${CANONICALIZE_SOURCE_PATH_REGEX}@@g" \
-    > ${TIDY_OUT}.tmp
-
-  mv ${TIDY_OUT}.tmp ${TIDY_OUT}
-  cat ${TIDY_OUT}
+if [ -s "${FILE_HASHES_TO_PROCESS}" ]; then
+  echo "::group::$(wc -l < ${FILE_HASHES_TO_PROCESS}) files to process"
+  cat "${FILE_HASHES_TO_PROCESS}"
   echo "::endgroup::"
 
-  echo ::group::Summary
-  sed -e 's|\(.*\)\(\[[a-zA-Z.-]*\]$\)|\2|p;d' < ${TIDY_OUT} | sort | uniq -c | sort -rn
+  # A compilation database is needed to run clang tidy.
+  echo ::group::Build compilation database
+  $(dirname $0)/make-compilation-db.sh
   echo "::endgroup::"
-else
-  echo "Skipping clang-tidy run: nothing to do"
+
+  # The files might be reported with various absolute prefixes that
+  # we remove to canonicalize and report as relative paths from project
+  # root.
+  readonly EXEC_ROOT="$(bazel info execution_root)"
+  readonly CURRENT_DIR="$(pwd)"
+  readonly CANONICALIZE_SOURCE_PATH_REGEX="^\(${EXEC_ROOT}\|${CURRENT_DIR}\|\.\)/"
+
+  # Call an in-line shell script in parallel that gets the file/hash tuple
+  # as parameter. Split the argument into ${args[0]} (hash value)
+  # and ${args[1]} (cc-file to process) and call clang-tidy on it. So each
+  # clang-tidy result is stored to its content-addressed file.
+  # (shell-quoting nightmare ahead:)
+  echo "Processing in ${PARALLEL_COUNT} parallel invocations of ${CLANG_TIDY}"
+  cat "${FILE_HASHES_TO_PROCESS}" | \
+    xargs -P"${PARALLEL_COUNT}" -d'\n' -n1 -- \
+          bash -c "read -a args <<< \$1 ;
+              ${CLANG_TIDY} --config=\"$(cat ${CLANG_CONFIG_FILE})\" \
+              --quiet ${ADDITIONAL_TIDY_OPTIONS} \${args[1]} 2>/dev/null \
+              | sed -e \"s@${CANONICALIZE_SOURCE_PATH_REGEX}@@g\" \
+              > ${CONTENT_DIR}/\${args[0]}" --args
 fi
 
+# Assemble the outputs of all files of interest into one clang tidy output
+while read -r content_hash ; do
+  cat "${CONTENT_DIR}/${content_hash}"
+done < "${HASHES_OF_INTEREST}" > "${TIDY_OUT}"
+
+ln -sf "${TIDY_OUT}" "${CURRENT_TIDY_OUT}"
 
 if [ -s "${TIDY_OUT}" ]; then
-  EXIT_CODE=1
-  echo "::error::There were clang-tidy warnings. Please fix"
-  echo "You find the raw output in ${TIDY_OUT}"
-  # Assemble a sed expression that matches all files that were mentioned
-  # in the clang-tidy output.
-  # Use that to filter the file list cache to leave out files with failures,
-  # but keep the ones that had no issues.
-  # That way, only files that had issues will have to be processed in
-  # subsequent clang-tidy runs.
+  EXIT_CODE="${EXIT_CODE_ON_WARNINGS}"
+  echo "::warning::There were clang-tidy warnings. Please fix."
+  echo "::group::clang-tidy detailed output"
+  cat "${TIDY_OUT}"
+  echo "Find this output in ${CURRENT_TIDY_OUT}"
+  echo "::endgroup::"
 
-  # Extract filenames from error messages in clang-tidy output
-  sed 's/^\([a-zA-Z0-9_/.-]\+\):[0-9].*/\1/p;d' "${TIDY_OUT}" \
-    | sort | uniq > "${CLANG_TIDY_SEEN_CACHE}".files_with_issues
-
-  # Escape regex special characters in paths, then convert to delete sed expr
-  sed 's|\([/.-]\)|\\\1|g' "${CLANG_TIDY_SEEN_CACHE}".files_with_issues \
-    | sed 's|^.*$|/\0/d|' > "${CLANG_TIDY_SEEN_CACHE}".exclude_expression
-
-  # Exclude all lines in cache representing files that need reprocessing
-  sed -f "${CLANG_TIDY_SEEN_CACHE}".exclude_expression \
-    < "${CLANG_TIDY_SEEN_CACHE}".new > "${CLANG_TIDY_SEEN_CACHE}"
+  echo "Summary"
+  sed -e 's|\(.*\)\(\[[a-zA-Z.-]*\]$\)|\2|p;d' < "${TIDY_OUT}" \
+    | sort | uniq -c | sort -rn
 else
-  # No complaints. We can keep the enire list now as baseline for next time.
-  cp "${CLANG_TIDY_SEEN_CACHE}".new "${CLANG_TIDY_SEEN_CACHE}"
   echo "No clang-tidy complaints.😎"
 fi
 
-echo "To reduce the work on next invocation, keep ${CLANG_TIDY_SEEN_CACHE}"
+find "${CONTENT_DIR}" -type f -mtime +30 -delete  # garbage collect not used
 
-exit ${EXIT_CODE}
+exit "${EXIT_CODE}"

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -75,10 +75,9 @@ jobs:
     - name: Install Dependencies
       run: |
         apt -qqy update
-        apt -qq -y install clang-tidy-11 clang-tidy-15 build-essential git wget
+        apt -qq -y install clang-tidy-11 clang-tidy-14 build-essential git wget
         source ./.github/settings.sh
         ./.github/bin/install-bazel.sh
-        echo "TMPDIR=/tmp" >> $GITHUB_ENV
 
     - name: Create Cache Timestamp
       id: cache_timestamp
@@ -90,7 +89,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          /tmp/verible-clang-tidy-*/contents
+          /root/.cache/clang-tidy
           /root/.cache/bazel
         key: clang-tidy-${{ steps.cache_timestamp.outputs.time }}
         restore-keys: clang-tidy-
@@ -99,7 +98,7 @@ jobs:
       run: |
         # For runtime references, use clang-tidy 11, everything else: latest.
         CLANG_TIDY=clang-tidy-11 ./.github/bin/run-clang-tidy.sh --checks="-*,google-runtime-references"
-        CLANG_TIDY=clang-tidy-15 ./.github/bin/run-clang-tidy.sh
+        CLANG_TIDY=clang-tidy-14 ./.github/bin/run-clang-tidy.sh
 
     - name: 📤 Upload performance graphs
       uses: actions/upload-artifact@v2

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt -qqy update
-        apt -qq -y install clang-tidy-11 build-essential git wget
+        apt -qq -y install clang-tidy-11 clang-tidy-15 build-essential git wget
         source ./.github/settings.sh
         ./.github/bin/install-bazel.sh
         echo "TMPDIR=/tmp" >> $GITHUB_ENV
@@ -90,13 +90,16 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          /tmp/verible-clang-tidy-hashes.cache
+          /tmp/verible-clang-tidy-*/contents
           /root/.cache/bazel
         key: clang-tidy-${{ steps.cache_timestamp.outputs.time }}
         restore-keys: clang-tidy-
 
     - name: Run clang tidy
-      run: ./.github/bin/run-clang-tidy.sh
+      run: |
+        # For runtime references, use clang-tidy 11, everything else: latest.
+        CLANG_TIDY=clang-tidy-11 ./.github/bin/run-clang-tidy.sh --checks="-*,google-runtime-references"
+        CLANG_TIDY=clang-tidy-15 ./.github/bin/run-clang-tidy.sh
 
     - name: 📤 Upload performance graphs
       uses: actions/upload-artifact@v2

--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ pkgs.mkShell {
 
       # Ease development
       lcov              # coverage html generation.
-      clang-tools_15    # clang-format, clang-tidy
+      clang-tools_14    # clang-format, clang-tidy
       bazel-buildtools  # buildifier
     ];
 }


### PR DESCRIPTION
Name the directory based on the active configuration, so that
it is possible to play with multiple configurations without
loosing cached information. In particular this means that files with
issues don't have to be reprocessed unless changed; the corresponding
cached clang-tidy output is just re-used.
    
For each cc-file, store the output of clang-tidy content-addressed,
so that a minimum of reprocessing is needed: if a file with a
particular content has been processed with a particular clang-tidy,
that content is cached and retrieved quickly.

Make sure that cc files are reprocessed if any of their headers
change.

Not only does this improve performance for unchanged files, the
implementation is also much simpler as we now use named files
instead of working with lines in a cache file.

Provide a symbolic link that points to the last called
clang-tidy output file; thus this can be used as a stable location.
    
If `CLANG_TIDY` environment variable is set, use its content
as the clang-tidy binary to call, otherwise fall back to search
in system path.