### PR TITLE
No temporary objects for emplace back. Test std::optional before use.

### DIFF
--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -1060,9 +1060,9 @@ ExtractAlignmentGroupsFunction ExtractAlignmentGroupsAdapter(
     for (const auto& range : ranges) {
       // Apply the same alignment scanner and policy to all alignment groups.
       // This ignores range.match_subtype.
-      groups.emplace_back(AlignablePartitionGroup{
+      groups.emplace_back(
           FilterAlignablePartitions(range.range, legacy_ignore_predicate),
-          alignment_cell_scanner, alignment_policy});
+          alignment_cell_scanner, alignment_policy);
       if (groups.back().IsEmpty()) groups.pop_back();
     }
     return groups;

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -59,7 +59,7 @@ class AlignmentTestFixture : public ::testing::Test,
         tokens_(absl::StrSplit(sample_, absl::ByAnyChar(" \n"),
                                absl::SkipEmpty())) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     // sample_ is the memory-owning string buffer
     CreateTokenInfosExternalStringBuffer(ftokens_);
@@ -1487,7 +1487,7 @@ class FormatUsingOriginalSpacingTest : public ::testing::Test,
         tokens_(absl::StrSplit(sample_, OutsideCharPairs('<', '>'),
                                absl::SkipEmpty())) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     // sample_ is the memory-owning string buffer
     CreateTokenInfosExternalStringBuffer(ftokens_);

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -149,7 +149,7 @@ class LayoutTest : public ::testing::Test, public UnwrappedLineMemoryHandler {
             "loooooong_line"),
         tokens_(absl::StrSplit(sample_, '\n')) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     CreateTokenInfos(ftokens_);
   }
@@ -677,8 +677,8 @@ class LayoutFunctionFactoryTest : public ::testing::Test,
     // Create two sets of tokens
     const size_t number_of_tokens_in_set = tokens_.size();
     ftokens_.reserve(number_of_tokens_in_set * 2);
-    for (const auto token : tokens_) ftokens_.emplace_back(TokenInfo{1, token});
-    for (const auto token : tokens_) ftokens_.emplace_back(TokenInfo{1, token});
+    for (const auto token : tokens_) ftokens_.emplace_back(1, token);
+    for (const auto token : tokens_) ftokens_.emplace_back(1, token);
 
     CreateTokenInfosExternalStringBuffer(ftokens_);
 
@@ -1965,7 +1965,7 @@ class TreeReconstructorTest : public ::testing::Test,
       : sample_("first_line second_line third_line fourth_line"),
         tokens_(absl::StrSplit(sample_, ' ')) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     CreateTokenInfos(ftokens_);
   }
@@ -2323,7 +2323,7 @@ class OptimizeTokenPartitionTreeTest : public ::testing::Test,
             "seven eight nine ten eleven twelve"),
         tokens_(absl::StrSplit(sample_, ' ')) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     CreateTokenInfos(ftokens_);
   }

--- a/common/formatting/token_partition_tree_test.cc
+++ b/common/formatting/token_partition_tree_test.cc
@@ -45,7 +45,7 @@ class TokenPartitionTreeTestFixture : public ::testing::Test,
       : sample_("one two three four five six"),
         tokens_(absl::StrSplit(sample_, ' ')) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     CreateTokenInfos(ftokens_);
   }
@@ -1239,7 +1239,7 @@ class GetSubpartitionsBetweenBlankLinesTest
         partition_(/* temporary */ UnwrappedLine()) {
     CHECK_EQ(tokens_.size(), 8);
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     // sample_ is the memory-owning string buffer
     CreateTokenInfosExternalStringBuffer(ftokens_);
@@ -2702,7 +2702,7 @@ class ReshapeFittingSubpartitionsTestFixture
             "type_e_eeeeeeee, type_f_ffff);"),
         tokens_(absl::StrSplit(sample_, ' ')) {
     for (const auto token : tokens_) {
-      ftokens_.emplace_back(TokenInfo{1, token});
+      ftokens_.emplace_back(1, token);
     }
     CreateTokenInfos(ftokens_);
   }

--- a/common/text/tree_context_visitor_test.cc
+++ b/common/text/tree_context_visitor_test.cc
@@ -48,6 +48,7 @@ class ContextRecorder : public BaseVisitor {
 
   std::vector<std::vector<int>> ContextTagHistory() const {
     std::vector<std::vector<int>> result;
+    result.reserve(context_history_.size());
     for (const auto& context : context_history_) {
       result.emplace_back(ContextToTags(context));
     }

--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ pkgs.mkShell {
 
       # Ease development
       lcov              # coverage html generation.
-      clang-tools_11    # clang-format, clang-tidy
+      clang-tools_15    # clang-format, clang-tidy
       bazel-buildtools  # buildifier
     ];
 }

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -1426,9 +1426,9 @@ static std::vector<AlignablePartitionGroup> ExtractAlignablePartitionGroups(
     // match_subtype.  This supports aligning a heterogenous collection of
     // alignable partition groups from the same parent partition (full_range).
     groups.emplace_back(
-      FilterAlignablePartitions(range.range, ignore_group_predicate),
-      AlignmentColumnScannerSelector(vstyle, range.match_subtype),
-      AlignmentPolicySelector(vstyle, range.match_subtype));
+        FilterAlignablePartitions(range.range, ignore_group_predicate),
+        AlignmentColumnScannerSelector(vstyle, range.match_subtype),
+        AlignmentPolicySelector(vstyle, range.match_subtype));
     if (groups.back().IsEmpty()) groups.pop_back();
   }
   return groups;

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -1425,10 +1425,10 @@ static std::vector<AlignablePartitionGroup> ExtractAlignablePartitionGroups(
     // Use the alignment scanner and policy that correspond to the
     // match_subtype.  This supports aligning a heterogenous collection of
     // alignable partition groups from the same parent partition (full_range).
-    groups.emplace_back(AlignablePartitionGroup{
-        FilterAlignablePartitions(range.range, ignore_group_predicate),
-        AlignmentColumnScannerSelector(vstyle, range.match_subtype),
-        AlignmentPolicySelector(vstyle, range.match_subtype)});
+    groups.emplace_back(
+      FilterAlignablePartitions(range.range, ignore_group_predicate),
+      AlignmentColumnScannerSelector(vstyle, range.match_subtype),
+      AlignmentPolicySelector(vstyle, range.match_subtype));
     if (groups.back().IsEmpty()) groups.pop_back();
   }
   return groups;

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -326,8 +326,8 @@ void VerilogPreprocess::RegisterMacroDefinition(
   const bool inserted = InsertOrUpdate(&preprocess_data_.macro_definitions,
                                        definition.Name(), definition);
   if (inserted) return;
-  preprocess_data_.warnings.emplace_back(
-      definition.NameToken(), "Re-defining macro");
+  preprocess_data_.warnings.emplace_back(definition.NameToken(),
+                                         "Re-defining macro");
   // TODO(hzeller): multiline warning with 'previously defined here' location
 }
 

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -258,8 +258,7 @@ absl::Status VerilogPreprocess::ConsumeAndParseMacroCall(
       continue;
     }
     if ((*token_iter)->text() == ",") {
-      macro_call->positional_arguments.emplace_back(
-          verible::DefaultTokenInfo());
+      macro_call->positional_arguments.emplace_back();  // default token info
       token_iter = GenerateBypassWhiteSpaces(generator);
       parameters_size--;
       continue;
@@ -270,8 +269,7 @@ absl::Status VerilogPreprocess::ConsumeAndParseMacroCall(
   }
   if (parameters_size > 0) {
     while (parameters_size--) {
-      macro_call->positional_arguments.emplace_back(
-          verible::DefaultTokenInfo());
+      macro_call->positional_arguments.emplace_back();  // default token info
     }
   }
   return absl::OkStatus();
@@ -292,9 +290,9 @@ absl::Status VerilogPreprocess::HandleMacroIdentifier(
   const auto* found =
       FindOrNull(preprocess_data_.macro_definitions, sv.substr(1));
   if (!found) {
-    preprocess_data_.errors.emplace_back(VerilogPreprocessError(
+    preprocess_data_.errors.emplace_back(
         **iter,
-        "Error expanding macro identifier, might not be defined before."));
+        "Error expanding macro identifier, might not be defined before.");
     return absl::InvalidArgumentError(
         "Error expanding macro identifier, might not be defined before.");
   }
@@ -329,7 +327,7 @@ void VerilogPreprocess::RegisterMacroDefinition(
                                        definition.Name(), definition);
   if (inserted) return;
   preprocess_data_.warnings.emplace_back(
-      VerilogPreprocessError(definition.NameToken(), "Re-defining macro"));
+      definition.NameToken(), "Re-defining macro");
   // TODO(hzeller): multiline warning with 'previously defined here' location
 }
 

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -331,6 +331,9 @@ std::optional<SignatureDigest> KytheFactsExtractor::GetParentTypeScope(
     focused_scope = parent_type->type_scope;
   }
 
+  if (!parent_type.has_value()) {
+    return std::nullopt;
+  }
   VLOG(2) << "GetParentTypeScope for " << node_name << " succeeded. Parent: "
           << scope_resolver_->ScopeDebug(parent_type->type_scope);
   return parent_type->type_scope;

--- a/verilog/tools/kythe/scope_resolver_test.cc
+++ b/verilog/tools/kythe/scope_resolver_test.cc
@@ -76,16 +76,20 @@ TEST(ScopeResolverTests, AddAndFindDefinition) {
       scope_resolver.FindScopeAndDefinition(vnames[2].signature.Names().back());
 
   ASSERT_TRUE(def_without_type.has_value());
-  EXPECT_EQ(def_without_type->instantiation_scope,
-            scope_resolver.CurrentScopeDigest());
-  EXPECT_EQ(def_without_type->type_scope, vnames[0].signature.Digest());
-  EXPECT_EQ(def_without_type->vname.signature, vnames[0].signature);
+  if (def_without_type.has_value()) {   // make clang-tidy happy.
+    EXPECT_EQ(def_without_type->instantiation_scope,
+              scope_resolver.CurrentScopeDigest());
+    EXPECT_EQ(def_without_type->type_scope, vnames[0].signature.Digest());
+    EXPECT_EQ(def_without_type->vname.signature, vnames[0].signature);
+  }
 
   ASSERT_TRUE(def_with_type.has_value());
-  EXPECT_EQ(def_with_type->instantiation_scope,
-            scope_resolver.CurrentScopeDigest());
-  EXPECT_EQ(def_with_type->type_scope, signatures[5].Digest());
-  EXPECT_EQ(def_with_type->vname.signature, vnames[1].signature);
+  if (def_with_type.has_value()) {   // make clang-tidy happy.
+    EXPECT_EQ(def_with_type->instantiation_scope,
+              scope_resolver.CurrentScopeDigest());
+    EXPECT_EQ(def_with_type->type_scope, signatures[5].Digest());
+    EXPECT_EQ(def_with_type->vname.signature, vnames[1].signature);
+  }
 
   EXPECT_FALSE(unknown_def.has_value());
 }
@@ -132,17 +136,22 @@ TEST(ScopeResolverTests, SameNameVariableInMultipleScopes) {
   const auto def_var1 =
       scope_resolver.FindScopeAndDefinition(name, signatures[6].Digest());
   ASSERT_TRUE(def_var1.has_value());
-  EXPECT_EQ(def_var1->vname.signature, sig1);
+  if (def_var1.has_value()) {  // make clang-tidy happy
+    EXPECT_EQ(def_var1->vname.signature, sig1);
+  }
 
   const auto def_var2 =
       scope_resolver.FindScopeAndDefinition(name, signatures[0].Digest());
   ASSERT_TRUE(def_var2.has_value());
-  EXPECT_EQ(def_var2->vname.signature, sig2);
-
+  if (def_var2.has_value()) {  // make clang-tidy happy
+    EXPECT_EQ(def_var2->vname.signature, sig2);
+  }
   const auto def_var_current_scope =
       scope_resolver.FindScopeAndDefinition(name);
   ASSERT_TRUE(def_var_current_scope.has_value());
-  EXPECT_EQ(def_var_current_scope->vname.signature, sig2);
+  if (def_var_current_scope.has_value()) {  // make clang-tidy happy.
+    EXPECT_EQ(def_var_current_scope->vname.signature, sig2);
+  }
 }
 
 TEST(ScopeResolverTests, ListScopeMembers) {

--- a/verilog/tools/kythe/scope_resolver_test.cc
+++ b/verilog/tools/kythe/scope_resolver_test.cc
@@ -76,7 +76,7 @@ TEST(ScopeResolverTests, AddAndFindDefinition) {
       scope_resolver.FindScopeAndDefinition(vnames[2].signature.Names().back());
 
   ASSERT_TRUE(def_without_type.has_value());
-  if (def_without_type.has_value()) {   // make clang-tidy happy.
+  if (def_without_type.has_value()) {  // make clang-tidy happy.
     EXPECT_EQ(def_without_type->instantiation_scope,
               scope_resolver.CurrentScopeDigest());
     EXPECT_EQ(def_without_type->type_scope, vnames[0].signature.Digest());
@@ -84,7 +84,7 @@ TEST(ScopeResolverTests, AddAndFindDefinition) {
   }
 
   ASSERT_TRUE(def_with_type.has_value());
-  if (def_with_type.has_value()) {   // make clang-tidy happy.
+  if (def_with_type.has_value()) {  // make clang-tidy happy.
     EXPECT_EQ(def_with_type->instantiation_scope,
               scope_resolver.CurrentScopeDigest());
     EXPECT_EQ(def_with_type->type_scope, signatures[5].Digest());


### PR DESCRIPTION
Detected by clang-tidy-15.
The std::optional test (bugprone-unchecked-optional-access) found one real issue, but also some false-positives (that are easily worked around) in unit tests.
    
