### PR TITLE
Added support for macro calls inside struct bodies

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -8258,6 +8258,19 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "endmodule : foo  // C\n"
      "                 // C.1\n"
      "                 // C.2\n"},
+    {"module foo\n"
+     "#(\n"
+     "  parameter type baz_t = struct packed { `BAZ(); }\n"
+     ")\n"
+     "();\n"
+     "endmodule\n",
+     "module foo #(\n"
+     "    parameter type\n"
+     "        baz_t = struct packed {\n"
+     "      `BAZ();\n"
+     "    }\n"
+     ") ();\n"
+     "endmodule\n"},
     // Check that comments with too large starting column difference are not
     // aligned as continuation comments.
     // Check that starting comments are not linked with a comment in

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -3685,6 +3685,11 @@ struct_union_member
     { $$ = MakeTaggedNode(N::kStructUnionMember, $1, $2, $3, $4, $5, $6); }
   | preprocessor_directive
     { $$ = std::move($1); }
+  | MacroCall
+    { $$ = std::move($1);}
+  // since the semicolon is optional, it is better to have both cases covered
+  | MacroCall ';'
+    { $$ = ExtendNode($1, $2);}
   ;
 
 case_item


### PR DESCRIPTION
This PR implements support for macro calls in the struct body. The syntax allows the flexibility to use or skip the semicolon.

Fixes #1873 