### PR TITLE
Fix an assumption that std::distance is a simple int.

### DIFF
--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -147,10 +147,10 @@ LineColumnRange TextStructureView::GetRangeForToken(
 
 LineColumnRange TextStructureView::GetRangeForText(
     absl::string_view text) const {
-  const int from = std::distance(Contents().begin(), text.begin());
-  const int to = std::distance(Contents().begin(), text.end());
+  const auto from = std::distance(Contents().begin(), text.begin());
+  const auto to = std::distance(Contents().begin(), text.end());
   CHECK_GE(from, 0) << '"' << text << '"';
-  CHECK_LE(to, static_cast<int>(Contents().length())) << '"' << text << '"';
+  CHECK_LE(to, static_cast<int64_t>(Contents().length())) << '"' << text << '"';
   return {GetLineColAtOffset(from), GetLineColAtOffset(to)};
 }
 

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -108,6 +108,7 @@ class TextStructureView {
   }
 
   // Given a byte offset, return the line/column
+  // TODO(hzeller): this should probably be int64_t or a DocumentOffset typedef
   LineColumn GetLineColAtOffset(int bytes_offset) const {
     return GetLineColumnMap().GetLineColAtOffset(contents_, bytes_offset);
   }


### PR DESCRIPTION
Given that we're dealing with memory addresses, this is likely some int64 type.