### PR TITLE
Work around uninitialized value in absl call_once.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ http_archive(
     # a string_view::iterator. This patch forces the use of absl's string_view
     # implementation to solve the issue
     patch_args = ["-p1"],
-    patches = ["//bazel:absl.patch"],
+    patches = ["//bazel:absl.patch", "//bazel:fix-uninitialized-var.patch"],
     sha256 = "e46fe4fd52b94dc344429b74b9520bead577f1db622def7a69bdefae6908836c",
     strip_prefix = "abseil-cpp-35e8e3f7a2c6972d4c591448e8bbe4f9ed9f815a",
     urls = ["https://github.com/abseil/abseil-cpp/archive/35e8e3f7a2c6972d4c591448e8bbe4f9ed9f815a.zip"],

--- a/bazel/fix-uninitialized-var.patch
+++ b/bazel/fix-uninitialized-var.patch
@@ -1,0 +1,13 @@
+diff --git a/absl/base/call_once.h b/absl/base/call_once.h
+index 96109f53..08436bac 100644
+--- a/absl/base/call_once.h
++++ b/absl/base/call_once.h
+@@ -123,7 +123,7 @@ class SchedulingHelper {
+ 
+  private:
+   base_internal::SchedulingMode mode_;
+-  bool guard_result_;
++  bool guard_result_ = false;
+ };
+ 
+ // Bit patterns for call_once state machine values.  Internal implementation


### PR DESCRIPTION
Will open an issue upstream, but for now, this fixes the clang-analyzer-optin.cplusplus.UninitializedObject we see.