### PR TITLE
File opening status messages: always include filename.

### DIFF
--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -147,6 +147,8 @@ TEST(FileUtil, StatusErrorReporting) {
   std::string content;
   absl::Status status = file::GetContents("does-not-exist", &content);
   EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(absl::StartsWith(status.message(), "does-not-exist:"))
+      << "expect filename prefixed, but got " << status;
   EXPECT_EQ(status.code(), absl::StatusCode::kNotFound) << status;
 
   const std::string test_file = file::JoinPath(testing::TempDir(), "test-err");
@@ -169,6 +171,9 @@ TEST(FileUtil, StatusErrorReporting) {
     status = file::GetContents(test_file, &content);
     EXPECT_FALSE(status.ok()) << "Expected permission denied for " << test_file;
     EXPECT_EQ(status.code(), absl::StatusCode::kPermissionDenied) << status;
+    EXPECT_TRUE(absl::StartsWith(status.message(), test_file))
+        << "expect filename prefixed, but got " << status;
+
     EXPECT_TRUE(content.empty()) << "'" << content << "'";
   }
 #endif

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -142,9 +142,10 @@ static bool formatOneFile(absl::string_view filename,
 
   // Read contents into memory first.
   std::string content;
-  absl::Status status = verible::file::GetContents(filename, &content);
-  if (!status.ok()) {
-    FileMsg(filename) << status << std::endl;
+  if (absl::Status status = verible::file::GetContents(filename, &content);
+      !status.ok()) {
+    // Not using FileMsg(): file status already has filename attached.
+    std::cerr << status.message() << std::endl;
     return false;
   }
 
@@ -208,8 +209,8 @@ static bool formatOneFile(absl::string_view filename,
     // Don't write if the output is exactly as the input, so that we don't mess
     // with tools that look for timestamp changes (such as make).
     if (content != formatted_output) {
-      status = verible::file::SetContents(filename, formatted_output);
-      if (!status.ok()) {
+      if (auto status = verible::file::SetContents(filename, formatted_output);
+          !status.ok()) {
         FileMsg(filename) << "error writing result " << status << std::endl;
         return false;
       }

--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -297,6 +297,7 @@ int main(int argc, char** argv) {
        verible::make_range(args.begin() + 1, args.end())) {
     auto content_status = verible::file::GetContentAsMemBlock(filename);
     if (!content_status.status().ok()) {
+      std::cerr << content_status.status().message() << std::endl;
       exit_status = 1;
       continue;
     }


### PR DESCRIPTION
The status messages due to opening files might be created deeply in the code, so it is good if issues with files percolate up with the filename included.