### PR TITLE
Nudge pointer alignment towards C/C++ semantic.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,9 @@
 # https://google.github.io/styleguide/cppguide.html
 BasedOnStyle: Google
 
+# ...but switch off determining pointer alignment from
+# prevalence in file but always make it align right
+# to match the semantics of the C/C++ language.
+DerivePointerAlignment: false
+PointerAlignment: Right
+ReferenceAlignment: Right

--- a/.github/bin/run-clang-format.sh
+++ b/.github/bin/run-clang-format.sh
@@ -22,9 +22,15 @@ CLANG_FORMAT_BINARY=clang-format
 ${CLANG_FORMAT_BINARY} --version
 
 # Run on all files.
+
+# For now, we only use the Google style, without enforcing the pointer
+# alignment. The toplevel .clang-format will over time make files people
+# edit and locally format adhere to the style.
+# (TODO: once there is a quiet phase with not much PRs open, do a bulk format).
+
 find . -name "*.h" -o -name "*.cc" \
   | egrep -v 'third_party/|external_libs/|.github/' \
-  | xargs -P2 ${CLANG_FORMAT_BINARY} -i
+  | xargs -P2 ${CLANG_FORMAT_BINARY} --style="Google" -i
 
 # Check if we got any diff
 git diff > ${FORMAT_OUT}


### PR DESCRIPTION
This changes the .clang-format to not derive the pointer alignment from the prevalence in the file, but always make sure the formatting matches C/C++ semantic (right-aligned).

The files in the code-base used different styles mostly based on who edited the files first.

The CI clang-format will not enforce it at this point, just whenever files are edited and cared to be formatted locally, they get the intended formatting.