### PR TITLE
VSCode extension: Added possibility to provide arguments to Language Server

### DIFF
--- a/verilog/tools/ls/README.md
+++ b/verilog/tools/ls/README.md
@@ -334,3 +334,21 @@ code --install-extension verible.vsix
 ```
 
 [release]: https://github.com/chipsalliance/verible/releases
+
+#### Configuring Language Server arguments
+
+To configure the extension, in Extensions list select Verible, and select `Extension Settings`.
+In there you can find an `Arguments` setting, where you can add command-line arguments for `verible-verilog-ls` executable, e.g.:
+
+* `--rules_config_search` - search recursively for linter configuration, starting from edited file's directory.
+* `--rules_config="<path-to-config>"` - use linter configuration in a specified path
+* `--wrap_end_else_clauses` - splits `end else` into separate lines.
+* `--indentation_spaces=4` - indent width specified for the formatter.
+
+There should be one flag per item.
+
+For more language server options, check:
+
+```bash
+verible-verilog-ls --helpfull
+```

--- a/verilog/tools/ls/vscode/package.json
+++ b/verilog/tools/ls/vscode/package.json
@@ -37,6 +37,14 @@
           "default": "verible-verilog-ls",
           "scope": "machine-overridable",
           "description": "The path to verible-verilog-ls executable, e.g.: /usr/bin/verible-verilog-ls."
+        },
+        "verible.arguments": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "Arguments for verible-verilog-ls server."
         }
       }
     }

--- a/verilog/tools/ls/vscode/src/extension.ts
+++ b/verilog/tools/ls/vscode/src/extension.ts
@@ -10,11 +10,12 @@ async function initLanguageClient() {
     const config = vscode.workspace.getConfiguration('verible');
     const binary_path: string = await checkAndDownloadBinaries(config.get('path') as string, output);
 
-    const clangd: vscodelc.Executable = {
-        command: binary_path
+    const verible_ls: vscodelc.Executable = {
+        command: binary_path,
+        args: await config.get<string[]>('arguments')
     };
 
-    const serverOptions: vscodelc.ServerOptions = clangd;
+    const serverOptions: vscodelc.ServerOptions = verible_ls;
 
     // Options to control the language client
     const clientOptions: vscodelc.LanguageClientOptions = {


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/verible/issues/1916

This PR adds possibility to provide command-line arguments for `verible-verilog-ls` from the level of VSCode extension.