### PR TITLE
Adapt verbosity of some logging for improved usefulness.

### DIFF
--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -822,7 +822,7 @@ static bool AlignedRowsFitUnderColumnLimit(
       const int aligned_partition_width =
           total_column_width + EffectiveCellWidth(epilog_range);
       if (aligned_partition_width > column_limit) {
-        VLOG(1) << "Total aligned partition width " << aligned_partition_width
+        VLOG(2) << "Total aligned partition width " << aligned_partition_width
                 << " exceeds limit " << column_limit
                 << ", so not aligning this group.";
         return false;
@@ -950,7 +950,7 @@ AlignablePartitionGroup::CalculateAlignmentSpacings(
     // align for now.  However, this check alone does not include text that
     // follows the last aligned column, like trailing comments and EOL comments.
     if (total_column_width > column_limit) {
-      VLOG(1) << "Total aligned column width " << total_column_width
+      VLOG(2) << "Total aligned column width " << total_column_width
               << " exceeds limit " << column_limit
               << ", so not aligning this group.";
       return result;
@@ -1277,7 +1277,7 @@ void TabularAlignTokens(
   const TokenPartitionRange subpartitions_range(subpartitions.begin(),
                                                 subpartitions.end());
   if (subpartitions_range.empty()) return;
-  VLOG(1) << "extracting alignment partition groups...";
+  VLOG(2) << "extracting alignment partition groups...";
   const std::vector<AlignablePartitionGroup> alignment_groups(
       extract_alignment_groups(subpartitions_range));
   for (const auto& alignment_group : alignment_groups) {

--- a/verilog/analysis/checkers/line_length_rule.cc
+++ b/verilog/analysis/checkers/line_length_rule.cc
@@ -162,7 +162,6 @@ void LineLengthRule::Lint(const TextStructureView& text_structure,
                           absl::string_view) {
   size_t lineno = 0;
   for (const auto& line : text_structure.Lines()) {
-    VLOG(2) << "Examining line: " << lineno + 1;
     const int observed_line_length = verible::utf8_len(line);
     if (observed_line_length > line_length_limit_) {
       const auto token_range = text_structure.TokenRangeOnLine(lineno);

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -1527,10 +1527,10 @@ void TabularAlignTokenPartitions(const FormatStyle& style,
   auto& partition = *partition_ptr;
   auto& uwline = partition.Value();
   const auto* origin = uwline.Origin();
-  VLOG(1) << "origin is nullptr? " << (origin == nullptr);
+  VLOG(2) << "origin is nullptr? " << (origin == nullptr);
   if (origin == nullptr) return;
   const auto* node = down_cast<const SyntaxTreeNode*>(origin);
-  VLOG(1) << "origin is node? " << (node != nullptr);
+  VLOG(2) << "origin is node? " << (node != nullptr);
   if (node == nullptr) return;
   // Dispatch aligning function based on syntax tree node type.
 

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -572,7 +572,7 @@ static SpacePolicy SpacesRequiredBetween(
   constexpr int kUnhandledSpacesDefault = 1;
   const auto spaces =
       SpacesRequiredBetween(left, right, left_context, right_context, style);
-  VLOG(1) << "spaces: " << spaces.value << ", reason: " << spaces.reason;
+  VLOG(2) << "spaces: " << spaces.value << ", reason: " << spaces.reason;
 
   if (spaces.value == kUnhandledSpacesRequired) {
     VLOG(1) << "Unhandled inter-token spacing between "


### PR DESCRIPTION
Observing the language server output with
VERIBLE_VLOG_DETAIL=1 showed some too detailed logging in places.

For macro expansion parsing: include original filename when logging issues.