### PR TITLE
Make sure include files are always fully qualified.

### DIFF
--- a/.github/bin/check-potential-problems.sh
+++ b/.github/bin/check-potential-problems.sh
@@ -61,4 +61,14 @@ if [ $? -eq 0 ]; then
   EXIT_CODE=1
 fi
 
+# Always use fully qualified include paths.
+# Exclude zlib.h, which is the only allowed header.
+find common verilog -name "*.h" -o -name "*.cc" | \
+  xargs egrep -n '#include "[^/]*"' | grep -v zlib.h
+if [ $? -eq 0 ]; then
+  echo "::error:: always use a fully qualified name for #includes"
+  echo
+  EXIT_CODE=1
+fi
+
 exit "${EXIT_CODE}"


### PR DESCRIPTION
To make sure headers are unique, always use a path relative to the toplevel.