### PR TITLE
ci: fix gh-pages deployment condition

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -590,7 +590,7 @@ jobs:
         run: ./.github/bin/github-pages-setup.sh $VERIBLE_BINDIR
 
       - name: Deployment
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.mode == 'compile'
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The documentation branch (`gh-pages`) was last updated in December 2022: https://github.com/chipsalliance/verible/tree/gh-pages. That's probably because the deployment step in the CI job does depend on `matrix.mode == 'compile'` but `matrix` is not defined in the job (https://github.com/chipsalliance/verible/blob/master/.github/workflows/verible-ci.yml#L575-L599), so the condition can never be met.

This PR removes the `matrix.mode` condition.