### PR TITLE
Refine interactive terminal session detecation.

### DIFF
--- a/common/analysis/violation_handler.cc
+++ b/common/analysis/violation_handler.cc
@@ -35,11 +35,12 @@ void PrintFixAlternatives(std::ostream& stream, absl::string_view text,
   const bool print_alternative_number = fixes.size() > 1;
   for (size_t i = 0; i < fixes.size(); ++i) {
     if (print_alternative_number) {
-      stream << verible::term::inverse(absl::StrCat(
-          "[ ", (i + 1), ". Alternative ", fixes[i].Description(), " ]\n"));
+      verible::term::inverse(stream,
+                             absl::StrCat("[ ", (i + 1), ". Alternative ",
+                                          fixes[i].Description(), " ]\n"));
     } else {
-      stream << verible::term::inverse(
-          absl::StrCat("[ ", fixes[i].Description(), " ]\n"));
+      verible::term::inverse(
+          stream, absl::StrCat("[ ", fixes[i].Description(), " ]\n"));
     }
     PrintFix(stream, text, fixes[i]);
   }
@@ -212,9 +213,9 @@ ViolationFixer::Answer ViolationFixer::InteractiveAnswerChooser(
 
   for (;;) {
     const char c = verible::ReadCharFromUser(
-        std::cin, std::cerr, verible::IsInteractiveTerminalSession(),
-        verible::term::bold("Autofix is available. Apply? [" +
-                            alternative_list + "y,n,a,d,A,D,p,P,?] "));
+        std::cin, std::cerr, verible::IsInteractiveTerminalSession(std::cerr),
+        "Autofix is available. Apply? [" + alternative_list +
+            "y,n,a,d,A,D,p,P,?] ");
 
     // Single character digit chooses the available alternative.
     if (c >= '1' && c <= '9' &&

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -362,7 +362,7 @@ LineNumberSet FilePatch::AddedLines() const {
 
 static char PromptHunkAction(std::istream& ins, std::ostream& outs) {
   // Suppress prompt in noninteractive mode.
-  if (IsInteractiveTerminalSession()) {
+  if (IsInteractiveTerminalSession(outs)) {
     outs << "Apply this hunk? [y,n,a,d,s,q,?] ";
   }
   char c;

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -88,7 +88,7 @@ static absl::Status StdinTest(const SubcommandArgsRange& args,
   for (; file_count < kOpenLimit; ++file_count) {
     outs << "==== file " << file_count << " ====" << std::endl;
     while (ins) {
-      if (verible::IsInteractiveTerminalSession()) outs << "enter text: ";
+      if (verible::IsInteractiveTerminalSession(outs)) outs << "enter text: ";
       std::getline(ins, line);
       outs << "echo: " << line << std::endl;
     }

--- a/common/util/user_interaction.h
+++ b/common/util/user_interaction.h
@@ -21,15 +21,15 @@
 
 namespace verible {
 namespace term {
-// Convenience functions that wrap a string to output colored on screen, iff
-// this is an interactive session.
-std::string bold(absl::string_view s);
-std::string inverse(absl::string_view s);
+// Convenience functions: Print bold or inverse if and only if this
+// is an interactive session connected to a terminal. Otherwise just plain.
+std::ostream& bold(std::ostream& out, absl::string_view s);
+std::ostream& inverse(std::ostream& out, absl::string_view s);
 }  // namespace term
 
-// Returns if this is likely a terminal session (tests if stdin filedescriptor
-// is a terminal).
-bool IsInteractiveTerminalSession();
+// Returns if the stream is likely a terminal session: stream is connected to
+// terminal and stdin is a terminal.
+bool IsInteractiveTerminalSession(const std::ostream& s);
 
 // Reads single character from user.
 //
@@ -46,7 +46,7 @@ bool IsInteractiveTerminalSession();
 // Typical use:
 //
 //   const char ch = ReadCharFromUser(std::cin, std::cout,
-//                                    IsInteractiveTerminalSession(),
+//                                    IsInteractiveTerminalSession(std::cout),
 //                                    "Type a letter and confirm with ENTER: ");
 char ReadCharFromUser(std::istream& input, std::ostream& output,
                       bool input_is_terminal, absl::string_view prompt);


### PR DESCRIPTION
Not only stdin is queried, but also if the output stream we attempt to write to is also a terminal (as this is used to determine if we use terminal code to output bold or inverse text).