### PR TITLE
Cover sha256 code with BSD-3 license. Add default_applicable_licenses to common/tools/BUILD package.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Files: *
 
                                  Apache License
                            Version 2.0, January 2004
@@ -200,3 +201,34 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+------------------
+
+Files: common/util/sha256*
+
+Copyright 2011 IETF Trust and the persons identified as authors of the code.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -4,6 +4,13 @@ load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
 load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 load("//common/tools:jcxxgen.bzl", "jcxxgen")
 
+package(
+    default_applicable_licenses = ["//:license"],
+    default_visibility = [
+        "//:__subpackages__",
+    ],
+)
+
 exports_files([
     "jcxxgen.bzl",
 ])
@@ -12,7 +19,6 @@ cc_binary(
     name = "verible-patch-tool",
     srcs = ["patch_tool.cc"],
     features = STATIC_EXECUTABLES_FEATURE,
-    visibility = ["//:__subpackages__"],
     deps = [
         "//common/strings:patch",
         "//common/util:file-util",
@@ -61,7 +67,6 @@ sh_test_with_runfiles_lib(
 cc_binary(
     name = "jcxxgen",
     srcs = ["jcxxgen.cc"],
-    visibility = ["//:__subpackages__"],
     deps = [
         "//common/util:init-command-line",
         "@com_google_absl//absl/container:flat_hash_map",


### PR DESCRIPTION
Resolve the licensing mismatch after adding sha256 code by adding the BSD-3 license to the LICENSE file (but limit it to the sha256 code). The compliance check tool is passing with this change.
Moving the code to a separate package, with a separate license didn't work -- the top level LICENSE file had to be updated anyway. This is the simplest & easiest to maintain solution.

I addition, add default_applicable_licenses to common/tools/BUILD package to silence the compliance check tool.
