### PR TITLE
Added macro call in struct test without a semicolon.

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -8271,6 +8271,21 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    }\n"
      ") ();\n"
      "endmodule\n"},
+    // The same as the previous test case, but without a semicolon at the macro
+    // call
+    {"module foo\n"
+     "#(\n"
+     "  parameter type baz_t = struct packed { `BAZ() }\n"
+     ")\n"
+     "();\n"
+     "endmodule\n",
+     "module foo #(\n"
+     "    parameter type\n"
+     "        baz_t = struct packed {\n"
+     "      `BAZ()\n"
+     "    }\n"
+     ") ();\n"
+     "endmodule\n"},
     // Check that comments with too large starting column difference are not
     // aligned as continuation comments.
     // Check that starting comments are not linked with a comment in

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -3685,11 +3685,13 @@ struct_union_member
     { $$ = MakeTaggedNode(N::kStructUnionMember, $1, $2, $3, $4, $5, $6); }
   | preprocessor_directive
     { $$ = std::move($1); }
-  | MacroCall
-    { $$ = std::move($1);}
   // since the semicolon is optional, it is better to have both cases covered
   | MacroCall ';'
     { $$ = ExtendNode($1, $2);}
+  | MacroCall
+    { $$ = std::move($1);}
+  | MacroCallId '(' macro_args_opt MacroCallCloseToEndLine
+    { $$ = MakeTaggedNode(N::kMacroCall, $1, MakeParenGroup($2, $3, $4)); }
   ;
 
 case_item


### PR DESCRIPTION
As I was asked in https://github.com/chipsalliance/verible/pull/1880, I have added the test without a semicolon.

However, this test required a change to how formatted code is being lexically compared to the original: Macro Calls are whitespace sensitive when there are no semicolons. The lexer might find a generic macro call with a "normal" closing bracket, or `MacroCallCloseToEndLine` when it is on a newline. As they are syntactically equivalent, I have added support for it in Yacc and changed the comparator to look for that similarity in this particular use case.