### PR TITLE
Adding flag for portable build of Verible binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,3 +27,5 @@ build:asan --copt -O1
 build:asan --copt -g
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
+
+build:create_static_linked_executables --linkopt=-fuse-ld=bfd --features=-supports_start_end_lib --//bazel:create_static_linked_executables

--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -111,6 +111,10 @@ case "$MODE" in
   compile|compile-clang|clean)
     bazel build --keep_going $BAZEL_OPTS :install-binaries
     ;;
+  
+  compile-static|compile-static-clang)
+    bazel build --keep_going --//bazel:create_static_linked_executables $BAZEL_OPTS :install-binaries
+    ;;
 
   test-c++20|test-c++20-clang)
     # Compile with C++ 20 to make sure to be compatible with the next version.

--- a/.github/bin/build-and-test.sh
+++ b/.github/bin/build-and-test.sh
@@ -113,7 +113,7 @@ case "$MODE" in
     ;;
   
   compile-static|compile-static-clang)
-    bazel build --keep_going --//bazel:create_static_linked_executables $BAZEL_OPTS :install-binaries
+    bazel build --keep_going --config=create_static_linked_executables $BAZEL_OPTS :install-binaries
     ;;
 
   test-c++20|test-c++20-clang)

--- a/.github/bin/generate-matrix.py
+++ b/.github/bin/generate-matrix.py
@@ -16,15 +16,25 @@
 
 from pathlib import Path
 
+ARCHS = ["x86_64", "arm64"]
 matrix = []
 
 with (Path(__file__).parent.resolve().parent.parent / 'releasing' / 'supported_bases.txt').open('r') as fptr:
     for items in [line.strip().split(':') for line in fptr.readlines()]:
-        for arch in ["x86_64", "arm64"]:
+        for arch in ARCHS:
             matrix.append({
                 'os': items[0],
                 'ver': items[1],
-                'arch': arch
+                'arch': arch,
+                'link': 'dynamic',
             })
+
+for arch in ARCHS:
+    matrix.append({
+        'os': 'ubuntu',
+        'ver': 'jammy',
+        'arch': arch,
+        'link': 'static',
+    })
 
 print('::set-output name=matrix::' + str(matrix))

--- a/.github/bin/github-releases-setup.sh
+++ b/.github/bin/github-releases-setup.sh
@@ -61,7 +61,8 @@ DISTRO_ARCH=$(uname -m)
 DISTRO=$(lsb_release --short --id)
 DISTRO_RELEASE=$(lsb_release --short --release)
 DISTRO_CODENAME=$(lsb_release --short --codename | sed -e's/[^A-Za-z0-9]//g')
-TARBALL=$RELEASE_DIR/verible-$GIT_VERSION-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME-$DISTRO_ARCH.tar.gz
+TARGET_LINK=${TARGET_LINK:-"dynamic"}
+TARBALL=$RELEASE_DIR/verible-$GIT_VERSION-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME-$DISTRO_ARCH-$TARGET_LINK.tar.gz
 (
     cd $RELEASE_DIR
     tar -zcvf $TARBALL verible-$GIT_VERSION

--- a/.github/bin/github-releases-setup.sh
+++ b/.github/bin/github-releases-setup.sh
@@ -61,8 +61,11 @@ DISTRO_ARCH=$(uname -m)
 DISTRO=$(lsb_release --short --id)
 DISTRO_RELEASE=$(lsb_release --short --release)
 DISTRO_CODENAME=$(lsb_release --short --codename | sed -e's/[^A-Za-z0-9]//g')
-TARGET_LINK=${TARGET_LINK:-"dynamic"}
-TARBALL=$RELEASE_DIR/verible-$GIT_VERSION-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME-$DISTRO_ARCH-$TARGET_LINK.tar.gz
+if [ "${TARGET_LINK}" = "static" ]; then
+    TARBALL=$RELEASE_DIR/verible-$GIT_VERSION-linux-static-$DISTRO_ARCH.tar.gz
+else
+    TARBALL=$RELEASE_DIR/verible-$GIT_VERSION-$DISTRO-$DISTRO_RELEASE-$DISTRO_CODENAME-$DISTRO_ARCH.tar.gz
+fi
 (
     cd $RELEASE_DIR
     tar -zcvf $TARBALL verible-$GIT_VERSION

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -327,9 +327,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        link: [static, dynamic]
         include: ${{ fromJson(needs.Matrix.outputs.matrix) }}
     env:
       MATRIX_OS: '${{ matrix.os }}:${{ matrix.ver }}'
+      LINK_TYPE: '${{ matrix.link }}'
       ARCH: '${{ matrix.arch }}'
       DOCKER_DATA_ROOT: "/root/.docker"
       GHA_MACHINE_TYPE: "${{ matrix.arch == 'arm64' && 't2a-standard-8' || 'n2-highcpu-8' }}"
@@ -361,7 +363,7 @@ jobs:
 
         docker pull $MATRIX_OS
         source ./.github/settings.sh
-        ARCH="$ARCH" ./releasing/docker-run.sh $MATRIX_OS
+        ARCH="$ARCH" LINK_TYPE="$LINK_TYPE" ./releasing/docker-run.sh $MATRIX_OS
 
     - name: 📤 Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -134,6 +134,8 @@ jobs:
         - asan-clang
         - compile
         - compile-clang
+        - compile-static
+        - compile-static-clang
         - coverage
         - clean
         arch:

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -327,7 +327,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        link: [static, dynamic]
         include: ${{ fromJson(needs.Matrix.outputs.matrix) }}
     env:
       MATRIX_OS: '${{ matrix.os }}:${{ matrix.ver }}'

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -323,7 +323,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, gcp-custom-runners]
     # Github actions resources are limited; don't build artifacts for all
     # platforms on every pull request, only on push.
-    if: ${{github.event_name == 'push'}}
+    # if: ${{github.event_name == 'push'}}
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ syntax checker will be at
 `bazel-bin/verilog/tools/syntax/verible-verilog-syntax` (corresponding to the
 target name `//verilog/tools/syntax:verible-verilog-syntax`).
 
+Moreover, if you need statically linked executables that don't depend on your
+shared libraries, you can use custom flag
+`--//bazel:create_static_linked_executables`.
+
+```bash
+# Generates statically linked executables
+bazel build -c opt --//bazel:create_static_linked_executables //...
+```
+
 ### Optionally using local flex/bison for build
 
 Flex and Bison, that are needed for the parser generation, are compiled as part

--- a/README.md
+++ b/README.md
@@ -182,12 +182,13 @@ syntax checker will be at
 target name `//verilog/tools/syntax:verible-verilog-syntax`).
 
 Moreover, if you need statically linked executables that don't depend on your
-shared libraries, you can use custom flag
-`--//bazel:create_static_linked_executables`.
+shared libraries, you can use custom config
+`create_static_linked_executables` (with this setting `bfd` linker will be used,
+instead of default `gold` linker).
 
 ```bash
 # Generates statically linked executables
-bazel build -c opt --//bazel:create_static_linked_executables //...
+bazel build -c opt --config=create_static_linked_executables //...
 ```
 
 ### Optionally using local flex/bison for build

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -35,3 +35,13 @@ config_setting(
     name = "use_local_flex_bison_enabled",
     flag_values = {":use_local_flex_bison": "true"},
 )
+
+bool_flag(
+    name = "create_static_linked_executables",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "static_linked_executables",
+    flag_values = {":create_static_linked_executables": "true"}
+)

--- a/bazel/variables.bzl
+++ b/bazel/variables.bzl
@@ -1,0 +1,4 @@
+STATIC_EXECUTABLES_FEATURE = select({
+    "//bazel:static_linked_executables": ["fully_static_link"],
+    "//conditions:default": [],
+})

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -1,6 +1,7 @@
 """This package contains language-agnostic tools in the Verible project."""
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 load("//common/tools:jcxxgen.bzl", "jcxxgen")
 
 licenses(["notice"])
@@ -13,6 +14,7 @@ cc_binary(
     name = "verible-patch-tool",
     srcs = ["patch_tool.cc"],
     visibility = ["//:__subpackages__"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/strings:patch",
         "//common/util:file_util",

--- a/releasing/centos/common/compiler.dockerstage
+++ b/releasing/centos/common/compiler.dockerstage
@@ -6,5 +6,6 @@ ENV BAZEL_LINKLIBS "-l%:libstdc++.a"
 # Get a newer GCC version
 RUN yum install -y --nogpgcheck centos-release-scl
 RUN yum install -y --nogpgcheck devtoolset-9
+RUN yum install -y --nogpgcheck glibc-static
 
 SHELL [ "scl", "enable", "devtoolset-9" ]

--- a/releasing/docker-run.sh
+++ b/releasing/docker-run.sh
@@ -28,6 +28,7 @@ export TARGET=`echo "$1" | sed 's#:#-#g'`
 
 TARGET_VERSION=`echo $TARGET | cut -d- -f2`
 TARGET_OS=`echo $TARGET | cut -d- -f1`
+export TARGET_LINK=${LINK_TYPE:-"dynamic"}
 
 export TAG=${TAG:-$(git describe --match=v*)}
 
@@ -72,6 +73,10 @@ case "$TARGET_OS" in
     cat ${TARGET_OS}/common/compiler.dockerstage >> ${OUT_DIR}/Dockerfile
   ;;
 esac
+
+if [ "${TARGET_LINK}" = static ]; then
+  BAZEL_OPTS="${BAZEL_OPTS} --//bazel:create_static_linked_executables"
+fi
 
 # Bazel
 cat bazel.dockerstage >> ${OUT_DIR}/Dockerfile
@@ -135,6 +140,7 @@ docker run --rm \
   -e GIT_VERSION="${GIT_VERSION:-$(git describe --match=v*)}" \
   -e GIT_DATE="${GIT_DATE:-$(git show -s --format=%ci)}" \
   -e GIT_HASH="${GIT_HASH:-$(git rev-parse HEAD)}" \
+  -e TARGET_LINK="${TARGET_LINK:-""}" \
   -v $(pwd)/out:/out \
   $IMAGE \
   ./releasing/build.sh

--- a/releasing/docker-run.sh
+++ b/releasing/docker-run.sh
@@ -74,8 +74,8 @@ case "$TARGET_OS" in
   ;;
 esac
 
-if [ "${TARGET_LINK}" = static ]; then
-  BAZEL_OPTS="${BAZEL_OPTS} --//bazel:create_static_linked_executables"
+if [ "${TARGET_LINK}" = "static" ]; then
+  BAZEL_OPTS="${BAZEL_OPTS} --config=create_static_linked_executables"
 fi
 
 # Bazel

--- a/releasing/docker-run.sh
+++ b/releasing/docker-run.sh
@@ -76,6 +76,9 @@ esac
 
 if [ "${TARGET_LINK}" = "static" ]; then
   BAZEL_OPTS="${BAZEL_OPTS} --config=create_static_linked_executables"
+  # Bazel link options with static libs cause error with
+  # --config=create_static_linked_executables and they are redundant
+  sed -i '/ENV BAZEL_LINK/d' ${OUT_DIR}/Dockerfile
 fi
 
 # Bazel
@@ -140,7 +143,7 @@ docker run --rm \
   -e GIT_VERSION="${GIT_VERSION:-$(git describe --match=v*)}" \
   -e GIT_DATE="${GIT_DATE:-$(git show -s --format=%ci)}" \
   -e GIT_HASH="${GIT_HASH:-$(git rev-parse HEAD)}" \
-  -e TARGET_LINK="${TARGET_LINK:-""}" \
+  -e TARGET_LINK \
   -v $(pwd)/out:/out \
   $IMAGE \
   ./releasing/build.sh

--- a/verilog/tools/diff/BUILD
+++ b/verilog/tools/diff/BUILD
@@ -2,6 +2,7 @@
 """
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 licenses(["notice"])
 
@@ -9,6 +10,7 @@ cc_binary(
     name = "verible-verilog-diff",
     srcs = ["verilog_diff.cc"],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/strings:obfuscator",
         "//common/util:enum_flags",

--- a/verilog/tools/formatter/BUILD
+++ b/verilog/tools/formatter/BUILD
@@ -2,6 +2,7 @@
 #
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 licenses(["notice"])
 
@@ -9,6 +10,7 @@ cc_binary(
     name = "verible-verilog-format",
     srcs = ["verilog_format.cc"],
     visibility = ["//visibility:public"],  # for verilog_style_lint.bzl
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/formatting:align",
         "//common/strings:position",

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -1,6 +1,7 @@
 # 'verible-verilog-kythe-extractor' is a program for extracting Verilog/SystemVerilog to kythe facts.
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 licenses(["notice"])
 
@@ -225,6 +226,7 @@ cc_binary(
         "verilog_kythe_extractor.cc",
     ],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         ":indexing_facts_tree_extractor",
         ":kythe_facts_extractor",
@@ -288,6 +290,7 @@ cc_binary(
         "verilog_kythe_kzip_writer.cc",
     ],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         ":kzip_creator",
         "//common/util:file_util",

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -6,6 +6,7 @@ load(
     "verilog_syntax",
 )
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 licenses(["notice"])
 
@@ -225,6 +226,7 @@ cc_binary(
     name = "verible-verilog-lint",
     srcs = ["verilog_lint.cc"],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/analysis:violation_handler",
         "//common/util:enum_flags",

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -226,7 +226,15 @@ cc_binary(
     name = "verible-verilog-lint",
     srcs = ["verilog_lint.cc"],
     visibility = ["//visibility:public"],
-    features = STATIC_EXECUTABLES_FEATURE,
+    features = STATIC_EXECUTABLES_FEATURE +
+    select({
+        "//bazel:static_linked_executables": ["-supports_start_end_lib"],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "//bazel:static_linked_executables": ["-fuse-ld=bfd"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//common/analysis:violation_handler",
         "//common/util:enum_flags",

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -3,6 +3,7 @@
 # [1]: https://microsoft.github.io/language-server-protocol/specification
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 licenses(["notice"])
 
@@ -167,6 +168,7 @@ cc_binary(
     name = "verible-verilog-ls",
     srcs = ["verilog_ls.cc"],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         ":verilog-language-server",
         "//common/util:init_command_line",

--- a/verilog/tools/obfuscator/BUILD
+++ b/verilog/tools/obfuscator/BUILD
@@ -4,11 +4,13 @@
 licenses(["notice"])
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 cc_binary(
     name = "verible-verilog-obfuscate",
     srcs = ["verilog_obfuscate.cc"],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/strings:obfuscator",
         "//common/util:file_util",

--- a/verilog/tools/preprocessor/BUILD
+++ b/verilog/tools/preprocessor/BUILD
@@ -4,11 +4,13 @@
 licenses(["notice"])
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 cc_binary(
     name = "verible-verilog-preprocessor",
     srcs = ["verilog_preprocessor.cc"],
     visibility = ["//visibility:public"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/util:file_util",
         "//common/util:init_command_line",

--- a/verilog/tools/project/BUILD
+++ b/verilog/tools/project/BUILD
@@ -4,11 +4,13 @@
 licenses(["notice"])
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 cc_binary(
     name = "verible-verilog-project",
     srcs = ["project_tool.cc"],
     visibility = ["//:__subpackages__"],
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/util:init_command_line",
         "//common/util:logging",

--- a/verilog/tools/syntax/BUILD
+++ b/verilog/tools/syntax/BUILD
@@ -3,11 +3,13 @@
 licenses(["notice"])
 
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
+load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 cc_binary(
     name = "verible-verilog-syntax",
     srcs = ["verilog_syntax.cc"],
     visibility = ["//visibility:public"],  # for verilog_style_lint.bzl
+    features = STATIC_EXECUTABLES_FEATURE,
     deps = [
         "//common/strings:compare",
         "//common/strings:mem_block",


### PR DESCRIPTION
This PR adds `--//bazel:create_portable_executables` flag, which allows to generate portable binaries. It can be useful for e.g. creating VS Code extension where only generated binaries will be needed -- without additional shared libraries.

This flag can be used with `build` command, e.g.:
```
bazel build -c opt --//bazel:create_portable_executables //...
```
