### PR TITLE
Remove AUTO expanded ports if they no longer exist

### DIFF
--- a/verilog/tools/ls/autoexpand.cc
+++ b/verilog/tools/ls/autoexpand.cc
@@ -1088,7 +1088,13 @@ std::optional<AutoExpander::Expansion> AutoExpander::ExpandAutoDeclarations(
            << '\n';
   const int64_t length_before_emit = new_text.tellp();
   emit(module, new_text);
-  if (length_before_emit == new_text.tellp()) return {};
+  if (length_before_emit == new_text.tellp()) {
+    if (auto_span != comment_span) {
+      return Expansion{.replaced_span = auto_span,
+                       .new_text = std::string{comment_span}};
+    }
+    return {};
+  }
   new_text << "// End of automatics";
   return Expansion{.replaced_span = auto_span, .new_text = new_text.str()};
 }

--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -1535,6 +1535,90 @@ endmodule
 )");
 }
 
+TEST(Autoexpand, AUTO_ExpandRemovePorts) {
+  TestTextEdits(
+      R"(
+module bar (
+    input i1,
+    output [15:0] o1
+);
+  input i2[4][8];
+endmodule
+
+module foo (  /*AUTOARG*/
+    // Inputs
+    i1,
+    i2,
+    // Inouts
+    io,
+    // Outputs
+    o1,
+    o2
+);
+  /*AUTOINPUT*/
+  // Beginning of automatic inputs (from autoinst inputs)
+  input i1;  // To b of bar
+  input i2[4][8];  // To b of bar
+  // End of automatics
+  /*AUTOOUTPUT*/
+  // Beginning of automatic outputs (from autoinst outputs)
+  output [15:0] o1;  // From b of bar
+  output [31:0] o2[8];  // From b of bar
+  // End of automatics
+  /*AUTOINOUT*/
+  // Beginning of automatic inouts (from autoinst inouts)
+  inout [7:0][7:0] io;  // To/From b of bar
+  // End of automatics
+
+  bar b (  /*AUTOINST*/
+      // Inputs
+      .i1(i1),
+      .i2(i2  /*.[4][8]*/),
+      // Inouts
+      .io(io  /*[7:0][7:0]*/),
+      // Outputs
+      .o1(o1[15:0]),
+      .o2(o2  /*[31:0].[8]*/)
+  );
+endmodule
+)",
+      R"(
+module bar (
+    input i1,
+    output [15:0] o1
+);
+  input i2[4][8];
+endmodule
+
+module foo (  /*AUTOARG*/
+    // Inputs
+    i1,
+    i2,
+    // Outputs
+    o1
+);
+  /*AUTOINPUT*/
+  // Beginning of automatic inputs (from autoinst inputs)
+  input i1;  // To b of bar
+  input i2[4][8];  // To b of bar
+  // End of automatics
+  /*AUTOOUTPUT*/
+  // Beginning of automatic outputs (from autoinst outputs)
+  output [15:0] o1;  // From b of bar
+  // End of automatics
+  /*AUTOINOUT*/
+
+  bar b (  /*AUTOINST*/
+      // Inputs
+      .i1(i1),
+      .i2(i2  /*.[4][8]*/),
+      // Outputs
+      .o1(o1[15:0])
+  );
+endmodule
+)");
+}
+
 TEST(Autoexpand, AUTO_ExpandPorts_AUTOARG_Order) {
   TestTextEdits(
 


### PR DESCRIPTION
This handles the case where all AUTO expanded ports of a particular type (e.g. `inout` ports) are removed. Previously the corresponding AUTO would be unaffected; now it's being reduced to just the AUTO comment.

This patch also adds a test that verifies this behavior.