### PR TITLE
obfuscator: add missing case in ObfuscateVerilogCodeInternal

### DIFF
--- a/verilog/transform/obfuscate.cc
+++ b/verilog/transform/obfuscate.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ static void ObfuscateVerilogCodeInternal(absl::string_view content,
         // needs to be preserved.
       case verilog_tokentype::MacroIdentifier:
       case verilog_tokentype::MacroCallId:
+      case verilog_tokentype::MacroIdItem:
         // TODO(fangism): verilog_tokentype::EscapedIdentifier
         *output << token.text()[0] << (*subst)(token.text().substr(1));
         break;

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2017-2020 The Verible Authors.
+// Copyright 2017-2023 The Verible Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,6 +94,8 @@ TEST(ObfuscateVerilogCodeTest, PreloadedSubstitutions) {
           "  BBB(); \\\n"
           "  // comment2\n",
       },
+      {"module ccc#(parameter aaa = `aaa, parameter bbb = `bbb)();endmodule",
+       "module CCC#(parameter AAA = `AAA, parameter BBB = `BBB)();endmodule"},
   };
   for (const auto &test : kTestCases) {
     std::ostringstream output;


### PR DESCRIPTION
Fixes #1985. Added a simple test case along with the fix.