### PR TITLE
Don't suggest to use emplace_back() all the time.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -67,6 +67,7 @@ Checks: >
   -modernize-raw-string-literal,
   -modernize-return-braced-init-list,
   -modernize-use-auto,
+  -modernize-use-emplace,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -modernize-use-transparent-functors,
@@ -76,6 +77,3 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,
   -misc-unused-parameters,
-
-WarningsAsErrors: ''
-HeaderFilterRegex: ''

--- a/.github/bin/run-clang-tidy-cached.cc
+++ b/.github/bin/run-clang-tidy-cached.cc
@@ -148,7 +148,7 @@ void ClangTidyProcessFiles(const fs::path &content_dir, const std::string &cmd,
 int main(int argc, char *argv[]) {
   const std::string kProjectPrefix = "verible_";
   const std::string kSearchDir = ".";
-  const std::string kFileExcludeRe = "vscode/|run-clang-tidy";
+  const std::string kFileExcludeRe = "vscode/|external_libs/|.github/";
 
   const std::string kTidySymlink = kProjectPrefix + "clang-tidy.out";
   const fs::path cache_dir = GetCacheDir() / "clang-tidy";


### PR DESCRIPTION
This is an interesting read: https://abseil.io/tips/112 TL;DR: yes, using emplace_back() can improve performance, but there can also be surprising effects. So using it might depend on the context, but it is not necessarily a 'should always' suggestion (but if we have them in the .clang-tidy, the CI will fail).

While at it, expand the set of directories that should be excluded as they don't contain the main project code.