### PR TITLE
Add new lint rule for negative array dimensions

### DIFF
--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -100,7 +100,9 @@ const verible::Symbol* GetConditionExpressionFalseCase(
 
 const verible::TokenInfo* GetUnaryPrefixOperator(
     const verible::Symbol& symbol) {
-  const SyntaxTreeNode* node = &verible::SymbolCastToNode(symbol);
+  const SyntaxTreeNode* node = symbol.Kind() == SymbolKind::kNode
+                                   ? &verible::SymbolCastToNode(symbol)
+                                   : nullptr;
   if (!node || !MatchNodeEnumOrNull(*node, NodeEnum::kUnaryPrefixExpression)) {
     return nullptr;
   }
@@ -110,7 +112,9 @@ const verible::TokenInfo* GetUnaryPrefixOperator(
 }
 
 const verible::Symbol* GetUnaryPrefixOperand(const verible::Symbol& symbol) {
-  const SyntaxTreeNode* node = &verible::SymbolCastToNode(symbol);
+  const SyntaxTreeNode* node = symbol.Kind() == SymbolKind::kNode
+                                   ? &verible::SymbolCastToNode(symbol)
+                                   : nullptr;
   if (!node || !MatchNodeEnumOrNull(*node, NodeEnum::kUnaryPrefixExpression)) {
     return nullptr;
   }

--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -100,15 +100,21 @@ const verible::Symbol* GetConditionExpressionFalseCase(
 
 const verible::TokenInfo* GetUnaryPrefixOperator(
     const verible::Symbol& symbol) {
-  const auto& children = verible::SymbolCastToNode(symbol).children();
-  const auto leaf_symbol = children.front().get();
+  const SyntaxTreeNode* node = &verible::SymbolCastToNode(symbol);
+  if (!node || !MatchNodeEnumOrNull(*node, NodeEnum::kUnaryPrefixExpression)) {
+    return nullptr;
+  }
+  const verible::Symbol* leaf_symbol = node->children().front().get();
   return &verible::down_cast<const verible::SyntaxTreeLeaf*>(leaf_symbol)
               ->get();
 }
 
 const verible::Symbol* GetUnaryPrefixOperand(const verible::Symbol& symbol) {
-  const auto& children = verible::SymbolCastToNode(symbol).children();
-  return children.back().get();
+  const SyntaxTreeNode* node = &verible::SymbolCastToNode(symbol);
+  if (!node || !MatchNodeEnumOrNull(*node, NodeEnum::kUnaryPrefixExpression)) {
+    return nullptr;
+  }
+  return node->children().back().get();
 }
 
 std::vector<verible::TreeSearchMatch> FindAllBinaryOperations(

--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -98,6 +98,19 @@ const verible::Symbol* GetConditionExpressionFalseCase(
   return GetSubtreeAsSymbol(condition_expr, NodeEnum::kConditionExpression, 4);
 }
 
+const verible::TokenInfo* GetUnaryPrefixOperator(
+    const verible::Symbol& symbol) {
+  const auto& children = verible::SymbolCastToNode(symbol).children();
+  const auto leaf_symbol = children.front().get();
+  return &verible::down_cast<const verible::SyntaxTreeLeaf*>(leaf_symbol)
+              ->get();
+}
+
+const verible::Symbol* GetUnaryPrefixOperand(const verible::Symbol& symbol) {
+  const auto& children = verible::SymbolCastToNode(symbol).children();
+  return children.back().get();
+}
+
 std::vector<verible::TreeSearchMatch> FindAllBinaryOperations(
     const verible::Symbol& root) {
   return verible::SearchSyntaxTree(root, NodekBinaryExpression());

--- a/verilog/CST/expression.h
+++ b/verilog/CST/expression.h
@@ -81,6 +81,12 @@ const verible::Symbol* GetConditionExpressionTrueCase(const verible::Symbol&);
 // Returns the false-case expression of a kConditionExpression.
 const verible::Symbol* GetConditionExpressionFalseCase(const verible::Symbol&);
 
+// Returns the operator of a kUnaryPrefixExpression
+const verible::TokenInfo* GetUnaryPrefixOperator(const verible::Symbol&);
+
+// Returns the operand of a kUnaryPrefixExpression
+const verible::Symbol* GetUnaryPrefixOperand(const verible::Symbol&);
+
 // From binary expression operations, e.g. "a + b".
 // Associative binary operators may span more than two operands, e.g. "a+b+c".
 std::vector<verible::TreeSearchMatch> FindAllBinaryOperations(

--- a/verilog/CST/expression.h
+++ b/verilog/CST/expression.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -446,6 +446,7 @@ TEST(GetUnaryPrefixOperator, Exprs) {
     } else {
       EXPECT_NE(NodeEnum(last_node->Tag().tag),
                 NodeEnum::kUnaryPrefixExpression);
+      EXPECT_FALSE(GetUnaryPrefixOperand(*last_node));
     }
   }
 }
@@ -472,6 +473,7 @@ TEST(GetUnaryPrefixOperand, Exprs) {
     } else {
       EXPECT_NE(NodeEnum(last_node->Tag().tag),
                 NodeEnum::kUnaryPrefixExpression);
+      EXPECT_FALSE(GetUnaryPrefixOperand(*last_node));
     }
   }
 }

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -34,6 +34,7 @@ cc_library(
         ":forbidden_anonymous_structs_unions_rule",
         ":forbidden_macro_rule",
         ":forbidden_symbol_rule",
+        ":forbid_negative_array_dim",
         ":generate_label_prefix_rule",
         ":generate_label_rule",
         ":interface_name_style_rule",
@@ -1371,6 +1372,45 @@ cc_test(
     srcs = ["unpacked_dimensions_rule_test.cc"],
     deps = [
         ":unpacked_dimensions_rule",
+        "//common/analysis:linter_test_utils",
+        "//common/analysis:syntax_tree_linter_test_utils",
+        "//common/text:symbol",
+        "//verilog/CST:verilog_nonterminals",
+        "//verilog/analysis:verilog_analyzer",
+        "//verilog/parser:verilog_token_enum",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "forbid_negative_array_dim",
+    srcs = ["forbid_negative_array_dim.cc"],
+    hdrs = ["forbid_negative_array_dim.h"],
+    deps = [
+        "//common/analysis:lint_rule_status",
+        "//common/analysis:syntax_tree_lint_rule",
+        "//common/analysis/matcher",
+        "//common/analysis/matcher:bound_symbol_manager",
+        "//common/text:symbol",
+        "//common/text:syntax_tree_context",
+        "//common/text:tree_utils",
+        "//common/util:logging",
+        "//verilog/CST:context_functions",
+        "//verilog/CST:dimensions",
+        "//verilog/CST:expression",
+        "//verilog/CST:verilog_matchers",
+        "//verilog/analysis:descriptions",
+        "//verilog/analysis:lint_rule_registry",
+        "@com_google_absl//absl/strings",
+    ],
+    alwayslink = 1,
+)
+
+cc_test(
+    name = "forbid_negative_array_dim_test",
+    srcs = ["forbid_negative_array_dim_test.cc"],
+    deps = [
+        ":forbid_negative_array_dim",
         "//common/analysis:linter_test_utils",
         "//common/analysis:syntax_tree_linter_test_utils",
         "//common/text:symbol",

--- a/verilog/analysis/checkers/forbid_negative_array_dim.cc
+++ b/verilog/analysis/checkers/forbid_negative_array_dim.cc
@@ -1,0 +1,97 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/forbid_negative_array_dim.h"
+
+#include <set>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/matcher/bound_symbol_manager.h"
+#include "common/analysis/matcher/matcher.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "common/text/tree_utils.h"
+#include "common/util/logging.h"
+#include "verilog/CST/context_functions.h"
+#include "verilog/CST/dimensions.h"
+#include "verilog/CST/expression.h"
+#include "verilog/CST/verilog_matchers.h"
+#include "verilog/analysis/descriptions.h"
+#include "verilog/analysis/lint_rule_registry.h"
+
+namespace verilog {
+namespace analysis {
+
+using verible::matcher::Matcher;
+
+// Register the lint rule
+VERILOG_REGISTER_LINT_RULE(ForbidNegativeArrayDim);
+
+static constexpr absl::string_view kMessage =
+    "Avoid using negative constant literals for array dimensions.";
+
+const LintRuleDescriptor& ForbidNegativeArrayDim::GetDescriptor() {
+  static const LintRuleDescriptor d{
+      .name = "forbid-negative-array-dim",
+      .topic = "forbid-negative-array-dim",
+      .desc = "Check for negative constant literals inside array dimensions.",
+  };
+  return d;
+}
+
+// Matches the begin node.
+static const Matcher& UnaryPrefixExprMatcher() {
+  static const Matcher matcher(NodekUnaryPrefixExpression());
+  return matcher;
+}
+
+void ForbidNegativeArrayDim::HandleSymbol(
+    const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
+  if (!context.IsInsideFirst(
+          {NodeEnum::kPackedDimensions, NodeEnum::kUnpackedDimensions},
+          {NodeEnum::kBinaryExpression, NodeEnum::kUnaryPrefixExpression}))
+    return;
+
+  verible::matcher::BoundSymbolManager manager;
+  if (UnaryPrefixExprMatcher().Matches(symbol, &manager)) {
+    const auto& node = SymbolCastToNode(symbol);
+    const auto& children = node.children();
+    const auto& leaf_symbol = *children[0].get();
+    const auto& term =
+        verible::down_cast<const verible::SyntaxTreeLeaf&>(leaf_symbol);
+
+    // mandatory? {leaf, node}
+    if (children.size() <= 1) return;
+
+    int value = -1;
+    const auto& child_node = children[1];
+    const bool is_constant = ConstantIntegerValue(*child_node.get(), &value);
+
+    const verible::TokenInfo token(TK_OTHER,
+                                   verible::StringSpanOfSymbol(symbol));
+    if (is_constant && value > 0 && term.get().text() == "-") {
+      violations_.insert(verible::LintViolation(token, kMessage, context));
+    }
+  }
+}
+
+verible::LintRuleStatus ForbidNegativeArrayDim::Report() const {
+  return verible::LintRuleStatus(violations_, GetDescriptor());
+}
+
+}  // namespace analysis
+}  // namespace verilog

--- a/verilog/analysis/checkers/forbid_negative_array_dim.cc
+++ b/verilog/analysis/checkers/forbid_negative_array_dim.cc
@@ -72,11 +72,12 @@ void ForbidNegativeArrayDim::HandleSymbol(
     int value = 0;
 
     // Extract operand and operator from kUnaryPrefixExpression
-    const auto u_operator = verilog::GetUnaryPrefixOperator(symbol);
-    const auto operand = verilog::GetUnaryPrefixOperand(symbol);
+    const verible::TokenInfo* u_operator =
+        verilog::GetUnaryPrefixOperator(symbol);
+    const verible::Symbol* operand = verilog::GetUnaryPrefixOperand(symbol);
 
     const bool is_constant = verilog::ConstantIntegerValue(*operand, &value);
-    if (is_constant > 0 && value > 0 && u_operator->text() == "-") {
+    if (is_constant && value > 0 && u_operator->text() == "-") {
       const verible::TokenInfo token(TK_OTHER,
                                      verible::StringSpanOfSymbol(symbol));
       violations_.insert(verible::LintViolation(token, kMessage, context));

--- a/verilog/analysis/checkers/forbid_negative_array_dim.cc
+++ b/verilog/analysis/checkers/forbid_negative_array_dim.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,22 +69,16 @@ void ForbidNegativeArrayDim::HandleSymbol(
 
   verible::matcher::BoundSymbolManager manager;
   if (UnaryPrefixExprMatcher().Matches(symbol, &manager)) {
-    const auto& node = SymbolCastToNode(symbol);
-    const auto& children = node.children();
-    const auto& leaf_symbol = *children[0].get();
-    const auto& term =
-        verible::down_cast<const verible::SyntaxTreeLeaf&>(leaf_symbol);
+    int value = 0;
 
-    // mandatory? {leaf, node}
-    if (children.size() <= 1) return;
+    // Extract operand and operator from kUnaryPrefixExpression
+    const auto u_operator = verilog::GetUnaryPrefixOperator(symbol);
+    const auto operand = verilog::GetUnaryPrefixOperand(symbol);
 
-    int value = -1;
-    const auto& child_node = children[1];
-    const bool is_constant = ConstantIntegerValue(*child_node.get(), &value);
-
-    const verible::TokenInfo token(TK_OTHER,
-                                   verible::StringSpanOfSymbol(symbol));
-    if (is_constant && value > 0 && term.get().text() == "-") {
+    const bool is_constant = verilog::ConstantIntegerValue(*operand, &value);
+    if (is_constant > 0 && value > 0 && u_operator->text() == "-") {
+      const verible::TokenInfo token(TK_OTHER,
+                                     verible::StringSpanOfSymbol(symbol));
       violations_.insert(verible::LintViolation(token, kMessage, context));
     }
   }

--- a/verilog/analysis/checkers/forbid_negative_array_dim.cc
+++ b/verilog/analysis/checkers/forbid_negative_array_dim.cc
@@ -63,8 +63,9 @@ void ForbidNegativeArrayDim::HandleSymbol(
     const verible::Symbol& symbol, const verible::SyntaxTreeContext& context) {
   if (!context.IsInsideFirst(
           {NodeEnum::kPackedDimensions, NodeEnum::kUnpackedDimensions},
-          {NodeEnum::kBinaryExpression, NodeEnum::kUnaryPrefixExpression}))
+          {NodeEnum::kBinaryExpression, NodeEnum::kUnaryPrefixExpression})) {
     return;
+  }
 
   verible::matcher::BoundSymbolManager manager;
   if (UnaryPrefixExprMatcher().Matches(symbol, &manager)) {

--- a/verilog/analysis/checkers/forbid_negative_array_dim.h
+++ b/verilog/analysis/checkers/forbid_negative_array_dim.h
@@ -1,0 +1,48 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_NEGATIVE_ARRAY_DIM_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_NEGATIVE_ARRAY_DIM_RULE_H_
+
+#include <set>
+#include <string>
+
+#include "common/analysis/lint_rule_status.h"
+#include "common/analysis/syntax_tree_lint_rule.h"
+#include "common/text/symbol.h"
+#include "common/text/syntax_tree_context.h"
+#include "verilog/analysis/descriptions.h"
+
+namespace verilog {
+namespace analysis {
+
+class ForbidNegativeArrayDim : public verible::SyntaxTreeLintRule {
+ public:
+  using rule_type = verible::SyntaxTreeLintRule;
+
+  static const LintRuleDescriptor& GetDescriptor();
+
+  void HandleSymbol(const verible::Symbol& symbol,
+                    const verible::SyntaxTreeContext& context) final;
+
+  verible::LintRuleStatus Report() const final;
+
+ private:
+  std::set<verible::LintViolation> violations_;
+};
+
+}  // namespace analysis
+}  // namespace verilog
+
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_NEGATIVE_ARRAY_DIM_RULE_H_

--- a/verilog/analysis/checkers/forbid_negative_array_dim.h
+++ b/verilog/analysis/checkers/forbid_negative_array_dim.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,16 @@
 
 namespace verilog {
 namespace analysis {
-
+/*
+ * Check for negative sizes inside array dimensions. It only
+ * detects constant literals at the moment.
+ *
+ * Examples:
+ *   logic l [-1:0];
+ *   logic [-1:0] l;
+ *
+ * See forbid_negative_array_dim_test.cc for more examples.
+ */
 class ForbidNegativeArrayDim : public verible::SyntaxTreeLintRule {
  public:
   using rule_type = verible::SyntaxTreeLintRule;

--- a/verilog/analysis/checkers/forbid_negative_array_dim_test.cc
+++ b/verilog/analysis/checkers/forbid_negative_array_dim_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,14 +35,33 @@ TEST(ForbidNegativeArrayDim, ForbidNegativeArrayDims) {
   constexpr int kScalar = TK_OTHER;
   const std::initializer_list<LintTestCase> kTestCases = {
       {""},
+      /* Unpacked */
       {"logic l [", {kScalar, "-10"}, ":0];"},
-      {"logic [", {kScalar, "-10"}, ":-0] l;"},
-      {"logic l [0:", {kScalar, "-10"}, "];"},
       {"logic l [+1:0];"},
       {"logic l [-p:0];"},
       {"logic l [10+(-5):0];"},
       {"logic l [(", {kScalar, "-5"}, "):0];"},
       {"logic l [-(-5):0];"},
+      /* Can't detect this at the moment */
+      {"logic l [+(-5):0];"},
+      /* Packed */
+      {"logic [", {kScalar, "-10"}, ":-0] l;"},
+      {"logic [0:", {kScalar, "-10"}, "] l;"},
+      {"logic [1:0] l;"},
+      /* Packed AND Unpacked */
+      {"logic [", {kScalar, "-10"}, ":0] l [0:", {kScalar, "-10"}, "];"},
+
+      /* Inside modules, in port declarations, ... */
+      {"module k(); logic l [(", {kScalar, "-5"}, "):0]; endmodule"},
+      {"module k(); logic l [1:0]; endmodule"},
+      {"module k(logic l [(", {kScalar, "-5"}, "):0]);  endmodule"},
+      {"module k(logic l [1:0]);  endmodule"},
+      {"module k(logic l [(", {kScalar, "-5"}, "):0]);  endmodule"},
+      {"struct { bit [1:0] l; } p;"},
+      {"struct { logic [", {kScalar, "-1"}, ":0] l; } p;"},
+      {"class p; bit [1:0] l; }; endclass"},
+      {"class p; logic [", {kScalar, "-1"}, ":0] l; endclass"},
+      {"function p(); logic [", {kScalar, "-1"}, ":0] l; endfunction"},
   };
   RunLintTestCases<VerilogAnalyzer, ForbidNegativeArrayDim>(kTestCases);
 }

--- a/verilog/analysis/checkers/forbid_negative_array_dim_test.cc
+++ b/verilog/analysis/checkers/forbid_negative_array_dim_test.cc
@@ -1,0 +1,52 @@
+// Copyright 2017-2020 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/analysis/checkers/forbid_negative_array_dim.h"
+
+#include <initializer_list>
+
+#include "common/analysis/linter_test_utils.h"
+#include "common/analysis/syntax_tree_linter_test_utils.h"
+#include "common/text/symbol.h"
+#include "gtest/gtest.h"
+#include "verilog/CST/verilog_nonterminals.h"
+#include "verilog/analysis/verilog_analyzer.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+namespace analysis {
+namespace {
+
+using verible::LintTestCase;
+using verible::RunLintTestCases;
+
+TEST(ForbidNegativeArrayDim, ForbidNegativeArrayDims) {
+  constexpr int kScalar = TK_OTHER;
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {""},
+      {"logic l [", {kScalar, "-10"}, ":0];"},
+      {"logic [", {kScalar, "-10"}, ":-0] l;"},
+      {"logic l [0:", {kScalar, "-10"}, "];"},
+      {"logic l [+1:0];"},
+      {"logic l [-p:0];"},
+      {"logic l [10+(-5):0];"},
+      {"logic l [(", {kScalar, "-5"}, "):0];"},
+      {"logic l [-(-5):0];"},
+  };
+  RunLintTestCases<VerilogAnalyzer, ForbidNegativeArrayDim>(kTestCases);
+}
+
+}  // namespace
+}  // namespace analysis
+}  // namespace verilog


### PR DESCRIPTION
Attempt to fix https://github.com/chipsalliance/verible/issues/382. I'm sure the code could use some improvements, so happy to accomodate any feedback!


Edit:

Sorry for the several updates, after making the pull request I realized that there are some corner cases (parenthesis, ...) so I tried to fix some of those. It still won't pick up things like +(-5) but I can't see an easy way to fix that.