### PR TITLE
Prepare code to be ready for asynchronous buffer updates.

### DIFF
--- a/verilog/tools/ls/autoexpand.cc
+++ b/verilog/tools/ls/autoexpand.cc
@@ -1451,7 +1451,7 @@ std::vector<CodeAction> GenerateAutoExpandCodeActions(
   Interval<size_t> line_range{static_cast<size_t>(p.range.start.line),
                               static_cast<size_t>(p.range.end.line)};
   if (!tracker) return {};
-  const ParsedBuffer *const current = tracker->current();
+  const auto current = tracker->current();
   if (!current) return {};  // Can only expand if we have latest version
   const TextStructureView &text_structure = current->parser().Data();
   AutoExpander range_expander(text_structure, symbol_table_handler, line_range);

--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -67,7 +67,7 @@ std::vector<TextEdit> AutoExpandCodeActionToTextEdits(
 std::vector<TextEdit> GenerateFullAutoExpandTextEdits(
     SymbolTableHandler* symbol_table_handler, const BufferTracker* tracker) {
   EXPECT_TRUE(tracker);
-  const ParsedBuffer* const current = tracker->current();
+  const auto current = tracker->current();
   EXPECT_TRUE(current);
   const TextStructureView& text_structure = current->parser().Data();
   return AutoExpandCodeActionToTextEdits(

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -66,14 +66,40 @@ class BufferTracker {
   void Update(const std::string &filename,
               const verible::lsp::EditTextBuffer &txt);
 
-  const ParsedBuffer *current() const { return current_.get(); }
-  const ParsedBuffer *last_good() const { return last_good_.get(); }
+  // ---
+  // Thread guarantee for the following functions.
+  // As long as the caller (typically some operation) holds on to the returned
+  // shared pointer, the object is alive and well, but there is no guarantee
+  // that if called multiple times it returns the same object (as it might
+  // be replaced asynchronously).
+  // ---
+
+  // Get the current ParsedBuffer from the last text update we received
+  // from the editor. This can be nullptr if it could not be parsed.
+  //
+  // Use in operations that only really makes sense on the latest view and
+  // only if it was parseable, e.g. suggesting edits.
+  std::shared_ptr<const ParsedBuffer> current() const { return current_; }
+
+  // Get the ParsedBuffer that represents that last time we were able to
+  // parse the document from the editor correctly. This can be the same
+  // as current() if the last text update was fully parseable, or nullptr
+  // if we never received a buffer that was parseable.
+  //
+  // Use in operations that focus on returning something even it it is slightly
+  // outdated, e.g. finding a particular symbol.
+  std::shared_ptr<const ParsedBuffer> last_good() const { return last_good_; }
 
  private:
   // The same ParsedBuffer can in both, current and last_good, or last_good can
-  // be an older version. Use shared_ptr to keep track of the reference count.
-  std::shared_ptr<ParsedBuffer> current_;
-  std::shared_ptr<ParsedBuffer> last_good_;
+  // be an older version. So the very same object can be in both of them.
+  // Use shared_ptr to keep track of the reference count.
+  //
+  // Also: We want to be able to replace contents asynchronously which means
+  // we need a thread-safe way to hand out a copy that survives while we
+  // replace this one.
+  std::shared_ptr<const ParsedBuffer> current_;
+  std::shared_ptr<const ParsedBuffer> last_good_;
 };
 
 // Container holding all buffer trackers keyed by file uri.

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -234,7 +234,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinitionLocation(
     LOG(ERROR) << "Could not find buffer with URI " << params.textDocument.uri;
     return {};
   }
-  const verilog::ParsedBuffer *parsedbuffer = tracker->current();
+  const auto parsedbuffer = tracker->current();
   if (!parsedbuffer) {
     LOG(ERROR) << "Buffer not found among opened buffers:  "
                << params.textDocument.uri;

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -55,7 +55,7 @@ std::vector<verible::lsp::Diagnostic> CreateDiagnostics(
     const BufferTracker &tracker, int message_limit) {
   // Diagnostics should come from the latest state, including all the
   // syntax errors.
-  const ParsedBuffer *const current = tracker.current();
+  const auto current = tracker.current();
   if (!current) return {};
   const auto &rejected_tokens = current->parser().GetRejectedTokens();
   auto const &lint_violations =
@@ -155,7 +155,7 @@ std::vector<verible::lsp::CodeAction> GenerateLinterCodeActions(
     const BufferTracker *tracker, const verible::lsp::CodeActionParams &p) {
   std::vector<verible::lsp::CodeAction> result;
   if (!tracker) return result;
-  const ParsedBuffer *const current = tracker->current();
+  const auto current = tracker->current();
   if (!current) return result;
 
   auto const &lint_violations =
@@ -198,7 +198,7 @@ std::vector<verible::lsp::CodeAction> GenerateCodeActions(
   std::vector<verible::lsp::CodeAction> result;
 
   if (!tracker) return result;
-  const ParsedBuffer *const current = tracker->current();
+  const auto current = tracker->current();
   if (!current) return result;
 
   result = GenerateLinterCodeActions(tracker, p);
@@ -216,7 +216,7 @@ nlohmann::json CreateDocumentSymbolOutline(
     bool kate_compatible_tags) {
   if (!tracker) return nlohmann::json::array();
   // Only if the tree has been fully parsed, it makes sense to create an outline
-  const ParsedBuffer *const last_good = tracker->last_good();
+  const auto last_good = tracker->last_good();
   if (!last_good) return nlohmann::json::array();
 
   verible::lsp::DocumentSymbol toplevel;
@@ -234,7 +234,7 @@ std::vector<verible::lsp::DocumentHighlight> CreateHighlightRanges(
     const verible::lsp::DocumentHighlightParams &p) {
   std::vector<verible::lsp::DocumentHighlight> result;
   if (!tracker) return result;
-  const ParsedBuffer *const current = tracker->current();
+  const auto current = tracker->current();
   if (!current) return result;
   const verible::LineColumn cursor{p.position.line, p.position.character};
   const verible::TextStructureView &text = current->parser().Data();
@@ -266,7 +266,7 @@ std::vector<verible::lsp::TextEdit> FormatRange(
     const verible::lsp::DocumentFormattingParams &p) {
   std::vector<verible::lsp::TextEdit> result;
   if (!tracker) return result;
-  const ParsedBuffer *const current = tracker->current();
+  const auto current = tracker->current();
   if (!current) return result;  // Can only format if we have latest version.
   const verible::TextStructureView &text = current->parser().Data();
 


### PR DESCRIPTION
Handing out the shared_ptr<> of the current()/last_good() buffer will make sure that ongoing operations will have a valid copy even if it is replaced asynchronously.

Just API update, no actual asynchronous operations happening yet.

While at it: add documentation to the function calls as well as thread guarantees.