### PR TITLE
CI: skip arm64/centos

### DIFF
--- a/.github/bin/generate-matrix.py
+++ b/.github/bin/generate-matrix.py
@@ -22,6 +22,9 @@ matrix = []
 with (Path(__file__).parent.resolve().parent.parent / 'releasing' / 'supported_bases.txt').open('r') as fptr:
     for items in [line.strip().split(':') for line in fptr.readlines()]:
         for arch in ARCHS:
+            # Temporary workaround until #1926 gets properly resolved
+            if arch == ARCHS[1] and items[0] == "centos":
+                continue
             matrix.append({
                 'os': items[0],
                 'ver': items[1],


### PR DESCRIPTION
As per #1926, this is a temporary workaround to unblock releasing until we properly resolve the underlying cause of `arm64/centos` failures.