### PR TITLE
Ripgrep based output analysis in smoke-test-analyzer

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -189,7 +189,7 @@ jobs:
       run: |
         set -x
         apt -qqy update
-        apt -qq -y install build-essential wget git python3 python-is-python3 default-jdk cmake python3-pip
+        apt -qq -y install build-essential wget git python3 python-is-python3 default-jdk cmake python3-pip ripgrep
         apt -qq -y install gcc-10 g++-10
         apt -qq -y install gcc-12 g++-12
         apt -qq -y install clang-12  # clang always a particular version.


### PR DESCRIPTION
Added a last-resort method to detect include statements containing the filename of the tested file, such that if it was included, the syntax errors would be attributed to the file being taken out of context. This change was made during the preparation for #1839.