### PR TITLE
Fix macro formatting divergence and splitting issues

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -3717,6 +3717,15 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    lbl : y = w;\n"  // TODO(fangism): no space before ':'
      "  endtask\n"
      "endclass\n"},
+    // task with macro call
+    {"module m1;\ntask automatic t1();\n"
+     "t2(`R1(1)+ 8);endtask : t1\nendmodule",
+     "module m1;\n"
+     "  task automatic t1();\n"
+     "    t2(`R1(1) + 8);\n"
+     "  endtask : t1\n"
+     "endmodule\n"},
+
     // tasks with control statements
     {"class c; task automatic waiter;"
      "if (count == 0) begin #0; return;end "
@@ -5564,7 +5573,16 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    x = 2;\n"
      "  end\n"
      "endmodule\n"},
-
+    // Macro calls inside [...]
+    {"module foo;\nlogic [`BAR(1)\n+2] foo;\nendmodule",
+     "module foo;\n"
+     "  logic [`BAR(1)\n"
+     "  +2] foo;\n"
+     "endmodule\n"},
+    {"module foo;\nlogic [`BAR(1)+2] foo;\nendmodule",
+     "module foo;\n"
+     "  logic [`BAR(1)+2] foo;\n"
+     "endmodule\n"},
     {
         // test that alternate top-syntax mode works
         "// verilog_syntax: parse-as-module-body\n"

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -5577,7 +5577,7 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
     {"module foo;\nlogic [`BAR(1)\n+2] foo;\nendmodule",
      "module foo;\n"
      "  logic [`BAR(1)\n"
-     "  +2] foo;\n"
+     "+2] foo;\n"
      "endmodule\n"},
     {"module foo;\nlogic [`BAR(1)+2] foo;\nendmodule",
      "module foo;\n"

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -5583,6 +5583,17 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "module foo;\n"
      "  logic [`BAR(1)+2] foo;\n"
      "endmodule\n"},
+    {"module foo ();\n  function bar();\n    "
+     "logic [12:34] data[`AAAAAAAAAAAAAAAAAAAAAAAA(1) : "
+     "`BBBBBBBBBBBBBBBBBBBBBBBB(2) + 3];\n  "
+     "endfunction\nendmodule",
+     "module foo ();\n"
+     "  function bar();\n"
+     "    logic [12:34] data[\n"
+     "    `AAAAAAAAAAAAAAAAAAAAAAAA(1) :\n"
+     "    `BBBBBBBBBBBBBBBBBBBBBBBB(2) + 3];\n"
+     "  endfunction\n"
+     "endmodule\n"},
     {
         // test that alternate top-syntax mode works
         "// verilog_syntax: parse-as-module-body\n"

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -441,7 +441,7 @@ static WithReason<int> SpacesRequiredBetween(
     if (InRangeLikeContext(right_context)) {
       int spaces = right.OriginalLeadingSpaces().length();
       if (spaces > 1) {
-        // If ExcessSpaces returns 0 if there was a newline - prevents
+        // ExcessSpaces returns 0 if there was a newline - prevents
         // counting indentation as spaces
         spaces = right.ExcessSpaces() ? 1 : 0;
       }
@@ -883,7 +883,7 @@ static WithReason<SpacingOptions> BreakDecisionBetween(
 
   if (left.TokenEnum() == verilog_tokentype::MacroCallCloseToEndLine) {
     if (!IsComment(FormatTokenType(right.format_token_enum)) &&
-        !IsAnySemicolon(right)) {
+        !IsAnySemicolon(right) && !InRangeLikeContext(left_context)) {
       return {SpacingOptions::kMustWrap,
               "Macro-closing ')' should end its own line except for comments "
               "nad ';'."};

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -161,18 +161,6 @@ static WithReason<int> SpacesRequiredBetween(
             "and \"{y}\" over \"{ y }\"."};
   }
 
-  // For now, leave everything inside [dimensions] alone.
-  if (InDeclaredDimensions(right_context)) {
-    // ... except for the spacing before '[' and around ':',
-    // which are covered elsewhere.
-    if (right.TokenEnum() != '[' && left.TokenEnum() != ':' &&
-        right.TokenEnum() != ':') {
-      return {kUnhandledSpacesRequired,
-              "Leave [expressions] inside scalar and range dimensions alone "
-              "(for now)."};
-    }
-  }
-
   // Unary operators (context-sensitive)
   if (IsUnaryPrefixExpressionOperand(left, right_context) &&
       (left.format_token_enum != FormatTokenType::binary_operator ||

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1126,6 +1126,8 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
         PushContextHint(ContextHint::kInsideStandaloneMacroCall);
         VisitIndentedSection(node, indent, PartitionPolicyEnum::kStack);
       } else {
+        // TODO(jbylicki): Check if there is a possibility of
+        // using kFitOnLineElseExpand - seems to have no effect
         VisitIndentedSection(node, indent,
                              PartitionPolicyEnum::kAppendFittingSubPartitions);
       }

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1109,8 +1109,8 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
                      NodeEnum::kIfBody,
                      NodeEnum::kIfClause,
                  })) &&
-                !(Context().IsInside(NodeEnum::kNetVariableAssignment)  //
-                  ));
+                !(Context().IsInside(NodeEnum::kNetVariableAssignment)) &&
+                !(Context().IsInside(NodeEnum::kUnpackedDimensions)));
       };
 
       // TODO(mglb): Format non-standalone calls with layout optimizer.

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -2714,13 +2714,10 @@ void TreeUnwrapper::ReshapeTokenPartitions(
       if (subnode.MatchesTagAnyOf({NodeEnum::kMethodCallExtension,
                                    NodeEnum::kParenGroup,
                                    NodeEnum::kRandomizeMethodCallExtension})) {
-        if (partition.Value().PartitionPolicy() ==
-            PartitionPolicyEnum::kAppendFittingSubPartitions) {
-          auto& last = RightmostDescendant(partition);
-          if (PartitionStartsWithCloseParen(last) ||
-              PartitionStartsWithSemicolon(last)) {
-            verible::MergeLeafIntoPreviousLeaf(&last);
-          }
+        auto& last = RightmostDescendant(partition);
+        if (PartitionStartsWithCloseParen(last) ||
+            PartitionStartsWithSemicolon(last)) {
+          verible::MergeLeafIntoPreviousLeaf(&last);
         }
       }
       break;


### PR DESCRIPTION
This PR removes a unnecessary check when dealing with kReferenceCallBase where the r_paren token should be added regardless of partition policy (as the style dictates that the bracket is always connected to the last token)

Fixes #1894 
Fixes #1924