### PR TITLE
Make it more visible if the file list is not found.

### DIFF
--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -53,11 +53,12 @@ std::string FindFileList(absl::string_view current_dir) {
   if (auto status = verible::file::UpwardFileSearch(
           current_dir, absl::GetFlag(FLAGS_file_list_path), &projectpath);
       !status.ok()) {
-    VLOG(1) << "Could not find " << absl::GetFlag(FLAGS_file_list_path)
-            << " file in the project root (" << current_dir << "):  " << status;
+    LOG(INFO) << "Could not find " << absl::GetFlag(FLAGS_file_list_path)
+              << " file in the project root (" << current_dir
+              << "):  " << status;
     return "";
   }
-  VLOG(1) << "Found file list under " << projectpath;
+  LOG(INFO) << "Found file list under " << projectpath;
   return projectpath;
 }
 
@@ -117,7 +118,6 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
       last_filelist_update_ = {};
       return false;
     }
-    VLOG(1) << "Found file list under " << projectpath;
     filelist_path_ = projectpath;
   }
   if (!last_filelist_update_) {

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -177,8 +177,9 @@ verible::lsp::InitializeResult VerilogLanguageServer::InitializeRequestHandler(
   } else if (!p.rootPath.empty()) {
     ConfigureProject(p.rootPath);
   } else {
-    VLOG(1) << "No root URI given. Initialize with root='.'";
-    ConfigureProject();
+    LOG(INFO) << "No root URI provided in language server initialization "
+              << "from IDE. Assuming root='.'";
+    ConfigureProject("");
   }
   return GetCapabilities();
 }

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -60,9 +60,9 @@ class VerilogLanguageServer {
 
   // sets up the VerilogProject structure for symbol table, sets listeners for
   // updating VerilogProject views for edited files
-  // if no project_root is provided, it is set to either current directory
+  // if "project_root" is an empty string, set to either current directory
   // or directory containing verible.filelist
-  void ConfigureProject(absl::string_view project_root = "");
+  void ConfigureProject(absl::string_view project_root);
 
   // Publish a diagnostic sent to the server.
   void SendDiagnostics(const std::string &uri,


### PR DESCRIPTION
If the file list is not found we should show it in the default logs (VERIBLE_LOGTHRESHOLD=0), not only the verbose logs. This makes it easier to discover if there are issues (e.g. #1786).

Also remove one default parameter - things are easier to see when explicitly called.

Now looking at the verilog-language-server_test, and autoexpand_test it is clear that each of them do some search for a file-list. In tests, unless we explicitly test for the searching capability, we always should specify these and not allow auto-searching. So maybe some infrastructure needed there to provide that at construction time (even if it is only used in tests). Left for a later change.