### PR TITLE
Add autofix for always_comb rule

### DIFF
--- a/verilog/CST/statement.cc
+++ b/verilog/CST/statement.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,297 +36,297 @@ using verible::SymbolCastToNode;
 using verible::SyntaxTreeNode;
 
 std::vector<verible::TreeSearchMatch> FindAllForLoopsInitializations(
-    const verible::Symbol& root) {
+    const verible::Symbol &root) {
   return SearchSyntaxTree(root, NodekForInitialization());
 }
 
 std::vector<verible::TreeSearchMatch> FindAllGenerateBlocks(
-    const verible::Symbol& root) {
+    const verible::Symbol &root) {
   return SearchSyntaxTree(root, NodekGenerateBlock());
 }
 
-static const SyntaxTreeNode* GetGenericStatementBody(
-    const SyntaxTreeNode* node) {
+static const SyntaxTreeNode *GetGenericStatementBody(
+    const SyntaxTreeNode *node) {
   if (!node) return node;
   // In most controlled constructs, the controlled statement body is
   // in tail position.  Exceptions include: DoWhile.
   return &SymbolCastToNode(*node->children().back());
 }
 
-const SyntaxTreeNode* GetIfClauseGenerateBody(const Symbol& if_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetIfClauseGenerateBody(const Symbol &if_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(if_clause), NodeEnum::kGenerateIfClause));
   if (!body_node) return nullptr;
   return GetSubtreeAsNode(*body_node, NodeEnum::kGenerateIfBody, 0);
 }
 
-const SyntaxTreeNode* GetElseClauseGenerateBody(const Symbol& else_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetElseClauseGenerateBody(const Symbol &else_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(else_clause), NodeEnum::kGenerateElseClause));
   if (!body_node) return nullptr;
   return GetSubtreeAsNode(*body_node, NodeEnum::kGenerateElseBody, 0);
 }
 
-const SyntaxTreeNode* GetLoopGenerateBody(const Symbol& loop) {
+const SyntaxTreeNode *GetLoopGenerateBody(const Symbol &loop) {
   return GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(loop), NodeEnum::kLoopGenerateConstruct));
 }
 
-const SyntaxTreeNode* GetConditionalGenerateIfClause(
-    const Symbol& conditional) {
+const SyntaxTreeNode *GetConditionalGenerateIfClause(
+    const Symbol &conditional) {
   return GetSubtreeAsNode(conditional, NodeEnum::kConditionalGenerateConstruct,
                           0, NodeEnum::kGenerateIfClause);
 }
 
-const SyntaxTreeNode* GetConditionalGenerateElseClause(
-    const Symbol& conditional) {
-  const auto* node = MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetConditionalGenerateElseClause(
+    const Symbol &conditional) {
+  const auto *node = MatchNodeEnumOrNull(
       SymbolCastToNode(conditional), NodeEnum::kConditionalGenerateConstruct);
   if (!node || node->children().size() < 2) return nullptr;
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kGenerateElseClause);
 }
 
-const SyntaxTreeNode* GetIfClauseStatementBody(const Symbol& if_clause) {
-  const auto* body_node = GetGenericStatementBody(
+const SyntaxTreeNode *GetIfClauseStatementBody(const Symbol &if_clause) {
+  const auto *body_node = GetGenericStatementBody(
       MatchNodeEnumOrNull(SymbolCastToNode(if_clause), NodeEnum::kIfClause));
   if (!body_node) return nullptr;
   return GetSubtreeAsNode(*body_node, NodeEnum::kIfBody, 0);
 }
 
-const SyntaxTreeNode* GetElseClauseStatementBody(const Symbol& else_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetElseClauseStatementBody(const Symbol &else_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(else_clause), NodeEnum::kElseClause));
   if (!body_node) return nullptr;
   return GetSubtreeAsNode(*body_node, NodeEnum::kElseBody, 0);
 }
 
-const SyntaxTreeNode* GetConditionalStatementIfClause(
-    const Symbol& conditional) {
+const SyntaxTreeNode *GetConditionalStatementIfClause(
+    const Symbol &conditional) {
   return GetSubtreeAsNode(conditional, NodeEnum::kConditionalStatement, 0,
                           NodeEnum::kIfClause);
 }
 
-const SyntaxTreeNode* GetConditionalStatementElseClause(
-    const Symbol& conditional) {
-  const auto* node = MatchNodeEnumOrNull(SymbolCastToNode(conditional),
+const SyntaxTreeNode *GetConditionalStatementElseClause(
+    const Symbol &conditional) {
+  const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(conditional),
                                          NodeEnum::kConditionalStatement);
   if (!node || node->children().size() < 2) return nullptr;
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode* GetAssertionStatementAssertClause(
-    const Symbol& assertion_statement) {
+const SyntaxTreeNode *GetAssertionStatementAssertClause(
+    const Symbol &assertion_statement) {
   return GetSubtreeAsNode(assertion_statement, NodeEnum::kAssertionStatement, 0,
                           NodeEnum::kAssertionClause);
 }
 
-const SyntaxTreeNode* GetAssertionClauseStatementBody(
-    const Symbol& assertion_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetAssertionClauseStatementBody(
+    const Symbol &assertion_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assertion_clause), NodeEnum::kAssertionClause));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kAssertionBody, 0));
 }
 
-const SyntaxTreeNode* GetAssertionStatementElseClause(
-    const Symbol& assertion_statement) {
-  const auto* node = MatchNodeEnumOrNull(SymbolCastToNode(assertion_statement),
+const SyntaxTreeNode *GetAssertionStatementElseClause(
+    const Symbol &assertion_statement) {
+  const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(assertion_statement),
                                          NodeEnum::kAssertionStatement);
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode* GetAssumeStatementAssumeClause(
-    const Symbol& assume_statement) {
+const SyntaxTreeNode *GetAssumeStatementAssumeClause(
+    const Symbol &assume_statement) {
   return GetSubtreeAsNode(assume_statement, NodeEnum::kAssumeStatement, 0,
                           NodeEnum::kAssumeClause);
 }
 
-const SyntaxTreeNode* GetAssumeClauseStatementBody(
-    const Symbol& assume_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetAssumeClauseStatementBody(
+    const Symbol &assume_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assume_clause), NodeEnum::kAssumeClause));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kAssumeBody, 0));
 }
 
-const SyntaxTreeNode* GetAssumeStatementElseClause(
-    const Symbol& assume_statement) {
-  const auto* node = MatchNodeEnumOrNull(SymbolCastToNode(assume_statement),
+const SyntaxTreeNode *GetAssumeStatementElseClause(
+    const Symbol &assume_statement) {
+  const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(assume_statement),
                                          NodeEnum::kAssumeStatement);
   if (!node) return nullptr;
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode* GetCoverStatementBody(const Symbol& cover_statement) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetCoverStatementBody(const Symbol &cover_statement) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(cover_statement), NodeEnum::kCoverStatement));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kCoverBody, 0));
 }
 
-const SyntaxTreeNode* GetWaitStatementBody(const Symbol& wait_statement) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetWaitStatementBody(const Symbol &wait_statement) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(wait_statement), NodeEnum::kWaitStatement));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kWaitBody, 0));
 }
 
-const SyntaxTreeNode* GetAssertPropertyStatementAssertClause(
-    const Symbol& assert_property_statement) {
+const SyntaxTreeNode *GetAssertPropertyStatementAssertClause(
+    const Symbol &assert_property_statement) {
   return GetSubtreeAsNode(assert_property_statement,
                           NodeEnum::kAssertPropertyStatement, 0,
                           NodeEnum::kAssertPropertyClause);
 }
 
-const SyntaxTreeNode* GetAssertPropertyStatementBody(
-    const Symbol& assert_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetAssertPropertyStatementBody(
+    const Symbol &assert_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assert_clause), NodeEnum::kAssertPropertyClause));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kAssertPropertyBody, 0));
 }
 
-const SyntaxTreeNode* GetAssertPropertyStatementElseClause(
-    const Symbol& assert_property_statement) {
-  const auto* node =
+const SyntaxTreeNode *GetAssertPropertyStatementElseClause(
+    const Symbol &assert_property_statement) {
+  const auto *node =
       MatchNodeEnumOrNull(SymbolCastToNode(assert_property_statement),
                           NodeEnum::kAssertPropertyStatement);
   if (!node) return nullptr;
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode* GetAssumePropertyStatementAssumeClause(
-    const Symbol& assume_property_statement) {
+const SyntaxTreeNode *GetAssumePropertyStatementAssumeClause(
+    const Symbol &assume_property_statement) {
   return GetSubtreeAsNode(assume_property_statement,
                           NodeEnum::kAssumePropertyStatement, 0,
                           NodeEnum::kAssumePropertyClause);
 }
 
-const SyntaxTreeNode* GetAssumePropertyStatementBody(
-    const Symbol& assume_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetAssumePropertyStatementBody(
+    const Symbol &assume_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assume_clause), NodeEnum::kAssumePropertyClause));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kAssumePropertyBody, 0));
 }
 
-const SyntaxTreeNode* GetAssumePropertyStatementElseClause(
-    const Symbol& assume_property_statement) {
-  const auto* node =
+const SyntaxTreeNode *GetAssumePropertyStatementElseClause(
+    const Symbol &assume_property_statement) {
+  const auto *node =
       MatchNodeEnumOrNull(SymbolCastToNode(assume_property_statement),
                           NodeEnum::kAssumePropertyStatement);
   if (!node) return nullptr;
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode* GetExpectPropertyStatementExpectClause(
-    const Symbol& expect_property_statement) {
+const SyntaxTreeNode *GetExpectPropertyStatementExpectClause(
+    const Symbol &expect_property_statement) {
   return GetSubtreeAsNode(expect_property_statement,
                           NodeEnum::kExpectPropertyStatement, 0,
                           NodeEnum::kExpectPropertyClause);
 }
 
-const SyntaxTreeNode* GetExpectPropertyStatementBody(
-    const Symbol& expect_clause) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetExpectPropertyStatementBody(
+    const Symbol &expect_clause) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(expect_clause), NodeEnum::kExpectPropertyClause));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kExpectPropertyBody, 0));
 }
 
-const SyntaxTreeNode* GetExpectPropertyStatementElseClause(
-    const Symbol& expect_property_statement) {
-  const auto* node =
+const SyntaxTreeNode *GetExpectPropertyStatementElseClause(
+    const Symbol &expect_property_statement) {
+  const auto *node =
       MatchNodeEnumOrNull(SymbolCastToNode(expect_property_statement),
                           NodeEnum::kExpectPropertyStatement);
   if (!node) return nullptr;
-  const Symbol* else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->children().back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode* GetCoverPropertyStatementBody(
-    const Symbol& cover_property) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetCoverPropertyStatementBody(
+    const Symbol &cover_property) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(cover_property), NodeEnum::kCoverPropertyStatement));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kCoverPropertyBody, 0));
 }
 
-const SyntaxTreeNode* GetCoverSequenceStatementBody(
-    const Symbol& cover_sequence) {
-  const auto* body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
+const SyntaxTreeNode *GetCoverSequenceStatementBody(
+    const Symbol &cover_sequence) {
+  const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(cover_sequence), NodeEnum::kCoverSequenceStatement));
   if (!body_node) return nullptr;
   return verible::CheckOptionalSymbolAsNode(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kCoverSequenceBody, 0));
 }
 
-const SyntaxTreeNode* GetLoopStatementBody(const Symbol& loop) {
+const SyntaxTreeNode *GetLoopStatementBody(const Symbol &loop) {
   return GetGenericStatementBody(
       MatchNodeEnumOrNull(SymbolCastToNode(loop), NodeEnum::kForLoopStatement));
 }
 
-const SyntaxTreeNode* GetDoWhileStatementBody(const Symbol& do_while) {
+const SyntaxTreeNode *GetDoWhileStatementBody(const Symbol &do_while) {
   return GetSubtreeAsNode(SymbolCastToNode(do_while),
                           NodeEnum::kDoWhileLoopStatement, 1);
 }
 
-const SyntaxTreeNode* GetForeverStatementBody(const Symbol& forever) {
+const SyntaxTreeNode *GetForeverStatementBody(const Symbol &forever) {
   return GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(forever), NodeEnum::kForeverLoopStatement));
 }
 
-const SyntaxTreeNode* GetForeachStatementBody(const Symbol& foreach) {
+const SyntaxTreeNode *GetForeachStatementBody(const Symbol &foreach) {
   return GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(foreach), NodeEnum::kForeachLoopStatement));
 }
 
-const SyntaxTreeNode* GetRepeatStatementBody(const Symbol& repeat) {
+const SyntaxTreeNode *GetRepeatStatementBody(const Symbol &repeat) {
   return GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(repeat), NodeEnum::kRepeatLoopStatement));
 }
 
-const SyntaxTreeNode* GetWhileStatementBody(const Symbol& while_stmt) {
+const SyntaxTreeNode *GetWhileStatementBody(const Symbol &while_stmt) {
   return GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(while_stmt), NodeEnum::kWhileLoopStatement));
 }
 
-const SyntaxTreeNode* GetProceduralTimingControlStatementBody(
-    const Symbol& proc_timing_control) {
+const SyntaxTreeNode *GetProceduralTimingControlStatementBody(
+    const Symbol &proc_timing_control) {
   return GetGenericStatementBody(
       MatchNodeEnumOrNull(SymbolCastToNode(proc_timing_control),
                           NodeEnum::kProceduralTimingControlStatement));
 }
 
-const SyntaxTreeNode* GetAnyControlStatementBody(const Symbol& statement) {
+const SyntaxTreeNode *GetAnyControlStatementBody(const Symbol &statement) {
   switch (NodeEnum(SymbolCastToNode(statement).Tag().tag)) {
     // generate
     case NodeEnum::kGenerateIfClause:
@@ -384,7 +384,7 @@ const SyntaxTreeNode* GetAnyControlStatementBody(const Symbol& statement) {
   }
 }
 
-const SyntaxTreeNode* GetAnyConditionalIfClause(const Symbol& conditional) {
+const SyntaxTreeNode *GetAnyConditionalIfClause(const Symbol &conditional) {
   // by IfClause, we main the first clause
   switch (NodeEnum(SymbolCastToNode(conditional).Tag().tag)) {
     // generate
@@ -414,7 +414,7 @@ const SyntaxTreeNode* GetAnyConditionalIfClause(const Symbol& conditional) {
   }
 }
 
-const SyntaxTreeNode* GetAnyConditionalElseClause(const Symbol& conditional) {
+const SyntaxTreeNode *GetAnyConditionalElseClause(const Symbol &conditional) {
   switch (NodeEnum(SymbolCastToNode(conditional).Tag().tag)) {
     // generate
     case NodeEnum::kConditionalGenerateConstruct:
@@ -444,9 +444,9 @@ const SyntaxTreeNode* GetAnyConditionalElseClause(const Symbol& conditional) {
 }
 
 // Returns the data type node from for loop initialization.
-const verible::SyntaxTreeNode* GetDataTypeFromForInitialization(
-    const verible::Symbol& for_initialization) {
-  const auto* data_type = verible::GetSubtreeAsSymbol(
+const verible::SyntaxTreeNode *GetDataTypeFromForInitialization(
+    const verible::Symbol &for_initialization) {
+  const auto *data_type = verible::GetSubtreeAsSymbol(
       for_initialization, NodeEnum::kForInitialization, 1);
   if (data_type == nullptr) {
     return nullptr;
@@ -455,36 +455,50 @@ const verible::SyntaxTreeNode* GetDataTypeFromForInitialization(
 }
 
 // Returns the variable name leaf from for loop initialization.
-const verible::SyntaxTreeLeaf* GetVariableNameFromForInitialization(
-    const verible::Symbol& for_initialization) {
-  const Symbol* child = verible::GetSubtreeAsSymbol(
+const verible::SyntaxTreeLeaf *GetVariableNameFromForInitialization(
+    const verible::Symbol &for_initialization) {
+  const Symbol *child = verible::GetSubtreeAsSymbol(
       for_initialization, NodeEnum::kForInitialization, 2);
   if (child->Kind() == verible::SymbolKind::kLeaf) {
     return &SymbolCastToLeaf(*child);
   }
-  const verible::SyntaxTreeNode* lpvalue =
+  const verible::SyntaxTreeNode *lpvalue =
       verible::GetSubtreeAsNode(*child, NodeEnum::kLPValue, 0);
   return AutoUnwrapIdentifier(*GetUnqualifiedIdFromReferenceCallBase(*lpvalue));
 }
 
 // Returns the rhs expression from for loop initialization.
-const verible::SyntaxTreeNode* GetExpressionFromForInitialization(
-    const verible::Symbol& for_initialization) {
+const verible::SyntaxTreeNode *GetExpressionFromForInitialization(
+    const verible::Symbol &for_initialization) {
   return verible::GetSubtreeAsNode(for_initialization,
                                    NodeEnum::kForInitialization, 4,
                                    NodeEnum::kExpression);
 }
 
-const verible::SyntaxTreeNode* GetGenerateBlockBegin(
-    const verible::Symbol& generate_block) {
+const verible::SyntaxTreeNode *GetGenerateBlockBegin(
+    const verible::Symbol &generate_block) {
   return verible::GetSubtreeAsNode(generate_block, NodeEnum::kGenerateBlock, 0,
                                    NodeEnum::kBegin);
 }
 
-const verible::SyntaxTreeNode* GetGenerateBlockEnd(
-    const verible::Symbol& generate_block) {
+const verible::SyntaxTreeNode *GetGenerateBlockEnd(
+    const verible::Symbol &generate_block) {
   return verible::GetSubtreeAsNode(generate_block, NodeEnum::kGenerateBlock, 2,
                                    NodeEnum::kEnd);
+}
+
+const verible::SyntaxTreeNode *GetProceduralTimingControlFromAlways(
+    const verible::SyntaxTreeNode &always_statement) {
+  return verible::GetSubtreeAsNode(always_statement, NodeEnum::kAlwaysStatement,
+                                   1,
+                                   NodeEnum::kProceduralTimingControlStatement);
+}
+
+const verible::Symbol *GetEventControlFromProceduralTimingControl(
+    const verible::SyntaxTreeNode &proc_timing_ctrl) {
+  return verible::GetSubtreeAsNode(proc_timing_ctrl,
+                                   NodeEnum::kProceduralTimingControlStatement,
+                                   0, NodeEnum::kEventControl);
 }
 
 }  // namespace verilog

--- a/verilog/CST/statement.h
+++ b/verilog/CST/statement.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,174 +25,182 @@
 namespace verilog {
 
 std::vector<verible::TreeSearchMatch> FindAllConditionalStatements(
-    const verible::Symbol& root);
+    const verible::Symbol &root);
 
 std::vector<verible::TreeSearchMatch> FindAllForLoopsInitializations(
-    const verible::Symbol& root);
+    const verible::Symbol &root);
 
 std::vector<verible::TreeSearchMatch> FindAllGenerateBlocks(
-    const verible::Symbol& root);
+    const verible::Symbol &root);
 
 // Generate flow control constructs
 //
 // TODO(fangism): consider moving the *GenerateBody functions to generate.{h,cc}
 
 // Returns the generate-item body of a generate-if construct.
-const verible::SyntaxTreeNode* GetIfClauseGenerateBody(
-    const verible::Symbol& if_clause);
+const verible::SyntaxTreeNode *GetIfClauseGenerateBody(
+    const verible::Symbol &if_clause);
 
 // Returns the generate-item body of a generate-else construct.
-const verible::SyntaxTreeNode* GetElseClauseGenerateBody(
-    const verible::Symbol& else_clause);
+const verible::SyntaxTreeNode *GetElseClauseGenerateBody(
+    const verible::Symbol &else_clause);
 
 // Returns the generate-item body of a generate-for-loop construct.
-const verible::SyntaxTreeNode* GetLoopGenerateBody(const verible::Symbol& loop);
+const verible::SyntaxTreeNode *GetLoopGenerateBody(const verible::Symbol &loop);
 
 // Returns the if-clause of a generate-if construct.
-const verible::SyntaxTreeNode* GetConditionalGenerateIfClause(
-    const verible::Symbol& conditional);
+const verible::SyntaxTreeNode *GetConditionalGenerateIfClause(
+    const verible::Symbol &conditional);
 
 // Returns the else-clause of a generate-if construct, or nullptr.
-const verible::SyntaxTreeNode* GetConditionalGenerateElseClause(
-    const verible::Symbol& conditional);
+const verible::SyntaxTreeNode *GetConditionalGenerateElseClause(
+    const verible::Symbol &conditional);
 
 // Statement flow control constructs
 
 // For if-conditional statement blocks, return the construct's
 // statement body (which should be some form of statement list).
-const verible::SyntaxTreeNode* GetIfClauseStatementBody(
-    const verible::Symbol& if_clause);
+const verible::SyntaxTreeNode *GetIfClauseStatementBody(
+    const verible::Symbol &if_clause);
 
 // For else-clause statement blocks, return the construct's
 // statement body (which should be some form of statement list).
-const verible::SyntaxTreeNode* GetElseClauseStatementBody(
-    const verible::Symbol& else_clause);
+const verible::SyntaxTreeNode *GetElseClauseStatementBody(
+    const verible::Symbol &else_clause);
 
 // Returns the if-clause of a conditional statement construct.
-const verible::SyntaxTreeNode* GetConditionalStatementIfClause(
-    const verible::Symbol& conditional);
+const verible::SyntaxTreeNode *GetConditionalStatementIfClause(
+    const verible::Symbol &conditional);
 
 // Returns the else-clause of a conditional statement construct, or nullptr.
-const verible::SyntaxTreeNode* GetConditionalStatementElseClause(
-    const verible::Symbol& conditional);
+const verible::SyntaxTreeNode *GetConditionalStatementElseClause(
+    const verible::Symbol &conditional);
 
 // Immediate assertion statements
 
 // Returns the assert-clause of an assertion statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssertionStatementAssertClause(
-    const verible::Symbol& assertion_statement);
+const verible::SyntaxTreeNode *GetAssertionStatementAssertClause(
+    const verible::Symbol &assertion_statement);
 
 // Returns the else-clause of an assertion statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssertionStatementElseClause(
-    const verible::Symbol& assertion_statement);
+const verible::SyntaxTreeNode *GetAssertionStatementElseClause(
+    const verible::Symbol &assertion_statement);
 
 // Returns the assume-clause of an assume statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssumeStatementAssumeClause(
-    const verible::Symbol& assume_statement);
+const verible::SyntaxTreeNode *GetAssumeStatementAssumeClause(
+    const verible::Symbol &assume_statement);
 
 // Returns the else-clause of an assume statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssumeStatementElseClause(
-    const verible::Symbol& assume_statement);
+const verible::SyntaxTreeNode *GetAssumeStatementElseClause(
+    const verible::Symbol &assume_statement);
 
 // Returns the statement body of a cover statement, or nullptr.
-const verible::SyntaxTreeNode* GetCoverStatementBody(
-    const verible::Symbol& cover_statement);
+const verible::SyntaxTreeNode *GetCoverStatementBody(
+    const verible::Symbol &cover_statement);
 
 // Returns the statement body of a wait statement, or nullptr.
-const verible::SyntaxTreeNode* GetWaitStatementBody(
-    const verible::Symbol& wait_statement);
+const verible::SyntaxTreeNode *GetWaitStatementBody(
+    const verible::Symbol &wait_statement);
 
 // Concurrent assertion statements
 
 // Returns the assert-clause of an assert property statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssertPropertyStatementAssertClause(
-    const verible::Symbol& assert_property_statement);
+const verible::SyntaxTreeNode *GetAssertPropertyStatementAssertClause(
+    const verible::Symbol &assert_property_statement);
 
 // Returns the else-clause of an assert property statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssertPropertyStatementElseClause(
-    const verible::Symbol& assert_property_statement);
+const verible::SyntaxTreeNode *GetAssertPropertyStatementElseClause(
+    const verible::Symbol &assert_property_statement);
 
 // Returns the assume-clause of an assume property statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssumePropertyStatementAssumeClause(
-    const verible::Symbol& assume_property_statement);
+const verible::SyntaxTreeNode *GetAssumePropertyStatementAssumeClause(
+    const verible::Symbol &assume_property_statement);
 
 // Returns the else-clause of an assume property statement, or nullptr.
-const verible::SyntaxTreeNode* GetAssumePropertyStatementElseClause(
-    const verible::Symbol& assume_property_statement);
+const verible::SyntaxTreeNode *GetAssumePropertyStatementElseClause(
+    const verible::Symbol &assume_property_statement);
 
 // Returns the expect-clause of an expect property statement, or nullptr.
-const verible::SyntaxTreeNode* GetExpectPropertyStatementExpectClause(
-    const verible::Symbol& expect_property_statement);
+const verible::SyntaxTreeNode *GetExpectPropertyStatementExpectClause(
+    const verible::Symbol &expect_property_statement);
 
 // Returns the else-clause of an expect property statement, or nullptr.
-const verible::SyntaxTreeNode* GetExpectPropertyStatementElseClause(
-    const verible::Symbol& expect_property_statement);
+const verible::SyntaxTreeNode *GetExpectPropertyStatementElseClause(
+    const verible::Symbol &expect_property_statement);
 
 // Loop-like statements
 
 // For loop statement blocks, return the looped statement body.
-const verible::SyntaxTreeNode* GetLoopStatementBody(
-    const verible::Symbol& loop);
+const verible::SyntaxTreeNode *GetLoopStatementBody(
+    const verible::Symbol &loop);
 
 // For do-while statement blocks, return the looped statement body.
-const verible::SyntaxTreeNode* GetDoWhileStatementBody(
-    const verible::Symbol& do_while);
+const verible::SyntaxTreeNode *GetDoWhileStatementBody(
+    const verible::Symbol &do_while);
 
 // Return the statement body of forever blocks.
-const verible::SyntaxTreeNode* GetForeverStatementBody(
-    const verible::Symbol& forever);
+const verible::SyntaxTreeNode *GetForeverStatementBody(
+    const verible::Symbol &forever);
 
 // Return the statement body of foreach blocks.
-const verible::SyntaxTreeNode* GetForeachStatementBody(
-    const verible::Symbol& foreach);
+const verible::SyntaxTreeNode *GetForeachStatementBody(
+    const verible::Symbol &foreach);
 
 // Return the statement body of repeat blocks.
-const verible::SyntaxTreeNode* GetRepeatStatementBody(
-    const verible::Symbol& repeat);
+const verible::SyntaxTreeNode *GetRepeatStatementBody(
+    const verible::Symbol &repeat);
 
 // Return the statement body of while blocks.
-const verible::SyntaxTreeNode* GetWhileStatementBody(
-    const verible::Symbol& while_stmt);
+const verible::SyntaxTreeNode *GetWhileStatementBody(
+    const verible::Symbol &while_stmt);
 
 // TODO(fangism): case-items
 
 // Return the statement body of procedural timing constructs.
-const verible::SyntaxTreeNode* GetProceduralTimingControlStatementBody(
-    const verible::Symbol& proc_timing_control);
+const verible::SyntaxTreeNode *GetProceduralTimingControlStatementBody(
+    const verible::Symbol &proc_timing_control);
 
 // Combines all of the above Get*StatementBody.
 // Also works for control flow generate constructs.
-const verible::SyntaxTreeNode* GetAnyControlStatementBody(
-    const verible::Symbol& statement);
+const verible::SyntaxTreeNode *GetAnyControlStatementBody(
+    const verible::Symbol &statement);
 
 // Returns the if-clause of a conditional generate/statement.
-const verible::SyntaxTreeNode* GetAnyConditionalIfClause(
-    const verible::Symbol& conditional);
+const verible::SyntaxTreeNode *GetAnyConditionalIfClause(
+    const verible::Symbol &conditional);
 
 // Returns the else-clause of a conditional generate/statement, or nullptr if it
 // doesn't exist.
-const verible::SyntaxTreeNode* GetAnyConditionalElseClause(
-    const verible::Symbol& conditional);
+const verible::SyntaxTreeNode *GetAnyConditionalElseClause(
+    const verible::Symbol &conditional);
 
 // Returns the data type node from for loop initialization.
-const verible::SyntaxTreeNode* GetDataTypeFromForInitialization(
-    const verible::Symbol&);
+const verible::SyntaxTreeNode *GetDataTypeFromForInitialization(
+    const verible::Symbol &);
 
 // Returns the variable name leaf from for loop initialization.
-const verible::SyntaxTreeLeaf* GetVariableNameFromForInitialization(
-    const verible::Symbol&);
+const verible::SyntaxTreeLeaf *GetVariableNameFromForInitialization(
+    const verible::Symbol &);
 
 // Returns the rhs expression from for loop initialization.
-const verible::SyntaxTreeNode* GetExpressionFromForInitialization(
-    const verible::Symbol&);
+const verible::SyntaxTreeNode *GetExpressionFromForInitialization(
+    const verible::Symbol &);
 
 // Returns the 'begin' node of a generate block.
-const verible::SyntaxTreeNode* GetGenerateBlockBegin(
-    const verible::Symbol& generate_block);
+const verible::SyntaxTreeNode *GetGenerateBlockBegin(
+    const verible::Symbol &generate_block);
 
 // Returns the 'end' node of a generate block.
-const verible::SyntaxTreeNode* GetGenerateBlockEnd(
-    const verible::Symbol& generate_block);
+const verible::SyntaxTreeNode *GetGenerateBlockEnd(
+    const verible::Symbol &generate_block);
+
+// Returns the procedural timing control statement of an always statement node
+const verible::SyntaxTreeNode *GetProceduralTimingControlFromAlways(
+    const verible::SyntaxTreeNode &always_statement);
+
+// Returns the event control symbol of a procedural timing control statement
+const verible::Symbol *GetEventControlFromProceduralTimingControl(
+    const verible::SyntaxTreeNode &proc_timing_ctrl);
 
 }  // namespace verilog
 

--- a/verilog/CST/statement_test.cc
+++ b/verilog/CST/statement_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -499,11 +499,11 @@ TEST(GetAnyControlStatementBodyTest, Various) {
         "\n"
         "endtask\n"}},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
         __FUNCTION__, test.token_data,
-        [&test](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
+        [&test](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
 
           // Grab outer statement constructs.
           const auto statements = verible::SearchSyntaxTree(
@@ -514,8 +514,8 @@ TEST(GetAnyControlStatementBodyTest, Various) {
 
           // Extract subtree of interest.
           std::vector<TreeSearchMatch> bodies;
-          for (const auto& statement : statements) {
-            const auto* body = GetAnyControlStatementBody(*statement.match);
+          for (const auto &statement : statements) {
+            const auto *body = GetAnyControlStatementBody(*statement.match);
             bodies.push_back(TreeSearchMatch{body, {/* ignored context */}});
           }
           return bodies;
@@ -720,11 +720,11 @@ TEST(GetAnyConditionalIfClauseTest, Various) {
         "   bar=foo;\n"
         "endtask\n"}},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
         __FUNCTION__, test.token_data,
-        [&test](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
+        [&test](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
 
           // Grab outer statement constructs.
           const auto statements = verible::SearchSyntaxTree(
@@ -735,8 +735,8 @@ TEST(GetAnyConditionalIfClauseTest, Various) {
 
           // Extract subtree of interest.
           std::vector<TreeSearchMatch> bodies;
-          for (const auto& statement : statements) {
-            const auto* clause = GetAnyConditionalIfClause(*statement.match);
+          for (const auto &statement : statements) {
+            const auto *clause = GetAnyConditionalIfClause(*statement.match);
             bodies.push_back(TreeSearchMatch{clause, {/* ignored context */}});
           }
           return bodies;
@@ -830,19 +830,19 @@ TEST(GetAnyConditionalElseClauseTest, NoElseClause) {
         "\n"
         "endtask\n"}},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     const absl::string_view code(test.token_data.code);
     VerilogAnalyzer analyzer(code, "test-file");
     ASSERT_OK(analyzer.Analyze()) << "failed on:\n" << code;
-    const auto& root = analyzer.Data().SyntaxTree();
+    const auto &root = analyzer.Data().SyntaxTree();
 
     const auto statements = verible::SearchSyntaxTree(
         *ABSL_DIE_IF_NULL(root),
         verible::matcher::DynamicTagMatchBuilder(SymbolTag{
             SymbolKind::kNode, static_cast<int>(test.expected_construct)})());
     ASSERT_EQ(statements.size(), 1);
-    const auto& statement = *statements.front().match;
-    const auto* clause = GetAnyConditionalElseClause(statement);
+    const auto &statement = *statements.front().match;
+    const auto *clause = GetAnyConditionalElseClause(statement);
     EXPECT_EQ(clause, nullptr);
   }
 }
@@ -1121,11 +1121,11 @@ TEST(GetAnyConditionalElseClauseTest, HaveElseClause) {
         "\n"
         "endtask\n"}},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
         __FUNCTION__, test.token_data,
-        [&test](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
+        [&test](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
 
           // Grab outer statement constructs.
           const auto statements = verible::SearchSyntaxTree(
@@ -1136,8 +1136,8 @@ TEST(GetAnyConditionalElseClauseTest, HaveElseClause) {
 
           // Extract subtree of interest.
           std::vector<TreeSearchMatch> bodies;
-          for (const auto& statement : statements) {
-            const auto* clause = GetAnyConditionalElseClause(*statement.match);
+          for (const auto &statement : statements) {
+            const auto *clause = GetAnyConditionalElseClause(*statement.match);
             bodies.push_back(TreeSearchMatch{clause, {/* ignored context */}});
           }
           return bodies;
@@ -1163,16 +1163,16 @@ TEST(FindAllForLoopsInitializations, FindForInitializationNames) {
        {kTag, "k"},
        " = 0; i < 50; i++) begin\nx+=i;\nend\nend\nendmodule"},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
-        __FUNCTION__, test, [](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
-          const auto& instances =
+        __FUNCTION__, test, [](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
+          const auto &instances =
               FindAllForLoopsInitializations(*ABSL_DIE_IF_NULL(root));
 
           std::vector<TreeSearchMatch> names;
-          for (const auto& instance : instances) {
-            const auto* variable_name =
+          for (const auto &instance : instances) {
+            const auto *variable_name =
                 GetVariableNameFromForInitialization(*instance.match);
             names.emplace_back(
                 TreeSearchMatch{variable_name, {/* ignored context */}});
@@ -1201,16 +1201,16 @@ TEST(FindAllForLoopsInitializations, FindForInitializationDataTypes) {
        {kTag, "bit"},
        " k = 0; i < 50; i++) begin\nx+=i;\nend\nend\nendmodule"},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
-        __FUNCTION__, test, [](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
-          const auto& instances =
+        __FUNCTION__, test, [](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
+          const auto &instances =
               FindAllForLoopsInitializations(*ABSL_DIE_IF_NULL(root));
 
           std::vector<TreeSearchMatch> types;
-          for (const auto& instance : instances) {
-            const auto* type =
+          for (const auto &instance : instances) {
+            const auto *type =
                 GetDataTypeFromForInitialization(*instance.match);
             if (type == nullptr) {
               continue;
@@ -1240,16 +1240,16 @@ TEST(FindAllForLoopsInitializations, FindForInitializationExpressions) {
        {kTag, "0"},
        "; i < 50;i++) begin\nx+=i;\nend\nend\nendmodule"},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
-        __FUNCTION__, test, [](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
-          const auto& instances =
+        __FUNCTION__, test, [](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
+          const auto &instances =
               FindAllForLoopsInitializations(*ABSL_DIE_IF_NULL(root));
 
           std::vector<TreeSearchMatch> expressions;
-          for (const auto& instance : instances) {
-            const auto* expression =
+          for (const auto &instance : instances) {
+            const auto *expression =
                 GetExpressionFromForInitialization(*instance.match);
             expressions.emplace_back(
                 TreeSearchMatch{expression, {/* ignored context */}});
@@ -1299,15 +1299,15 @@ TEST(GetGenerateBlockBeginTest, Various) {
        "  end\n"
        "endmodule\n"},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
-        __FUNCTION__, test, [](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
-          const auto& blocks = FindAllGenerateBlocks(*ABSL_DIE_IF_NULL(root));
+        __FUNCTION__, test, [](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
+          const auto &blocks = FindAllGenerateBlocks(*ABSL_DIE_IF_NULL(root));
 
           std::vector<TreeSearchMatch> begins;
-          for (const auto& block : blocks) {
-            const auto* begin = GetGenerateBlockBegin(*block.match);
+          for (const auto &block : blocks) {
+            const auto *begin = GetGenerateBlockBegin(*block.match);
             begins.emplace_back(
                 TreeSearchMatch{begin, {/* ignored context */}});
           }
@@ -1357,15 +1357,15 @@ TEST(GetGenerateBlockEndTest, Various) {
        "\n"
        "endmodule\n"},
   };
-  for (const auto& test : kTestCases) {
+  for (const auto &test : kTestCases) {
     TestVerilogSyntaxRangeMatches(
-        __FUNCTION__, test, [](const TextStructureView& text_structure) {
-          const auto& root = text_structure.SyntaxTree();
-          const auto& blocks = FindAllGenerateBlocks(*ABSL_DIE_IF_NULL(root));
+        __FUNCTION__, test, [](const TextStructureView &text_structure) {
+          const auto &root = text_structure.SyntaxTree();
+          const auto &blocks = FindAllGenerateBlocks(*ABSL_DIE_IF_NULL(root));
 
           std::vector<TreeSearchMatch> ends;
-          for (const auto& block : blocks) {
-            const auto* end = GetGenerateBlockEnd(*block.match);
+          for (const auto &block : blocks) {
+            const auto *end = GetGenerateBlockEnd(*block.match);
             ends.emplace_back(TreeSearchMatch{end, {/* ignored context */}});
           }
           return ends;

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -1068,6 +1068,7 @@ cc_library(
         "//common/text:symbol",
         "//common/text:syntax-tree-context",
         "//verilog/CST:verilog-matchers",
+        "//verilog/CST:statement",
         "//verilog/analysis:descriptions",
         "//verilog/analysis:lint-rule-registry",
         "@com_google_absl//absl/strings",

--- a/verilog/analysis/checkers/always_comb_rule_test.cc
+++ b/verilog/analysis/checkers/always_comb_rule_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunLintTestCases;
 
 TEST(AlwaysCombTest, FunctionFailures) {
@@ -53,6 +54,33 @@ TEST(AlwaysCombTest, FunctionFailures) {
   };
 
   RunLintTestCases<VerilogAnalyzer, AlwaysCombRule>(kAlwaysCombTestCases);
+}
+
+TEST(AlwaysCombTest, AutoFixAlwaysComb) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module m;\nalways @* begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @(*) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @( *) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @(* ) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @( * ) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @(/*t*/*) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @(*/*t*/) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways @(/*t*/*/*t*/) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+      {"module m;\nalways \n@(/*t*/*/*t*/)\n begin end\nendmodule",
+       "module m;\nalways_comb\n begin end\nendmodule"},
+      {"module m;\nalways @(\n*\n) begin end\nendmodule",
+       "module m;\nalways_comb begin end\nendmodule"},
+  };
+
+  RunApplyFixCases<VerilogAnalyzer, AlwaysCombRule>(kTestCases, "");
 }
 
 }  // namespace


### PR DESCRIPTION
Note: clang-format introduced many changes in the files. 

First attempt on adding an AutoFix for the always_comb rule. It looks somewhat decent but there are some things I'm not completely satisfied with.

After inspecting the syntax tree with the cli tool
```
Node @0 (tag: kAlwaysStatement) {
        Leaf @0 (#"always" @266-272: "always")
        Node @1 (tag: kProceduralTimingControlStatement) {
          Node @0 (tag: kEventControl) {
             "..."
          }
```

My approach has been to replace the *StringSpanOfSymbol* for kEvenControl for the empty string, as the syntax tree for an 'always_comb' doesnt present this element. With this, I also noticed that when performing this transformation we're changing the syntax tree, so I don't know whether this is ok or could cause problems elsewhere.

Other issues:

- The end result contains an 'extra' space. I don't know if it is possible to remove that extra space.
```diff
-always @(*) begin
+always_comb  begin
```
- Auxilary functions: For clarity, I added two functions to get to the kProceduralTimingControlStatement and the kEventControl nodes inside an AlwaysStatement. I'm not sure if the functions could be generalized to extract them in every possible appearence or if we keep them AlwaysStatement-specific and rename them (although GetProceduralTimingControlStatementInAlwaysStatement seems a bit long :laughing:  )

Edit: kAlwaysStatement nodes might not even present a kProceduralTimingStatement/kEventControl, so I don't know what to do with this auxiliary functions.

- TODO: 
  - [ ] Add tests for the auxiliary functions after agreeing on how they should look like 