### PR TITLE
Be more specific about library visibilities.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,7 +12,7 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-# More machine-readable way to specify the license
+# Machine-readable license specification.
 license(
     name = "license",
     package_name = "verible",

--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -4,7 +4,6 @@ package(
     default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//verilog/formatting:__subpackages__",
-        "//verilog/tools/formatter:__pkg__",
     ],
 )
 

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -628,7 +628,6 @@ cc_library(
     name = "simple_zip",
     srcs = ["simple_zip.cc"],
     hdrs = ["simple_zip.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//third_party/portable_endian",
         "@com_google_absl//absl/strings",

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -4,6 +4,7 @@ package(
     default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//verilog/tools/formatter:__pkg__",
+        "//verilog/tools/ls:__pkg__",
     ],
 )
 
@@ -130,7 +131,6 @@ cc_library(
     hdrs = [
         "formatter.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         ":align",
         ":comment_controls",
@@ -239,7 +239,6 @@ cc_test(
 cc_library(
     name = "format_style",
     hdrs = ["format_style.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//common/formatting:align",
         "//common/formatting:basic_format_style",
@@ -251,7 +250,6 @@ cc_library(
     name = "format_style_init",
     srcs = ["format_style_init.cc"],
     hdrs = ["format_style_init.h"],
-    visibility = ["//visibility:public"],
     deps = [
         ":format_style",
         "//common/formatting:basic_format_style_init",

--- a/verilog/tools/formatter/BUILD
+++ b/verilog/tools/formatter/BUILD
@@ -8,7 +8,6 @@ cc_binary(
     srcs = ["verilog_format.cc"],
     visibility = ["//visibility:public"],  # for verilog_style_lint.bzl
     deps = [
-        "//common/formatting:align",
         "//common/strings:position",
         "//common/util:file_util",
         "//common/util:init_command_line",

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -36,7 +36,6 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
-#include "common/formatting/align.h"
 #include "common/strings/position.h"
 #include "common/util/file_util.h"
 #include "common/util/init_command_line.h"


### PR DESCRIPTION
Some were public, but didn't need to be.
The only public items are the final binaries.