### PR TITLE
Use `RE2` instead of `std::regex` in AUTO expansion

### DIFF
--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -36,6 +36,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/container:node_hash_map",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 


### PR DESCRIPTION
* Replaces all usage of `std::regex` with `RE2` in AUTO expansion code,
* Simplifies some of the code that used to pass `std::cmatch`es around.

Closes #1794.