### PR TITLE
Make streaming concatenation rules check the style for compacting indexes

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -18360,6 +18360,35 @@ TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases100ColumnsLimit) {
   }
 }
 
+static constexpr FormatterTestCase noCompactIndexingAndSelectionsTestCases[]{
+    {"module m1 ();\n"
+     "  assign s1 = msg[1 : 2 + 3];\n"
+     "  assign s2 = {<<8{msg[1 : 2 + 3]}};\n"
+     "endmodule\n",
+     "module m1 ();\n"
+     "  assign s1 = msg[1 : 2 + 3];\n"
+     "  assign s2 = {<< 8{msg[1 : 2 + 3]}};\n"
+     "endmodule\n"}};
+
+TEST(FormatterEndToEndTest, compactIndexingAndSelectionsTestCases) {
+  // Use a fixed style.
+  FormatStyle style;
+  style.column_limit = 100;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.compact_indexing_and_selections = false;
+
+  for (const auto& test_case : noCompactIndexingAndSelectionsTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
 static constexpr FormatterTestCase kFunctionCallsWithComments[] = {
     {// no comments
      "module foo;\n"

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -204,7 +204,8 @@ static WithReason<int> SpacesRequiredBetween(
     return {1, "Space between return keyword and return value"};
   }
 
-  if (right_context.IsInsideFirst({NodeEnum::kStreamingConcatenation}, {})) {
+  if (right_context.IsInsideFirst({NodeEnum::kStreamingConcatenation}, {}) &&
+      style.compact_indexing_and_selections) {
     if (left.TokenEnum() == TK_LS || left.TokenEnum() == TK_RS) {
       return {0, "No space around streaming operators"};
     }

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -5246,6 +5246,18 @@ TEST(TokenAnnotatorTest, OriginalSpacingSensitiveTests) {
           {0, SpacingOptions::kUndecided},
       },
       {
+          // [a + b]
+          CompactIndexSelectionStyle,
+          verilog_tokentype::SymbolIdentifier,
+          "a",
+          " ",
+          '+',
+          "+",
+          {NodeEnum::kDimensionScalar},
+          {NodeEnum::kStreamingConcatenation},
+          {1, SpacingOptions::kUndecided},
+      },
+      {
           // [a+b]
           CompactIndexSelectionStyle,
           verilog_tokentype::SymbolIdentifier,


### PR DESCRIPTION
This PR adds a rule check for `compact_indexing_and_selections` in the streaming concatenation token annotation.

Fixes #1851 