### PR TITLE
Changed how system calls are handled when in conditional begin-end blocks

### DIFF
--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -2530,6 +2530,14 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "    a <= b.c;\n"
      "  end\n"
      "endmodule\n"},
+    {"module foo ();\nif (1) begin\n$finish(\n"
+     "      1    ); $finish    ();\n  end\nendmodule",
+     "module foo ();\n"
+     "  if (1) begin\n"
+     "    $finish(1);\n"
+     "    $finish();\n"
+     "  end\n"
+     "endmodule\n"},
     {"  module bar;for(genvar i = 0 ; i<N ; ++ i  ) begin end endmodule\n",
      "module bar;\n"
      "  for (genvar i = 0; i < N; ++i) begin\n"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -1047,6 +1047,9 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
       } else if (is_standalone_call()) {
         PushContextHint(ContextHint::kInsideStandaloneMacroCall);
         VisitIndentedSection(node, 0, PartitionPolicyEnum::kStack);
+      } else if (Context().DirectParentIs(NodeEnum::kGenerateItemList)) {
+        VisitIndentedSection(node, 0,
+                             PartitionPolicyEnum::kFitOnLineElseExpand);
       } else {
         TraverseChildren(node);
       }


### PR DESCRIPTION
This PR adds a case for system calls in conditional begin-end blocks, as the current options provide a non-conditional stack layout and don't split the calls (they exist within the same UWLine) when formatting them.

Fixes #1914 