### PR TITLE
Format preprocessed token stream in multiple passes

### DIFF
--- a/common/formatting/tree_unwrapper.cc
+++ b/common/formatting/tree_unwrapper.cc
@@ -70,7 +70,22 @@ TreeUnwrapper::TreeUnwrapper(
   // array, and be able to 'extend' into the array of preformatted_tokens_.
 }
 
-const TokenPartitionTree* TreeUnwrapper::Unwrap() {
+TreeUnwrapper::TreeUnwrapper(TreeUnwrapper&& other) noexcept
+    : TreeContextVisitor(std::move(other)),
+      text_structure_view_(other.text_structure_view_),
+      preformatted_tokens_(other.preformatted_tokens_),
+      next_unfiltered_token_(other.next_unfiltered_token_),
+      current_indentation_spaces_(other.current_indentation_spaces_),
+      unwrapped_lines_(std::move(other.unwrapped_lines_)) {
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  if (other.active_unwrapped_lines_ == &other.unwrapped_lines_) {
+    active_unwrapped_lines_ = &unwrapped_lines_;
+  } else {
+    active_unwrapped_lines_ = other.active_unwrapped_lines_;
+  }
+}
+
+void TreeUnwrapper::Unwrap() {
   // Collect tokens that appear before first syntax tree leaf, e.g. comments.
   CollectLeadingFilteredTokens();
 
@@ -105,8 +120,6 @@ const TokenPartitionTree* TreeUnwrapper::Unwrap() {
   }
 
   VerifyFullTreeFormatTokenRanges();
-
-  return &unwrapped_lines_;
 }
 
 std::vector<UnwrappedLine> TreeUnwrapper::FullyPartitionedUnwrappedLines()

--- a/common/formatting/tree_unwrapper.h
+++ b/common/formatting/tree_unwrapper.h
@@ -48,7 +48,7 @@ class TreeUnwrapper : public TreeContextVisitor {
   // Deleted standard interfaces:
   TreeUnwrapper() = delete;
   TreeUnwrapper(const TreeUnwrapper&) = delete;
-  TreeUnwrapper(TreeUnwrapper&&) = delete;
+  TreeUnwrapper(TreeUnwrapper&&) noexcept;
   TreeUnwrapper& operator=(const TreeUnwrapper&) = delete;
   TreeUnwrapper& operator=(TreeUnwrapper&&) = delete;
 
@@ -57,7 +57,7 @@ class TreeUnwrapper : public TreeContextVisitor {
   // Partitions the token stream (in text_structure_view_) into
   // unwrapped_lines_ by traversing the syntax tree representation.
   // TODO(fangism): rename this Partition.
-  const TokenPartitionTree* Unwrap();
+  void Unwrap();
 
   // Returns a flattened copy of all of the deepest nodes in the tree of
   // unwrapped lines, which represents maximal partitioning into the smallest
@@ -80,6 +80,8 @@ class TreeUnwrapper : public TreeContextVisitor {
   TokenPartitionTree* CurrentTokenPartition() {
     return active_unwrapped_lines_;
   }
+
+  TokenPartitionTree* UnwrappedLines() { return &unwrapped_lines_; }
 
   // Returns text spanned by the syntax tree being traversed.
   absl::string_view FullText() const { return text_structure_view_.Contents(); }

--- a/common/formatting/unwrapped_line.h
+++ b/common/formatting/unwrapped_line.h
@@ -162,6 +162,12 @@ class UnwrappedLine {
   // Note that this is a *copy*, and not a reference to the underlying range.
   FormatTokenRange TokensRange() const { return tokens_; }
 
+  // Sets the PreFormatToken range.
+  void SetTokensRange(std::vector<PreFormatToken>::const_iterator begin,
+                      std::vector<PreFormatToken>::const_iterator end) {
+    tokens_ = {begin, end};
+  }
+
   // Returns the number of tokens in this UnwrappedLine
   size_t Size() const { return tokens_.size(); }
 

--- a/common/text/text_structure.h
+++ b/common/text/text_structure.h
@@ -79,6 +79,7 @@ class TextStructureView {
 
   // Do not copy/assign.  This contains pointers/iterators to internals.
   TextStructureView(const TextStructureView&) = delete;
+  TextStructureView(TextStructureView&&) = default;
   TextStructureView& operator=(const TextStructureView&) = delete;
 
   absl::string_view Contents() const { return contents_; }
@@ -171,6 +172,9 @@ class TextStructureView {
   // analysis results passed through the expansions is transferred (consumed)
   // by this function.
   void ExpandSubtrees(NodeExpansionMap* expansions);
+
+  // Sets the 'color' of all tokens in the token stream view.
+  void ColorStreamViewTokens(size_t color);
 
   // All of this class's consistency checks combined.
   absl::Status InternalConsistencyCheck() const;
@@ -282,6 +286,11 @@ class TextStructure {
 
   // DeferredExpansion::subanalysis requires this destructor to be virtual.
   virtual ~TextStructure();
+
+  // Update tokens to point their text into the contents of the given
+  // TextStructure. The contents_ pointer in this TextStructure will point to
+  // the other TextStructure's contents.
+  void RebaseTokens(const TextStructure& other);
 
   const TextStructureView& Data() const { return data_; }
 

--- a/common/text/token_info.h
+++ b/common/text/token_info.h
@@ -157,6 +157,11 @@ class TokenInfo {
 
   bool isEOF() const { return token_enum_ == TK_EOF; }
 
+  // The color is used for differentiating tokens from different preprocess
+  // variants. If color equals 0, the token is part of preprocessor-disabled
+  // code. Only used in the formatter.
+  int color = 0;  // FIXME: do this differently
+
  protected:  // protected, as ExpectedTokenInfo accesses it.
   int token_enum_;
 

--- a/common/util/vector_tree.h
+++ b/common/util/vector_tree.h
@@ -276,6 +276,7 @@ class VectorTree {
   // Only the root node of a tree has a nullptr parent_.
   // This value is managed by ChildrenList, constructors, and
   // operator=(). There should be no need to set it manually in other places.
+ public:
   this_type* parent_ = nullptr;
 
   // Array of nodes/subtrees.

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -32,7 +32,7 @@
 namespace verilog {
 namespace {
 
-static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+static VerilogPreprocess::Config kDefaultPreprocess;
 
 using verible::SyntaxTreeSearchTestCase;
 using verible::TextStructureView;

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -79,10 +79,13 @@ cc_library(
     hdrs = ["flow_tree.h"],
     deps = [
         "//common/text:token-stream-view",
+        "//common/util:interval-set",
         "//common/util:logging",
         "//common/util:status-macros",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/verilog/analysis/extractors_test.cc
+++ b/verilog/analysis/extractors_test.cc
@@ -26,7 +26,7 @@
 namespace verilog {
 namespace analysis {
 namespace {
-static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+static VerilogPreprocess::Config kDefaultPreprocess;
 
 TEST(CollectInterfaceNamesTest, NonModuleTests) {
   const std::pair<absl::string_view, std::set<std::string>> kTestCases[] = {

--- a/verilog/analysis/flow_tree.h
+++ b/verilog/analysis/flow_tree.h
@@ -20,7 +20,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "common/text/token_stream_view.h"
 
 namespace verilog {
@@ -79,6 +81,17 @@ class FlowTree {
 
   // Generates all possible variants.
   absl::Status GenerateVariants(const VariantReceiver &receiver);
+
+  // Set of macro name defines.
+  using DefineSet = absl::flat_hash_set<absl::string_view>;
+
+  // A list of macro name sets; each set represents a variant of the source;
+  // together they should cover the entire source.
+  using DefineVariants = std::vector<DefineSet>;
+
+  // Returns the minimum set of defines needed to generate token stream variants
+  // that cover the entire source.
+  absl::StatusOr<DefineVariants> MinCoverDefineVariants();
 
   // Returns all the used macros in conditionals, ordered with the same ID as
   // used in BitSets.

--- a/verilog/analysis/verilog_analyzer_test.cc
+++ b/verilog/analysis/verilog_analyzer_test.cc
@@ -62,7 +62,7 @@ using verible::SyntaxTreeLeaf;
 using verible::TokenInfo;
 using verible::TokenInfoTestData;
 
-static constexpr verilog::VerilogPreprocess::Config kDefaultPreprocess;
+static verilog::VerilogPreprocess::Config kDefaultPreprocess;
 
 bool TreeContainsToken(const ConcreteSyntaxTree& tree, const TokenInfo& token) {
   const auto* matching_leaf =
@@ -509,10 +509,10 @@ TEST(AnalyzeVerilogAutomaticMode, InferredModuleBodyMode) {
 }
 
 TEST(AnalyzeVerilogAutomaticMode, AutomaticWithFallback) {
-  static constexpr verilog::VerilogPreprocess::Config kNoBranchFilter{
+  static verilog::VerilogPreprocess::Config kNoBranchFilter{
       .filter_branches = false,
   };
-  static constexpr verilog::VerilogPreprocess::Config kWithBranchFilter{
+  static verilog::VerilogPreprocess::Config kWithBranchFilter{
       .filter_branches = true,
   };
 

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -36,7 +36,7 @@ namespace verilog {
 // All files we process with the verilog project, essentially applications that
 // build a symbol table (project-tool, kythe-indexer) only benefit from
 // processing the same sequence of tokens a synthesis tool sees.
-static constexpr verilog::VerilogPreprocess::Config kPreprocessConfig{
+static verilog::VerilogPreprocess::Config kPreprocessConfig{
     .filter_branches = true,
 };
 

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -163,6 +163,7 @@ cc_library(
         "//common/util:vector-tree-iterators",
         "//verilog/CST:declaration",
         "//verilog/CST:module",
+        "//verilog/analysis:flow-tree",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/analysis:verilog-equivalence",
         "//verilog/parser:verilog-token-enum",

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <vector>
 
+#include "absl/algorithm/container.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "common/formatting/format_token.h"
@@ -46,6 +47,7 @@
 #include "common/util/vector_tree_iterators.h"
 #include "verilog/CST/declaration.h"
 #include "verilog/CST/module.h"
+#include "verilog/analysis/flow_tree.h"
 #include "verilog/analysis/verilog_analyzer.h"
 #include "verilog/analysis/verilog_equivalence.h"
 #include "verilog/formatting/align.h"
@@ -53,8 +55,9 @@
 #include "verilog/formatting/format_style.h"
 #include "verilog/formatting/token_annotator.h"
 #include "verilog/formatting/tree_unwrapper.h"
+#include "verilog/parser/verilog_lexer.h"
+#include "verilog/parser/verilog_token_classifications.h"
 #include "verilog/parser/verilog_token_enum.h"
-#include "verilog/preprocessor/verilog_preprocess.h"
 
 namespace verilog {
 namespace formatter {
@@ -73,31 +76,39 @@ using verible::VectorTreeLeavesIterator;
 
 using partition_node_type = VectorTree<TreeViewNodeInfo<TokenPartitionTree>>;
 
+using PreprocessConfigVariants = std::vector<VerilogPreprocess::Config>;
+
 // Takes a TextStructureView and FormatStyle, and formats UnwrappedLines.
 class Formatter {
  public:
-  Formatter(const verible::TextStructureView& text_structure,
-            const FormatStyle& style)
-      : text_structure_(text_structure), style_(style) {}
+  Formatter(const absl::string_view text, const FormatStyle& style,
+            const PreprocessConfigVariants& preproc_config_variants_ = {{}})
+      : text_(text),
+        preproc_config_variants_(preproc_config_variants_),
+        style_(style) {}
 
   // Formats the source code
-  Status Format(const ExecutionControl&);
+  Status Format(const ExecutionControl&, const verible::LineNumberSet&);
 
-  Status Format() { return Format(ExecutionControl()); }
-
-  void SelectLines(const LineNumberSet& lines);
+  Status Format() { return Format(ExecutionControl(), {}); }
 
   // Outputs all of the FormattedExcerpt lines to stream.
   // If "include_disabled" is false, does not contain the disabled ranges.
   void Emit(bool include_disabled, std::ostream& stream) const;
 
  private:
-  // Contains structural information about the code to format, such as
-  // TokenSequence from lexing, and ConcreteSyntaxTree from parsing
-  const verible::TextStructureView& text_structure_;
+  // The original text to format
+  absl::string_view text_;
+
+  // Preprocessor configuration variants to use for formatting.
+  std::vector<VerilogPreprocess::Config> preproc_config_variants_;
 
   // The style configuration for the formatter
   FormatStyle style_;
+
+  // Contains structural information about the code to format, such as
+  // TokenSequence from lexing, and ConcreteSyntaxTree from parsing
+  std::vector<std::unique_ptr<verible::TextStructure>> text_structures_;
 
   // Ranges of text where formatter is disabled (by comment directives).
   ByteOffsetSet disabled_ranges_;
@@ -107,48 +118,47 @@ class Formatter {
 };
 
 // TODO(b/148482625): make this public/re-usable for general content comparison.
-Status VerifyFormatting(const verible::TextStructureView& text_structure,
-                        absl::string_view formatted_output,
-                        absl::string_view filename) {
+Status VerifyFormatting(
+    absl::string_view text, absl::string_view formatted_output,
+    absl::string_view filename,
+    const PreprocessConfigVariants& preproc_config_variants = {{}}) {
   // Verify that the formatted output creates the same lexical
   // stream (filtered) as the original.  If any tokens were lost, fall back to
   // printing the original source unformatted.
   // Note: We cannot just Tokenize() and compare because Analyze()
   // performs additional transformations like expanding MacroArgs to
   // expression subtrees.
-  const auto reanalyzer = VerilogAnalyzer::AnalyzeAutomaticMode(
-      formatted_output, filename, verilog::VerilogPreprocess::Config());
-  const auto relex_status = ABSL_DIE_IF_NULL(reanalyzer)->LexStatus();
-  const auto reparse_status = reanalyzer->ParseStatus();
+  for (const VerilogPreprocess::Config& config : preproc_config_variants) {
+    {
+      const auto reanalyzer = VerilogAnalyzer::AnalyzeAutomaticMode(
+          formatted_output, filename, config);
+      const auto relex_status = ABSL_DIE_IF_NULL(reanalyzer)->LexStatus();
+      const auto reparse_status = reanalyzer->ParseStatus();
 
-  if (!relex_status.ok() || !reparse_status.ok()) {
-    const auto& token_errors = reanalyzer->TokenErrorMessages();
-    // Only print the first error.
-    if (!token_errors.empty()) {
-      return absl::DataLossError(
-          absl::StrCat("Error lex/parsing-ing formatted output.  "
-                       "Please file a bug.\nFirst error: ",
-                       token_errors.front()));
+      if (!relex_status.ok() || !reparse_status.ok()) {
+        const auto& token_errors = reanalyzer->TokenErrorMessages();
+        // Only print the first error.
+        if (!token_errors.empty()) {
+          return absl::DataLossError(
+              absl::StrCat("Error lexing/parsing formatted output.  "
+                           "Please file a bug.\nFirst error: ",
+                           token_errors.front()));
+        }
+      }
     }
-  }
 
-  {
-    // Filter out only whitespaces and compare.
-    // First difference will be printed to cerr for debugging.
-    std::ostringstream errstream;
-    // Note: text_structure.TokenStream() and reanalyzer->Data().TokenStream()
-    // contain already lexed tokens, so this comparison check is repeating the
-    // work done by the lexers.
-    // Should performance be a concern, we could pass in those tokens to
-    // avoid lexing twice, but for now, using plain strings as an interface
-    // to comparator functions is simpler and more intuitive.
-    // See analysis/verilog_equivalence.cc implementation.
-    if (verilog::FormatEquivalent(text_structure.Contents(), formatted_output,
-                                  &errstream) != DiffStatus::kEquivalent) {
-      return absl::DataLossError(absl::StrCat(
-          "Formatted output is lexically different from the input.    "
-          "Please file a bug.  Details:\n",
-          errstream.str()));
+    {
+      // Filter out only whitespaces and compare.
+      // First difference will be printed to cerr for debugging.
+      std::ostringstream errstream;
+      // See analysis/verilog_equivalence.cc implementation.
+      if (verilog::FormatEquivalent(text, formatted_output, &errstream) !=
+          DiffStatus::kEquivalent) {
+        return absl::DataLossError(absl::StrCat(
+            "Formatted output is lexically different from the input.    "
+            "Please file a bug.  Details:\n",
+            errstream.str()));
+      }
     }
   }
 
@@ -160,7 +170,8 @@ static Status ReformatVerilogIncrementally(absl::string_view original_text,
                                            absl::string_view filename,
                                            const FormatStyle& style,
                                            std::ostream& reformat_stream,
-                                           const ExecutionControl& control) {
+                                           const ExecutionControl& control,
+                                           FormatMethod preprocess) {
   // Differences from the first formatting.
   const verible::LineDiffs formatting_diffs(original_text, formatted_text);
   // Added lines will be re-applied to incremental re-formatting.
@@ -173,16 +184,14 @@ static Status ReformatVerilogIncrementally(absl::string_view original_text,
   formatted_lines.Add(formatting_diffs.after_lines.size() + 1);
   VLOG(1) << "formatted changed lines: " << formatted_lines;
   return FormatVerilog(formatted_text, filename, style, reformat_stream,
-                       formatted_lines, control);
+                       formatted_lines, control, preprocess);
 }
 
-static Status ReformatVerilog(absl::string_view original_text,
-                              absl::string_view formatted_text,
-                              absl::string_view filename,
-                              const FormatStyle& style,
-                              std::ostream& reformat_stream,
-                              const LineNumberSet& lines,
-                              const ExecutionControl& control) {
+static Status ReformatVerilog(
+    absl::string_view original_text, absl::string_view formatted_text,
+    absl::string_view filename, const FormatStyle& style,
+    std::ostream& reformat_stream, const LineNumberSet& lines,
+    const ExecutionControl& control, FormatMethod preprocess) {
   // Disable reformat check to terminate recursion.
   ExecutionControl convergence_control(control);
   convergence_control.verify_convergence = false;
@@ -190,19 +199,19 @@ static Status ReformatVerilog(absl::string_view original_text,
   if (lines.empty()) {
     // format whole file
     return FormatVerilog(formatted_text, filename, style, reformat_stream,
-                         lines, convergence_control);
+                         lines, convergence_control, preprocess);
   }
   // reformat incrementally
   return ReformatVerilogIncrementally(original_text, formatted_text, filename,
                                       style, reformat_stream,
-                                      convergence_control);
+                                      convergence_control, preprocess);
 }
 
 static absl::StatusOr<std::unique_ptr<VerilogAnalyzer>> ParseWithStatus(
-    absl::string_view text, absl::string_view filename) {
+    absl::string_view text, absl::string_view filename,
+    const verilog::VerilogPreprocess::Config& preprocess_config = {}) {
   std::unique_ptr<VerilogAnalyzer> analyzer =
-      VerilogAnalyzer::AnalyzeAutomaticMode(
-          text, filename, verilog::VerilogPreprocess::Config());
+      VerilogAnalyzer::AnalyzeAutomaticMode(text, filename, preprocess_config);
   {
     // Lex and parse code.  Exit on failure.
     const auto lex_status = ABSL_DIE_IF_NULL(analyzer)->LexStatus();
@@ -222,16 +231,15 @@ static absl::StatusOr<std::unique_ptr<VerilogAnalyzer>> ParseWithStatus(
   return analyzer;
 }
 
-absl::Status FormatVerilog(const verible::TextStructureView& text_structure,
-                           absl::string_view filename, const FormatStyle& style,
-                           std::string* formatted_text,
-                           const verible::LineNumberSet& lines,
-                           const ExecutionControl& control) {
-  Formatter fmt(text_structure, style);
-  fmt.SelectLines(lines);
+absl::Status FormatVerilog(
+    const absl::string_view text, absl::string_view filename,
+    const FormatStyle& style, std::string* formatted_text,
+    const verible::LineNumberSet& lines, const ExecutionControl& control,
+    const std::vector<VerilogPreprocess::Config>& preproc_config_variants) {
+  Formatter fmt(text, style, preproc_config_variants);
 
   // Format code.
-  Status format_status = fmt.Format(control);
+  Status format_status = fmt.Format(control, lines);
   if (!format_status.ok()) {
     if (format_status.code() != StatusCode::kResourceExhausted) {
       // Some more fatal error, halt immediately.
@@ -252,8 +260,8 @@ absl::Status FormatVerilog(const verible::TextStructureView& text_structure,
   *formatted_text = output_buffer.str();
 
   // For now, unconditionally verify.
-  if (Status verify_status =
-          VerifyFormatting(text_structure, *formatted_text, filename);
+  if (Status verify_status = VerifyFormatting(text, *formatted_text, filename,
+                                              preproc_config_variants);
       !verify_status.ok()) {
     return verify_status;
   }
@@ -261,17 +269,54 @@ absl::Status FormatVerilog(const verible::TextStructureView& text_structure,
   return format_status;
 }
 
+// Returns the minimum set of filtering preprocess configs needed to generate
+// token stream variants that cover the entire source.
+absl::StatusOr<PreprocessConfigVariants> GetMinCoverPreprocessConfigs(
+    VerilogAnalyzer* analyzer) {
+  if (Status tokenize_status = analyzer->Tokenize(); !tokenize_status.ok()) {
+    return tokenize_status;
+  }
+  FlowTree control_flow_tree(analyzer->Data().TokenStream());
+  auto define_variants = control_flow_tree.MinCoverDefineVariants();
+  if (!define_variants.ok()) return define_variants.status();
+
+  std::vector<VerilogPreprocess::Config> config_variants;
+  config_variants.reserve(define_variants->size());
+  for (const FlowTree::DefineSet& defines : *define_variants) {
+    VerilogPreprocess::Config config_variant{.filter_branches = true};
+    for (auto define : defines) {
+      config_variant.macro_definitions.emplace(define, std::nullopt);
+    }
+    config_variants.push_back(config_variant);
+  }
+  return config_variants;
+}
+
 Status FormatVerilog(absl::string_view text, absl::string_view filename,
                      const FormatStyle& style, std::ostream& formatted_stream,
                      const LineNumberSet& lines,
-                     const ExecutionControl& control) {
-  const auto analyzer = ParseWithStatus(text, filename);
-  if (!analyzer.ok()) return analyzer.status();
+                     const ExecutionControl& control, FormatMethod preprocess) {
+  // Prepare preprocess config variants
+  std::vector<VerilogPreprocess::Config> preproc_config_variants;
+  // TODO: Make VerilogAnalyzer movable and make this an std::optional
+  std::unique_ptr<VerilogAnalyzer> preprocess_variants_analyzer;
+  // Keep this analyzer alive, as the defines in preprocess_config_variants
+  // refer to its text contents
+  if (preprocess == FormatMethod::kPreprocessVariants) {
+    preprocess_variants_analyzer =
+        std::make_unique<VerilogAnalyzer>(text, filename);
+    auto variants_or =
+        GetMinCoverPreprocessConfigs(&*preprocess_variants_analyzer);
+    if (!variants_or.ok()) return variants_or.status();
+    preproc_config_variants = std::move(*variants_or);
+  } else {
+    preproc_config_variants.push_back(VerilogPreprocess::Config());
+  }
 
-  const verible::TextStructureView& text_structure = analyzer->get()->Data();
   std::string formatted_text;
-  Status format_status = FormatVerilog(text_structure, filename, style,
-                                       &formatted_text, lines, control);
+  Status format_status = FormatVerilog(text, filename, style, &formatted_text,
+                                       lines, control, preproc_config_variants);
+
   // Commit formatted text to the output stream independent of status.
   formatted_stream << formatted_text;
   if (!format_status.ok()) return format_status;
@@ -283,7 +328,7 @@ Status FormatVerilog(absl::string_view text, absl::string_view filename,
     std::ostringstream reformat_stream;
     if (auto reformat_status =
             ReformatVerilog(text, formatted_text, filename, style,
-                            reformat_stream, lines, control);
+                            reformat_stream, lines, control, preprocess);
         !reformat_status.ok()) {
       return reformat_status;
     }
@@ -303,11 +348,10 @@ absl::Status FormatVerilogRange(const verible::TextStructureView& structure,
     return absl::OkStatus();
   }
 
-  Formatter fmt(structure, style);
-  fmt.SelectLines({line_range});
+  Formatter fmt(structure.Contents(), style);
 
   // Format code.
-  Status format_status = fmt.Format(control);
+  Status format_status = fmt.Format(control, {line_range});
   if (!format_status.ok()) return format_status;
 
   // In any diagnostic mode, proceed no further.
@@ -603,11 +647,6 @@ std::ostream& ExecutionControl::Stream() const {
   return (stream != nullptr) ? *stream : std::cout;
 }
 
-void Formatter::SelectLines(const LineNumberSet& lines) {
-  disabled_ranges_ = EnabledLinesToDisabledByteRanges(
-      lines, text_structure_.GetLineColumnMap());
-}
-
 // Given control flags and syntax tree, selectively disable some ranges
 // of text from formatting.  This provides an easy way to preserve spacing on
 // selected syntax subtrees to reduce formatter harm while allowing
@@ -786,44 +825,222 @@ class ContinuationCommentAligner {
   int formatted_column_ = kInvalidColumn;
 };
 
-Status Formatter::Format(const ExecutionControl& control) {
-  const absl::string_view full_text(text_structure_.Contents());
-  const auto& token_stream(text_structure_.TokenStream());
+// Merges the second partition tree into the first one. Whenever there is a
+// discrepancy, it chooses the more granular partition.
+// This function assumes that the two trees point to the same token stream.
+void MergePartitionTrees(verible::TokenPartitionTree* target,
+                         const verible::TokenPartitionTree& source) {
+  const auto tokens_begin = [](const TokenPartitionTree& node) {
+    return node.Value().TokensRange().begin();
+  };
+  const auto tokens_end = [](const TokenPartitionTree& node) {
+    return node.Value().TokensRange().end();
+  };
+  auto target_it = verible::VectorTreePreOrderIterator(target);
+  const auto target_end =
+      ++verible::VectorTreePreOrderIterator(&RightmostDescendant(*target));
+  auto source_it = verible::VectorTreePreOrderIterator(&source);
+  const auto source_end = ++verible::VectorTreePreOrderIterator(
+      &verible::RightmostDescendant(source));
+  while (target_it != target_end && source_it != source_end) {
+    if (tokens_begin(*target_it) == tokens_begin(*source_it) &&
+        target_it->Children().empty()) {
+      // The first tokens of source and target are aligned. This is the only
+      // case that modifies target.
+      if (tokens_end(*target_it) == tokens_end(*source_it)) {
+        VLOG(1) << "Exact match of partitions: " << *target_it;
+        // Assign if the target node has no origin, or if the source node has
+        // children (which means it is more granular).
+        if (!target_it->Value().Origin() || !source_it->Children().empty()) {
+          VLOG(1) << "Assigning to target: " << *source_it;
+          *target_it = *source_it;
+        } else {
+          VLOG(1) << "Skipping";
+        }
+        ++target_it;
+        ++source_it;
+      } else if (tokens_end(*target_it) < tokens_end(*source_it) &&
+                 !source_it->Children().empty()) {
+        // Source node has children, so it should be assigned to target.
+        // However, its token range ends after the target node's. We have to cut
+        // the tokens that exceed the target node.
+        VLOG(1) << "Replacing: " << *target_it;
+        VLOG(1) << "With: " << *source_it;
+        TokenPartitionTree source_copy = *source_it;
+        const auto end = ++verible::VectorTreePreOrderIterator(
+            &RightmostDescendant(source_copy));
+        // Remove surplus nodes from the copied partition tree.
+        for (auto erase_it = verible::VectorTreePreOrderIterator(&source_copy);
+             erase_it != end && tokens_end(*erase_it) <= tokens_end(*source_it);
+             ++erase_it) {
+          // Only erase after we move past target_it
+          if (tokens_begin(*erase_it) < tokens_end(*target_it)) continue;
+          TokenPartitionTree* parent = erase_it->Parent();
+          size_t i = &*erase_it - &parent->Children().front();
+          parent->Children().erase(parent->Children().begin() + i,
+                                   parent->Children().end());
+          // erase_it is invalid, move back by one
+          erase_it = i > 0 ? verible::VectorTreePreOrderIterator(
+                                 &parent->Children()[i - 1])
+                           : verible::VectorTreePreOrderIterator(parent);
+        }
+        // Now we can copy the cut down tree to the target tree
+        *target_it = source_copy;
+        VLOG(1) << "Result: " << *target_it;
+        // Move source_it after target_it
+        while (source_it != source_end &&
+               tokens_begin(*source_it) < tokens_end(*target_it)) {
+          ++source_it;
+        }
+      } else if (tokens_end(*target_it) > tokens_end(*source_it)) {
+        // Target node is longer than source node. To preserve information, we
+        // split the target node into two. The first part is the same length as
+        // the source node, and replaced by it.
+        VLOG(1) << "Splitting partition: " << *target_it;
+        VLOG(1) << "First part will be replaced by: " << *source_it;
+        // Construct the second part
+        TokenPartitionTree second_part = *target_it;
+        second_part.Value().SetTokensRange(
+            source_it->Value().TokensRange().end(),
+            target_it->Value().TokensRange().end());
+        // Replace the first part
+        *target_it = *source_it;
+        // Insert the second part after the first part
+        TokenPartitionTree* parent = target_it->Parent();
+        size_t i = &*target_it - &parent->Children().front();
+        parent->Children().insert(parent->Children().begin() + i + 1,
+                                  second_part);
+        target_it =
+            verible::VectorTreePreOrderIterator(&parent->Children()[i + 1]);
+      } else {
+        // tokens_end(*target_it) < tokens_end(*source_it)
+        VLOG(1) << "Target partition more granular than source partition; "
+                   "moving source forward";
+        ++source_it;
+      }
+    } else if (tokens_begin(*source_it) < tokens_begin(*target_it)) {
+      // Catch up source_it to target_it
+      ++source_it;
+    } else if (tokens_begin(*target_it) < tokens_begin(*source_it)) {
+      // Catch up target_it to source_it
+      ++target_it;
+    } else {
+      // tokens_begin(*source_it) == tokens_begin(*target_it)
+      // But *target_it has children, so we cannot replace it. Iterate forward.
+      ++source_it;
+      ++target_it;
+    }
+  }
+}
 
-  // Initialize auxiliary data needed for TreeUnwrapper.
-  UnwrapperData unwrapper_data(token_stream);
+Status Formatter::Format(const ExecutionControl& control,
+                         const verible::LineNumberSet& lines) {
+  struct FormatVariant {
+    FormatVariant(const FormatVariant&) = delete;
+    FormatVariant(FormatVariant&&) = default;
+
+    const verible::TextStructureView& text_structure;
+    std::unique_ptr<UnwrapperData> unwrapper_data;
+    TreeUnwrapper tree_unwrapper;
+
+    FormatVariant(const verible::TextStructureView& text_struct,
+                  const FormatStyle& style)
+        : text_structure(text_struct),
+          unwrapper_data{
+              std::make_unique<UnwrapperData>(text_structure.TokenStream())},
+          tree_unwrapper{text_structure, style,
+                         unwrapper_data->preformatted_tokens} {}
+  };
+
+  std::vector<FormatVariant> format_variants;
+  format_variants.reserve(preproc_config_variants_.size());
+  size_t color = 0;
+  for (const VerilogPreprocess::Config& config : preproc_config_variants_) {
+    color++;
+
+    const auto analyzer = ParseWithStatus(text_, "", config);
+    if (!analyzer.ok()) return analyzer.status();
+    auto text_structure = (*analyzer)->ReleaseTextStructure();
+
+    if (!text_structures_.empty()) {
+      text_structure->RebaseTokens(*text_structures_.front());
+    }
+
+    text_structure->MutableData().ColorStreamViewTokens(color);
+    format_variants.push_back({text_structure->Data(), style_});
+
+    text_structures_.push_back(std::move(text_structure));
+  }
+  disabled_ranges_ = EnabledLinesToDisabledByteRanges(
+      lines, text_structures_.front()->Data().GetLineColumnMap());
+  // Update text, as it may have been modified by the analyzer.
+  text_ = text_structures_.front()->Data().Contents();
 
   // Partition input token stream into hierarchical set of UnwrappedLines.
-  TreeUnwrapper tree_unwrapper(text_structure_, style_,
-                               unwrapper_data.preformatted_tokens);
 
-  const TokenPartitionTree* format_tokens_partitions = nullptr;
   // TODO(fangism): The following block could be parallelized because
   // full-partitioning does not depend on format annotations.
-  {
+  for (FormatVariant& format_variant : format_variants) {
     // Annotate inter-token information between all adjacent PreFormatTokens.
     // This must be done before any decisions about ExpandableTreeView
     // can be made because they depend on minimum-spacing, and must-break.
-    AnnotateFormattingInformation(style_, text_structure_,
-                                  &unwrapper_data.preformatted_tokens);
+    AnnotateFormattingInformation(
+        style_, format_variant.text_structure,
+        &format_variant.unwrapper_data->preformatted_tokens);
 
     // Determine ranges of disabling the formatter, based on comment controls.
-    disabled_ranges_.Union(DisableFormattingRanges(full_text, token_stream));
+    disabled_ranges_.Union(DisableFormattingRanges(
+        text_, format_variant.text_structure.TokenStream()));
 
     // Find disabled formatting ranges for specific syntax tree node types.
     // These are typically temporary workarounds for sections that users
     // habitually prefer to format themselves.
-    if (const auto& root = text_structure_.SyntaxTree()) {
-      DisableSyntaxBasedRanges(&disabled_ranges_, *root, style_, full_text);
+    if (const auto& root = format_variant.text_structure.SyntaxTree()) {
+      DisableSyntaxBasedRanges(&disabled_ranges_, *root, style_, text_);
     }
 
     // Disable formatting ranges.
     verible::PreserveSpacesOnDisabledTokenRanges(
-        &unwrapper_data.preformatted_tokens, disabled_ranges_, full_text);
+        &format_variant.unwrapper_data->preformatted_tokens, disabled_ranges_,
+        text_);
 
     // Partition PreFormatTokens into candidate unwrapped lines.
-    format_tokens_partitions = tree_unwrapper.Unwrap();
+    format_variant.tree_unwrapper.Unwrap();
   }
+
+  // Merge partition trees from all format variants into the first one.
+  for (auto it = format_variants.begin() + 1; it != format_variants.end();
+       ++it) {
+    // Rebase the the source partitions to the target tree tokens.
+    // This is necessary for MergePartitionTrees to work.
+    auto target =
+        format_variants.front().tree_unwrapper.CurrentTokenPartition();
+    auto source = it->tree_unwrapper.CurrentTokenPartition();
+    auto old_base = source->Value().TokensRange().begin();
+    auto new_base = target->Value().TokensRange().begin();
+    verible::ApplyPostOrder(*source, [old_base,
+                                      new_base](TokenPartitionTree& node) {
+      if (node.Children().empty()) {
+        auto begin =
+            new_base +
+            std::distance(old_base, node.Value().TokensRange().begin());
+        auto end = new_base +
+                   std::distance(old_base, node.Value().TokensRange().end());
+        node.Value().SetTokensRange(begin, end);
+      } else {
+        node.Value().SetTokensRange(
+            node.Children().front().Value().TokensRange().begin(),
+            node.Children().back().Value().TokensRange().end());
+      }
+    });
+    MergePartitionTrees(target, *source);
+  }
+
+  const verible::TextStructureView& text_structure =
+      format_variants.front().text_structure;
+  TreeUnwrapper& tree_unwrapper = format_variants.front().tree_unwrapper;
+  verible::TokenPartitionTree* format_tokens_partitions =
+      tree_unwrapper.UnwrappedLines();
 
   {
     // For debugging only: identify largest leaf partitions, and stop.
@@ -837,7 +1054,7 @@ Status Formatter::Format(const ExecutionControl& control) {
     if (control.show_largest_token_partitions != 0) {
       PrintLargestPartitions(control.Stream(), *format_tokens_partitions,
                              control.show_largest_token_partitions,
-                             text_structure_.GetLineColumnMap(), full_text);
+                             text_structure.GetLineColumnMap(), text_);
     }
     if (control.AnyStop()) {
       return absl::OkStatus();
@@ -862,11 +1079,10 @@ Status Formatter::Format(const ExecutionControl& control) {
           verible::OptimizeTokenPartitionTree(style_, &node);
           break;
         case PartitionPolicyEnum::kTabularAlignment:
-          // TODO(b/145170750): Adjust inter-token spacing to achieve alignment,
-          // but leave partitioning intact.
-          // This relies on inter-token spacing having already been annotated.
-          TabularAlignTokenPartitions(style_, full_text, disabled_ranges_,
-                                      &node);
+          // TODO(b/145170750): Adjust inter-token spacing to achieve
+          // alignment, but leave partitioning intact. This relies on
+          // inter-token spacing having already been annotated.
+          TabularAlignTokenPartitions(style_, text_, disabled_ranges_, &node);
           break;
         default:
           break;
@@ -874,10 +1090,13 @@ Status Formatter::Format(const ExecutionControl& control) {
     });
   }
 
+  verible::TokenPartitionTree* const root =
+      tree_unwrapper.CurrentTokenPartition();
+  const auto unwrapper_data = std::move(format_variants.front().unwrapper_data);
+
   // Apply token spacing from partitions to tokens. This is permanent, so it
   // must be done after all reshaping is done.
   {
-    auto* root = tree_unwrapper.CurrentTokenPartition();
     auto node_iter = VectorTreeLeavesIterator(&LeftmostDescendant(*root));
     const auto end = ++VectorTreeLeavesIterator(&RightmostDescendant(*root));
 
@@ -888,7 +1107,7 @@ Status Formatter::Format(const ExecutionControl& control) {
 
       if (partition_policy == PartitionPolicyEnum::kAlreadyFormatted) {
         verible::ApplyAlreadyFormattedPartitionPropertiesToTokens(
-            &(*node_iter), &unwrapper_data.preformatted_tokens);
+            &(*node_iter), &unwrapper_data->preformatted_tokens);
       } else if (partition_policy == PartitionPolicyEnum::kInline) {
         auto* parent = node_iter->Parent();
         CHECK_NOTNULL(parent);
@@ -897,7 +1116,7 @@ Status Formatter::Format(const ExecutionControl& control) {
         // This removes the node pointed to by node_iter (and all other
         // siblings)
         verible::ApplyAlreadyFormattedPartitionPropertiesToTokens(
-            parent, &unwrapper_data.preformatted_tokens);
+            parent, &unwrapper_data->preformatted_tokens);
         // Move to the parent which is now a leaf
         node_iter = verible::VectorTreeLeavesIterator(parent);
       }
@@ -906,8 +1125,8 @@ Status Formatter::Format(const ExecutionControl& control) {
 
   // Produce sequence of independently operable UnwrappedLines.
   const auto unwrapped_lines = MakeUnwrappedLinesWorklist(
-      style_, full_text, disabled_ranges_, *format_tokens_partitions,
-      &unwrapper_data.preformatted_tokens);
+      style_, text_, disabled_ranges_, *format_tokens_partitions,
+      &unwrapper_data->preformatted_tokens);
 
   // For each UnwrappedLine: minimize total penalty of wrap/break decisions.
   // TODO(fangism): This could be parallelized if results are written
@@ -915,7 +1134,7 @@ Status Formatter::Format(const ExecutionControl& control) {
   std::vector<const UnwrappedLine*> partially_formatted_lines;
   formatted_lines_.reserve(unwrapped_lines.size());
   ContinuationCommentAligner continuation_comment_aligner(
-      text_structure_.GetLineColumnMap(), text_structure_.Contents());
+      text_structure.GetLineColumnMap(), text_);
   for (const auto& uwline : unwrapped_lines) {
     // TODO(fangism): Use different formatting strategies depending on
     // uwline.PartitionPolicy().
@@ -925,6 +1144,12 @@ Status Formatter::Format(const ExecutionControl& control) {
       // For partitions that were successfully aligned, do not search
       // line-wrapping, but instead accept the adjusted padded spacing.
       formatted_lines_.emplace_back(uwline);
+    } else if (IsPreprocessorControlFlow(verilog_tokentype(
+                   uwline.TokensRange().begin()->TokenEnum()))) {
+      // Remove indentation before preprocessing control flow.
+      UnwrappedLine formatted_line = uwline;
+      formatted_line.SetIndentationSpaces(0);
+      formatted_lines_.emplace_back(formatted_line);
     } else {
       // In other case, default to searching for optimal line wrapping.
       const auto optimal_solutions =
@@ -961,13 +1186,12 @@ Status Formatter::Format(const ExecutionControl& control) {
 }
 
 void Formatter::Emit(bool include_disabled, std::ostream& stream) const {
-  const absl::string_view full_text(text_structure_.Contents());
   std::function<bool(const verible::TokenInfo&)> include_token_p;
   if (include_disabled) {
     include_token_p = [](const verible::TokenInfo&) { return true; };
   } else {
-    include_token_p = [this, &full_text](const verible::TokenInfo& tok) {
-      return !disabled_ranges_.Contains(tok.left(full_text));
+    include_token_p = [this](const verible::TokenInfo& tok) {
+      return !disabled_ranges_.Contains(tok.left(text_));
     };
   }
 
@@ -976,14 +1200,13 @@ void Formatter::Emit(bool include_disabled, std::ostream& stream) const {
     // TODO(fangism): The handling of preserved spaces before tokens is messy:
     // some of it is handled here, some of it is inside FormattedToken.
     // TODO(mglb): Test empty line handling when this method becomes testable.
-    const auto front_offset =
-        line.Tokens().empty() ? position
-                              : line.Tokens().front().token->left(full_text);
+    const auto front_offset = line.Tokens().empty()
+                                  ? position
+                                  : line.Tokens().front().token->left(text_);
     const absl::string_view leading_whitespace(
-        full_text.substr(position, front_offset - position));
-    FormatWhitespaceWithDisabledByteRanges(full_text, leading_whitespace,
-                                           disabled_ranges_, include_disabled,
-                                           stream);
+        text_.substr(position, front_offset - position));
+    FormatWhitespaceWithDisabledByteRanges(
+        text_, leading_whitespace, disabled_ranges_, include_disabled, stream);
 
     // When front of first token is format-disabled, the previous call will
     // already cover the space up to the front token, in which case,
@@ -992,15 +1215,14 @@ void Formatter::Emit(bool include_disabled, std::ostream& stream) const {
     if (!line.Tokens().empty()) {
       line.FormattedText(stream, !disabled_ranges_.Contains(front_offset),
                          include_token_p);
-      position = line.Tokens().back().token->right(full_text);
+      position = line.Tokens().back().token->right(text_);
     }
   }
 
   // Handle trailing spaces after last token.
-  const absl::string_view trailing_whitespace(full_text.substr(position));
-  FormatWhitespaceWithDisabledByteRanges(full_text, trailing_whitespace,
-                                         disabled_ranges_, include_disabled,
-                                         stream);
+  const absl::string_view trailing_whitespace(text_.substr(position));
+  FormatWhitespaceWithDisabledByteRanges(
+      text_, trailing_whitespace, disabled_ranges_, include_disabled, stream);
 }
 
 }  // namespace formatter

--- a/verilog/formatting/formatter.h
+++ b/verilog/formatting/formatter.h
@@ -21,7 +21,9 @@
 #include "absl/status/status.h"
 #include "common/strings/position.h"
 #include "common/text/text_structure.h"
+#include "verilog/analysis/flow_tree.h"
 #include "verilog/formatting/format_style.h"
+#include "verilog/preprocessor/verilog_preprocess.h"
 
 namespace verilog {
 namespace formatter {
@@ -66,6 +68,15 @@ struct ExecutionControl {
   }
 };
 
+// Used to select which formatting method to use by FormatVerilog.
+enum class FormatMethod {
+  kSinglePass,          // The default single-pass formatting
+                        // method
+  kPreprocessVariants,  // The '--preprocess_variants' method
+};
+
+using PreprocessConfigVariants = std::vector<VerilogPreprocess::Config>;
+
 // Formats Verilog/SystemVerilog source code.
 // 'lines' controls which lines have formattting explicitly enabled.
 // If this is empty, interpret as all lines enabled for formatting.
@@ -75,14 +86,16 @@ absl::Status FormatVerilog(absl::string_view text, absl::string_view filename,
                            const FormatStyle& style,
                            std::ostream& formatted_stream,
                            const verible::LineNumberSet& lines = {},
-                           const ExecutionControl& control = {});
+                           const ExecutionControl& control = {},
+                           FormatMethod preprocess = FormatMethod::kSinglePass);
 // Ditto, but with TextStructureView as input and std::string as output.
 // This does verification of the resulting format, but _no_ convergence test.
-absl::Status FormatVerilog(const verible::TextStructureView& text_structure,
-                           absl::string_view filename, const FormatStyle& style,
-                           std::string* formatted_text,
-                           const verible::LineNumberSet& lines = {},
-                           const ExecutionControl& control = {});
+absl::Status FormatVerilog(
+    absl::string_view text, absl::string_view filename,
+    const FormatStyle& style, std::string* formatted_text,
+    const verible::LineNumberSet& lines = {},
+    const ExecutionControl& control = {},
+    const PreprocessConfigVariants& preproc_config_variants = {{}});
 
 // Format only lines in line_range interval [min, max) in "full_content"
 // using "style". Emits _only_ the formatted code in the range

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -48,13 +48,14 @@ namespace verilog {
 namespace formatter {
 
 // private, extern function in formatter.cc, directly tested here.
-absl::Status VerifyFormatting(const verible::TextStructureView& text_structure,
-                              absl::string_view formatted_output,
-                              absl::string_view filename);
+absl::Status VerifyFormatting(
+    absl::string_view text, absl::string_view formatted_output,
+    absl::string_view filename,
+    const PreprocessConfigVariants& preproc_config_variants = {{}});
 
 namespace {
 
-static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+static VerilogPreprocess::Config kDefaultPreprocess;
 
 using absl::StatusCode;
 using testing::HasSubstr;
@@ -68,7 +69,8 @@ TEST(VerifyFormattingTest, NoError) {
   const std::unique_ptr<VerilogAnalyzer> analyzer =
       VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
-  const auto status = VerifyFormatting(text_structure, code, "<filename>");
+  const auto status =
+      VerifyFormatting(text_structure.Contents(), code, "<filename>");
   EXPECT_OK(status);
 }
 
@@ -79,7 +81,8 @@ TEST(VerifyFormattingTest, LexError) {
       VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const absl::string_view bad_code("1class c;endclass\n");  // lexical error
-  const auto status = VerifyFormatting(text_structure, bad_code, "<filename>");
+  const auto status =
+      VerifyFormatting(text_structure.Contents(), bad_code, "<filename>");
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), StatusCode::kDataLoss);
 }
@@ -91,7 +94,8 @@ TEST(VerifyFormattingTest, ParseError) {
       VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const absl::string_view bad_code("classc;endclass\n");  // syntax error
-  const auto status = VerifyFormatting(text_structure, bad_code, "<filename>");
+  const auto status =
+      VerifyFormatting(text_structure.Contents(), bad_code, "<filename>");
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), StatusCode::kDataLoss);
 }
@@ -103,17 +107,37 @@ TEST(VerifyFormattingTest, LexicalDifference) {
       VerilogAnalyzer::AnalyzeAutomaticMode(code, "<file>", kDefaultPreprocess);
   const auto& text_structure = ABSL_DIE_IF_NULL(analyzer)->Data();
   const absl::string_view bad_code("class c;;endclass\n");  // different tokens
-  const auto status = VerifyFormatting(text_structure, bad_code, "<filename>");
+  const auto status =
+      VerifyFormatting(text_structure.Contents(), bad_code, "<filename>");
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.code(), StatusCode::kDataLoss);
 }
 
+enum class FormatTestMethod {
+  kSinglePassOnly,          // Only test the default single-pass formatting
+                            // method
+  kPreprocessVariantsOnly,  // Only test the '--preprocess_variants' method
+  kBoth                     // Test both methods
+};
+
 struct FormatterTestCase {
   absl::string_view input;
   absl::string_view expected;
+  FormatTestMethod method = FormatTestMethod::kBoth;
+
+  bool SinglePassMethod() const {
+    return method == FormatTestMethod::kSinglePassOnly ||
+           method == FormatTestMethod::kBoth;
+  }
+
+  bool PreprocessVariantsMethod() const {
+    return method == FormatTestMethod::kPreprocessVariantsOnly ||
+           method == FormatTestMethod::kBoth;
+  }
 };
 
 static const LineNumberSet kEnableAllLines;
+static const ExecutionControl kDefaultControl;
 
 // Test that the expected output is produced with the formatter using a custom
 // FormatStyle.
@@ -131,11 +155,24 @@ TEST(FormatterTest, FormatCustomStyleTest) {
   style.indentation_spaces = 10;  // unconventional indentation
   style.wrap_spaces = 4;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
     EXPECT_OK(status);
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
   }
 }
@@ -437,7 +474,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
     {// macro call nested with function call containing an ifdef
      "`J(D(`ifdef e))\n",
      "`J(D(\n"
-     "   `ifdef e))\n"},
+     "   `ifdef e))\n",
+     FormatTestMethod::kSinglePassOnly},
 
     // `uvm macros indenting
     {
@@ -1538,7 +1576,8 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    output reg  yy\n"
      "`endif\n"
      ");\n"
-     "endmodule : foo\n"},
+     "endmodule : foo\n",
+     FormatTestMethod::kSinglePassOnly},
     {"module foo(\n"
      "input w , \n"
      "`define   FOO BAR\n"
@@ -15464,6 +15503,46 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "end\n",
      "always @(  /*t*/ *  /*t*/) begin\n"
      "end\n"},
+    {"`ifdef FOO always  @ (*  ) begin\n"
+     "`else always_comb begin `endif\n"
+     "end\n",
+     "`ifdef FOO\n"
+     "always @(*) begin\n"
+     "`else\n"
+     "always_comb begin\n"
+     "`endif\n"
+     "end\n",
+     FormatTestMethod::kPreprocessVariantsOnly},
+    {"module\n"
+     "`ifdef FOO foo; `else bar; `endif\n"
+     "endmodule\n",
+     "module\n"
+     "`ifdef FOO\n"
+     "foo;\n"
+     "`else\n"
+     "bar;\n"
+     "`endif\n"
+     "endmodule\n",
+     FormatTestMethod::kPreprocessVariantsOnly},
+    {"`ifdef FOO function int foo;\n"
+     "foo = 42;\n"
+     "`else task bar;\n"
+     "$display(\"bar\");\n"
+     "`endif\n"
+     "`ifdef FOO endfunction `else endtask `endif",
+     "`ifdef FOO\n"
+     "function int foo;\n"
+     "  foo = 42;\n"
+     "`else\n"
+     "task bar;\n"
+     "  $display(\"bar\");\n"
+     "`endif\n"
+     "`ifdef FOO\n"
+     "endfunction\n"
+     "`else\n"
+     "endtask\n"
+     "`endif\n",
+     FormatTestMethod::kPreprocessVariantsOnly},
 
     // -----------------------------------------------------------------
 };
@@ -15476,10 +15555,23 @@ TEST(FormatterEndToEndTest, VerilogFormatTest) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -15555,7 +15647,8 @@ TEST(FormatterEndToEndTest, AutoInferAlignment) {
        "    output reg     bar\n"   // ... and triggers alignment.
        "`endif\n"
        ");\n"
-       "endmodule : pd\n"},
+       "endmodule : pd\n",
+       FormatTestMethod::kSinglePassOnly},
       {"module pd(\n"
        "input logic [31:0] bus,\n"
        "input logic [7:0] bus2,\n"
@@ -16457,10 +16550,23 @@ TEST(FormatterEndToEndTest, AutoInferAlignment) {
   style.ApplyToAllAlignmentPolicies(AlignmentPolicy::kInferUserIntent);
 
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16559,10 +16665,23 @@ TEST(FormatterEndToEndTest, VerilogFormatWideTest) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kFormatterWideTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kFormatterWideTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16609,10 +16728,23 @@ TEST(FormatterEndToEndTest, DisableModulePortDeclarations) {
   style.wrap_spaces = 4;
   style.port_declarations_alignment = verible::AlignmentPolicy::kPreserve;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16703,10 +16835,23 @@ TEST(FormatterEndToEndTest, DisableModuleInstantiations) {
   style.named_parameter_alignment = AlignmentPolicy::kPreserve;
   style.named_port_alignment = AlignmentPolicy::kPreserve;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16812,10 +16957,23 @@ TEST(FormatterEndToEndTest, DisableTryWrapLongLines) {
   style.wrap_spaces = 4;
   style.try_wrap_long_lines = false;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16872,10 +17030,23 @@ TEST(FormatterEndToEndTest, ModulePortDeclarationsIndentNotWrap) {
   // Indent 2 spaces instead of wrapping 4 spaces.
   style.port_declarations_indentation = IndentationStyle::kIndent;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16920,10 +17091,23 @@ TEST(FormatterEndToEndTest, NamedPortConnectionsIndentNotWrap) {
   // Indent 2 spaces instead of wrapping 4 spaces.
   style.named_port_indentation = IndentationStyle::kIndent;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -16963,10 +17147,23 @@ TEST(FormatterEndToEndTest, WrapEndElseStatements) {
   style.wrap_spaces = 4;
   style.wrap_end_else_clauses = true;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -17034,10 +17231,23 @@ TEST(FormatterEndToEndTest, FormalParametersIndentNotWrap) {
   // Indent 2 spaces instead of wrapping 4 spaces.
   style.formal_parameters_indentation = IndentationStyle::kIndent;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -17109,10 +17319,23 @@ TEST(FormatterEndToEndTest, NamedParametersIndentNotWrap) {
   // Indent 2 spaces instead of wrapping 4 spaces.
   style.named_parameter_indentation = IndentationStyle::kIndent;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -17123,6 +17346,17 @@ struct SelectLinesTestCase {
   absl::string_view input;
   LineNumberSet lines;  // explicit set of lines to enable formatting
   absl::string_view expected;
+  FormatTestMethod method = FormatTestMethod::kBoth;
+
+  bool SinglePassMethod() const {
+    return method == FormatTestMethod::kSinglePassOnly ||
+           method == FormatTestMethod::kBoth;
+  }
+
+  bool PreprocessVariantsMethod() const {
+    return method == FormatTestMethod::kPreprocessVariantsOnly ||
+           method == FormatTestMethod::kBoth;
+  }
 };
 
 // Tests that formatter honors selected line numbers.
@@ -17325,10 +17559,26 @@ TEST(FormatterEndToEndTest, SelectLines) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status = FormatVerilog(test_case.input, "<filename>", style,
                                       stream, test_case.lines);
+    EXPECT_OK(status) << status.message() << '\n'
+                      << "Lines: " << test_case.lines;
+    EXPECT_EQ(stream.str(), test_case.expected)
+        << "code:\n"
+        << test_case.input << "\nlines: " << test_case.lines;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, test_case.lines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
+    // Require these test cases to be valid.
     EXPECT_OK(status) << status.message() << '\n'
                       << "Lines: " << test_case.lines;
     EXPECT_EQ(stream.str(), test_case.expected)
@@ -17453,10 +17703,23 @@ TEST(FormatterEndToEndTest, PreserveVSpacesOnly) {
   };
   FormatStyle style;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
+    // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
   }
@@ -17703,10 +17966,23 @@ TEST(FormatterEndToEndTest, FormatElseStatements) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kFormatterTestCasesElseStatements) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kFormatterTestCasesElseStatements) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
+    // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
   }
@@ -17796,10 +18072,23 @@ TEST(FormatterEndToEndTest, ConstraintExpressions) {
   style.wrap_spaces = 4;
   style.port_declarations_alignment = verible::AlignmentPolicy::kPreserve;
   for (const auto& test_case : kTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -17887,10 +18176,22 @@ TEST(FormatterEndToEndTest, FormatAlignEnumDeclarations) {
   style.wrap_spaces = 4;
   style.enum_assignment_statement_alignment = AlignmentPolicy::kInferUserIntent;
   for (const auto& test_case : kFormatterTestCasesEnumDeclarations) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kFormatterTestCasesEnumDeclarations) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
   }
@@ -17903,12 +18204,27 @@ TEST(FormatterEndToEndTest, DiagnosticShowFullTree) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     std::ostringstream stream, debug_stream;
     ExecutionControl control;
     control.stream = &debug_stream;
     control.show_token_partition_tree = true;
     const auto status = FormatVerilog(test_case.input, "<filename>", style,
                                       stream, kEnableAllLines, control);
+    EXPECT_EQ(status.code(), StatusCode::kCancelled);
+    EXPECT_TRUE(
+        absl::StartsWith(debug_stream.str(), "Full token partition tree"));
+  }
+
+  for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    std::ostringstream stream, debug_stream;
+    ExecutionControl control;
+    control.stream = &debug_stream;
+    control.show_token_partition_tree = true;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, control,
+                                      FormatMethod::kPreprocessVariants);
     EXPECT_EQ(status.code(), StatusCode::kCancelled);
     EXPECT_TRUE(
         absl::StartsWith(debug_stream.str(), "Full token partition tree"));
@@ -17922,12 +18238,27 @@ TEST(FormatterEndToEndTest, DiagnosticLargestPartitions) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     std::ostringstream stream, debug_stream;
     ExecutionControl control;
     control.stream = &debug_stream;
     control.show_largest_token_partitions = 2;
     const auto status = FormatVerilog(test_case.input, "<filename>", style,
                                       stream, kEnableAllLines, control);
+    EXPECT_EQ(status.code(), StatusCode::kCancelled);
+    EXPECT_TRUE(absl::StartsWith(debug_stream.str(), "Showing the "))
+        << "got: " << debug_stream.str();
+  }
+
+  for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    std::ostringstream stream, debug_stream;
+    ExecutionControl control;
+    control.stream = &debug_stream;
+    control.show_largest_token_partitions = 2;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, control,
+                                      FormatMethod::kPreprocessVariants);
     EXPECT_EQ(status.code(), StatusCode::kCancelled);
     EXPECT_TRUE(absl::StartsWith(debug_stream.str(), "Showing the "))
         << "got: " << debug_stream.str();
@@ -17941,12 +18272,30 @@ TEST(FormatterEndToEndTest, DiagnosticEquallyOptimalWrappings) {
   style.indentation_spaces = 2;
   style.wrap_spaces = 4;
   for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     std::ostringstream stream, debug_stream;
     ExecutionControl control;
     control.stream = &debug_stream;
     control.show_equally_optimal_wrappings = true;
     const auto status = FormatVerilog(test_case.input, "<filename>", style,
                                       stream, kEnableAllLines, control);
+    EXPECT_OK(status) << status.message();
+    if (!debug_stream.str().empty()) {
+      EXPECT_TRUE(absl::StartsWith(debug_stream.str(), "Showing the "))
+          << "got: " << debug_stream.str();
+      // Cannot guarantee among unit tests that there will be >1 solution.
+    }
+  }
+
+  for (const auto& test_case : kFormatterTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    std::ostringstream stream, debug_stream;
+    ExecutionControl control;
+    control.stream = &debug_stream;
+    control.show_equally_optimal_wrappings = true;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, control,
+                                      FormatMethod::kPreprocessVariants);
     EXPECT_OK(status) << status.message();
     if (!debug_stream.str().empty()) {
       EXPECT_TRUE(absl::StartsWith(debug_stream.str(), "Showing the "))
@@ -17969,8 +18318,13 @@ TEST(FormatterEndToEndTest, UnfinishedLineWrapSearching) {
   ExecutionControl control;
   control.max_search_states = 2;  // Cause search to abort early.
   control.stream = &debug_stream;
-  const auto status = FormatVerilog(code, "<filename>", style, stream,
-                                    kEnableAllLines, control);
+  auto status = FormatVerilog(code, "<filename>", style, stream,
+                              kEnableAllLines, control);
+  EXPECT_EQ(status.code(), StatusCode::kResourceExhausted);
+  EXPECT_TRUE(absl::StartsWith(status.message(), "***"));
+
+  status = FormatVerilog(code, "<filename>", style, stream, kEnableAllLines,
+                         control, FormatMethod::kPreprocessVariants);
   EXPECT_EQ(status.code(), StatusCode::kResourceExhausted);
   EXPECT_TRUE(absl::StartsWith(status.message(), "***"));
 }
@@ -18022,6 +18376,7 @@ TEST(FormatterEndToEndTest, OnelineFormatBaselineTest) {
   style.wrap_spaces = 4;
   style.expand_coverpoints = false;
   for (const auto& test_case : kOnelineFormatBaselineTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
@@ -18033,6 +18388,30 @@ TEST(FormatterEndToEndTest, OnelineFormatBaselineTest) {
   // Test again with the switch, should not affect formatting
   style.expand_coverpoints = true;
   for (const auto& test_case : kOnelineFormatBaselineTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kOnelineFormatBaselineTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+  // Test again with the switch, should not affect formatting
+  style.expand_coverpoints = true;
+  for (const auto& test_case : kOnelineFormatBaselineTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
@@ -18102,10 +18481,23 @@ TEST(FormatterEndToEndTest, OnelineFormatReferenceTest) {
   style.expand_coverpoints = false;
 
   for (const auto& test_case : kOnelineFormatReferenceTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kOnelineFormatReferenceTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18123,10 +18515,23 @@ TEST(FormatterEndToEndTest, OnelineFormatExpandTest) {
   style.expand_coverpoints = true;
 
   for (const auto& test_case : kOnelineFormatExpandTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kOnelineFormatExpandTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18322,10 +18727,23 @@ TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases40ColumnsLimit) {
   style.wrap_spaces = 4;
 
   for (const auto& test_case : kNestedFunctionsTestCases40ColumnsLimit) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kNestedFunctionsTestCases40ColumnsLimit) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18366,10 +18784,23 @@ TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases60ColumnsLimit) {
   style.wrap_spaces = 4;
 
   for (const auto& test_case : kNestedFunctionsTestCases60ColumnsLimit) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kNestedFunctionsTestCases60ColumnsLimit) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18420,10 +18851,23 @@ TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases80ColumnsLimit) {
   style.wrap_spaces = 4;
 
   for (const auto& test_case : kNestedFunctionsTestCases80ColumnsLimit) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kNestedFunctionsTestCases80ColumnsLimit) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18491,10 +18935,23 @@ TEST(FormatterEndToEndTest, FormatNestedFunctionsTestCases100ColumnsLimit) {
   style.wrap_spaces = 4;
 
   for (const auto& test_case : kNestedFunctionsTestCases100ColumnsLimit) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kNestedFunctionsTestCases100ColumnsLimit) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18520,10 +18977,23 @@ TEST(FormatterEndToEndTest, compactIndexingAndSelectionsTestCases) {
   style.compact_indexing_and_selections = false;
 
   for (const auto& test_case : noCompactIndexingAndSelectionsTestCases) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : noCompactIndexingAndSelectionsTestCases) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
@@ -18581,10 +19051,23 @@ TEST(FormatterEndToEndTest, FunctionCallsWithComments) {
   style.wrap_spaces = 4;
 
   for (const auto& test_case : kFunctionCallsWithComments) {
+    if (!test_case.SinglePassMethod()) continue;
     VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
     std::ostringstream stream;
     const auto status =
         FormatVerilog(test_case.input, "<filename>", style, stream);
+    // Require these test cases to be valid.
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+
+  for (const auto& test_case : kFunctionCallsWithComments) {
+    if (!test_case.PreprocessVariantsMethod()) continue;
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status = FormatVerilog(test_case.input, "<filename>", style,
+                                      stream, kEnableAllLines, kDefaultControl,
+                                      FormatMethod::kPreprocessVariants);
     // Require these test cases to be valid.
     EXPECT_OK(status) << status.message();
     EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -146,6 +146,9 @@ enum TokenScannerState {
   // While encountering any string of consecutive newlines
   kHaveNewline,
 
+  // While encountering tokens related to preprocessor control flow
+  kPreprocessorControlFlow,
+
   // Transition from newline to non-newline
   kNewPartition,
 
@@ -163,6 +166,8 @@ TokenScannerStateStrings() {
           {"kStart", TokenScannerState::kStart},
           {"kHaveNewline", TokenScannerState::kHaveNewline},
           {"kNewPartition", TokenScannerState::kNewPartition},
+          {"kPreprocessorControlFlow",
+           TokenScannerState::kPreprocessorControlFlow},
           {"kEndWithNewline", TokenScannerState::kEndWithNewline},
           {"kEndNoNewline", TokenScannerState::kEndNoNewline},
       });
@@ -196,14 +201,17 @@ class TreeUnwrapper::TokenScanner {
   }
 
   // Calls TransitionState using current_state_ and the tranition token_Type
-  void UpdateState(verilog_tokentype token_type) {
-    current_state_ = TransitionState(current_state_, token_type);
+  void UpdateState(verilog_tokentype token_type, int color) {
+    current_state_ = TransitionState(current_state_, token_type, color);
+    on_preproc_ident_ = token_type == PP_Identifier;
     seen_any_nonspace_ |= IsComment(token_type);
   }
 
   // Returns true if this is a state that should start a new token partition.
   bool ShouldStartNewPartition() const {
     return current_state_ == State::kNewPartition ||
+           (current_state_ == State::kPreprocessorControlFlow &&
+            !on_preproc_ident_) ||
            (current_state_ == State::kEndWithNewline && seen_any_nonspace_);
   }
 
@@ -212,12 +220,13 @@ class TreeUnwrapper::TokenScanner {
 
   // The current state of the TokenScanner.
   State current_state_ = kStart;
+  bool on_preproc_ident_ = false;
   bool seen_any_nonspace_ = false;
 
   // Transitions the TokenScanner given a TokenState and a verilog_tokentype
   // transition
   static State TransitionState(const State& old_state,
-                               verilog_tokentype token_type);
+                               verilog_tokentype token_type, int color);
 };
 
 static bool IsNewlineOrEOF(verilog_tokentype token_type) {
@@ -238,11 +247,24 @@ static bool IsNewlineOrEOF(verilog_tokentype token_type) {
  *   TreeUnwrapper::CatchUpToCurrentLeaf()
  */
 TokenScannerState TreeUnwrapper::TokenScanner::TransitionState(
-    const State& old_state, verilog_tokentype token_type) {
+    const State& old_state, verilog_tokentype token_type, int color) {
   VLOG(4) << "state transition on: " << old_state
           << ", token: " << verilog_symbol_name(token_type);
+  if (IsPreprocessorControlFlow(token_type)) {
+    const State new_state = kPreprocessorControlFlow;
+    VLOG(4) << "new state: " << new_state;
+    return new_state;
+  }
   State new_state = old_state;
   switch (old_state) {
+    case kPreprocessorControlFlow: {
+      if (IsComment(token_type)) {
+        new_state = kStart;
+      } else if (token_type != PP_Identifier) {
+        new_state = kNewPartition;
+      }
+      break;
+    }
     case kStart: {
       if (IsNewlineOrEOF(token_type)) {
         new_state = kHaveNewline;
@@ -274,6 +296,7 @@ TokenScannerState TreeUnwrapper::TokenScanner::TransitionState(
       break;
     }
     case kEndWithNewline:
+      if (!color) new_state = kEndNoNewline;
     case kEndNoNewline: {
       // Terminal states.  Must Reset() next.
       break;
@@ -313,6 +336,8 @@ TreeUnwrapper::TreeUnwrapper(const verible::TextStructureView& view,
   CHECK(back.isEOF());
   CHECK(back.text().empty());
 }
+
+TreeUnwrapper::TreeUnwrapper(TreeUnwrapper&& other) noexcept = default;
 
 TreeUnwrapper::~TreeUnwrapper() = default;
 
@@ -368,9 +393,10 @@ static bool ShouldIndentRelativeToDirectParent(
   });
 }
 
-void TreeUnwrapper::UpdateInterLeafScanner(verilog_tokentype token_type) {
+void TreeUnwrapper::UpdateInterLeafScanner(verilog_tokentype token_type,
+                                           int color) {
   VLOG(4) << __FUNCTION__ << ", token: " << verilog_symbol_name(token_type);
-  inter_leaf_scanner_->UpdateState(token_type);
+  inter_leaf_scanner_->UpdateState(token_type, color);
   if (inter_leaf_scanner_->ShouldStartNewPartition()) {
     VLOG(4) << "new partition";
     // interleaf-tokens like comments do not have corresponding syntax tree
@@ -386,7 +412,7 @@ void TreeUnwrapper::AdvanceLastVisitedLeaf() {
   const auto& next_token = *NextUnfilteredToken();
   const verilog_tokentype token_enum =
       verilog_tokentype(next_token.token_enum());
-  UpdateInterLeafScanner(token_enum);
+  UpdateInterLeafScanner(token_enum, next_token.color);
   AdvanceNextUnfilteredToken();
   VLOG(4) << "end of " << __FUNCTION__;
 }
@@ -493,6 +519,7 @@ static verible::TokenSequence::const_iterator StopAtLastNewlineBeforeTreeLeaf(
   VLOG(4) << __FUNCTION__;
   auto token_iter = token_begin;
   auto last_newline = token_begin;
+  bool always_last_newline = false;
   bool have_last_newline = false;
 
   // Find next syntax tree token or EOF.
@@ -513,12 +540,23 @@ static verible::TokenSequence::const_iterator StopAtLastNewlineBeforeTreeLeaf(
         ++token_iter;
         break;
       default:
-        break_while = true;
+        if (token_iter->color) {
+          break_while = true;
+        } else {
+          if (token_iter->token_enum() == PP_Identifier ||
+              token_iter->token_enum() == PP_else ||
+              token_iter->token_enum() == PP_endif) {
+            always_last_newline = true;
+          }
+          ++token_iter;
+        }
         break;
     }
   }
 
-  const auto result = have_last_newline ? last_newline : token_iter;
+  const auto result = always_last_newline ? token_iter
+                      : have_last_newline ? last_newline
+                                          : token_iter;
   VLOG(4) << "end of " << __FUNCTION__ << ", advanced "
           << std::distance(token_begin, result) << " tokens";
   return result;
@@ -542,7 +580,7 @@ void TreeUnwrapper::LookAheadBeyondCurrentNode() {
     VLOG(4) << "token: " << VerboseToken(next_token);
     const verilog_tokentype token_enum =
         verilog_tokentype(next_token.token_enum());
-    UpdateInterLeafScanner(token_enum);
+    UpdateInterLeafScanner(token_enum, next_token.color);
     if (next_token_iter != token_end) {
       AdvanceNextUnfilteredToken();
     } else {
@@ -1525,6 +1563,32 @@ static bool PartitionIsForcedIntoNewLine(const TokenPartitionTree& partition) {
   return ftokens.front().before.break_decision == SpacingOptions::kMustWrap;
 }
 
+bool IsPreprocessorPartition(const TokenPartitionTree& partition) {
+  auto tok = partition.Value().TokensRange().front().TokenEnum();
+  return IsPreprocessorControlFlow(verilog_tokentype(tok)) ||
+         tok == PP_Identifier;
+}
+
+TokenPartitionTree* MergeLeafIntoPreviousLeafIfNotPreprocessor(
+    TokenPartitionTree* const leaf) {
+  if (IsPreprocessorPartition(*leaf)) {
+    VLOG(5) << "  preprocessor partition; not merging into previous partition.";
+    return nullptr;
+  }
+  VLOG(5) << "  merge into previous partition.";
+  return MergeLeafIntoPreviousLeaf(leaf);
+}
+
+TokenPartitionTree* MergeLeafIntoNextLeafIfNotPreprocessor(
+    TokenPartitionTree* const leaf) {
+  if (IsPreprocessorPartition(*leaf)) {
+    VLOG(5) << "  preprocessor partition; not merging into next partition.";
+    return nullptr;
+  }
+  VLOG(5) << "  merge into next partition.";
+  return MergeLeafIntoNextLeaf(leaf);
+}
+
 // Joins partition containing only a ',' (and optionally comments) with
 // a partition preceding or following it.
 static void AttachSeparatorToPreviousOrNextPartition(
@@ -1562,6 +1626,12 @@ static void AttachSeparatorToPreviousOrNextPartition(
     return;
   }
 
+  if (IsPreprocessorPartition(partition[0])) {
+    VLOG(5) << "  preprocessor partition at [0]; not attaching to other "
+               "partitions.";
+    return;
+  }
+
   // Merge with previous partition if both partitions are in the same line in
   // original text
   const auto* previous_partition = PreviousLeaf(*partition);
@@ -1572,8 +1642,7 @@ static void AttachSeparatorToPreviousOrNextPartition(
       absl::string_view original_text_between = verible::make_string_view_range(
           previous_token.Text().end(), separator->Text().begin());
       if (!absl::StrContains(original_text_between, '\n')) {
-        VLOG(5) << "  merge into previous partition.";
-        verible::MergeLeafIntoPreviousLeaf(partition);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(partition);
         return;
       }
     }
@@ -1588,8 +1657,7 @@ static void AttachSeparatorToPreviousOrNextPartition(
       absl::string_view original_text_between = verible::make_string_view_range(
           separator->Text().end(), next_token.Text().begin());
       if (!absl::StrContains(original_text_between, '\n')) {
-        VLOG(5) << "  merge into next partition.";
-        verible::MergeLeafIntoNextLeaf(partition);
+        MergeLeafIntoNextLeafIfNotPreprocessor(partition);
         return;
       }
     }
@@ -1599,16 +1667,14 @@ static void AttachSeparatorToPreviousOrNextPartition(
   if (partition->Value().TokensRange().size() == 1) {
     // Try merging with previous partition
     if (!PartitionIsForcedIntoNewLine(*partition)) {
-      VLOG(5) << "  merge into previous partition.";
-      verible::MergeLeafIntoPreviousLeaf(partition);
+      MergeLeafIntoPreviousLeafIfNotPreprocessor(partition);
       return;
     }
 
     // Try merging with next partition
     if (next_partition != nullptr &&
         !PartitionIsForcedIntoNewLine(*next_partition)) {
-      VLOG(5) << "  merge into next partition.";
-      verible::MergeLeafIntoNextLeaf(partition);
+      MergeLeafIntoNextLeafIfNotPreprocessor(partition);
       return;
     }
   }
@@ -1657,7 +1723,7 @@ static void AttachTrailingSemicolonToPreviousPartition(
       semicolon_partition->Value().SetIndentationSpaces(
           group->Value().IndentationSpaces());
     } else {
-      verible::MergeLeafIntoPreviousLeaf(semicolon_partition);
+      MergeLeafIntoPreviousLeafIfNotPreprocessor(semicolon_partition);
     }
     VLOG(4) << "after moving semicolon:\n" << *partition;
   }
@@ -1726,7 +1792,7 @@ static void AttachOpeningBraceToDeclarationsAssignmentOperator(
     }
 
     if (!PartitionIsForcedIntoNewLine(next)) {
-      verible::MergeLeafIntoNextLeaf(&current);
+      MergeLeafIntoNextLeafIfNotPreprocessor(&current);
       // There shouldn't be more matching partitions
       return;
     }
@@ -1747,7 +1813,7 @@ static void ReshapeIfClause(const SyntaxTreeNode& node,
   // Then fuse the 'begin' partition with the preceding 'if (...)'
   auto& if_body_partition = partition.Children().back();
   auto& begin_partition = if_body_partition.Children().front();
-  verible::MergeLeafIntoPreviousLeaf(&begin_partition);
+  MergeLeafIntoPreviousLeafIfNotPreprocessor(&begin_partition);
   partition.Value().SetPartitionPolicy(
       if_body_partition.Value().PartitionPolicy());
   // if seq_block body was empty, that leaves only 'end', so hoist.
@@ -1792,7 +1858,7 @@ static void ReshapeElseClause(const SyntaxTreeNode& node,
     return;
   }
 
-  verible::MergeLeafIntoNextLeaf(&else_partition);
+  MergeLeafIntoNextLeafIfNotPreprocessor(&else_partition);
 }
 
 static void HoistOnlyChildPartition(TokenPartitionTree* partition) {
@@ -1815,7 +1881,7 @@ static void PushEndIntoElsePartition(TokenPartitionTree* partition_ptr) {
   auto& partition = *partition_ptr;
   auto& if_clause_partition = partition.Children().front();
   auto* end_partition = &RightmostDescendant(if_clause_partition);
-  auto* end_parent = verible::MergeLeafIntoNextLeaf(end_partition);
+  auto* end_parent = MergeLeafIntoNextLeafIfNotPreprocessor(end_partition);
   // if moving leaf results in any singleton partitions, hoist.
   if (end_parent != nullptr) {
     HoistOnlyChildPartition(end_parent);
@@ -1972,7 +2038,7 @@ class MacroCallReshaper {
       if (semicolon_ == NextSibling(*paren_group_)) {
         if (!PartitionIsForcedIntoNewLine(*semicolon_)) {
           // Merge with ')'
-          verible::MergeLeafIntoPreviousLeaf(semicolon_);
+          MergeLeafIntoPreviousLeafIfNotPreprocessor(semicolon_);
           semicolon_ = nullptr;
         }
       }
@@ -2225,7 +2291,7 @@ class MacroCallReshaper {
                          return IsComment(verilog_tokentype(t.TokenEnum()));
                        })) {
         // Merge
-        verible::MergeLeafIntoPreviousLeaf(r_paren_);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(r_paren_);
         r_paren_ = &argument_list_->Children().back();
       } else {
         // Group
@@ -2305,7 +2371,7 @@ class MacroCallReshaper {
     CHECK(!PartitionIsForcedIntoNewLine(*l_paren_));
     verible::AdjustIndentationAbsolute(paren_group_,
                                        main_node_->Value().IndentationSpaces());
-    verible::MergeLeafIntoNextLeaf(identifier_);
+    MergeLeafIntoNextLeafIfNotPreprocessor(identifier_);
     HoistOnlyChildPartition(main_node_);
 
     paren_group_ = main_node_;
@@ -2638,7 +2704,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       // Push the "import..." down.
       {
         if (partition.Children().size() > 1) {
-          verible::MergeLeafIntoNextLeaf(&partition.Children().front());
+          MergeLeafIntoNextLeafIfNotPreprocessor(&partition.Children().front());
           AttachTrailingSemicolonToPreviousPartition(&partition);
         }
         break;
@@ -2651,7 +2717,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       auto& target_instance_partition = partition;
       auto& children = target_instance_partition.Children();
       // Attach ')' to the instance name
-      verible::MergeLeafIntoNextLeaf(PreviousSibling(children.back()));
+      MergeLeafIntoNextLeafIfNotPreprocessor(PreviousSibling(children.back()));
 
       verible::AdjustIndentationRelative(&children.back(), -style.wrap_spaces);
       break;
@@ -2668,7 +2734,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
         auto& last_prev = *ABSL_DIE_IF_NULL(PreviousSibling(last));
         if (PartitionStartsWithCloseParen(last) &&
             PartitionEndsWithOpenParen(last_prev)) {
-          verible::MergeLeafIntoPreviousLeaf(&last);
+          MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
         }
       }
       // If there were any parameters or ports at all, expand.
@@ -2688,7 +2754,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
         auto& last_prev = *ABSL_DIE_IF_NULL(PreviousSibling(last));
         if (PartitionStartsWithCloseParen(last) &&
             PartitionEndsWithOpenParen(last_prev)) {
-          verible::MergeLeafIntoPreviousLeaf(&last);
+          MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
         }
       }
       break;
@@ -2703,7 +2769,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
     case NodeEnum::kTaskPrototype: {
       auto& last = RightmostDescendant(partition);
       if (PartitionIsCloseParenSemi(last)) {
-        verible::MergeLeafIntoPreviousLeaf(&last);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
       }
       break;
     }
@@ -2746,7 +2812,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
             auto* group = verible::GroupLeafWithPreviousLeaf(&last);
             group->Value().SetPartitionPolicy(PartitionPolicyEnum::kStack);
           } else {
-            verible::MergeLeafIntoPreviousLeaf(&last);
+            MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
           }
         }
       }
@@ -2770,7 +2836,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
             auto* group = verible::GroupLeafWithPreviousLeaf(&last);
             group->Value().SetPartitionPolicy(PartitionPolicyEnum::kStack);
           } else {
-            verible::MergeLeafIntoPreviousLeaf(&last);
+            MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
           }
         }
       } else if (policy == PartitionPolicyEnum::kStack) {
@@ -2870,7 +2936,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       auto& last = RightmostDescendant(partition);
       // TODO(fangism): why does test fail without this clause?
       if (PartitionStartsWithCloseParen(last)) {
-        verible::MergeLeafIntoPreviousLeaf(&last);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
       }
       break;
     }
@@ -2880,7 +2946,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       if (partition.Children().size() == 2) {
         auto& last = RightmostDescendant(partition);
         if (PartitionIsCloseBrace(last)) {
-          verible::MergeLeafIntoPreviousLeaf(&last);
+          MergeLeafIntoPreviousLeafIfNotPreprocessor(&last);
         }
       }
       break;
@@ -2919,7 +2985,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       if (children.size() == 2 &&
           verible::is_leaf(children.front()) /* left side */ &&
           !PartitionIsForcedIntoNewLine(children.back())) {
-        verible::MergeLeafIntoNextLeaf(&children.front());
+        MergeLeafIntoNextLeafIfNotPreprocessor(&children.front());
         VLOG(4) << "after merge leaf (left-into-right):\n" << partition;
       }
       break;
@@ -2948,7 +3014,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       AttachSeparatorsToListElementPartitions(&partition);
       // Merge the 'assign' keyword with the (first) x=y assignment.
       // TODO(fangism): reshape for multiple assignments.
-      verible::MergeLeafIntoNextLeaf(&partition.Children().front());
+      MergeLeafIntoNextLeafIfNotPreprocessor(&partition.Children().front());
       VLOG(4) << "after merging 'assign':\n" << partition;
       AdjustSubsequentPartitionsIndentation(&partition, style.wrap_spaces);
       VLOG(4) << "after adjusting partitions indentation:\n" << partition;
@@ -2970,10 +3036,10 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       VLOG(4) << "kForSpec got ';' at child " << dist1 << " and " << dist2;
       // Merge from back-to-front to keep indices valid.
       if (dist2 > 0 && (dist2 - dist1 > 1)) {
-        verible::MergeLeafIntoPreviousLeaf(&*iter2);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(&*iter2);
       }
       if (dist1 > 0) {
-        verible::MergeLeafIntoPreviousLeaf(&*iter1);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(&*iter1);
       }
       break;
     }
@@ -3017,7 +3083,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
         auto& begin_partition = LeftmostDescendant(seq_block_partition);
         VLOG(4) << "begin partition: " << begin_partition;
         CHECK(is_leaf(begin_partition));
-        verible::MergeLeafIntoPreviousLeaf(&begin_partition);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(&begin_partition);
         VLOG(4) << "after merging 'begin' to predecessor:\n" << partition;
         // Flatten only the statement block so that the control partition
         // can retain its own partition policy.
@@ -3033,11 +3099,11 @@ void TreeUnwrapper::ReshapeTokenPartitions(
 
         // merge "do" <- "begin"
         auto& begin_partition = LeftmostDescendant(seq_block_partition);
-        verible::MergeLeafIntoPreviousLeaf(&begin_partition);
+        MergeLeafIntoPreviousLeafIfNotPreprocessor(&begin_partition);
 
         // merge "end" -> "while"
         auto& end_partition = RightmostDescendant(seq_block_partition);
-        verible::MergeLeafIntoNextLeaf(&end_partition);
+        MergeLeafIntoNextLeafIfNotPreprocessor(&end_partition);
 
         // Flatten only the statement block so that the control partition
         // can retain its own partition policy.
@@ -3051,7 +3117,7 @@ void TreeUnwrapper::ReshapeTokenPartitions(
               ->MatchesTagAnyOf({NodeEnum::kProceduralTimingControlStatement,
                                  NodeEnum::kSeqBlock})) {
         // Merge 'always' keyword with next sibling, and adjust subtree indent.
-        verible::MergeLeafIntoNextLeaf(&partition.Children().front());
+        MergeLeafIntoNextLeafIfNotPreprocessor(&partition.Children().front());
         verible::AdjustIndentationAbsolute(
             &partition.Children().front(),
             partition.Value().IndentationSpaces());
@@ -3184,7 +3250,7 @@ void TreeUnwrapper::Visit(const verible::SyntaxTreeLeaf& leaf) {
   VLOG(4) << "Visit leaf: after CatchUp";
 
   // Possibly start new partition (without advancing token iterator).
-  UpdateInterLeafScanner(tag);
+  UpdateInterLeafScanner(tag, leaf.get().color);
 
   // Sanity check that NextUnfilteredToken() is aligned to the current leaf.
   CHECK_EQ(NextUnfilteredToken()->text().begin(), leaf.get().text().begin());

--- a/verilog/formatting/tree_unwrapper.h
+++ b/verilog/formatting/tree_unwrapper.h
@@ -65,7 +65,7 @@ class TreeUnwrapper final : public verible::TreeUnwrapper {
   // Deleted standard interfaces:
   TreeUnwrapper() = delete;
   TreeUnwrapper(const TreeUnwrapper&) = delete;
-  TreeUnwrapper(TreeUnwrapper&&) = delete;
+  TreeUnwrapper(TreeUnwrapper&&) noexcept;
   TreeUnwrapper& operator=(const TreeUnwrapper&) = delete;
   TreeUnwrapper& operator=(TreeUnwrapper&&) = delete;
 
@@ -120,7 +120,7 @@ class TreeUnwrapper final : public verible::TreeUnwrapper {
   void EatSpaces();
 
   // Update token tracking, and possibly start a new partition.
-  void UpdateInterLeafScanner(verilog_tokentype);
+  void UpdateInterLeafScanner(verilog_tokentype, int);
 
   // This should only be called directly from CatchUpToCurrentLeaf and
   // LookAheadBeyondCurrentLeaf.

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -246,6 +246,8 @@ class TreeUnwrapperTest : public ::testing::Test {
         std::cout << message << std::endl;
       }
     }
+
+    analyzer_->MutableData().ColorStreamViewTokens(1);
   }
   // Creates a TreeUnwrapper populated with a concrete syntax tree and
   // token stream view from the file input
@@ -2886,7 +2888,8 @@ TEST_F(TreeUnwrapperTest, UnwrapModuleTests) {
   for (const auto& test_case : kUnwrapModuleTestCases) {
     VLOG(1) << "Test: " << test_case.test_name;
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -3145,7 +3148,8 @@ TEST_F(TreeUnwrapperTest, UnwrapCommentsTests) {
   for (const auto& test_case : kUnwrapCommentsTestCases) {
     VLOG(1) << "Test: " << test_case.test_name;
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case))
         << "code:\n"
@@ -3275,7 +3279,8 @@ TEST_F(TreeUnwrapperTest, UnwrapUvmTests) {
   for (const auto& test_case : kUnwrapUvmTestCases) {
     VLOG(1) << "Test: " << test_case.test_name;
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case))
         << "code:\n"
@@ -3958,7 +3963,8 @@ TEST_F(TreeUnwrapperTest, UnwrapClassTests) {
   for (const auto& test_case : kClassTestCases) {
     VLOG(1) << "Test: " << test_case.test_name;
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -4146,7 +4152,8 @@ const TreeUnwrapperTestData kUnwrapPackageTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapPackageTests) {
   for (const auto& test_case : kUnwrapPackageTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -4218,7 +4225,8 @@ const TreeUnwrapperTestData kDescriptionTestCases[] = {
 TEST_F(TreeUnwrapperTest, DescriptionTests) {
   for (const auto& test_case : kDescriptionTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -4887,7 +4895,8 @@ const TreeUnwrapperTestData kUnwrapPreprocessorTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapPreprocessorTests) {
   for (const auto& test_case : kUnwrapPreprocessorTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -5064,7 +5073,8 @@ const TreeUnwrapperTestData kUnwrapInterfaceTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapInterfaceTests) {
   for (const auto& test_case : kUnwrapInterfaceTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -6235,7 +6245,8 @@ const TreeUnwrapperTestData kUnwrapTaskTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapTaskTests) {
   for (const auto& test_case : kUnwrapTaskTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -7679,7 +7690,8 @@ TEST_F(TreeUnwrapperTest, UnwrapFunctionTests) {
   for (const auto& test_case : kUnwrapFunctionTestCases) {
     VLOG(4) << "==== kUnwrapFunctionTests ====\n" << test_case.source_code;
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -7711,7 +7723,8 @@ const TreeUnwrapperTestData kUnwrapStructTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapStructTests) {
   for (const auto& test_case : kUnwrapStructTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -7743,7 +7756,8 @@ const TreeUnwrapperTestData kUnwrapUnionTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapUnionTests) {
   for (const auto& test_case : kUnwrapUnionTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -7805,7 +7819,8 @@ const TreeUnwrapperTestData kUnwrapEnumTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapEnumTests) {
   for (const auto& test_case : kUnwrapEnumTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -7954,7 +7969,8 @@ const TreeUnwrapperTestData kUnwrapPropertyTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapPropertyTests) {
   for (const auto& test_case : kUnwrapPropertyTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -8092,7 +8108,8 @@ const TreeUnwrapperTestData kUnwrapCovergroupTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapCovergroupTests) {
   for (const auto& test_case : kUnwrapCovergroupTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -8163,7 +8180,8 @@ const TreeUnwrapperTestData kUnwrapSequenceTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapSequenceTests) {
   for (const auto& test_case : kUnwrapSequenceTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }
@@ -8447,7 +8465,8 @@ const TreeUnwrapperTestData kUnwrapPrimitivesTestCases[] = {
 TEST_F(TreeUnwrapperTest, UnwrapPrimitivesTests) {
   for (const auto& test_case : kUnwrapPrimitivesTestCases) {
     auto tree_unwrapper = CreateTreeUnwrapper(test_case.source_code);
-    const auto* uwline_tree = tree_unwrapper->Unwrap();
+    tree_unwrapper->Unwrap();
+    const auto* uwline_tree = tree_unwrapper->UnwrappedLines();
     EXPECT_TRUE(VerifyUnwrappedLines(&std::cout, *ABSL_DIE_IF_NULL(uwline_tree),
                                      test_case));
   }

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -39,7 +39,7 @@ using ParserTestData = verible::TokenInfoTestData;
 
 using ParserTestCaseArray = std::initializer_list<const char*>;
 
-static constexpr VerilogPreprocess::Config kDefaultPreprocess;
+static VerilogPreprocess::Config kDefaultPreprocess;
 
 // No syntax tree expected from these inputs.
 static constexpr ParserTestCaseArray kEmptyTests = {

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -44,10 +44,13 @@ namespace verilog {
 using verible::TokenGenerator;
 using verible::TokenStreamView;
 using verible::container::FindOrNull;
+using verible::container::FindWithDefault;
 using verible::container::InsertOrUpdate;
 
 VerilogPreprocess::VerilogPreprocess(const Config& config)
-    : VerilogPreprocess(config, nullptr) {}
+    : VerilogPreprocess(config, nullptr) {
+  preprocess_data_.macro_definitions = config_.macro_definitions;
+}
 
 VerilogPreprocess::VerilogPreprocess(const Config& config, FileOpener opener)
     : config_(config), file_opener_(std::move(opener)) {
@@ -55,6 +58,7 @@ VerilogPreprocess::VerilogPreprocess(const Config& config, FileOpener opener)
   // place a toplevel 'conditional' that is always selected.
   // Thus we only need to test in `else and `endif to see if we underrun due
   // to unbalanced statements.
+  preprocess_data_.macro_definitions = config_.macro_definitions;
   conditional_block_.push(
       BranchBlock(true, true, verible::TokenInfo::EOFToken()));
 }
@@ -288,8 +292,8 @@ absl::Status VerilogPreprocess::HandleMacroIdentifier(
 
   // Finding the macro definition.
   const absl::string_view sv = (*iter)->text();
-  const auto* found =
-      FindOrNull(preprocess_data_.macro_definitions, sv.substr(1));
+  const auto found = FindWithDefault(preprocess_data_.macro_definitions,
+                                     sv.substr(1), std::nullopt);
   if (!found) {
     preprocess_data_.errors.emplace_back(
         **iter,
@@ -302,7 +306,7 @@ absl::Status VerilogPreprocess::HandleMacroIdentifier(
     verible::MacroCall macro_call;
     RETURN_IF_ERROR(
         ConsumeAndParseMacroCall(iter, generator, &macro_call, *found));
-    RETURN_IF_ERROR(ExpandMacro(macro_call, found));
+    RETURN_IF_ERROR(ExpandMacro(macro_call, *found));
   }
   auto& lexed = preprocess_data_.lexed_macros_backup.back();
   if (!forward) return absl::OkStatus();
@@ -378,16 +382,16 @@ absl::Status VerilogPreprocess::ExpandText(
 // `MACRO([param1],[param2],...)
 absl::Status VerilogPreprocess::ExpandMacro(
     const verible::MacroCall& macro_call,
-    const verible::MacroDefinition* macro_definition) {
+    const verible::MacroDefinition& macro_definition) {
   const auto& actual_parameters = macro_call.positional_arguments;
 
   std::map<absl::string_view, verible::DefaultTokenInfo> subs_map;
-  if (macro_definition->IsCallable()) {
-    RETURN_IF_ERROR(macro_definition->PopulateSubstitutionMap(actual_parameters,
-                                                              &subs_map));
+  if (macro_definition.IsCallable()) {
+    RETURN_IF_ERROR(
+        macro_definition.PopulateSubstitutionMap(actual_parameters, &subs_map));
   }
 
-  VerilogLexer lexer(macro_definition->DefinitionText().text());
+  VerilogLexer lexer(macro_definition.DefinitionText().text());
   verible::TokenSequence lexed_sequence;
   verible::TokenSequence expanded_lexed_sequence;
   // Populating the lexed token sequence.
@@ -420,7 +424,7 @@ absl::Status VerilogPreprocess::ExpandMacro(
       for (auto& u : expanded_child) expanded_lexed_sequence.push_back(u);
       continue;
     }
-    if (macro_definition->IsCallable()) {
+    if (macro_definition.IsCallable()) {
       // Check if the last token is a formal parameter
       const auto* replacement = FindOrNull(subs_map, last_token.text());
       if (replacement) {

--- a/verilog/preprocessor/verilog_preprocess.h
+++ b/verilog/preprocessor/verilog_preprocess.h
@@ -69,7 +69,8 @@ struct VerilogPreprocessError {
 // Information that results from preprocessing.
 struct VerilogPreprocessData {
   using MacroDefinition = verible::MacroDefinition;
-  using MacroDefinitionRegistry = std::map<absl::string_view, MacroDefinition>;
+  using MacroDefinitionRegistry =
+      std::map<absl::string_view, std::optional<MacroDefinition>>;
   using TokenSequence = std::vector<verible::TokenInfo>;
 
   // Resulting token stream after preprocessing
@@ -94,6 +95,8 @@ struct VerilogPreprocessData {
 class VerilogPreprocess {
   using TokenStreamView = verible::TokenStreamView;
   using MacroDefinition = verible::MacroDefinition;
+  using MacroDefinitionRegistry =
+      std::map<absl::string_view, std::optional<MacroDefinition>>;
   using MacroParameterInfo = verible::MacroParameterInfo;
 
  public:
@@ -115,7 +118,9 @@ class VerilogPreprocess {
 
     // Expand macro definition bodies, this will relexes the macro body.
     bool expand_macros = false;
-    // TODO(hzeller): Provide a map of command-line provided +define+'s
+
+    MacroDefinitionRegistry macro_definitions;
+    // TODO(hzeller): Provide a way to +define+ from the command line.
   };
 
   explicit VerilogPreprocess(const Config& config);
@@ -182,7 +187,7 @@ class VerilogPreprocess {
   void RegisterMacroDefinition(const MacroDefinition&);
   absl::Status ExpandText(const absl::string_view&);
   absl::Status ExpandMacro(const verible::MacroCall&,
-                           const verible::MacroDefinition*);
+                           const verible::MacroDefinition&);
   absl::Status HandleInclude(TokenStreamView::const_iterator,
                              const StreamIteratorGenerator&);
 

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -37,7 +37,7 @@ namespace {
 using testing::ElementsAre;
 using testing::Pair;
 using testing::StartsWith;
-using verible::container::FindOrNull;
+using verible::container::FindWithDefault;
 using verible::file::CreateDir;
 using verible::file::JoinPath;
 using verible::file::testing::ScopedTestFile;
@@ -171,11 +171,13 @@ TEST(VerilogPreprocessTest, OneMacroDefinitionNoParamsNoValue) {
 
     const auto& definitions = tester.PreprocessorData().macro_definitions;
     EXPECT_THAT(definitions, ElementsAre(Pair("FOOOO", testing::_)));
-    auto macro = FindOrNull(definitions, "FOOOO");
-    ASSERT_NE(macro, nullptr);
+    auto macro = FindWithDefault(definitions, "FOOOO", std::nullopt);
+    ASSERT_TRUE(macro.has_value());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_EQ(macro->DefinitionText().text(), "");
     EXPECT_FALSE(macro->IsCallable());
     EXPECT_TRUE(macro->Parameters().empty());
+    // NOLINTEND(bugprone-unchecked-optional-access)
   }
 }
 
@@ -187,11 +189,13 @@ TEST(VerilogPreprocessTest, OneMacroDefinitionNoParamsSimpleValue) {
 
   const auto& definitions = tester.PreprocessorData().macro_definitions;
   EXPECT_THAT(definitions, ElementsAre(Pair("FOOOO", testing::_)));
-  auto macro = FindOrNull(definitions, "FOOOO");
-  ASSERT_NE(macro, nullptr);
+  auto macro = FindWithDefault(definitions, "FOOOO", std::nullopt);
+  ASSERT_TRUE(macro.has_value());
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_EQ(macro->DefinitionText().text(), "\"bar\"");
   EXPECT_FALSE(macro->IsCallable());
   EXPECT_TRUE(macro->Parameters().empty());
+  // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(VerilogPreprocessTest, OneMacroDefinitionOneParamWithValue) {
@@ -202,11 +206,13 @@ TEST(VerilogPreprocessTest, OneMacroDefinitionOneParamWithValue) {
 
   const auto& definitions = tester.PreprocessorData().macro_definitions;
   EXPECT_THAT(definitions, ElementsAre(Pair("FOOOO", testing::_)));
-  auto macro = FindOrNull(definitions, "FOOOO");
-  ASSERT_NE(macro, nullptr);
+  auto macro = FindWithDefault(definitions, "FOOOO", std::nullopt);
+  ASSERT_TRUE(macro.has_value());
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_EQ(macro->DefinitionText().text(), "(x+1)");
   EXPECT_TRUE(macro->IsCallable());
   const auto& params = macro->Parameters();
+  // NOLINTEND(bugprone-unchecked-optional-access)
   EXPECT_EQ(params.size(), 1);
   const auto& param(params[0]);
   EXPECT_EQ(param.name.text(), "x");
@@ -221,11 +227,13 @@ TEST(VerilogPreprocessTest, OneMacroDefinitionOneParamDefaultWithValue) {
 
   const auto& definitions = tester.PreprocessorData().macro_definitions;
   EXPECT_THAT(definitions, ElementsAre(Pair("FOOOO", testing::_)));
-  auto macro = FindOrNull(definitions, "FOOOO");
-  ASSERT_NE(macro, nullptr);
+  auto macro = FindWithDefault(definitions, "FOOOO", std::nullopt);
+  ASSERT_TRUE(macro.has_value());
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_EQ(macro->DefinitionText().text(), "(x+3)");
   EXPECT_TRUE(macro->IsCallable());
   const auto& params = macro->Parameters();
+  // NOLINTEND(bugprone-unchecked-optional-access)
   EXPECT_EQ(params.size(), 1);
   const auto& param(params[0]);
   EXPECT_EQ(param.name.text(), "x");
@@ -243,17 +251,21 @@ TEST(VerilogPreprocessTest, TwoMacroDefinitions) {
   EXPECT_THAT(definitions, ElementsAre(Pair("BAAAAR", testing::_),
                                        Pair("FOOOO", testing::_)));
   {
-    auto macro = FindOrNull(definitions, "BAAAAR");
-    ASSERT_NE(macro, nullptr);
+    auto macro = FindWithDefault(definitions, "BAAAAR", std::nullopt);
+    ASSERT_TRUE(macro.has_value());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_TRUE(macro->IsCallable());
     const auto& params = macro->Parameters();
+    // NOLINTEND(bugprone-unchecked-optional-access)
     EXPECT_EQ(params.size(), 2);
   }
   {
-    auto macro = FindOrNull(definitions, "FOOOO");
-    ASSERT_NE(macro, nullptr);
+    auto macro = FindWithDefault(definitions, "FOOOO", std::nullopt);
+    ASSERT_TRUE(macro.has_value());
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     EXPECT_TRUE(macro->IsCallable());
     const auto& params = macro->Parameters();
+    // NOLINTEND(bugprone-unchecked-optional-access)
     EXPECT_EQ(params.size(), 1);
   }
 }

--- a/verilog/tools/formatter/verilog_format.cc
+++ b/verilog/tools/formatter/verilog_format.cc
@@ -48,6 +48,7 @@
 using absl::StatusCode;
 using verible::LineNumberSet;
 using verilog::formatter::ExecutionControl;
+using verilog::formatter::FormatMethod;
 using verilog::formatter::FormatStyle;
 using verilog::formatter::FormatVerilog;
 
@@ -101,6 +102,11 @@ ABSL_FLAG(bool, verify_convergence, true,
           "If true, and not incrementally formatting with --lines, "
           "verify that re-formatting the formatted output yields "
           "no further changes, i.e. formatting is convergent.");
+ABSL_FLAG(bool, preprocess_variants, false,
+          "Experimental feature. If true, formatting is done on multiple "
+          "preprocessed variants of "
+          "the input file and merged together. This can help with some "
+          "preprocessor-related parsing issues.");
 
 ABSL_FLAG(bool, verbose, false, "Be more verbose.");
 
@@ -176,7 +182,10 @@ static bool formatOneFile(absl::string_view filename,
   std::ostringstream stream;
   const auto format_status =
       FormatVerilog(*content_or, diagnostic_filename, format_style, stream,
-                    lines_to_format, formatter_control);
+                    lines_to_format, formatter_control,
+                    absl::GetFlag(FLAGS_preprocess_variants)
+                        ? FormatMethod::kPreprocessVariants
+                        : FormatMethod::kSinglePass);
 
   const std::string& formatted_output(stream.str());
   if (!format_status.ok()) {

--- a/verilog/tools/ls/autoexpand.cc
+++ b/verilog/tools/ls/autoexpand.cc
@@ -1642,8 +1642,8 @@ std::vector<TextEdit> ConvertAutoExpansionsToFormattedTextEdits(
   }
 
   std::string formatted;
-  const absl::Status format_status =
-      FormatVerilog(analyzer.Data(), "", format_style, &formatted, lines);
+  const absl::Status format_status = FormatVerilog(
+      analyzer.Data().Contents(), "", format_style, &formatted, lines);
 
   std::string &new_text = text;
   if (format_status.ok()) {

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -296,7 +296,8 @@ std::vector<verible::lsp::TextEdit> FormatRange(
         .newText = formatted_range});
   } else {
     std::string newText;
-    if (!FormatVerilog(text, current->uri(), format_style, &newText).ok()) {
+    if (!FormatVerilog(text.Contents(), current->uri(), format_style, &newText)
+             .ok()) {
       return result;
     }
     // Emit a single edit that replaces the full range the file covers.

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -193,12 +193,7 @@ static absl::Status GenerateVariants(const SubcommandArgsRange& args,
   verible::TokenSequence lexed_sequence;
   for (lexer.DoNextToken(); !lexer.GetLastToken().isEOF();
        lexer.DoNextToken()) {
-    // For now we will store the syntax tree tokens only, ignoring all the
-    // white-space characters. however that should be stored to output the
-    // source code just like it was.
-    if (verilog::VerilogLexer::KeepSyntaxTreeTokens(lexer.GetLastToken())) {
-      lexed_sequence.push_back(lexer.GetLastToken());
-    }
+    lexed_sequence.push_back(lexer.GetLastToken());
   }
 
   // Control flow tree constructing.
@@ -210,7 +205,11 @@ static absl::Status GenerateVariants(const SubcommandArgsRange& args,
         if (counter == limit_variants) return false;
         counter++;
         message_stream << "Variant number " << counter << ":\n";
-        for (auto token : variant.sequence) outs << token << '\n';
+        for (auto token : variant.sequence) {
+          if (verilog::VerilogLexer::KeepSyntaxTreeTokens(token)) {
+            outs << token << '\n';
+          }
+        }
         // TODO(karimtera): Consider creating an output file per vairant,
         // Such that the files naming reflects which defines are
         // defined/undefined.


### PR DESCRIPTION
Currently, the formatter doesn't handle many scenarios involving preprocessor `ifdef`s/`endif`s interleaved with `begin`s, module headers, etc. (#228, #241, #267) This patch attempts to solve this problem by performing multiple passes of the formatter on preprocessed variants of the source. Each of these variants has a different set of preprocessor branches enabled. Together, they should cover the entire source (though that doesn't work in all cases yet). After several formatting passes for different variants of the AST, a correct and properly formatted file is produced.

This is still work in progress, so not everything works, and the code isn't very clean. I'd love to get some early feedback on this.