### PR TITLE
Update README with min version of gcc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ guide and the [development resources](./doc/development.md).
 
 Verible's code base is written in C++.
 
-To build, you need the [bazel] (>= 4.0) build system and a C++17 compatible compiler
-(e.g. >= g++-9), as well as python3.
+To build, you need the [bazel] (>= 4.0) build system and a C++17 compatible
+compiler (e.g. >= g++-10), as well as python3.
 
 Use your package manager to install the dependencies; on a system with
 the nix package manager simply run `nix-shell` to get a build environment.
@@ -194,7 +194,8 @@ shared libraries, you can use custom config
 instead of default `gold` linker).
 
 ```bash
-# Generates statically linked executables
+# Generate statically linked executables.
+# Uses bfd linker and needs static system libs available.
 bazel build -c opt --config=create_static_linked_executables //...
 ```
 


### PR DESCRIPTION
The gcc-9 mentioned before only had c++17 compatibility as experimental feature, in particular library completeness. Suggest g++ 10 as minimum (which is already very old at this point, so should not be a problem).