### PR TITLE
Avoid performing filename lint rules for stdin

### DIFF
--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -152,7 +152,7 @@ absl::StatusOr<std::string> GetContentAsString(absl::string_view filename) {
   std::string content;
   std::ifstream fs;
   std::istream *stream = nullptr;
-  const bool use_stdin = filename == "-";  // convention: honor "-" as stdin
+  const bool use_stdin = IsStdin(filename);
   if (use_stdin) {
     stream = &std::cin;
   } else {
@@ -288,6 +288,11 @@ absl::StatusOr<Directory> ListDir(absl::string_view dir) {
   std::sort(d.files.begin(), d.files.end());
   std::sort(d.directories.begin(), d.directories.end());
   return d;
+}
+
+bool IsStdin(absl::string_view filename) {
+  static constexpr absl::string_view kStdinFilename = "-";
+  return filename == kStdinFilename;
 }
 
 namespace testing {

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -33,6 +33,12 @@
 namespace verible {
 namespace file {
 
+// Check if the input filename corresponds to stdin.
+// Convention: honor "-" as stdin
+// Added to avoid performing lint filename rules such as
+// {package,module}_filename_rule
+bool IsStdin(absl::string_view filename);
+
 // A representation of a filesystem directory.
 struct Directory {
   // Path to the directory.

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -366,6 +366,11 @@ TEST(FileUtil, ReadDirectory) {
   EXPECT_EQ(dir.files, test_files);
 }
 
+TEST(FileUtil, IsStdin) {
+  EXPECT_EQ(file::IsStdin("-"), true);
+  EXPECT_EQ(file::IsStdin("not stdin!"), false);
+}
+
 }  // namespace
 }  // namespace util
 }  // namespace verible

--- a/verilog/analysis/checkers/module_filename_rule.cc
+++ b/verilog/analysis/checkers/module_filename_rule.cc
@@ -73,6 +73,10 @@ static bool ModuleNameMatches(const verible::Symbol& s,
 
 void ModuleFilenameRule::Lint(const TextStructureView& text_structure,
                               absl::string_view filename) {
+  if (verible::file::IsStdin(filename)) {
+    return;
+  }
+
   const auto& tree = text_structure.SyntaxTree();
   if (tree == nullptr) return;
 
@@ -94,6 +98,7 @@ void ModuleFilenameRule::Lint(const TextStructureView& text_structure,
 
   // See if any names match the stem of the filename.
   const absl::string_view basename = verible::file::Basename(filename);
+
   std::vector<absl::string_view> basename_components =
       absl::StrSplit(basename, '.');
   std::string unitname(basename_components[0].begin(),

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -65,6 +65,10 @@ const LintRuleDescriptor& PackageFilenameRule::GetDescriptor() {
 
 void PackageFilenameRule::Lint(const TextStructureView& text_structure,
                                absl::string_view filename) {
+  if (verible::file::IsStdin(filename)) {
+    return;
+  }
+
   const auto& tree = text_structure.SyntaxTree();
   if (tree == nullptr) return;
 

--- a/verilog/tools/lint/lint_tool_test.sh
+++ b/verilog/tools/lint/lint_tool_test.sh
@@ -231,6 +231,56 @@ status="$?"
 }
 
 ################################################################################
+echo "=== Test module filename rule for stdin"
+
+TEST_FILE="${TEST_TMPDIR}/module-filename-error.sv"
+
+cat > ${TEST_FILE} <<EOF
+module m;
+endmodule
+EOF
+
+"$lint_tool" "$TEST_FILE" --nocheck_syntax > /dev/null 2> "${MY_OUTPUT_FILE}.err"
+
+status="$?"
+[[ $status == 1 ]] || {
+  echo "Expected exit code 1, but got $status"
+  exit 1
+}
+
+cat "$TEST_FILE" | "$lint_tool" - --nocheck_syntax > /dev/null 2> "${MY_OUTPUT_FILE}.err"
+
+status="$?"
+[[ $status == 0 ]] || {
+  echo "Expected exit code 0, but got $status"
+  exit 1
+}
+
+echo "=== Test package filename rule for stdin"
+TEST_FILE="${TEST_TMPDIR}/package-filename-error.sv"
+
+cat > ${TEST_FILE} <<EOF
+package k;
+endpackage
+EOF
+
+"$lint_tool" "$TEST_FILE" --nocheck_syntax > /dev/null 2> "${MY_OUTPUT_FILE}.err"
+
+status="$?"
+[[ $status == 1 ]] || {
+  echo "Expected exit code 1, but got $status"
+  exit 1
+}
+
+cat "$TEST_FILE" | "$lint_tool" - --nocheck_syntax > /dev/null 2> "${MY_OUTPUT_FILE}.err"
+
+status="$?"
+[[ $status == 0 ]] || {
+  echo "Expected exit code 0, but got $status"
+  exit 1
+}
+
+################################################################################
 echo "=== Test invalid rule (--rules)"
 
 # using same ${TEST_FILE}


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/verible/issues/1359. Went ahead and fixed the package_filename_rule too. 

As I'm not familiar with the tool, I don't know if every time we consume stdin input the filename is always "-", or if we should have an array of possible stdin filenames to match against. For example: 
```c++
static const char *STDIN_FILENAMES[NUM_STDIM_NAMES] = {
  "-",
  "stdin",
  "something something"
};
```

I'm not sure if adding tests for this would be an easy task, but I suspect it isn't.