### PR TITLE
Move function to convert verible source range to lsp::Range in header.

### DIFF
--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -77,10 +77,20 @@ cc_library(
 )
 
 cc_library(
+    name = "lsp-conversion",
+    hdrs = ["lsp-conversion.h"],
+    deps = [
+        "//common/lsp:lsp-protocol",
+        "//common/strings:line-column-map",
+    ],
+)
+
+cc_library(
     name = "document-symbol-filler",
     srcs = ["document-symbol-filler.cc"],
     hdrs = ["document-symbol-filler.h"],
     deps = [
+        ":lsp-conversion",
         "//common/lsp:lsp-protocol",
         "//common/lsp:lsp-protocol-enums",
         "//common/text:text-structure",
@@ -99,6 +109,7 @@ cc_library(
     srcs = ["symbol-table-handler.cc"],
     hdrs = ["symbol-table-handler.h"],
     deps = [
+        ":lsp-conversion",
         ":lsp-parse-buffer",
         "//common/lsp:lsp-file-utils",
         "//common/lsp:lsp-protocol",

--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -22,6 +22,7 @@
 #include "verilog/CST/module.h"
 #include "verilog/CST/package.h"
 #include "verilog/CST/seq_block.h"
+#include "verilog/tools/ls/lsp-conversion.h"
 
 // Magic value to hint that we have to fill out the start range.
 static constexpr int kUninitializedStartLine = -1;
@@ -164,8 +165,6 @@ verible::lsp::Range DocumentSymbolFiller::RangeFromLeaf(
 
 verible::lsp::Range DocumentSymbolFiller::RangeFromToken(
     const verible::TokenInfo &token) const {
-  const verible::LineColumnRange range = text_view_.GetRangeForToken(token);
-  return {.start = {.line = range.start.line, .character = range.start.column},
-          .end = {.line = range.end.line, .character = range.end.column}};
+  return RangeFromLineColumn(text_view_.GetRangeForToken(token));
 }
 }  // namespace verilog

--- a/verilog/tools/ls/lsp-conversion.h
+++ b/verilog/tools/ls/lsp-conversion.h
@@ -1,0 +1,30 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/lsp/lsp-protocol.h"
+#include "common/strings/line_column_map.h"
+
+// Simple conversion functions between verible data structures and Language
+// Server Protocol structs.
+
+namespace verilog {
+
+// Convert a Verible internal source code range to a language server protocol
+// range.
+inline verible::lsp::Range RangeFromLineColumn(
+    const verible::LineColumnRange &range) {
+  return {.start = {.line = range.start.line, .character = range.start.column},
+          .end = {.line = range.end.line, .character = range.end.column}};
+}
+}  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -24,6 +24,7 @@
 #include "common/strings/line_column_map.h"
 #include "common/util/file_util.h"
 #include "verilog/analysis/verilog_filelist.h"
+#include "verilog/tools/ls/lsp-conversion.h"
 
 ABSL_FLAG(std::string, file_list_path, "verible.filelist",
           "Name of the file with Verible FileList for the project");
@@ -261,18 +262,10 @@ SymbolTableHandler::GetLocationFromSymbolName(
 
   verible::lsp::Location location;
   location.uri = PathToLSPUri(file_origin->ResolvedPath());
-  const verible::TextStructureView *textstructure =
-      file_origin->GetTextStructure();
-  if (!textstructure->ContainsText(symbol_name)) return std::nullopt;
+  const verible::TextStructureView *text_view = file_origin->GetTextStructure();
+  if (!text_view->ContainsText(symbol_name)) return std::nullopt;
+  location.range = RangeFromLineColumn(text_view->GetRangeForText(symbol_name));
 
-  verible::LineColumnRange symbollocation =
-      textstructure->GetRangeForText(symbol_name);
-  // TODO (glatosinski) add method for converting verible::LineColumnRange
-  // to verible::lsp::Range
-  location.range.start = {.line = symbollocation.start.line,
-                          .character = symbollocation.start.column};
-  location.range.end = {.line = symbollocation.end.line,
-                        .character = symbollocation.end.column};
   return location;
 }
 


### PR DESCRIPTION
We use the same conversion in multiple places, so let's give it a name and put in a header.