### PR TITLE
Fix syntax tree equality checking and `FirstSubtreeFinder`'s base class

### DIFF
--- a/common/text/concrete_syntax_tree.cc
+++ b/common/text/concrete_syntax_tree.cc
@@ -40,6 +40,7 @@ bool SyntaxTreeNode::equals(const Symbol* symbol,
 // equal trees.
 bool SyntaxTreeNode::equals(const SyntaxTreeNode* node,
                             const TokenComparator& compare_tokens) const {
+  if (Tag().tag != node->Tag().tag) return false;
   if (children_.size() != node->children().size()) {
     return false;
   }

--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -178,9 +178,9 @@ class FirstSubtreeFinderMutable : public MutableTreeVisitorRecursive {
 };
 
 // FirstSubtreeFinder is a visitor class that supports the implementation of
-// FindFirstSubtree().  It is derived from TreeVisitorRecursive because it is
-// only intended for searching a tree given a predicate.
-class FirstSubtreeFinder : public TreeVisitorRecursive {
+// FindFirstSubtree().  It is derived from SymbolVisitor so that it's able to
+// exit early if a match is found.
+class FirstSubtreeFinder : public SymbolVisitor {
  public:
   explicit FirstSubtreeFinder(const TreePredicate& predicate)
       : predicate_(predicate) {}


### PR DESCRIPTION
This PR contains two fixes:

1. Before this change, checking for equality of `SyntaxTreeNode`s did not take into
account the node tag. This meant two trees with different tags inside would be
considered equal. This patch simply adds a check for the node tag to the
equality function.

2. `TreeVisitorRecursive` visits an entire tree, traversing it in pre-order. In
contrast, `SymbolVisitor` only visits a single `Symbol` and needs to manually be
applied for subtrees. This is what already happens in `FirstSubtreeFinder` with
the intention that if it finds the first match, it can return early. However,
`FirstSubtreeFinder` inherits from `TreeVisitorRecursive`, which means it
traverses the entire tree anyway, and the manual applications within it only
create additional, unnecessary work. This patch fixes that by changing
`FirstSubtreeFinder`'s base class to `SymbolVisitor`.
