### PR TITLE
Start using RE2 instad of std:;regex

### DIFF
--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -66,6 +66,7 @@ cc_binary(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 


### PR DESCRIPTION
std::regex is not optimized for performance and can be quite slow on different platforms.
While it does not matter in this particular tool, this is to test it in a small context so that we then can apply it in other places where performance matters.