### PR TITLE
[LSP] Initial support for textDocument/hover request

### DIFF
--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -96,7 +96,7 @@ std::ostream& operator<<(std::ostream& stream, SymbolMetaType symbol_type) {
   return SymbolMetaTypeNames().Unparse(symbol_type, stream);
 }
 
-static absl::string_view SymbolMetaTypeAsString(SymbolMetaType type) {
+absl::string_view SymbolMetaTypeAsString(SymbolMetaType type) {
   return SymbolMetaTypeNames().EnumName(type);
 }
 

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -67,6 +67,8 @@ enum class SymbolMetaType {
 
 std::ostream& operator<<(std::ostream&, SymbolMetaType);
 
+absl::string_view SymbolMetaTypeAsString(SymbolMetaType type);
+
 // This classifies the type of reference that a single identifier is.
 enum class ReferenceType {
   // The base identifier in any chain.

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -105,6 +105,18 @@ cc_library(
 )
 
 cc_library(
+  name = "hover",
+  srcs = ["hover.cc"],
+  hdrs = ["hover.h"],
+  deps = [
+      ":lsp-parse-buffer",
+      ":symbol-table-handler",
+      "//common/lsp:lsp-protocol",
+      "//verilog/parser:verilog_token_enum",
+  ],
+)
+
+cc_library(
     name = "symbol-table-handler",
     srcs = ["symbol-table-handler.cc"],
     hdrs = ["symbol-table-handler.h"],

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -105,15 +105,19 @@ cc_library(
 )
 
 cc_library(
-  name = "hover",
-  srcs = ["hover.cc"],
-  hdrs = ["hover.h"],
-  deps = [
-      ":lsp-parse-buffer",
-      ":symbol-table-handler",
-      "//common/lsp:lsp-protocol",
-      "//verilog/parser:verilog_token_enum",
-  ],
+    name = "hover",
+    srcs = ["hover.cc"],
+    hdrs = ["hover.h"],
+    deps = [
+        ":lsp-parse-buffer",
+        ":symbol-table-handler",
+        "//common/util:casts",
+        "//verilog/CST:seq_block",
+        "//common/lsp:lsp-protocol",
+        "//verilog/CST:verilog_nonterminals",
+        "//common/text:tree_context_visitor",
+        "//verilog/parser:verilog_token_enum",
+    ],
 )
 
 cc_library(

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -111,12 +111,13 @@ cc_library(
     deps = [
         ":lsp-parse-buffer",
         ":symbol-table-handler",
-        "//common/util:casts",
-        "//verilog/CST:seq_block",
         "//common/lsp:lsp-protocol",
-        "//verilog/CST:verilog_nonterminals",
-        "//common/text:tree_context_visitor",
-        "//verilog/parser:verilog_token_enum",
+        "//common/text:tree-context-visitor",
+        "//common/util:casts",
+        "//common/util:range",
+        "//verilog/CST:seq-block",
+        "//verilog/CST:verilog-nonterminals",
+        "//verilog/parser:verilog-token-enum",
     ],
 )
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -160,6 +160,7 @@ cc_library(
         ":lsp-parse-buffer",
         ":symbol-table-handler",
         ":verible-lsp-adapter",
+        ":hover",
         "//common/lsp:json-rpc-dispatcher",
         "//common/lsp:lsp-file-utils",
         "//common/lsp:lsp-protocol",

--- a/verilog/tools/ls/hover.cc
+++ b/verilog/tools/ls/hover.cc
@@ -17,6 +17,7 @@
 
 #include "common/text/tree_context_visitor.h"
 #include "common/util/casts.h"
+#include "common/util/range.h"
 #include "verilog/CST/seq_block.h"
 #include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/symbol_table.h"
@@ -52,7 +53,7 @@ class FindBeginLabel : public TreeContextVisitor {
 
  private:
   void Visit(const SyntaxTreeLeaf &leaf) override {
-    if (IsStringViewContained(leaf.get().text(), substring_)) {
+    if (verible::IsSubRange(leaf.get().text(), substring_)) {
       substring_found_ = true;
     }
   }

--- a/verilog/tools/ls/hover.cc
+++ b/verilog/tools/ls/hover.cc
@@ -1,0 +1,86 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "verilog/tools/ls/hover.h"
+
+#include "verilog/analysis/symbol_table.h"
+#include "verilog/parser/verilog_token_enum.h"
+
+namespace verilog {
+
+namespace {
+
+class HoverBuilder {
+ public:
+  HoverBuilder(SymbolTableHandler *symbol_table_handler,
+               const BufferTrackerContainer &tracker_container)
+      : symbol_table_handler(symbol_table_handler),
+        tracker_container(tracker_container) {}
+
+  verible::lsp::Hover Build(const verible::lsp::HoverParams &p) {
+    std::optional<verible::TokenInfo> token =
+        symbol_table_handler->GetTokenAtTextDocumentPosition(p,
+                                                             tracker_container);
+    if (!token) return {};
+    verible::lsp::Hover response;
+    switch (token->token_enum()) {
+      case verilog_tokentype::TK_end:
+        HoverInfoEndToken(&response, *token);
+        break;
+      default:
+        HoverInfoIdentifier(&response, *token);
+    }
+    return response;
+  }
+
+ private:
+  void HoverInfoEndToken(verible::lsp::Hover *response,
+                         const verible::TokenInfo &token) {
+    // TODO implement walking up to begin
+  }
+  void HoverInfoIdentifier(verible::lsp::Hover *response,
+                           const verible::TokenInfo &token) {
+    absl::string_view symbol = token.text();
+    const SymbolTableNode *node =
+        symbol_table_handler->FindDefinitionNode(symbol);
+    if (!node) return;
+    const SymbolInfo &info = node->Value();
+    response->contents.value = absl::StrCat(
+        "### ", SymbolMetaTypeAsString(info.metatype), " ", symbol, "\n\n");
+    if (!info.declared_type.syntax_origin && info.declared_type.implicit) {
+      absl::StrAppend(&response->contents.value,
+                      "---\n\nType: (implicit)\n\n---");
+    } else if (info.declared_type.syntax_origin) {
+      absl::StrAppend(
+          &response->contents.value, "---\n\n", "Type: ",
+          verible::StringSpanOfSymbol(*info.declared_type.syntax_origin),
+          "\n\n---");
+    }
+  }
+  SymbolTableHandler *symbol_table_handler;
+  const BufferTrackerContainer &tracker_container;
+};
+
+}  // namespace
+
+verible::lsp::Hover CreateHoverInformation(
+    SymbolTableHandler *symbol_table_handler,
+    const BufferTrackerContainer &tracker, const verible::lsp::HoverParams &p) {
+  verible::lsp::Hover response;
+  HoverBuilder builder(symbol_table_handler, tracker);
+  return builder.Build(p);
+}
+
+}  // namespace verilog

--- a/verilog/tools/ls/hover.cc
+++ b/verilog/tools/ls/hover.cc
@@ -15,6 +15,10 @@
 
 #include "verilog/tools/ls/hover.h"
 
+#include "common/text/tree_context_visitor.h"
+#include "common/util/casts.h"
+#include "verilog/CST/seq_block.h"
+#include "verilog/CST/verilog_nonterminals.h"
 #include "verilog/analysis/symbol_table.h"
 #include "verilog/parser/verilog_token_enum.h"
 
@@ -22,16 +26,83 @@ namespace verilog {
 
 namespace {
 
+using verible::Symbol;
+using verible::SyntaxTreeLeaf;
+using verible::SyntaxTreeNode;
+using verible::TreeContextVisitor;
+
+// Finds names/labels of named blocks
+class FindBeginLabel : public TreeContextVisitor {
+ public:
+  explicit FindBeginLabel() = default;
+
+  absl::string_view LabelSearch(const verible::ConcreteSyntaxTree &tree,
+                                absl::string_view substring, NodeEnum endtag,
+                                NodeEnum begintag) {
+    this->substring = substring;
+    this->begintag = begintag;
+    this->endtag = endtag;
+    substring_found = false;
+    finished = false;
+    tree->Accept(this);
+    return label;
+  }
+
+ private:
+  void Visit(const SyntaxTreeLeaf &leaf) override {
+    if (IsStringViewContained(leaf.get().text(), substring)) {
+      substring_found = true;
+    }
+  }
+  void Visit(const SyntaxTreeNode &node) override {
+    if (finished) return;
+    const std::unique_ptr<Symbol> *lastbegin = nullptr;
+    for (const std::unique_ptr<Symbol> &child : node.children()) {
+      if (!child) continue;
+      if (child->Kind() == verible::SymbolKind::kLeaf &&
+          node.Tag().tag == static_cast<int>(endtag)) {
+        Visit(verible::down_cast<const SyntaxTreeLeaf &>(*child));
+        if (substring_found) return;
+      } else if (child->Tag().tag == static_cast<int>(begintag)) {
+        lastbegin = &child;
+      } else if (child->Kind() == verible::SymbolKind::kNode) {
+        Visit(verible::down_cast<const SyntaxTreeNode &>(*child));
+        if (!label.empty()) return;
+        if (substring_found) {
+          if (!lastbegin) {
+            finished = true;
+            return;
+          }
+          const verible::TokenInfo *info = GetBeginLabelTokenInfo(**lastbegin);
+          finished = true;
+          if (!info) return;
+          label = info->text();
+          return;
+        }
+      }
+      if (finished) return;
+    }
+  }
+  absl::string_view substring;
+  NodeEnum endtag;
+  NodeEnum begintag;
+  absl::string_view label;
+  bool substring_found;
+  bool finished;
+};
+
 class HoverBuilder {
  public:
   HoverBuilder(SymbolTableHandler *symbol_table_handler,
-               const BufferTrackerContainer &tracker_container)
+               const BufferTrackerContainer &tracker_container,
+               const verible::lsp::HoverParams &params)
       : symbol_table_handler(symbol_table_handler),
-        tracker_container(tracker_container) {}
+        tracker_container(tracker_container),
+        params(params) {}
 
-  verible::lsp::Hover Build(const verible::lsp::HoverParams &p) {
+  verible::lsp::Hover Build() {
     std::optional<verible::TokenInfo> token =
-        symbol_table_handler->GetTokenAtTextDocumentPosition(p,
+        symbol_table_handler->GetTokenAtTextDocumentPosition(params,
                                                              tracker_container);
     if (!token) return {};
     verible::lsp::Hover response;
@@ -48,8 +119,23 @@ class HoverBuilder {
  private:
   void HoverInfoEndToken(verible::lsp::Hover *response,
                          const verible::TokenInfo &token) {
-    // TODO implement walking up to begin
+    const verilog::BufferTracker *tracker =
+        tracker_container.FindBufferTrackerOrNull(params.textDocument.uri);
+    if (!tracker) return;
+    std::shared_ptr<const ParsedBuffer> parsedbuffer = tracker->current();
+    if (!parsedbuffer) return;
+    const verible::ConcreteSyntaxTree &tree =
+        parsedbuffer->parser().SyntaxTree();
+    if (!tree) return;
+    FindBeginLabel search;
+    absl::string_view label = search.LabelSearch(
+        tree, token.text(), NodeEnum::kEnd, NodeEnum::kBegin);
+    if (label.empty()) return;
+    response->contents.value = "### End of block\n\n";
+    absl::StrAppend(&response->contents.value, "---\n\nName: ", label,
+                    "\n\n---");
   }
+
   void HoverInfoIdentifier(verible::lsp::Hover *response,
                            const verible::TokenInfo &token) {
     absl::string_view symbol = token.text();
@@ -71,6 +157,7 @@ class HoverBuilder {
   }
   SymbolTableHandler *symbol_table_handler;
   const BufferTrackerContainer &tracker_container;
+  const verible::lsp::HoverParams &params;
 };
 
 }  // namespace
@@ -78,9 +165,8 @@ class HoverBuilder {
 verible::lsp::Hover CreateHoverInformation(
     SymbolTableHandler *symbol_table_handler,
     const BufferTrackerContainer &tracker, const verible::lsp::HoverParams &p) {
-  verible::lsp::Hover response;
-  HoverBuilder builder(symbol_table_handler, tracker);
-  return builder.Build(p);
+  HoverBuilder builder(symbol_table_handler, tracker, p);
+  return builder.Build();
 }
 
 }  // namespace verilog

--- a/verilog/tools/ls/hover.h
+++ b/verilog/tools/ls/hover.h
@@ -1,0 +1,29 @@
+// Copyright 2023 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef VERILOG_TOOLS_LS_HOVER_H_INCLUDED
+#define VERILOG_TOOLS_LS_HOVER_H_INCLUDED
+
+#include "common/lsp/lsp-protocol.h"
+#include "verilog/tools/ls/lsp-parse-buffer.h"
+#include "verilog/tools/ls/symbol-table-handler.h"
+
+namespace verilog {
+verible::lsp::Hover CreateHoverInformation(
+    SymbolTableHandler *symbol_table_handler,
+    const BufferTrackerContainer &tracker, const verible::lsp::HoverParams &p);
+}  // namespace verilog
+
+#endif  // hover_h_INCLUDED

--- a/verilog/tools/ls/hover.h
+++ b/verilog/tools/ls/hover.h
@@ -21,6 +21,7 @@
 #include "verilog/tools/ls/symbol-table-handler.h"
 
 namespace verilog {
+// Provides hover information for given location
 verible::lsp::Hover CreateHoverInformation(
     SymbolTableHandler *symbol_table_handler,
     const BufferTrackerContainer &tracker, const verible::lsp::HoverParams &p);

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -292,13 +292,15 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinitionLocation(
   return {*location};
 }
 
+const SymbolTableNode *SymbolTableHandler::FindDefinitionNode(
+    absl::string_view symbol) {
+  Prepare();
+  return ScanSymbolTreeForDefinition(&symbol_table_->Root(), symbol);
+}
+
 const verible::Symbol *SymbolTableHandler::FindDefinitionSymbol(
     absl::string_view symbol) {
-  if (files_dirty_) {
-    BuildProjectSymbolTable();
-  }
-  const SymbolTableNode *symbol_table_node =
-      ScanSymbolTreeForDefinition(&symbol_table_->Root(), symbol);
+  const SymbolTableNode *symbol_table_node = FindDefinitionNode(symbol);
   if (symbol_table_node) return symbol_table_node->Value().syntax_origin;
   return nullptr;
 }

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -221,9 +221,10 @@ void SymbolTableHandler::Prepare() {
   }
 }
 
-absl::string_view SymbolTableHandler::GetTokenAtTextDocumentPosition(
+std::optional<verible::TokenInfo>
+SymbolTableHandler::GetTokenAtTextDocumentPosition(
     const verible::lsp::TextDocumentPositionParams &params,
-    const verilog::BufferTrackerContainer &parsed_buffers) {
+    const verilog::BufferTrackerContainer &parsed_buffers) const {
   const verilog::BufferTracker *tracker =
       parsed_buffers.FindBufferTrackerOrNull(params.textDocument.uri);
   if (!tracker) {
@@ -240,8 +241,7 @@ absl::string_view SymbolTableHandler::GetTokenAtTextDocumentPosition(
                                    params.position.character};
   const verible::TextStructureView &text = parsedbuffer->parser().Data();
 
-  const verible::TokenInfo cursor_token = text.FindTokenAt(cursor);
-  return cursor_token.text();
+  return text.FindTokenAt(cursor);
 }
 
 std::optional<verible::lsp::Location>
@@ -263,14 +263,16 @@ SymbolTableHandler::GetLocationFromSymbolName(
 }
 
 std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinitionLocation(
-    const verible::lsp::DefinitionParams &params,
+    const verible::lsp::TextDocumentPositionParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
   // TODO add iterating over multiple definitions
   Prepare();
   const absl::string_view filepath = LSPUriToPath(params.textDocument.uri);
   std::string relativepath = curr_project_->GetRelativePathToSource(filepath);
-  absl::string_view symbol =
+  std::optional<verible::TokenInfo> token =
       GetTokenAtTextDocumentPosition(params, parsed_buffers);
+  if (!token) return {};
+  absl::string_view symbol = token->text();
   VLOG(1) << "Looking for symbol:  " << symbol;
   VerilogSourceFile *reffile =
       curr_project_->LookupRegisteredFile(relativepath);
@@ -305,8 +307,10 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindReferencesLocations(
     const verible::lsp::ReferenceParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
   Prepare();
-  absl::string_view symbol =
+  std::optional<verible::TokenInfo> token =
       GetTokenAtTextDocumentPosition(params, parsed_buffers);
+  if (!token) return {};
+  absl::string_view symbol = token->text();
   const SymbolTableNode &root = symbol_table_->Root();
   const SymbolTableNode *node = ScanSymbolTreeForDefinition(&root, symbol);
   if (!node) {

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -55,6 +55,9 @@ class SymbolTableHandler {
       const verible::lsp::TextDocumentPositionParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
 
+  // Finds the node of the symbol table with definition for a given symbol.
+  const SymbolTableNode *FindDefinitionNode(absl::string_view symbol);
+
   // Finds the symbol of the definition for the given identifier.
   const verible::Symbol *FindDefinitionSymbol(absl::string_view symbol);
 

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -33,9 +33,6 @@ namespace verilog {
 // Looks for FileList file for SymbolTableHandler
 std::string FindFileList(absl::string_view current_dir);
 
-// Checks if one string_view is contained in another
-bool IsStringViewContained(absl::string_view origin, absl::string_view substr);
-
 // A class interfacing the SymbolTable with the LSP messages.
 // It manages the SymbolTable and its necessary components,
 // and provides such information as symbol definitions

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -52,7 +52,7 @@ class SymbolTableHandler {
   // message delivered i.e. in textDocument/definition message.
   // Provides a list of locations with symbol's definitions.
   std::vector<verible::lsp::Location> FindDefinitionLocation(
-      const verible::lsp::DefinitionParams &params,
+      const verible::lsp::TextDocumentPositionParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
 
   // Finds the symbol of the definition for the given identifier.
@@ -73,6 +73,13 @@ class SymbolTableHandler {
   // Creates a symbol table for entire project (public: needed in unit-test)
   std::vector<absl::Status> BuildProjectSymbolTable();
 
+  // Returns TokenInfo for token pointed by the LSP request based on
+  // TextDocumentPositionParams. If text is not found, empty-initialized
+  // string_view is returned.
+  std::optional<verible::TokenInfo> GetTokenAtTextDocumentPosition(
+      const verible::lsp::TextDocumentPositionParams &params,
+      const verilog::BufferTrackerContainer &parsed_buffers) const;
+
  private:
   // prepares structures for symbol-based requests
   void Prepare();
@@ -80,13 +87,6 @@ class SymbolTableHandler {
   // Creates a new symbol table given the VerilogProject in setProject
   // method.
   void ResetSymbolTable();
-
-  // Returns text pointed by the LSP request based on
-  // TextDocumentPositionParams. If text is not found, empty-initialized
-  // string_view is returned.
-  absl::string_view GetTokenAtTextDocumentPosition(
-      const verible::lsp::TextDocumentPositionParams &params,
-      const verilog::BufferTrackerContainer &parsed_buffers);
 
   // Returns the Location of the symbol name in source file
   // pointed by the file_origin.

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -33,6 +33,9 @@ namespace verilog {
 // Looks for FileList file for SymbolTableHandler
 std::string FindFileList(absl::string_view current_dir);
 
+// Checks if one string_view is contained in another
+bool IsStringViewContained(absl::string_view origin, absl::string_view substr);
+
 // A class interfacing the SymbolTable with the LSP messages.
 // It manages the SymbolTable and its necessary components,
 // and provides such information as symbol definitions


### PR DESCRIPTION
Resolves #1187

This PR adds initial support for `textDocument/hover` request.

It adds a HoverBuilder that constructs hover messages for the current position.

Tasks:

- [X] Adds hover feature to LS capabilities
- [X] Prints metatype for symbol
- [X] Prints type for symbol
- [ ] Prints documentation for symbol
- [X] Provides label for `end`
- [ ] Provides label for `endmodule`, `endfunction` of block (currently WIP)
- [ ] Tests for the `textDocument/hover` method (currently WIP)