### PR TITLE
Added option to break apart end and else tokens

### DIFF
--- a/verilog/formatting/format_style.h
+++ b/verilog/formatting/format_style.h
@@ -113,6 +113,9 @@ struct FormatStyle : public verible::BasicFormatStyle {
   // Compact binary expressions inside indexing / bit selection operators
   bool compact_indexing_and_selections = true;
 
+  // Split with a \n end and else clauses
+  bool wrap_end_else_clauses = false;
+
   // -- Note: when adding new fields, add them in format_style_init.cc
 
   // TODO(fangism): introduce the following knobs:

--- a/verilog/formatting/format_style_init.cc
+++ b/verilog/formatting/format_style_init.cc
@@ -84,6 +84,10 @@ ABSL_FLAG(AlignmentPolicy, enum_assignment_statement_alignment,
 ABSL_FLAG(bool, compact_indexing_and_selections, true,
           "Use compact binary expressions inside indexing / bit selection "
           "operators");
+
+ABSL_FLAG(bool, wrap_end_else_clauses, false,
+          "Split end and else keywords into separate lines");
+
 ABSL_FLAG(bool, port_declarations_right_align_packed_dimensions, false,
           "If true, packed dimensions in contexts with enabled alignment are "
           "aligned to the right.");
@@ -131,6 +135,7 @@ void InitializeFromFlags(FormatStyle *style) {
   STYLE_FROM_FLAG(try_wrap_long_lines);
   STYLE_FROM_FLAG(expand_coverpoints);
   STYLE_FROM_FLAG(compact_indexing_and_selections);
+  STYLE_FROM_FLAG(wrap_end_else_clauses);
 
 #undef STYLE_FROM_FLAG
 }

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -849,9 +849,12 @@ static WithReason<SpacingOptions> BreakDecisionBetween(
   if (right.TokenEnum() == TK_else) {
     // TODO(fangism): feels like this should be the responsibility of
     // tree_unwrapper, handled by kElseClause, kGenerateElseClause, etc.
-    if (left.TokenEnum() == TK_end) {
+    if (left.TokenEnum() == TK_end && !style.wrap_end_else_clauses) {
       return {SpacingOptions::kMustAppend,
               "'end'-'else' and should be together on one line."};
+    }
+    if (left.TokenEnum() == TK_end && style.wrap_end_else_clauses) {
+      return {SpacingOptions::kMustWrap, "'end'-'else' Should be split."};
     }
     if (left.TokenEnum() == '}') {
       return {SpacingOptions::kMustAppend,

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1832,14 +1832,17 @@ static void FlattenElseIfElse(const SyntaxTreeNode& else_clause,
 }
 
 static void ReshapeConditionalConstruct(const SyntaxTreeNode& conditional,
-                                        TokenPartitionTree* partition_ptr) {
+                                        TokenPartitionTree* partition_ptr,
+                                        const FormatStyle& style) {
   const auto* else_clause = GetAnyConditionalElseClause(conditional);
   if (else_clause == nullptr) {
     VLOG(4) << "there was no else clause";
     return;
   }
   VLOG(4) << "there was an else clause";
-  MergeEndElseWithoutLabel(conditional, partition_ptr);
+  if (!style.wrap_end_else_clauses) {
+    MergeEndElseWithoutLabel(conditional, partition_ptr);
+  }
   FlattenElseIfElse(*else_clause, partition_ptr);
 }
 
@@ -2832,7 +2835,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
     case NodeEnum::kConditionalGenerateConstruct:
       // Contains a kGenerateIfClause and possibly a kGenerateElseClause
       {
-        ReshapeConditionalConstruct(node, &partition);
+        ReshapeConditionalConstruct(node, &partition, style_);
         break;
       }
 


### PR DESCRIPTION
This PR implements a new flag to the formatter: `wrap_end_else_clauses`. It allows the control over if end-else pairs should be formatted as `[...] end else if...` or
```
end
else if (...)
```