### PR TITLE
VSCode extension: Download necessary binary

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -569,6 +569,7 @@ jobs:
         # Patch the JSON file to contain our current git tag+commit
         VERSION=$(git describe | sed 's|v\([^-]\+\)-\([[:digit:]]\+\).*|\1.\2|')
         sed -i 's|\(.*version.*\): "\([^"]\+\)"|\1: "'${VERSION}'"|g' package.json
+        sed -i 's|\(.*tag.*\): "\([^"]\+\)"|\1: "'${TAG}'"|g' package.json
         vsce publish -p ${VSC_MARKETPLACE_TOKEN}
 
   GhPages:

--- a/verilog/tools/ls/vscode/README.md
+++ b/verilog/tools/ls/vscode/README.md
@@ -32,6 +32,9 @@ The language server provides a couple of features from the [Verible SystemVerilo
 The Verible plug-in needs the `verible-verilog-ls` executable installed
 on your machine.
 
+On Linux and Windows, the plug-in will try to download the necessary
+executable (if it's not already available).
+
 Get a binary distribution for your Operating System at
 https://github.com/chipsalliance/verible/releases
 

--- a/verilog/tools/ls/vscode/package.json
+++ b/verilog/tools/ls/vscode/package.json
@@ -2,11 +2,12 @@
   "name": "verible",
   "displayName": "Verible",
   "description": "Verible Language Server",
-  "version": "0.0.2700",
+  "version": "0.0.3220",
   "publisher": "chipsalliance",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chipsalliance/verible"
+    "url": "https://github.com/chipsalliance/verible",
+    "tag": "v0.0-3220-g9c63b8ad"
   },
   "engines": {
     "vscode": "^1.61.0"
@@ -67,6 +68,8 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "14.x",
     "@types/vscode": "^1.61.0",
+    "@types/decompress": "^4.2.4",
+    "@types/follow-redirects": "^1.14.1",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "@vscode/test-electron": "^1.6.2",
@@ -80,6 +83,9 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
+    "decompress": "^4.2.1",
+    "decompress-targz": "^4.1.1",
+    "follow-redirects": "^1.15.2",
     "vscode-languageclient": "^7.0.0"
   }
 }

--- a/verilog/tools/ls/vscode/src/download-ls.ts
+++ b/verilog/tools/ls/vscode/src/download-ls.ts
@@ -1,0 +1,108 @@
+import { platform, arch } from "os";
+import * as fs from "fs";
+import * as path from "path";
+import { IncomingMessage } from "http";
+import { https as httpsFr } from "follow-redirects";
+import { execSync } from "child_process";
+import * as decompress from "decompress";
+const decompressTargz = require("decompress-targz");
+const TAG = require("../package.json").repository.tag;
+
+
+function checkIfBinaryExists(binaryPath: string) {
+  let whichCommand: string, binaryExists: boolean;
+  if (platform() == "win32") whichCommand = "where";
+  else whichCommand = "which";
+
+  binaryExists = true;
+  try {
+    execSync(`${whichCommand} ${binaryPath}`, { windowsHide: true });
+  } catch {
+    binaryExists = false;
+  }
+
+  return binaryExists;
+}
+
+export async function checkAndDownloadBinaries(
+  binaryPath: string
+): Promise<string> {
+  if (platform() === "darwin") {
+    // There is no static binaries for MacOS -- aborting
+    return binaryPath;
+  }
+  if (checkIfBinaryExists(binaryPath)) {
+    // Language server binary exists -- nothing to do
+    return binaryPath;
+  }
+
+  const pluginDir = path.join(__dirname, "..");
+  const binDir = path.join(pluginDir, "bin");
+  const pluginBinaryPath = path.join(
+    binDir,
+    "verible-verilog-ls" + (platform() === "win32" ? ".exe" : "")
+  );
+  if (checkIfBinaryExists(pluginBinaryPath)) {
+    // Language server binary already downloaded
+    return pluginBinaryPath;
+  }
+
+  // Retreving tag based on plugin's version
+  if (TAG === undefined || TAG === null) {
+    // No tag found -- aborting
+    return binaryPath;
+  }
+
+  // Preparing URL
+  let platformName,
+    extension,
+    archName = "";
+  if (platform() == "win32") {
+    platformName = "win64";
+    extension = "zip";
+  } else {
+    platformName = "linux-static";
+    archName = arch() === "x64" ? "-x86_64" : "-aarch64";
+    extension = "tar.gz";
+  }
+  const releaseUrl = `https://github.com/chipsalliance/verible/releases/download/${TAG}/verible-${TAG}-${platformName}${archName}.${extension}`;
+
+  // Creating bin directory
+  fs.mkdirSync(binDir, { recursive: true });
+
+  // Downloading release
+  const archivePath = path.join(pluginDir, `verible.${extension}`);
+  const archive = fs.createWriteStream(archivePath);
+  await new Promise<void>((resolve, reject) =>
+    httpsFr.get(releaseUrl, (response: IncomingMessage) => {
+      if (response.statusCode !== 200){
+        reject("Status code " + response.statusCode);
+      }
+      response.pipe(archive);
+
+      archive.on("finish", () => {
+        archive.close();
+        resolve();
+      });
+    }).on("error", (_err) =>{
+      return binaryPath;
+    })
+  );
+
+  // Unpacking and removing downloaded archive
+  await decompress(archivePath, binDir, {
+    filter: (file) => path.basename(file.path).startsWith("verible-verilog-ls"),
+    map: (file) => {
+      file.path = path.basename(file.path);
+      return file;
+    },
+    plugins: platform() === "win32" ? [] : [decompressTargz()],
+  }).catch((_err) => {
+    return binaryPath;
+  })
+  .finally(() => {
+    fs.rm(archivePath, () => null);
+  });
+
+  return pluginBinaryPath;
+}

--- a/verilog/tools/ls/vscode/src/extension.ts
+++ b/verilog/tools/ls/vscode/src/extension.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import * as vscodelc from 'vscode-languageclient/node';
+import { checkAndDownloadBinaries } from './download-ls';
 
 // Global object to dispose of previous language clients.
 let client: undefined | vscodelc.LanguageClient = undefined;
 
-function initLanguageClient() {
+async function initLanguageClient() {
     const config = vscode.workspace.getConfiguration('verible');
-    const binary_path: string = config.get('path') as string;
+    const binary_path: string = await checkAndDownloadBinaries(config.get('path') as string);
 
     const clangd: vscodelc.Executable = {
         command: binary_path
@@ -35,7 +36,7 @@ function initLanguageClient() {
 export function activate(_: vscode.ExtensionContext) {
     // If a configuration change even it fired, let's dispose
     // of the previous client and create a new one.
-    vscode.workspace.onDidChangeConfiguration((event) => {
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
         if (!event.affectsConfiguration('verible')) {
             return;
         }

--- a/verilog/tools/ls/vscode/src/extension.ts
+++ b/verilog/tools/ls/vscode/src/extension.ts
@@ -6,8 +6,9 @@ import { checkAndDownloadBinaries } from './download-ls';
 let client: undefined | vscodelc.LanguageClient = undefined;
 
 async function initLanguageClient() {
+    const output = vscode.window.createOutputChannel('Verible Language Server');
     const config = vscode.workspace.getConfiguration('verible');
-    const binary_path: string = await checkAndDownloadBinaries(config.get('path') as string);
+    const binary_path: string = await checkAndDownloadBinaries(config.get('path') as string, output);
 
     const clangd: vscodelc.Executable = {
         command: binary_path
@@ -19,7 +20,8 @@ async function initLanguageClient() {
     const clientOptions: vscodelc.LanguageClientOptions = {
         // Register the server for (System)Verilog documents
         documentSelector: [{ scheme: 'file', language: 'systemverilog' },
-                           { scheme: 'file', language: 'verilog' }]
+                           { scheme: 'file', language: 'verilog' }],
+        outputChannel: output
     };
 
     // Create the language client and start the client.


### PR DESCRIPTION
This PR adds downloading `verible-verilog-ls` (from GitHub release with tag matching plugin's version) to VSCode extension. 

Binary is downloaded only when language server's executable (from configs `verible.path`) is not available.