### PR TITLE
Break tree_operations test into shards.

### DIFF
--- a/.github/bin/run-clang-tidy-cached.cc
+++ b/.github/bin/run-clang-tidy-cached.cc
@@ -148,7 +148,9 @@ void ClangTidyProcessFiles(const fs::path &content_dir, const std::string &cmd,
 int main(int argc, char *argv[]) {
   const std::string kProjectPrefix = "verible_";
   const std::string kSearchDir = ".";
-  const std::string kFileExcludeRe = "vscode/|external_libs/|.github/";
+  const std::string kFileExcludeRe = "vscode/|external_libs/|.github/"
+    "|tree_operations_test"  // very slow
+    "|symbol_table_test";
 
   const std::string kTidySymlink = kProjectPrefix + "clang-tidy.out";
   const fs::path cache_dir = GetCacheDir() / "clang-tidy";

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -542,17 +542,30 @@ cc_test(
     ],
 )
 
-cc_test(
-    name = "tree-operations_test",
-    srcs = ["tree_operations_test.cc"],
-    deps = [
-        ":spacer",
-        ":tree-operations",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+[
+    (
+        cc_test(
+            name = "tree-operations_" + shard + "_test",
+            srcs = ["tree_operations_test.cc"],
+            defines = ["COMPILATION_SHARD=" + shard],
+            deps = [
+                ":spacer",
+                ":tree-operations",
+                "@com_google_absl//absl/strings",
+                "@com_google_absl//absl/strings:str_format",
+                "@com_google_googletest//:gtest_main",
+            ],
+        ),
+    )
+    for shard in [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+    ]
+]
 
 cc_test(
     name = "expandable-tree-view_test",


### PR DESCRIPTION
This test puts a lot of burden on the compiler and compilation alone takes about 120 seconds or so. Break it up into shards in which only parts of the tests are ifdef'ed in in each shard. Now each shard takes around 20-25 seconds, less likely to dominate the critical compilation path.