### PR TITLE
Matcher tests: print the corresponding symbol tree on failure.

### DIFF
--- a/common/analysis/matcher/BUILD
+++ b/common/analysis/matcher/BUILD
@@ -149,6 +149,7 @@ cc_library(
         "//common/text:concrete_syntax_leaf",
         "//common/text:concrete_syntax_tree",
         "//common/text:symbol",
+        "//common/text:tree_utils",
         "//common/text:visitors",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",

--- a/common/analysis/matcher/matcher_test_utils.cc
+++ b/common/analysis/matcher/matcher_test_utils.cc
@@ -23,6 +23,7 @@
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/concrete_syntax_tree.h"
 #include "common/text/symbol.h"
+#include "common/text/tree_utils.h"
 #include "common/text/visitors.h"
 #include "gtest/gtest.h"
 
@@ -84,7 +85,9 @@ class MatchCounter : public TreeVisitorRecursive {
 void ExpectMatchesInAST(const Symbol& tree, const Matcher& matcher,
                         int num_matches, absl::string_view code) {
   MatchCounter counter(matcher);
-  EXPECT_EQ(num_matches, counter.Count(tree)) << "code:\n" << code;
+  EXPECT_EQ(num_matches, counter.Count(tree)) << "code:\n"
+                                              << code << "\ntree:\n"
+                                              << RawTreePrinter(tree, true);
 }
 
 }  // namespace matcher

--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -439,7 +439,11 @@ void RawSymbolPrinter::Visit(const SyntaxTreeNode& node) {
     const ValueSaver<int> value_saver(&indent_, indent_ + 2);
     const ValueSaver<int> rank_saver(&child_rank_, 0);
     for (const auto& child : node.children()) {
-      if (child) child->Accept(this);
+      if (child) {
+        child->Accept(this);
+      } else if (print_null_nodes_) {
+        auto_indent() << "NULL @" << child_rank_ << std::endl;
+      }
       // Note that nullptrs will appear as gaps in the child rank sequence.
       // nullptr nodes in tail position are not shown.
       ++child_rank_;
@@ -449,7 +453,7 @@ void RawSymbolPrinter::Visit(const SyntaxTreeNode& node) {
 }
 
 std::ostream& RawTreePrinter::Print(std::ostream& stream) const {
-  RawSymbolPrinter printer(&stream);
+  RawSymbolPrinter printer(&stream, print_null_nodes_);
   root_.Accept(&printer);
   return stream;
 }

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -303,36 +303,40 @@ void MutateLeaves(ConcreteSyntaxTree* tree, const LeafMutator& mutator);
 // Nodes are rendered with proper indendation.
 class RawSymbolPrinter : public SymbolVisitor {
  public:
-  explicit RawSymbolPrinter(std::ostream* stream) : stream_(stream) {}
+  // Print output to stream"; include NULL nodes if "print_null_nodes" set.
+  explicit RawSymbolPrinter(std::ostream* stream, bool print_null_nodes = false)
+      : stream_(stream), print_null_nodes_(print_null_nodes) {}
 
   void Visit(const SyntaxTreeLeaf&) override;
   void Visit(const SyntaxTreeNode&) override;
 
  protected:
-  // Output stream.
-  std::ostream* stream_;
+  // Prints start of line with correct indentation.
+  std::ostream& auto_indent();
 
-  // Indentation tracks current depth in tree.
-  int indent_ = 0;
+  std::ostream* const stream_;   // Output stream.
+  const bool print_null_nodes_;  // Include empty null children.
+
+  int indent_ = 0;  // Indentation tracks current depth in tree.
 
   // Each set of siblings is enumerated starting at 0.
   // This is set by parent nodes during traversal.
   int child_rank_ = 0;
-
-  // Prints start of line with correct indentation.
-  std::ostream& auto_indent();
 };
 
 // Streamable print adapter using RawSymbolPrinter.
 // Usage: stream << RawTreePrinter(*tree_root);
 class RawTreePrinter {
  public:
-  explicit RawTreePrinter(const Symbol& root) : root_(root) {}
+  // Print tree "root"; include NULL nodes if "print_null_nodes" set.
+  explicit RawTreePrinter(const Symbol& root, bool print_null_nodes = false)
+      : root_(root), print_null_nodes_(print_null_nodes) {}
 
   std::ostream& Print(std::ostream&) const;
 
  private:
   const Symbol& root_;
+  const bool print_null_nodes_;
 };
 
 std::ostream& operator<<(std::ostream&, const RawTreePrinter&);

--- a/common/text/tree_utils_test.cc
+++ b/common/text/tree_utils_test.cc
@@ -290,7 +290,7 @@ TEST(TreePrintTest, RawPrint) {
   EXPECT_EQ(stream.str(), expected);
 }
 
-TEST(TreePrintTest, RawPrintSkipNullptrs) {
+TEST(TreePrintTest, RawPrintNullptrPrinting) {
   constexpr absl::string_view text("leaf 1 leaf 2 leaf 3 leaf 4");
   SymbolPtr tree = Node(nullptr,                           //
                         Leaf(0, text.substr(0, 6)),        //
@@ -302,19 +302,41 @@ TEST(TreePrintTest, RawPrintSkipNullptrs) {
                         nullptr,                           //
                         Leaf(3, text.substr(21, 6)),       //
                         nullptr);
-  // Output excludes byte offsets.
-  constexpr absl::string_view expected =
-      "Node @0 {\n"
-      "  Leaf @1 (#0: \"leaf 1\")\n"
-      "  Node @3 {\n"
-      "    Leaf @0 (#1: \"leaf 2\")\n"
-      "    Leaf @2 (#2: \"leaf 3\")\n"
-      "  }\n"
-      "  Leaf @5 (#3: \"leaf 4\")\n"
-      "}\n";
-  std::ostringstream stream;
-  stream << RawTreePrinter(*tree);
-  EXPECT_EQ(stream.str(), expected);
+  {
+    // Output excludes byte offsets.
+    constexpr absl::string_view expected =
+        "Node @0 {\n"
+        "  Leaf @1 (#0: \"leaf 1\")\n"
+        "  Node @3 {\n"
+        "    Leaf @0 (#1: \"leaf 2\")\n"
+        "    Leaf @2 (#2: \"leaf 3\")\n"
+        "  }\n"
+        "  Leaf @5 (#3: \"leaf 4\")\n"
+        "}\n";
+    std::ostringstream stream;
+    stream << RawTreePrinter(*tree);
+    EXPECT_EQ(stream.str(), expected);
+  }
+  {
+    // Now the same, but with nullptr printing enabled.
+    constexpr absl::string_view expected =
+        "Node @0 {\n"
+        "  NULL @0\n"
+        "  Leaf @1 (#0: \"leaf 1\")\n"
+        "  NULL @2\n"
+        "  Node @3 {\n"
+        "    Leaf @0 (#1: \"leaf 2\")\n"
+        "    NULL @1\n"
+        "    Leaf @2 (#2: \"leaf 3\")\n"
+        "  }\n"
+        "  NULL @4\n"
+        "  Leaf @5 (#3: \"leaf 4\")\n"
+        "  NULL @6\n"
+        "}\n";
+    std::ostringstream stream;
+    stream << RawTreePrinter(*tree, true);
+    EXPECT_EQ(stream.str(), expected);
+  }
 }
 
 TEST(TreePrintTest, PrettyPrint) {


### PR DESCRIPTION
This aids debugging while working on such matchers.

To make it visually more obvious of 'holes' in the children list, add an option to RawTreePrinter to include null-children.