### PR TITLE
GH Actions: Reduced version of the Windows image to 2019

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -465,7 +465,7 @@ jobs:
         apt -qq -y install npm nodejs
 
   WindowsBuild:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
This PR changes `windows-latest` to `windows-2019` to allow Bazel to correctly find and use Visual Studio binaries. Currently, Bazel has problem with proper finding of necessary binaries to build the project with newest Visual Studio 2022 (since version `20230606.1` of `windows-2022`, with Bazel 6.2.1)