### PR TITLE
json-rpc-dispatcher: Make calling with no parameters more robust.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -77,3 +77,4 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,

--- a/common/lsp/dummy-ls_test.sh
+++ b/common/lsp/dummy-ls_test.sh
@@ -29,7 +29,7 @@ MSG_OUT=${TEST_TMPDIR:-/tmp/}/test-lsp-out-msg.txt
 # Simple end-to-end test
 awk '{printf("Content-Length: %d\r\n\r\n%s", length($0), $0)}' > ${TMP_IN} <<EOF
 {"jsonrpc":"2.0","method":"initialize","params":null,"id":1}
-{"jsonrpc":"2.0","method":"shutdown","params":{},"id":2}
+{"jsonrpc":"2.0","method":"shutdown","id":2}
 EOF
 
 cat > "${JSON_EXPECTED}" <<EOF


### PR DESCRIPTION
I noticed that vscode calls the shutdown method without actually sending a "params" object - which is fine, as there are none. Make sure that we handle the absense of a "params" object gracefully.