### PR TITLE
Color the diffs/hunks presented to the user #526

### DIFF
--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -79,10 +79,10 @@ absl::Status MarkedLine::Parse(absl::string_view text) {
 }
 
 std::ostream& operator<<(std::ostream& stream, const MarkedLine& line) {
-  term::Color c = line.IsDeleted() ? term::Color::kRed
-                  : line.IsAdded() ? term::Color::kCyan
-                                   : term::Color::kNone;
-  return stream << StartColor(c) << line.line << EndColor(c);
+  const term::Color c = line.IsDeleted() ? term::Color::kRed
+                        : line.IsAdded() ? term::Color::kCyan
+                                         : term::Color::kNone;
+  return stream << StartColor(stream, c) << line.line << EndColor(stream, c);
 }
 
 absl::Status HunkIndices::Parse(absl::string_view text) {
@@ -149,9 +149,10 @@ absl::Status HunkHeader::Parse(absl::string_view text) {
 }
 
 std::ostream& operator<<(std::ostream& stream, const HunkHeader& header) {
-  return stream << term::StartColor(term::Color::kGreen) << "@@ -"
+  return stream << term::StartColor(stream, term::Color::kGreen) << "@@ -"
                 << header.old_range << " +" << header.new_range << " @@"
-                << header.context << term::EndColor(term::Color::kGreen);
+                << header.context
+                << term::EndColor(stream, term::Color::kGreen);
 }
 
 // Type M could be any container or range of MarkedLines.
@@ -367,8 +368,7 @@ LineNumberSet FilePatch::AddedLines() const {
 static char PromptHunkAction(std::istream& ins, std::ostream& outs) {
   // Suppress prompt in noninteractive mode.
   if (IsInteractiveTerminalSession(outs)) {
-    outs << term::StartColor(term::Color::kYellow)
-         << "Apply this hunk? [y,n,a,d,s,q,?] " << term::EndColor();
+    outs << term::bold("Apply this hunk? [y,n,a,d,s,q,?] ");
   }
   char c;
   ins >> c;  // user will need to hit <enter> after the character
@@ -410,10 +410,10 @@ absl::Status FilePatch::PickApply(std::istream& ins, std::ostream& outs,
 
   if (!hunks_.empty()) {
     // Display the file being processed, if there are any hunks.
-    outs << term::StartColor(term::Color::kRed) << "--- " << old_file_.path
-         << term::EndColor() << '\n';
-    outs << term::StartColor(term::Color::kCyan) << "+++ " << new_file_.path
-         << term::EndColor() << '\n';
+    outs << term::StartColor(outs, term::Color::kRed) << "--- "
+         << old_file_.path << term::EndColor(outs) << '\n';
+    outs << term::StartColor(outs, term::Color::kCyan) << "+++ "
+         << new_file_.path << term::EndColor(outs) << '\n';
   }
 
   const std::vector<absl::string_view> orig_lines(SplitLines(*orig_file_or));

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -367,9 +367,7 @@ LineNumberSet FilePatch::AddedLines() const {
 
 static char PromptHunkAction(std::istream& ins, std::ostream& outs) {
   // Suppress prompt in noninteractive mode.
-  if (IsInteractiveTerminalSession(outs)) {
-    outs << term::bold("Apply this hunk? [y,n,a,d,s,q,?] ");
-  }
+  term::bold(outs, "Apply this hunk? [y,n,a,d,s,q,?] ");
   char c;
   ins >> c;  // user will need to hit <enter> after the character
   if (ins.eof()) {

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -79,7 +79,10 @@ absl::Status MarkedLine::Parse(absl::string_view text) {
 }
 
 std::ostream& operator<<(std::ostream& stream, const MarkedLine& line) {
-  return stream << line.line;
+  term::Color c = line.IsDeleted() ? term::Color::kRed
+                  : line.IsAdded() ? term::Color::kCyan
+                                   : term::Color::kNone;
+  return stream << StartColor(c) << line.line << EndColor(c);
 }
 
 absl::Status HunkIndices::Parse(absl::string_view text) {
@@ -146,8 +149,9 @@ absl::Status HunkHeader::Parse(absl::string_view text) {
 }
 
 std::ostream& operator<<(std::ostream& stream, const HunkHeader& header) {
-  return stream << "@@ -" << header.old_range << " +" << header.new_range
-                << " @@" << header.context;
+  return stream << term::StartColor(term::Color::kGreen) << "@@ -"
+                << header.old_range << " +" << header.new_range << " @@"
+                << header.context << term::EndColor(term::Color::kGreen);
 }
 
 // Type M could be any container or range of MarkedLines.
@@ -363,7 +367,8 @@ LineNumberSet FilePatch::AddedLines() const {
 static char PromptHunkAction(std::istream& ins, std::ostream& outs) {
   // Suppress prompt in noninteractive mode.
   if (IsInteractiveTerminalSession(outs)) {
-    outs << "Apply this hunk? [y,n,a,d,s,q,?] ";
+    outs << term::StartColor(term::Color::kYellow)
+         << "Apply this hunk? [y,n,a,d,s,q,?] " << term::EndColor();
   }
   char c;
   ins >> c;  // user will need to hit <enter> after the character
@@ -405,8 +410,10 @@ absl::Status FilePatch::PickApply(std::istream& ins, std::ostream& outs,
 
   if (!hunks_.empty()) {
     // Display the file being processed, if there are any hunks.
-    outs << "--- " << old_file_.path << std::endl;
-    outs << "+++ " << new_file_.path << std::endl;
+    outs << term::StartColor(term::Color::kRed) << "--- " << old_file_.path
+         << term::EndColor() << '\n';
+    outs << term::StartColor(term::Color::kCyan) << "+++ " << new_file_.path
+         << term::EndColor() << '\n';
   }
 
   const std::vector<absl::string_view> orig_lines(SplitLines(*orig_file_or));

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -85,7 +85,7 @@ std::ostream& operator<<(std::ostream& stream, const MarkedLine& line) {
   return term::Colored(stream, line.line, c);
 }
 
-std::string HunkIndices::ToString() const {
+std::string HunkIndices::FormatToString() const {
   return absl::StrCat(start, ",", count);
 }
 
@@ -104,7 +104,7 @@ absl::Status HunkIndices::Parse(absl::string_view text) {
 }
 
 std::ostream& operator<<(std::ostream& stream, const HunkIndices& indices) {
-  return stream << indices.ToString();
+  return stream << indices.FormatToString();
 }
 
 absl::Status HunkHeader::Parse(absl::string_view text) {
@@ -155,8 +155,8 @@ absl::Status HunkHeader::Parse(absl::string_view text) {
 std::ostream& operator<<(std::ostream& stream, const HunkHeader& header) {
   return term::Colored(
       stream,
-      absl::StrCat("@@ -", header.old_range.ToString(), " +",
-                   header.new_range.ToString(), " @@", header.context),
+      absl::StrCat("@@ -", header.old_range.FormatToString(), " +",
+                   header.new_range.FormatToString(), " @@", header.context),
       term::Color::kGreen);
 }
 

--- a/common/strings/patch.h
+++ b/common/strings/patch.h
@@ -147,7 +147,7 @@ struct HunkIndices {
   }
   bool operator!=(const HunkIndices& other) const { return !(*this == other); }
 
-  std::string ToString() const;
+  std::string FormatToString() const;
 
   absl::Status Parse(absl::string_view);
 };

--- a/common/strings/patch.h
+++ b/common/strings/patch.h
@@ -147,6 +147,8 @@ struct HunkIndices {
   }
   bool operator!=(const HunkIndices& other) const { return !(*this == other); }
 
+  std::string ToString() const;
+
   absl::Status Parse(absl::string_view);
 };
 

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -95,19 +95,13 @@ std::ostream& inverse(std::ostream& out, absl::string_view s) {
   }
   return out;
 }
-
-absl::string_view StartColor(const std::ostream& stream, Color c) {
-  if (!IsInteractiveTerminalSession(stream)) {
-    return "";
+std::ostream& Colored(std::ostream& out, absl::string_view s, Color c) {
+  if (IsInteractiveTerminalSession(out) && c != Color::kNone) {
+    out << kColorsStart[c] << s << kNormalEscape;
+  } else {
+    out << s;
   }
-  return kColorsStart[c];
-}
-
-absl::string_view EndColor(const std::ostream& stream, Color c) {
-  if (!IsInteractiveTerminalSession(stream) || c == Color::kNone) {
-    return "";
-  }
-  return kNormalEscape;
+  return out;
 }
 
 }  // namespace term

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -97,13 +97,17 @@ std::ostream& inverse(std::ostream& out, absl::string_view s) {
   return out;
 }
 
-absl::string_view StartColor(Color c) {
-  if (!IsInteractiveTerminalSession()) return "";
+absl::string_view StartColor(const std::ostream& stream, Color c) {
+  if (!IsInteractiveTerminalSession(stream)) {
+    return "";
+  }
   return kColorsStart[c];
 }
 
-absl::string_view EndColor(Color c) {
-  if (!IsInteractiveTerminalSession() || c == Color::kNone) return "";
+absl::string_view EndColor(const std::ostream& stream, Color c) {
+  if (!IsInteractiveTerminalSession(stream) || c == Color::kNone) {
+    return "";
+  }
   return kNormalEscape;
 }
 

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -71,7 +71,7 @@ static constexpr absl::string_view kInverseEscape("\033[7m");
 static constexpr absl::string_view kNormalEscape("\033[0m");
 
 // clang-format off
-static constexpr absl::string_view kColorsStart[Color::kNumColors] = {
+static constexpr absl::string_view kColorsStart[static_cast<uint32_t>(Color::kNumColors)] = {
     "\033[1;32m", // GREEN
     "\033[1;36m", // CYAN
     "\033[1;31m", // RED
@@ -97,7 +97,7 @@ std::ostream& inverse(std::ostream& out, absl::string_view s) {
 }
 std::ostream& Colored(std::ostream& out, absl::string_view s, Color c) {
   if (IsInteractiveTerminalSession(out) && c != Color::kNone) {
-    out << kColorsStart[c] << s << kNormalEscape;
+    out << kColorsStart[static_cast<uint32_t>(c)] << s << kNormalEscape;
   } else {
     out << s;
   }

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -75,7 +75,6 @@ static constexpr absl::string_view kColorsStart[Color::kNumColors] = {
     "\033[1;32m", // GREEN
     "\033[1;36m", // CYAN
     "\033[1;31m", // RED
-    "\033[1;33m", // YELLOW
     "",           // NONE
 };
 // clang-format on

--- a/common/util/user_interaction.cc
+++ b/common/util/user_interaction.cc
@@ -70,6 +70,16 @@ static constexpr absl::string_view kBoldEscape("\033[1m");
 static constexpr absl::string_view kInverseEscape("\033[7m");
 static constexpr absl::string_view kNormalEscape("\033[0m");
 
+// clang-format off
+static constexpr absl::string_view kColorsStart[Color::kNumColors] = {
+    "\033[1;32m", // GREEN
+    "\033[1;36m", // CYAN
+    "\033[1;31m", // RED
+    "\033[1;33m", // YELLOW
+    "",           // NONE
+};
+// clang-format on
+
 std::ostream& bold(std::ostream& out, absl::string_view s) {
   if (IsInteractiveTerminalSession(out)) {
     out << kBoldEscape << s << kNormalEscape;
@@ -86,5 +96,16 @@ std::ostream& inverse(std::ostream& out, absl::string_view s) {
   }
   return out;
 }
+
+absl::string_view StartColor(Color c) {
+  if (!IsInteractiveTerminalSession()) return "";
+  return kColorsStart[c];
+}
+
+absl::string_view EndColor(Color c) {
+  if (!IsInteractiveTerminalSession() || c == Color::kNone) return "";
+  return kNormalEscape;
+}
+
 }  // namespace term
 }  // namespace verible

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -25,6 +25,30 @@ namespace term {
 // is an interactive session connected to a terminal. Otherwise just plain.
 std::ostream& bold(std::ostream& out, absl::string_view s);
 std::ostream& inverse(std::ostream& out, absl::string_view s);
+
+enum Color {
+  kGreen = 0,
+  kCyan,
+  kRed,
+  kYellow,
+  kNone,
+  kNumColors,
+};
+
+// Start color string to be sent to an output stream. If we're not in an
+// interactive setting, no changes are made.
+absl::string_view StartColor(Color c);
+
+// End color string to be sent to an output stream. If we're not in an
+// interactive setting, no changes are made. If there is no color, an empty
+// string is sent. We require a color as input parameter because we might want
+// to color to Color::NONE (to simplify code, MarkedLine's operator <<), so we
+// have to if this is the case to send an empty string.
+//
+// The default color makes it so we can call EndColor() if we know 100%
+// we're coloring to SOME color.
+absl::string_view EndColor(Color c = Color::kGreen);
+
 }  // namespace term
 
 // Returns if the stream is likely a terminal session: stream is connected to

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -34,19 +34,9 @@ enum Color {
   kNumColors,
 };
 
-// Start color string to be sent to an output stream. If we're not in an
-// interactive setting, no changes are made.
-absl::string_view StartColor(const std::ostream&, Color c);
-
-// End color string to be sent to an output stream. If we're not in an
-// interactive setting, no changes are made. If there is no color, an empty
-// string is sent. We require a color as input parameter because we might want
-// to color to Color::NONE (to simplify code, MarkedLine's operator <<), so we
-// have to if this is the case to send an empty string.
-//
-// The default color makes it so we can call EndColor() if we know 100%
-// we're coloring to SOME color.
-absl::string_view EndColor(const std::ostream&, Color c = Color::kGreen);
+// Print the `s` string to `out` ostream colored with color `c`.
+// This will only apply if we're in an interactive terminal session
+std::ostream& Colored(std::ostream& out, absl::string_view s, Color c);
 
 }  // namespace term
 

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -26,7 +26,7 @@ namespace term {
 std::ostream& bold(std::ostream& out, absl::string_view s);
 std::ostream& inverse(std::ostream& out, absl::string_view s);
 
-enum Color {
+enum class Color {
   kGreen = 0,
   kCyan,
   kRed,

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -30,7 +30,6 @@ enum Color {
   kGreen = 0,
   kCyan,
   kRed,
-  kYellow,
   kNone,
   kNumColors,
 };

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -37,7 +37,7 @@ enum Color {
 
 // Start color string to be sent to an output stream. If we're not in an
 // interactive setting, no changes are made.
-absl::string_view StartColor(Color c);
+absl::string_view StartColor(const std::ostream&, Color c);
 
 // End color string to be sent to an output stream. If we're not in an
 // interactive setting, no changes are made. If there is no color, an empty
@@ -47,7 +47,7 @@ absl::string_view StartColor(Color c);
 //
 // The default color makes it so we can call EndColor() if we know 100%
 // we're coloring to SOME color.
-absl::string_view EndColor(Color c = Color::kGreen);
+absl::string_view EndColor(const std::ostream&, Color c = Color::kGreen);
 
 }  // namespace term
 


### PR DESCRIPTION
Hello, as the issue seemed stale I took the liberty of making a pull request, hope that's ok.

This would be my preferred approach to add coloring to the terminal output, but let me know if you think other solution is better.

Once we agree on how to add the colors, I'd be happy to make it configurable (ON/OFF, Different color palletes) if you want.

Current output:
![image](https://user-images.githubusercontent.com/42119338/232223019-d65517d7-ce06-40c9-8cf6-19e1db8dcfcd.png)
* the typo in '---' NEW instead of '+++' has already been corrected

The issue says "Possibly detect terminal type as well". Could you ellaborate on what that means?

TODO:

- [x] Add tests to coloring functions once we have a stable api
- [ ] Detect terminal type (?)
- [ ] Make it configurable
- [x] Document