### PR TITLE
Encourage compiler to pick up openssl header from WORKSPACE first.

### DIFF
--- a/verilog/tools/kythe/kzip_creator.cc
+++ b/verilog/tools/kythe/kzip_creator.cc
@@ -14,8 +14,6 @@
 
 #include "verilog/tools/kythe/kzip_creator.h"
 
-#include <openssl/sha.h>
-
 #include <array>
 #include <cstdio>
 #include <string>
@@ -26,6 +24,7 @@
 #include "absl/strings/string_view.h"
 #include "common/util/file_util.h"
 #include "common/util/simple_zip.h"
+#include "openssl/sha.h"
 #include "third_party/proto/kythe/analysis.pb.h"
 
 namespace verilog {


### PR DESCRIPTION
Issues: #1404