### PR TITLE
Language Server - Avoid trying to format code in the presence of syntax errors

### DIFF
--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -267,9 +267,11 @@ std::vector<verible::lsp::TextEdit> FormatRange(
   std::vector<verible::lsp::TextEdit> result;
   if (!tracker) return result;
   const auto current = tracker->current();
-  if (!current) return result;  // Can only format if we have latest version.
-  const verible::TextStructureView &text = current->parser().Data();
 
+  // Can only format if we have latest version and it could be parsed.
+  if (!current || !current->parsed_successfully()) return result;
+
+  const verible::TextStructureView &text = current->parser().Data();
   verilog::formatter::FormatStyle format_style;
   verilog::formatter::InitializeFromFlags(&format_style);
 


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/verible/issues/1843. 

The comments on current() seemed a bit confusing to me when investigating the problem.

```c++
  // Get the current ParsedBuffer from the last text update we received
  // from the editor. This can be nullptr if it could not be parsed.
  //
  // Use in operations that only really makes sense on the latest view and
  // only if it was parseable, e.g. suggesting edits.
  std::shared_ptr<const ParsedBuffer> current() const { return current_; }
```

When reading the comments, I thought maybe doing a .reset() on current_ would solve the problem and would be cleaner than adding the extra check of parsed_correctly(). However, this doesn't work because we need to work with the incorrect buffer to provide diagnostics.

On the other hand, I don't see how current_ could end up being nullptr. 