### PR TITLE
Fix c++20 string_view constructor ambiguity.

### DIFF
--- a/common/analysis/line_linter_test.cc
+++ b/common/analysis/line_linter_test.cc
@@ -65,7 +65,7 @@ TEST(LineLinterTest, NoRules) {
 
 // This test verifies that LineLinter works with a single rule.
 TEST(LineLinterTest, OneRuleAcceptsLines) {
-  std::vector<absl::string_view> lines{{"abc", "def"}};
+  std::vector<absl::string_view> lines{"abc", "def"};
   LineLinter linter;
   linter.AddRule(MakeBlankLineRule());
   linter.Lint(lines);
@@ -77,7 +77,7 @@ TEST(LineLinterTest, OneRuleAcceptsLines) {
 
 // This test verifies that LineLinter can find violations.
 TEST(LineLinterTest, OneRuleRejectsLine) {
-  std::vector<absl::string_view> lines{{"abc", "", "def"}};
+  std::vector<absl::string_view> lines{"abc", "", "def"};
   LineLinter linter;
   linter.AddRule(MakeBlankLineRule());
   linter.Lint(lines);
@@ -115,7 +115,7 @@ std::unique_ptr<LineLintRule> MakeEmptyFileRule() {
 
 // This test verifies that LineLinter calls Finalize without error.
 TEST(LineLinterTest, FinalizeAccepts) {
-  std::vector<absl::string_view> lines{{"x"}};
+  std::vector<absl::string_view> lines{"x"};
   LineLinter linter;
   linter.AddRule(MakeEmptyFileRule());
   linter.Lint(lines);


### PR DESCRIPTION
In C++20, a new constructor for std::string_view (of which absl::string_view is an alias in most cases starting in C++17), causes a double-braced pair of string literals in this context to be treated as a std::vector of a single string_view which is constructed from both literals.

This new constructor is intended to take a pair of begin and end iterators, but can also accept two string literals (since they are iterators of char, after all). In that case, a string_view over all of the intervening memory is returned. That is not the intention here.