### PR TITLE
Prevent expansion of misplaced AUTOs

### DIFF
--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -220,6 +220,31 @@ class FirstSubtreeFinder : public SymbolVisitor {
   // Contains first matching result found or nullptr if no match is found.
   const Symbol* result_ = nullptr;
 };
+
+// A visitor that finds the last matching node. Inherits from
+// TreeVisitorRecursive, as it needs to visit all nodes in the tree.
+class LastSubtreeFinder : public TreeVisitorRecursive {
+ public:
+  explicit LastSubtreeFinder(const TreePredicate& predicate)
+      : predicate_(predicate) {}
+
+  void Visit(const SyntaxTreeNode& node) final {
+    if (predicate_(node)) result_ = &node;
+  }
+
+  void Visit(const SyntaxTreeLeaf& leaf) final {
+    if (predicate_(leaf)) result_ = &leaf;
+  }
+
+  const Symbol* result() const { return result_; }
+
+ private:
+  // Matching criterion.
+  TreePredicate predicate_;
+
+  // Contains last matching result found or nullptr if no match is found.
+  const Symbol* result_ = nullptr;
+};
 }  // namespace
 
 ConcreteSyntaxTree* FindFirstSubtreeMutable(ConcreteSyntaxTree* tree,
@@ -233,6 +258,13 @@ ConcreteSyntaxTree* FindFirstSubtreeMutable(ConcreteSyntaxTree* tree,
 const Symbol* FindFirstSubtree(const Symbol* tree, const TreePredicate& pred) {
   if (tree == nullptr) return nullptr;
   FirstSubtreeFinder finder(pred);
+  tree->Accept(&finder);
+  return finder.result();
+}
+
+const Symbol* FindLastSubtree(const Symbol* tree, const TreePredicate& pred) {
+  if (tree == nullptr) return nullptr;
+  LastSubtreeFinder finder(pred);
   tree->Accept(&finder);
   return finder.result();
 }

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -255,6 +255,10 @@ ConcreteSyntaxTree* FindFirstSubtreeMutable(ConcreteSyntaxTree* tree,
 // tree must not be null. This is for non-mutating searches.
 const Symbol* FindFirstSubtree(const Symbol*, const TreePredicate&);
 
+// Returns the last syntax tree leaf or node that matches the given predicate.
+// Tree must not be null. This is for non-mutating searches.
+const Symbol* FindLastSubtree(const Symbol*, const TreePredicate&);
+
 // Returns the first syntax tree node whose token starts at or after
 // the given first_token_offset, or nullptr if not found.
 // tree must not be null.

--- a/common/text/tree_utils_test.cc
+++ b/common/text/tree_utils_test.cc
@@ -653,6 +653,136 @@ TEST(FindFirstSubtreeTest, MatchLeaf) {
   EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
 }
 
+// FindLastSubtree test
+
+// Test that 1-node tree and always-true predicate yields the root node.
+TEST(FindLastSubtreeTest, OneNodePredicateTrue) {
+  SymbolPtr tree = Node();
+  const Symbol* result =
+      FindLastSubtree(tree.get(), [](const Symbol&) { return true; });
+  EXPECT_EQ(result, tree.get());
+}
+
+// Test that 1-node tree and always-false predicate yields no match.
+TEST(FindLastSubtreeTest, OneNodePredicateFalse) {
+  SymbolPtr tree = Node();
+  const Symbol* result =
+      FindLastSubtree(tree.get(), [](const Symbol&) { return false; });
+  EXPECT_EQ(result, nullptr);
+}
+
+// Test that 2-node tree and always-true predicate yields the second node.
+TEST(FindLastSubtreeTest, TwoLevelPredicateTrue) {
+  SymbolPtr tree = TNode(1, TNode(2));
+  SymbolPtr expect = TNode(2);
+  const Symbol* result =
+      FindLastSubtree(tree.get(), [](const Symbol&) { return true; });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
+// Test that 2-node tree and always-false predicate yields nullptr.
+TEST(FindLastSubtreeTest, TwoLevelPredicateFalse) {
+  SymbolPtr tree = TNode(1, TNode(2));
+  const Symbol* result =
+      FindLastSubtree(tree.get(), [](const Symbol&) { return false; });
+  EXPECT_EQ(result, nullptr);
+}
+
+// Test that tree and predicate can match the root node.
+TEST(FindLastSubtreeTest, TwoLevelNodeTagIs1) {
+  SymbolPtr tree = TNode(1, TNode(2));
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsNodeTagged(s, 1); });
+  EXPECT_EQ(result, tree.get());
+}
+
+// Test that tree and predicate can skip over null nodes.
+TEST(FindLastSubtreeTest, SkipNulls) {
+  SymbolPtr tree = TNode(1, nullptr, nullptr, TNode(2), nullptr);
+  SymbolPtr expect = TNode(2);
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsNodeTagged(s, 2); });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
+// Test that tree and predicate can match no node.
+TEST(FindLastSubtreeTest, TwoLevelNoNodeMatch) {
+  SymbolPtr tree = TNode(1, TNode(2));
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsLeafTagged(s, 3); });
+  EXPECT_EQ(result, nullptr);
+}
+
+// Test that tree and predicate can match no node with null leaves.
+TEST(FindLastSubtreeTest, TwoLevelNoNodeMatchNullLeaves) {
+  SymbolPtr tree = TNode(1, nullptr, nullptr);
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsLeafTagged(s, 4); });
+  EXPECT_EQ(result, nullptr);
+}
+
+// Test that tree and predicate can match no leaf.
+TEST(FindLastSubtreeTest, TwoLevelNoLeafTag) {
+  SymbolPtr tree = TNode(1, TNode(2));
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsLeafTagged(s, 1); });
+  EXPECT_EQ(result, nullptr);
+}
+
+// Test that tree and predicate can match an inner node.
+TEST(FindLastSubtreeTest, TwoLevelNodeTagIs2) {
+  SymbolPtr tree = TNode(1, TNode(2));
+  SymbolPtr expect = TNode(2);
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsNodeTagged(s, 2); });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
+// Test that tree and predicate can match an inner leaf.
+TEST(FindLastSubtreeTest, TwoLevelLeafTagIs2) {
+  SymbolPtr tree = TNode(1, XLeaf(2));
+  SymbolPtr expect = XLeaf(2);
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsLeafTagged(s, 2); });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
+// Test that tree and predicate can match no leaf.
+TEST(FindLastSubtreeTest, TwoLevelLeafTagNoMatch) {
+  SymbolPtr tree = TNode(1, XLeaf(2), XLeaf(3));
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsLeafTagged(s, 1); });
+  EXPECT_EQ(result, nullptr);
+}
+
+// Test that tree and predicate finds the last matching subtree.
+TEST(FindLastSubtreeTest, MatchLastOfSiblings) {
+  SymbolPtr tree = TNode(1, TNode(2, TNode(2, TNode(2))), TNode(2, TNode(3)));
+  SymbolPtr expect = TNode(2, TNode(3));
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsNodeTagged(s, 2); });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
+// Test that tree and predicate finds the last match in-order.
+TEST(FindLastSubtreeTest, MatchLastInOrder) {
+  SymbolPtr tree = TNode(1, TNode(2, TNode(3)), TNode(3, TNode(4)));
+  SymbolPtr expect = TNode(3, TNode(4));
+  const Symbol* result = FindLastSubtree(
+      tree.get(), [](const Symbol& s) { return IsNodeTagged(s, 3); });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
+// Test that tree and predicate finds the last match in-order.
+TEST(FindLastSubtreeTest, MatchLeaf) {
+  SymbolPtr tree = TNode(1, TNode(2, XLeaf(3)), TNode(3, TNode(4, XLeaf(4))));
+  SymbolPtr expect = XLeaf(4);
+  const Symbol* result = FindLastSubtree(tree.get(), [](const Symbol& s) {
+    return IsLeafTagged(s, 3) || IsLeafTagged(s, 4);
+  });
+  EXPECT_TRUE(EqualTreesByEnum(result, expect.get()));
+}
+
 // FindSubtreeStartingAtOffset tests
 
 constexpr absl::string_view kFindSubtreeTestText("abcdef");

--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -223,7 +223,9 @@ endmodule
 TEST(Autoexpand, AUTOARG_NoExpand) {
   TestTextEdits(GenerateFullAutoExpandTextEdits,
                 R"(
-module t ();
+module t (
+    .o(out  /*AUTOARG*/)
+);
   /*AUTOARG*/
   input logic clk;
   input logic rst;
@@ -231,7 +233,9 @@ module t ();
 endmodule
 )",
                 R"(
-module t ();
+module t (
+    .o(out  /*AUTOARG*/)
+);
   /*AUTOARG*/
   input logic clk;
   input logic rst;
@@ -372,6 +376,7 @@ module foo;
 
   bar b ();
   /*AUTOINST*/
+  bar c (.i1(io  /*AUTOINST*/));
 endmodule
 )",
                 R"(
@@ -388,6 +393,7 @@ module foo;
 
   bar b ();
   /*AUTOINST*/
+  bar c (.i1(io  /*AUTOINST*/));
 endmodule
 )");
 
@@ -1051,9 +1057,19 @@ module bar;
 endmodule
 
 module foo;
+  input i;
+  output o;
+
   /*AUTOINPUT*/
 
   bar b (  /*AUTOINST*/);
+endmodule
+
+module qux;
+  output o  /*AUTOINPUT*/
+  ;
+
+  foo f (  /*AUTOINST*/);
 endmodule
 )",
                 R"(
@@ -1061,9 +1077,24 @@ module bar;
 endmodule
 
 module foo;
+  input i;
+  output o;
+
   /*AUTOINPUT*/
 
   bar b (  /*AUTOINST*/);
+endmodule
+
+module qux;
+  output o  /*AUTOINPUT*/
+  ;
+
+  foo f (  /*AUTOINST*/
+      // Inputs
+      .i(i),
+      // Outputs
+      .o(o)
+  );
 endmodule
 )");
 }
@@ -1180,9 +1211,20 @@ module bar;
 endmodule
 
 module foo;
+  input i;
+  inout io;
+  output o;
+
   /*AUTOINOUT*/
 
   bar b (  /*AUTOINST*/);
+endmodule
+
+module qux;
+  output o  /*AUTOINOUT*/
+  ;
+
+  foo f (  /*AUTOINST*/);
 endmodule
 )",
                 R"(
@@ -1190,9 +1232,27 @@ module bar;
 endmodule
 
 module foo;
+  input i;
+  inout io;
+  output o;
+
   /*AUTOINOUT*/
 
   bar b (  /*AUTOINST*/);
+endmodule
+
+module qux;
+  output o  /*AUTOINOUT*/
+  ;
+
+  foo f (  /*AUTOINST*/
+      // Inputs
+      .i(i),
+      // Inouts
+      .io(io),
+      // Outputs
+      .o(o)
+  );
 endmodule
 )");
 }
@@ -1308,9 +1368,19 @@ module bar;
 endmodule
 
 module foo;
+  input i;
+  output o;
+
   /*AUTOOUTPUT*/
 
   bar b (  /*AUTOINST*/);
+endmodule
+
+module qux;
+  output o  /*AUTOOUTPUT*/
+  ;
+
+  foo f (  /*AUTOINST*/);
 endmodule
 )",
                 R"(
@@ -1318,9 +1388,24 @@ module bar;
 endmodule
 
 module foo;
+  input i;
+  output o;
+
   /*AUTOOUTPUT*/
 
   bar b (  /*AUTOINST*/);
+endmodule
+
+module qux;
+  output o  /*AUTOOUTPUT*/
+  ;
+
+  foo f (  /*AUTOINST*/
+      // Inputs
+      .i(i),
+      // Outputs
+      .o(o)
+  );
 endmodule
 )");
 }
@@ -1817,7 +1902,8 @@ endmodule
 
 module foo (  /*AUTOWIRE*/
 );
-  wire o1;
+  wire o1  /*AUTOWIRE*/
+  ;
 
   bar b (  /*AUTOINST*/);
 endmodule
@@ -1834,7 +1920,8 @@ endmodule
 
 module foo (  /*AUTOWIRE*/
 );
-  wire o1;
+  wire o1  /*AUTOWIRE*/
+  ;
 
   bar b (  /*AUTOINST*/
       // Inputs
@@ -2001,7 +2088,8 @@ module foo (  /*AUTOREG*/
 );
   output [15:0] o1;
   output [31:0] o2[8];
-  output [3:0][3:0] o3[16];
+  output [3:0][3:0] o3[16]  /*AUTOREG*/
+  ;
 
   bar b (  /*AUTOINST*/);
 endmodule
@@ -2020,7 +2108,8 @@ module foo (  /*AUTOREG*/
 );
   output [15:0] o1;
   output [31:0] o2[8];
-  output [3:0][3:0] o3[16];
+  output [3:0][3:0] o3[16]  /*AUTOREG*/
+  ;
 
   bar b (  /*AUTOINST*/
       // Inputs


### PR DESCRIPTION
This patch addresses situations where AUTOs are expanded in incorrect contexts, such as expanding `AUTOINST` under a port actual, instead of directly in module instantiation parens.

The syntax tree is traversed until the deepest node that encompasses a given AUTO expansion is found. If the node kind is expected for the expansion, it can be applied. Otherwise, the expansion is discarded. For example, `AUTOINST` expansion can only be done directly under module instantiation, but not any deeper in the tree, e.g. in a port actual.