### PR TITLE
Replace calls to GetContents() with GetContentAsString()

### DIFF
--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -378,15 +378,15 @@ static absl::Status WaiveCommandHandler(
         }
 
         if (!can_use_regex && !can_use_lineno) {
-          std::string content;
-          absl::Status status =
-              verible::file::GetContents(lintee_filename, &content);
-          if (!status.ok()) {
-            return WaiveCommandError(token_pos, waive_file, status.ToString());
+          absl::StatusOr<std::string> content_or =
+              verible::file::GetContentAsString(lintee_filename);
+          if (!content_or.ok()) {
+            return WaiveCommandError(token_pos, waive_file,
+                                     content_or.status().ToString());
           }
 
           const size_t number_of_lines =
-              std::count(content.begin(), content.end(), '\n');
+              std::count(content_or->begin(), content_or->end(), '\n');
           waiver->WaiveLineRange(rule, 1, number_of_lines);
         }
 

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -154,6 +154,7 @@ cc_library(
         "//common/util:user_interaction",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/common/strings/mem_block.h
+++ b/common/strings/mem_block.h
@@ -43,6 +43,7 @@ class MemBlock {
 class StringMemBlock final : public MemBlock {
  public:
   StringMemBlock() = default;
+  explicit StringMemBlock(std::string&& move_from) : content_(move_from) {}
   explicit StringMemBlock(absl::string_view copy_from)
       : content_(copy_from.begin(), copy_from.end()) {}
 

--- a/common/strings/patch.h
+++ b/common/strings/patch.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "common/strings/compare.h"
 #include "common/strings/position.h"
@@ -33,9 +34,9 @@ namespace internal {
 // Forward declarations
 class FilePatch;
 
-// function interface like file::GetContents()
-using FileReaderFunction = std::function<absl::Status(
-    absl::string_view filename, std::string* contents)>;
+// function interface like file::GetContentAsString()
+using FileReaderFunction =
+    std::function<absl::StatusOr<std::string>(absl::string_view filename)>;
 
 // function interface like file::SetContents()
 using FileWriterFunction = std::function<absl::Status(

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -180,13 +180,6 @@ absl::StatusOr<std::string> GetContentAsString(absl::string_view filename) {
   return std::move(content);
 }
 
-absl::Status GetContents(absl::string_view filename, std::string *content) {
-  absl::StatusOr<std::string> content_or = GetContentAsString(filename);
-  if (!content_or.ok()) return content_or.status();
-  *content = std::move(*content_or);
-  return absl::OkStatus();
-}
-
 static absl::StatusOr<std::unique_ptr<MemBlock>> AttemptMemMapFile(
     absl::string_view filename) {
 #ifndef _WIN32
@@ -239,12 +232,9 @@ absl::StatusOr<std::unique_ptr<MemBlock>> GetContentAsMemBlock(
   }
 
   // Still here ? Well, let's try the traditional way
-  auto mem_block = std::make_unique<StringMemBlock>();
-  if (auto status = GetContents(filename, mem_block->mutable_content());
-      !status.ok()) {
-    return status;
-  }
-  return mem_block;
+  auto content_or = GetContentAsString(filename);
+  if (!content_or.ok()) return content_or.status();
+  return std::make_unique<StringMemBlock>(std::move(*content_or));
 }
 
 absl::Status SetContents(absl::string_view filename,

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -71,10 +71,6 @@ absl::Status FileExists(const std::string& filename);
 // Read file "filename" and return its content as string.
 absl::StatusOr<std::string> GetContentAsString(absl::string_view filename);
 
-// Adapter method for the one above. To be removed after all call-sites have
-// been updated. Deprecated.
-absl::Status GetContents(absl::string_view filename, std::string* content);
-
 // Read file "filename" and store its content in MemBlock. Attempts to MemMap
 // first; if that fails, reads file regularly.
 absl::StatusOr<std::unique_ptr<MemBlock>> GetContentAsMemBlock(

--- a/verilog/analysis/verilog_filelist.cc
+++ b/verilog/analysis/verilog_filelist.cc
@@ -80,10 +80,9 @@ absl::Status AppendFileListFromContent(absl::string_view file_list_path,
 
 absl::Status AppendFileListFromFile(absl::string_view file_list_file,
                                     FileList* append_to) {
-  std::string content;
-  auto read_status = verible::file::GetContents(file_list_file, &content);
-  if (!read_status.ok()) return read_status;
-  return AppendFileListFromContent(file_list_file, content, append_to);
+  auto content_or = verible::file::GetContentAsString(file_list_file);
+  if (!content_or.ok()) return content_or.status();
+  return AppendFileListFromContent(file_list_file, *content_or, append_to);
 }
 
 absl::Status AppendFileListFromCommandline(

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -295,12 +295,12 @@ absl::Status LinterConfiguration::AppendFromFile(
   // Read local configuration file
   std::string content;
 
-  absl::Status config_read_status =
-      verible::file::GetContents(config_filename, &content);
-  if (config_read_status.ok()) {
+  absl::StatusOr<std::string> config_or =
+      verible::file::GetContentAsString(config_filename);
+  if (config_or.ok()) {
     RuleBundle local_rules_bundle;
     std::string error;
-    if (local_rules_bundle.ParseConfiguration(content, '\n', &error)) {
+    if (local_rules_bundle.ParseConfiguration(*config_or, '\n', &error)) {
       if (!error.empty()) {
         std::cerr << "Warnings in parse configuration: " << error << std::endl;
       }
@@ -312,7 +312,7 @@ absl::Status LinterConfiguration::AppendFromFile(
     return absl::OkStatus();
   }
 
-  return config_read_status;
+  return config_or.status();
 }
 
 absl::Status LinterConfiguration::ConfigureFromOptions(

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -49,7 +49,7 @@ using ::testing::EndsWith;
 using ::testing::StartsWith;
 using verible::ViolationFixer;
 using verible::ViolationPrinter;
-using verible::file::GetContents;
+using verible::file::GetContentAsString;
 using verible::file::testing::ScopedTestFile;
 
 class DefaultLinterConfigTestFixture {
@@ -466,7 +466,10 @@ class ViolationFixerTest : public testing::Test {
     violation_fixer->HandleViolations(violations, text_structure.Contents(),
                                       temp_file.filename());
 
-    const auto ok = GetContents(temp_file.filename(), fixed_content);
+    if (auto content_or = GetContentAsString(temp_file.filename());
+        content_or.ok()) {
+      *fixed_content = std::move(*content_or);
+    }
     return lint_result.status();
   }
 

--- a/verilog/tools/diff/verilog_diff.cc
+++ b/verilog/tools/diff/verilog_diff.cc
@@ -102,16 +102,14 @@ int main(int argc, char** argv) {
   }
 
   // Open both files.
-  std::string content1;
-  absl::Status status = verible::file::GetContents(args[1], &content1);
-  if (!status.ok()) {
-    std::cerr << args[1] << ": " << status << std::endl;
+  const auto content1_or = verible::file::GetContentAsString(args[1]);
+  if (!content1_or.ok()) {
+    std::cerr << args[1] << ": " << content1_or.status() << std::endl;
     return kUserErrorCode;
   }
-  std::string content2;
-  status = verible::file::GetContents(args[2], &content2);
-  if (!status.ok()) {
-    std::cerr << args[1] << ": " << status << std::endl;
+  const auto content2_or = verible::file::GetContentAsString(args[2]);
+  if (!content2_or.ok()) {
+    std::cerr << args[1] << ": " << content1_or.status() << std::endl;
     return kUserErrorCode;
   }
 
@@ -123,7 +121,7 @@ int main(int argc, char** argv) {
 
   // Compare.
   std::ostringstream errstream;
-  const auto diff_status = diff_func(content1, content2, &errstream);
+  const auto diff_status = diff_func(*content1_or, *content2_or, &errstream);
 
   // Signal result of comparison.
   switch (diff_status) {


### PR DESCRIPTION
... including the necessary changes from return value of absl::Status to absl::StatusOr<std::string>.

Remove old file::GetContents() function.