### PR TITLE
Fix missing includes of standard headers.

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -132,30 +132,30 @@ ExpectedFailCount[lint:ibex]=14
 ExpectedFailCount[project:ibex]=193
 ExpectedFailCount[preprocessor:ibex]=368
 
-ExpectedFailCount[syntax:opentitan]=36
-ExpectedFailCount[lint:opentitan]=36
-ExpectedFailCount[project:opentitan]=733
-ExpectedFailCount[preprocessor:opentitan]=1957
+ExpectedFailCount[syntax:opentitan]=35
+ExpectedFailCount[lint:opentitan]=35
+ExpectedFailCount[project:opentitan]=739
+ExpectedFailCount[preprocessor:opentitan]=1978
 
 ExpectedFailCount[syntax:sv-tests]=77
 ExpectedFailCount[lint:sv-tests]=76
 ExpectedFailCount[project:sv-tests]=187
 ExpectedFailCount[preprocessor:sv-tests]=139
 
-ExpectedFailCount[syntax:caliptra-rtl]=19
-ExpectedFailCount[lint:caliptra-rtl]=19
-ExpectedFailCount[project:caliptra-rtl]=315
-ExpectedFailCount[preprocessor:caliptra-rtl]=698
+ExpectedFailCount[syntax:caliptra-rtl]=21
+ExpectedFailCount[lint:caliptra-rtl]=21
+ExpectedFailCount[project:caliptra-rtl]=324
+ExpectedFailCount[preprocessor:caliptra-rtl]=758
 
 ExpectedFailCount[syntax:Cores-VeeR-EH2]=2
 ExpectedFailCount[lint:Cores-VeeR-EH2]=2
 ExpectedFailCount[project:Cores-VeeR-EH2]=42
 ExpectedFailCount[preprocessor:Cores-VeeR-EH2]=43
 
-ExpectedFailCount[syntax:cva6]=4
-ExpectedFailCount[lint:cva6]=4
-ExpectedFailCount[project:cva6]=69
-ExpectedFailCount[preprocessor:cva6]=65
+ExpectedFailCount[syntax:cva6]=5
+ExpectedFailCount[lint:cva6]=5
+ExpectedFailCount[project:cva6]=76
+ExpectedFailCount[preprocessor:cva6]=98
 
 ExpectedFailCount[syntax:uvm]=1
 ExpectedFailCount[lint:uvm]=1
@@ -175,10 +175,10 @@ ExpectedFailCount[lint:XilinxUnisimLibrary]=4
 ExpectedFailCount[project:XilinxUnisimLibrary]=22
 ExpectedFailCount[preprocessor:XilinxUnisimLibrary]=96
 
-ExpectedFailCount[syntax:black-parrot]=156
-ExpectedFailCount[lint:black-parrot]=156
-ExpectedFailCount[project:black-parrot]=171
-ExpectedFailCount[preprocessor:black-parrot]=172
+ExpectedFailCount[syntax:black-parrot]=155
+ExpectedFailCount[lint:black-parrot]=155
+ExpectedFailCount[project:black-parrot]=170
+ExpectedFailCount[preprocessor:black-parrot]=171
 
 ExpectedFailCount[syntax:ivtest]=166
 ExpectedFailCount[lint:ivtest]=166
@@ -190,8 +190,8 @@ ExpectedFailCount[lint:nontrivial-mips]=2
 ExpectedFailCount[project:nontrivial-mips]=81
 ExpectedFailCount[preprocessor:nontrivial-mips]=78
 
-ExpectedFailCount[project:axi]=73
-ExpectedFailCount[preprocessor:axi]=70
+ExpectedFailCount[project:axi]=74
+ExpectedFailCount[preprocessor:axi]=71
 
 ExpectedFailCount[syntax:rsd]=5
 ExpectedFailCount[lint:rsd]=5
@@ -207,7 +207,7 @@ ExpectedFailCount[preprocessor:serv]=1
 ExpectedFailCount[syntax:basejump_stl]=466
 ExpectedFailCount[lint:basejump_stl]=466
 ExpectedFailCount[project:basejump_stl]=577
-ExpectedFailCount[preprocessor:basejump_stl]=610
+ExpectedFailCount[preprocessor:basejump_stl]=611
 
 # Ideally, we expect all tools to process all files with a zero exit code.
 # However, that is not always the case, so we document the current

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -507,10 +507,10 @@ jobs:
       run: bazel info
 
     - name: Run Tests
-      run: bazel test --noshow_progress --test_output=errors //...
+      run: bazel test --keep_going --noshow_progress --test_output=errors //...
 
     - name: Build Verible Binaries
-      run: bazel build --noshow_progress -c opt :install-binaries
+      run: bazel build --keep_going --noshow_progress -c opt :install-binaries
 
     - name: Prepare release
       run: |

--- a/common/analysis/citation.cc
+++ b/common/analysis/citation.cc
@@ -14,6 +14,8 @@
 
 #include "common/analysis/citation.h"
 
+#include <string>
+
 #include "absl/strings/str_cat.h"
 
 namespace verible {

--- a/common/analysis/command_file_lexer.cc
+++ b/common/analysis/command_file_lexer.cc
@@ -14,6 +14,9 @@
 
 #include "common/analysis/command_file_lexer.h"
 
+#include <algorithm>
+#include <vector>
+
 #include "absl/strings/string_view.h"
 #include "common/analysis/lint_waiver.h"
 #include "common/lexer/token_stream_adapter.h"

--- a/common/analysis/command_file_lexer.h
+++ b/common/analysis/command_file_lexer.h
@@ -27,6 +27,8 @@
 #  undef yyFlexLexer  // this is how FlexLexer.h says to do things
 #  define yyFlexLexer veribleCommandFileFlexLexer
 #  include <FlexLexer.h>
+
+#include <vector>
 #endif
 // clang-format on
 

--- a/common/analysis/file_analyzer.cc
+++ b/common/analysis/file_analyzer.cc
@@ -17,6 +17,7 @@
 #include "common/analysis/file_analyzer.h"
 
 #include <algorithm>
+#include <ostream>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
 #include <vector>

--- a/common/analysis/file_analyzer.h
+++ b/common/analysis/file_analyzer.h
@@ -41,7 +41,9 @@
 
 #include <functional>
 #include <iosfwd>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/common/analysis/line_linter_test.cc
+++ b/common/analysis/line_linter_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/analysis/lint_rule_status.cc
+++ b/common/analysis/lint_rule_status.cc
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <iterator>
 #include <ostream>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/common/analysis/lint_rule_status_test.cc
+++ b/common/analysis/lint_rule_status_test.cc
@@ -14,8 +14,11 @@
 
 #include "common/analysis/lint_rule_status.h"
 
+#include <iostream>
+#include <set>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/str_split.h"

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -22,6 +22,7 @@
 #include <map>
 #include <regex>  // NOLINT
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/common/analysis/lint_waiver.h
+++ b/common/analysis/lint_waiver.h
@@ -19,6 +19,8 @@
 #include <map>
 #include <regex>  // NOLINT
 #include <set>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/analysis/lint_waiver_test.cc
+++ b/common/analysis/lint_waiver_test.cc
@@ -15,6 +15,7 @@
 #include "common/analysis/lint_waiver.h"
 
 #include <cstddef>
+#include <set>
 #include <vector>
 
 #include "common/strings/line_column_map.h"

--- a/common/analysis/linter_test_utils.cc
+++ b/common/analysis/linter_test_utils.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <iterator>
+#include <set>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/analysis/linter_test_utils.h
+++ b/common/analysis/linter_test_utils.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <set>
 #include <sstream>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"

--- a/common/analysis/linter_test_utils_test.cc
+++ b/common/analysis/linter_test_utils_test.cc
@@ -14,6 +14,7 @@
 
 #include "common/analysis/linter_test_utils.h"
 
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/common/analysis/syntax_tree_linter_test.cc
+++ b/common/analysis/syntax_tree_linter_test.cc
@@ -15,6 +15,7 @@
 #include "common/analysis/syntax_tree_linter.h"
 
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "common/analysis/lint_rule_status.h"

--- a/common/analysis/text_structure_linter_test.cc
+++ b/common/analysis/text_structure_linter_test.cc
@@ -15,6 +15,7 @@
 #include "common/analysis/text_structure_linter.h"
 
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "absl/strings/match.h"

--- a/common/analysis/token_stream_linter_test.cc
+++ b/common/analysis/token_stream_linter_test.cc
@@ -15,6 +15,7 @@
 #include "common/analysis/token_stream_linter.h"
 
 #include <memory>
+#include <set>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/analysis/violation_handler.cc
+++ b/common/analysis/violation_handler.cc
@@ -14,6 +14,13 @@
 
 #include "common/analysis/violation_handler.h"
 
+#include <iostream>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include "absl/status/status.h"
 #include "common/strings/diff.h"
 #include "common/util/file_util.h"

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -15,11 +15,17 @@
 #include "common/formatting/align.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <numeric>
+#include <sstream>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/str_join.h"

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -16,6 +16,8 @@
 #define VERIBLE_COMMON_FORMATTING_ALIGN_H_
 
 #include <functional>
+#include <ostream>
+#include <string>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -14,6 +14,9 @@
 
 #include "common/formatting/align.h"
 
+#include <algorithm>
+#include <iterator>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/common/formatting/format_token.cc
+++ b/common/formatting/format_token.cc
@@ -14,9 +14,12 @@
 
 #include "common/formatting/format_token.h"
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>  // pragma IWYU: keep  // for ostringstream
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/base/macros.h"
 #include "absl/strings/string_view.h"

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -20,8 +20,12 @@
 #include "common/formatting/layout_optimizer.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
+#include <ios>
+#include <limits>
 #include <ostream>
+#include <utility>
 
 #include "absl/container/fixed_array.h"
 #include "common/formatting/basic_format_style.h"

--- a/common/formatting/layout_optimizer_internal.h
+++ b/common/formatting/layout_optimizer_internal.h
@@ -18,9 +18,12 @@
 #define VERIBLE_VERILOG_FORMATTING_LAYOUT_OPTIMIZER_INTERNAL_H_
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
 #include <ostream>
+#include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "absl/container/fixed_array.h"

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -14,6 +14,9 @@
 //
 #include "common/formatting/layout_optimizer.h"
 
+#include <algorithm>
+#include <limits>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/common/formatting/line_wrap_searcher.cc
+++ b/common/formatting/line_wrap_searcher.cc
@@ -15,6 +15,7 @@
 #include "common/formatting/line_wrap_searcher.h"
 
 #include <memory>
+#include <ostream>
 #include <queue>
 #include <vector>
 

--- a/common/formatting/line_wrap_searcher_test.cc
+++ b/common/formatting/line_wrap_searcher_test.cc
@@ -14,6 +14,7 @@
 
 #include "common/formatting/line_wrap_searcher.h"
 
+#include <sstream>
 #include <vector>
 
 #include "absl/strings/match.h"

--- a/common/formatting/state_node.cc
+++ b/common/formatting/state_node.cc
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <ostream>
 #include <stack>
 #include <vector>
 

--- a/common/formatting/state_node_test.cc
+++ b/common/formatting/state_node_test.cc
@@ -15,6 +15,7 @@
 #include "common/formatting/state_node.h"
 
 #include <memory>
+#include <sstream>
 #include <stack>
 #include <string>
 #include <vector>

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -14,8 +14,12 @@
 
 #include "common/formatting/token_partition_tree.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <memory>
+#include <ostream>
+#include <utility>
 #include <vector>
 
 #include "common/formatting/format_token.h"

--- a/common/formatting/tree_annotator.cc
+++ b/common/formatting/tree_annotator.cc
@@ -14,6 +14,7 @@
 
 #include "common/formatting/tree_annotator.h"
 
+#include <iterator>
 #include <vector>
 
 #include "common/text/concrete_syntax_leaf.h"

--- a/common/formatting/tree_annotator_test.cc
+++ b/common/formatting/tree_annotator_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/formatting/tree_annotator.h"
 
+#include <vector>
+
 #include "common/formatting/format_token.h"
 #include "common/text/constants.h"
 #include "common/text/token_info.h"

--- a/common/formatting/tree_unwrapper.cc
+++ b/common/formatting/tree_unwrapper.cc
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iterator>
 #include <memory>
+#include <ostream>
 #include <vector>
 
 #include "common/formatting/format_token.h"

--- a/common/formatting/tree_unwrapper_test.cc
+++ b/common/formatting/tree_unwrapper_test.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <sstream>
 #include <vector>
 
 #include "absl/strings/ascii.h"

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -15,6 +15,7 @@
 #include "common/formatting/unwrapped_line.h"
 
 #include <algorithm>
+#include <functional>
 #include <iostream>
 #include <iterator>
 #include <map>

--- a/common/formatting/unwrapped_line_test.cc
+++ b/common/formatting/unwrapped_line_test.cc
@@ -15,6 +15,7 @@
 #include "common/formatting/unwrapped_line.h"
 
 #include <iterator>
+#include <ostream>
 #include <sstream>
 #include <vector>
 

--- a/common/formatting/unwrapped_line_test_utils.h
+++ b/common/formatting/unwrapped_line_test_utils.h
@@ -15,6 +15,7 @@
 #ifndef VERIBLE_COMMON_FORMATTING_UNWRAPPED_LINE_TEST_UTILS_H_
 #define VERIBLE_COMMON_FORMATTING_UNWRAPPED_LINE_TEST_UTILS_H_
 
+#include <string>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/lexer/lexer_test_util_test.cc
+++ b/common/lexer/lexer_test_util_test.cc
@@ -16,6 +16,7 @@
 
 #include <initializer_list>
 #include <iterator>
+#include <sstream>
 #include <vector>
 
 #include "absl/strings/match.h"

--- a/common/lexer/token_stream_adapter.cc
+++ b/common/lexer/token_stream_adapter.cc
@@ -14,6 +14,8 @@
 
 #include "common/lexer/token_stream_adapter.h"
 
+#include <functional>
+
 #include "absl/status/status.h"
 #include "common/lexer/lexer.h"
 #include "common/lexer/token_generator.h"

--- a/common/lexer/token_stream_adapter_test.cc
+++ b/common/lexer/token_stream_adapter_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/lexer/token_stream_adapter.h"
 
+#include <initializer_list>
+
 #include "absl/status/status.h"
 #include "common/lexer/lexer.h"
 #include "common/lexer/lexer_test_util.h"

--- a/common/lsp/dummy-ls.cc
+++ b/common/lsp/dummy-ls.cc
@@ -31,6 +31,8 @@
 #define read(fd, buf, size) _read(fd, buf, size)
 #endif
 
+#include <iostream>
+
 using verible::lsp::BufferCollection;
 using verible::lsp::InitializeResult;
 using verible::lsp::JsonRpcDispatcher;

--- a/common/lsp/json-rpc-dispatcher.cc
+++ b/common/lsp/json-rpc-dispatcher.cc
@@ -14,6 +14,10 @@
 
 #include "common/lsp/json-rpc-dispatcher.h"
 
+#include <exception>
+#include <sstream>
+#include <string>
+
 #include "common/util/logging.h"
 
 namespace verible {

--- a/common/lsp/json-rpc-dispatcher.h
+++ b/common/lsp/json-rpc-dispatcher.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"

--- a/common/lsp/json-rpc-dispatcher_test.cc
+++ b/common/lsp/json-rpc-dispatcher_test.cc
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 #include <exception>
+#include <iostream>
+#include <stdexcept>
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"

--- a/common/lsp/json-rpc-expect.cc
+++ b/common/lsp/json-rpc-expect.cc
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <streambuf>
 #include <string>
 

--- a/common/lsp/lsp-file-utils.cc
+++ b/common/lsp/lsp-file-utils.cc
@@ -16,7 +16,9 @@
 #include "common/lsp/lsp-file-utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
+#include <string>
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"

--- a/common/lsp/lsp-file-utils.h
+++ b/common/lsp/lsp-file-utils.h
@@ -16,6 +16,8 @@
 #ifndef VERIBLE_COMMON_LSP_LSP_FILE_UTILS_H
 #define VERIBLE_COMMON_LSP_LSP_FILE_UTILS_H
 
+#include <string>
+
 #include "absl/strings/string_view.h"
 
 namespace verible::lsp {

--- a/common/lsp/lsp-file-utils_test.cc
+++ b/common/lsp/lsp-file-utils_test.cc
@@ -15,6 +15,8 @@
 
 #include "common/lsp/lsp-file-utils.h"
 
+#include <string>
+
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 

--- a/common/lsp/lsp-text-buffer.cc
+++ b/common/lsp/lsp-text-buffer.cc
@@ -14,6 +14,10 @@
 
 #include "common/lsp/lsp-text-buffer.h"
 
+#include <numeric>
+#include <string>
+#include <vector>
+
 #include "common/strings/utf8.h"
 
 namespace verible {

--- a/common/lsp/lsp-text-buffer.h
+++ b/common/lsp/lsp-text-buffer.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"

--- a/common/lsp/lsp-text-buffer_test.cc
+++ b/common/lsp/lsp-text-buffer_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/lsp/lsp-text-buffer.h"
 
+#include <string>
+
 #include "absl/strings/str_cat.h"
 #include "common/lsp/json-rpc-dispatcher.h"
 #include "gtest/gtest.h"

--- a/common/lsp/message-stream-splitter.cc
+++ b/common/lsp/message-stream-splitter.cc
@@ -17,6 +17,8 @@
 #include <algorithm>
 
 #include "absl/strings/escaping.h"
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
 #include "common/util/status_macros.h"
 
 namespace verible {

--- a/common/lsp/message-stream-splitter.h
+++ b/common/lsp/message-stream-splitter.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/strings/numbers.h"

--- a/common/lsp/message-stream-splitter_test.cc
+++ b/common/lsp/message-stream-splitter_test.cc
@@ -15,6 +15,7 @@
 #include "common/lsp/message-stream-splitter.h"
 
 #include <algorithm>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"

--- a/common/parser/parser_param.h
+++ b/common/parser/parser_param.h
@@ -20,6 +20,7 @@
 #define VERIBLE_COMMON_PARSER_PARSER_PARAM_H_
 
 #include <cstdint>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/common/strings/compare_test.cc
+++ b/common/strings/compare_test.cc
@@ -14,6 +14,9 @@
 
 #include "common/strings/compare.h"
 
+#include <map>
+#include <string>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/common/strings/diff_test.cc
+++ b/common/strings/diff_test.cc
@@ -15,7 +15,10 @@
 #include "common/strings/diff.h"
 
 #include <initializer_list>
+#include <ostream>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"

--- a/common/strings/display_utils_test.cc
+++ b/common/strings/display_utils_test.cc
@@ -16,6 +16,7 @@
 
 #include <sstream>
 #include <utility>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/common/strings/obfuscator_test.cc
+++ b/common/strings/obfuscator_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/strings/obfuscator.h"
 
+#include <string>
+
 #include "common/strings/random.h"
 #include "common/util/bijective_map.h"
 #include "common/util/logging.h"

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -14,9 +14,13 @@
 
 #include "common/strings/patch.h"
 
+#include <algorithm>
 #include <deque>
+#include <functional>
 #include <iostream>
 #include <iterator>
+#include <string>
+#include <vector>
 
 #include "absl/base/macros.h"
 #include "absl/status/status.h"

--- a/common/strings/patch_test.cc
+++ b/common/strings/patch_test.cc
@@ -16,6 +16,8 @@
 
 #include <initializer_list>
 #include <sstream>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/common/strings/range.cc
+++ b/common/strings/range.cc
@@ -15,6 +15,7 @@
 #include "common/strings/range.h"
 
 #include <algorithm>
+#include <iterator>
 #include <utility>
 
 #include "absl/strings/string_view.h"

--- a/common/strings/range_test.cc
+++ b/common/strings/range_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/strings/range.h"
 
+#include <utility>
+
 #include "common/util/range.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/common/strings/split_test.cc
+++ b/common/strings/split_test.cc
@@ -14,6 +14,10 @@
 
 #include "common/strings/split.h"
 
+#include <functional>
+#include <utility>
+#include <vector>
+
 #include "common/strings/range.h"
 #include "common/util/range.h"
 #include "gmock/gmock.h"

--- a/common/strings/string_memory_map_test.cc
+++ b/common/strings/string_memory_map_test.cc
@@ -14,6 +14,7 @@
 
 #include "common/strings/string_memory_map.h"
 
+#include <functional>
 #include <memory>
 #include <string>
 

--- a/common/text/config_utils.cc
+++ b/common/text/config_utils.cc
@@ -14,10 +14,13 @@
 
 #include "common/text/config_utils.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <initializer_list>
+#include <iterator>
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/match.h"

--- a/common/text/config_utils_test.cc
+++ b/common/text/config_utils_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/common/text/token_info.cc
+++ b/common/text/token_info.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <iterator>
+#include <ostream>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
 #include <vector>

--- a/common/text/token_info.h
+++ b/common/text/token_info.h
@@ -18,7 +18,9 @@
 #include <algorithm>   // for std::distance, std::copy
 #include <functional>  // for std::function
 #include <iosfwd>
+#include <iterator>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/text/token_info_json.cc
+++ b/common/text/token_info_json.cc
@@ -15,6 +15,7 @@
 #include "common/text/token_info_json.h"
 
 #include <sstream>
+#include <string>
 
 #include "common/text/token_info.h"
 

--- a/common/text/token_info_json_test.cc
+++ b/common/text/token_info_json_test.cc
@@ -15,6 +15,7 @@
 #include "common/text/token_info_json.h"
 
 #include <memory>
+#include <ostream>
 
 #include "absl/strings/string_view.h"
 #include "common/text/constants.h"

--- a/common/text/token_info_test.cc
+++ b/common/text/token_info_test.cc
@@ -16,6 +16,8 @@
 
 #include "common/text/token_info.h"
 
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/common/text/tree_context_visitor.h
+++ b/common/text/tree_context_visitor.h
@@ -15,6 +15,8 @@
 #ifndef VERIBLE_COMMON_TEXT_TREE_CONTEXT_VISITOR_H_
 #define VERIBLE_COMMON_TEXT_TREE_CONTEXT_VISITOR_H_
 
+#include <vector>
+
 #include "common/strings/display_utils.h"
 #include "common/text/syntax_tree_context.h"
 #include "common/text/visitors.h"

--- a/common/text/tree_context_visitor_test.cc
+++ b/common/text/tree_context_visitor_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/text/tree_context_visitor.h"
 
+#include <sstream>
+#include <utility>
 #include <vector>
 
 #include "common/text/tree_builder_test_util.h"

--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <utility>

--- a/common/text/tree_utils_test.cc
+++ b/common/text/tree_utils_test.cc
@@ -14,7 +14,9 @@
 
 #include "common/text/tree_utils.h"
 
+#include <cstddef>
 #include <memory>
+#include <ostream>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
 #include <vector>

--- a/common/tools/jcxxgen.cc
+++ b/common/tools/jcxxgen.cc
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/flags/flag.h"

--- a/common/tools/jcxxgen_test.cc
+++ b/common/tools/jcxxgen_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <exception>
+
 #include "absl/strings/match.h"
 #include "common/tools/jcxxgen_testfile.h"
 #include "gtest/gtest.h"

--- a/common/tools/patch_tool.cc
+++ b/common/tools/patch_tool.cc
@@ -15,6 +15,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <utility>
 
 #include "absl/flags/usage.h"
 #include "absl/status/status.h"

--- a/common/util/auto_iterator_test.cc
+++ b/common/util/auto_iterator_test.cc
@@ -17,6 +17,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <type_traits>
 #include <vector>
 
 #include "gmock/gmock.h"

--- a/common/util/bijective_map_test.cc
+++ b/common/util/bijective_map_test.cc
@@ -14,7 +14,10 @@
 
 #include "common/util/bijective_map.h"
 
+#include <functional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "common/strings/compare.h"
 #include "common/util/logging.h"

--- a/common/util/container_proxy_test.cc
+++ b/common/util/container_proxy_test.cc
@@ -15,7 +15,9 @@
 #include "common/util/container_proxy.h"
 
 #include <list>
+#include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "common/strings/display_utils.h"

--- a/common/util/enum_flags.h
+++ b/common/util/enum_flags.h
@@ -16,6 +16,7 @@
 #define VERIBLE_COMMON_UTIL_ENUM_FLAGS_H_
 
 #include <initializer_list>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/common/util/file_util.cc
+++ b/common/util/file_util.cc
@@ -21,9 +21,11 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <streambuf>
 #include <string>
 #include <system_error>
+#include <utility>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"

--- a/common/util/file_util.h
+++ b/common/util/file_util.h
@@ -17,6 +17,7 @@
 #ifndef VERIBLE_COMMON_UTIL_FILE_UTIL_H_
 #define VERIBLE_COMMON_UTIL_FILE_UTIL_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/common/util/file_util_test.cc
+++ b/common/util/file_util_test.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/common/util/forward_test.cc
+++ b/common/util/forward_test.cc
@@ -15,6 +15,7 @@
 #include "common/util/forward.h"
 
 #include <string>
+#include <type_traits>
 
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"

--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <string>
 #include <vector>
 
 #include "absl/debugging/failure_signal_handler.h"

--- a/common/util/init_command_line.h
+++ b/common/util/init_command_line.h
@@ -15,6 +15,7 @@
 #ifndef VERIBLE_COMMON_UTIL_INIT_COMMAND_LINE_H_
 #define VERIBLE_COMMON_UTIL_INIT_COMMAND_LINE_H_
 
+#include <string>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/util/interval_map_test.cc
+++ b/common/util/interval_map_test.cc
@@ -14,9 +14,11 @@
 
 #include "common/util/interval_map.h"
 
+#include <iterator>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/string_view.h"

--- a/common/util/interval_set.h
+++ b/common/util/interval_set.h
@@ -19,7 +19,9 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/random/random.h"
 #include "absl/strings/numbers.h"

--- a/common/util/interval_set_test.cc
+++ b/common/util/interval_set_test.cc
@@ -15,7 +15,11 @@
 #include "common/util/interval_set.h"
 
 #include <initializer_list>
+#include <iterator>
+#include <map>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/common/util/map_tree_test.cc
+++ b/common/util/map_tree_test.cc
@@ -14,8 +14,10 @@
 
 #include "common/util/map_tree.h"
 
+#include <ostream>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "absl/strings/string_view.h"
 #include "common/util/spacer.h"

--- a/common/util/range_test.cc
+++ b/common/util/range_test.cc
@@ -16,6 +16,8 @@
 
 #include <iterator>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "common/util/iterator_range.h"

--- a/common/util/sha256.cc
+++ b/common/util/sha256.cc
@@ -36,6 +36,7 @@
 #include "common/util/sha256.h"
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 #include "absl/strings/escaping.h"

--- a/common/util/sha256_test.cc
+++ b/common/util/sha256_test.cc
@@ -15,9 +15,7 @@
 #include "common/util/sha256.h"
 
 #include <array>
-#include <cstdio>
 #include <string>
-#include <vector>
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/string_view.h"

--- a/common/util/simple_zip.cc
+++ b/common/util/simple_zip.cc
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "absl/strings/string_view.h"
 #include "third_party/portable_endian/portable_endian.h"

--- a/common/util/subcommand.cc
+++ b/common/util/subcommand.cc
@@ -15,6 +15,7 @@
 #include "common/util/subcommand.h"
 
 #include <iostream>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"

--- a/common/util/subcommand.h
+++ b/common/util/subcommand.h
@@ -19,6 +19,7 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/common/util/thread_pool.cc
+++ b/common/util/thread_pool.cc
@@ -14,6 +14,10 @@
 
 #include "common/util/thread_pool.h"
 
+#include <functional>
+#include <mutex>
+#include <thread>
+
 namespace verible {
 ThreadPool::ThreadPool(int thread_count) {
   for (int i = 0; i < thread_count; ++i) {

--- a/common/util/thread_pool.h
+++ b/common/util/thread_pool.h
@@ -15,9 +15,12 @@
 #ifndef VERIBLE_COMMON_UTIL_THREAD_POOL_H
 #define VERIBLE_COMMON_UTIL_THREAD_POOL_H
 
+#include <condition_variable>
 #include <deque>
+#include <exception>
 #include <functional>
 #include <future>
+#include <mutex>
 #include <thread>
 #include <vector>
 

--- a/common/util/thread_pool_test.cc
+++ b/common/util/thread_pool_test.cc
@@ -15,6 +15,7 @@
 #include "common/util/thread_pool.h"
 
 #include <chrono>
+#include <future>
 #include <vector>
 
 #include "absl/time/clock.h"

--- a/common/util/type_traits_test.cc
+++ b/common/util/type_traits_test.cc
@@ -14,6 +14,8 @@
 
 #include "common/util/type_traits.h"
 
+#include <type_traits>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/common/util/vector_tree_iterators.h
+++ b/common/util/vector_tree_iterators.h
@@ -17,6 +17,7 @@
 #ifndef VERIBLE_COMMON_UTIL_VECTOR_TREE_ITERATORS_H_
 #define VERIBLE_COMMON_UTIL_VECTOR_TREE_ITERATORS_H_
 
+#include <cstddef>
 #include <iterator>
 
 #include "common/util/iterator_range.h"

--- a/common/util/vector_tree_iterators_test.cc
+++ b/common/util/vector_tree_iterators_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <ostream>
 #include <sstream>
 #include <type_traits>
 #include <vector>

--- a/common/util/vector_tree_test.cc
+++ b/common/util/vector_tree_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <iterator>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/verilog/CST/DPI.cc
+++ b/verilog/CST/DPI.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/CST/DPI.h"
 
+#include <vector>
+
 #include "verilog/CST/verilog_matchers.h"
 
 namespace verilog {

--- a/verilog/CST/DPI_test.cc
+++ b/verilog/CST/DPI_test.cc
@@ -15,6 +15,7 @@
 #include "verilog/CST/DPI.h"
 
 #include <utility>
+#include <vector>
 
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"

--- a/verilog/CST/class.h
+++ b/verilog/CST/class.h
@@ -18,6 +18,8 @@
 #ifndef VERIBLE_VERILOG_CST_CLASS_H_
 #define VERIBLE_VERILOG_CST_CLASS_H_
 
+#include <vector>
+
 #include "common/analysis/syntax_tree_search.h"
 #include "common/text/concrete_syntax_tree.h"
 

--- a/verilog/CST/declaration.cc
+++ b/verilog/CST/declaration.cc
@@ -17,6 +17,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/concrete_syntax_tree.h"

--- a/verilog/CST/declaration.h
+++ b/verilog/CST/declaration.h
@@ -20,6 +20,7 @@
 // of std::forward in Make* helper functions.
 
 #include <utility>
+#include <vector>
 
 #include "common/analysis/syntax_tree_search.h"
 #include "common/text/concrete_syntax_tree.h"

--- a/verilog/CST/expression.h
+++ b/verilog/CST/expression.h
@@ -20,6 +20,7 @@
 // of std::forward in Make* helper functions.
 
 #include <utility>
+#include <vector>
 
 #include "common/analysis/syntax_tree_search.h"
 #include "common/text/concrete_syntax_tree.h"

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"

--- a/verilog/CST/macro.cc
+++ b/verilog/CST/macro.cc
@@ -17,6 +17,8 @@
 
 #include "verilog/CST/macro.h"
 
+#include <vector>
+
 #include "common/text/tree_utils.h"
 #include "verilog/CST/verilog_matchers.h"
 #include "verilog/CST/verilog_nonterminals.h"

--- a/verilog/CST/macro_test.cc
+++ b/verilog/CST/macro_test.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/CST/macro.h"
 
+#include <vector>
+
 #include "common/analysis/syntax_tree_search.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"
 #include "common/text/text_structure.h"

--- a/verilog/CST/match_test_utils.cc
+++ b/verilog/CST/match_test_utils.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/CST/match_test_utils.h"
 
+#include <functional>
 #include <sstream>
 #include <vector>
 

--- a/verilog/CST/numbers.cc
+++ b/verilog/CST/numbers.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cctype>
 #include <iterator>
+#include <ostream>
 #include <string>
 
 #include "absl/strings/match.h"

--- a/verilog/CST/type.cc
+++ b/verilog/CST/type.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/CST/type.h"
 
+#include <utility>
 #include <vector>
 
 #include "common/analysis/matcher/matcher.h"

--- a/verilog/CST/verilog_tree_json.cc
+++ b/verilog/CST/verilog_tree_json.cc
@@ -14,6 +14,9 @@
 
 #include "verilog/CST/verilog_tree_json.h"
 
+#include <ostream>
+#include <utility>
+
 #include "absl/strings/string_view.h"
 #include "common/text/concrete_syntax_leaf.h"
 #include "common/text/concrete_syntax_tree.h"

--- a/verilog/analysis/checkers/always_comb_rule.cc
+++ b/verilog/analysis/checkers/always_comb_rule.cc
@@ -16,6 +16,7 @@
 
 #include <set>
 #include <string>
+#include <vector>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/analysis/checkers/always_ff_non_blocking_rule.h"
 
+#include <algorithm>
+#include <ostream>
 #include <set>
 #include <string>
 

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.h
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.h
@@ -18,6 +18,7 @@
 #include <set>
 #include <stack>
 #include <string>
+#include <vector>
 
 #include "common/analysis/lint_rule_status.h"
 #include "common/analysis/syntax_tree_lint_rule.h"

--- a/verilog/analysis/checkers/disable_statement_rule.cc
+++ b/verilog/analysis/checkers/disable_statement_rule.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/checkers/disable_statement_rule.h"
 
+#include <iterator>
 #include <set>
 #include <string>
 

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
@@ -16,6 +16,7 @@
 
 #include <set>
 #include <string>
+#include <vector>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"

--- a/verilog/analysis/checkers/numeric_format_string_style_rule.cc
+++ b/verilog/analysis/checkers/numeric_format_string_style_rule.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/checkers/numeric_format_string_style_rule.h"
 
+#include <algorithm>
 #include <set>
 #include <string>
 

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/checkers/package_filename_rule.h"
 
+#include <algorithm>
 #include <memory>
 #include <set>
 #include <string>

--- a/verilog/analysis/checkers/parameter_name_style_rule.cc
+++ b/verilog/analysis/checkers/parameter_name_style_rule.cc
@@ -16,6 +16,8 @@
 
 #include <set>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"

--- a/verilog/analysis/checkers/port_name_suffix_rule.cc
+++ b/verilog/analysis/checkers/port_name_suffix_rule.cc
@@ -14,8 +14,10 @@
 
 #include "verilog/analysis/checkers/port_name_suffix_rule.h"
 
+#include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"

--- a/verilog/analysis/checkers/suggest_parentheses_rule.h
+++ b/verilog/analysis/checkers/suggest_parentheses_rule.h
@@ -15,6 +15,8 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_SUGGEST_PARENTHESES_RULE_H_
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_SUGGEST_PARENTHESES_RULE_H_
 
+#include <set>
+
 #include "common/analysis/syntax_tree_lint_rule.h"
 #include "verilog/analysis/descriptions.h"
 

--- a/verilog/analysis/checkers/suggest_parentheses_rule_test.cc
+++ b/verilog/analysis/checkers/suggest_parentheses_rule_test.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/analysis/checkers/suggest_parentheses_rule.h"
 
+#include <initializer_list>
+
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "verilog/analysis/verilog_analyzer.h"
 

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/checkers/truncated_numeric_literal_rule.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <set>

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule_test.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule_test.cc
@@ -15,6 +15,7 @@
 #include "verilog/analysis/checkers/truncated_numeric_literal_rule.h"
 
 #include <initializer_list>
+#include <string>
 
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.cc
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"

--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule.h
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule.h
@@ -15,6 +15,7 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_UVM_MACRO_SEMICOLON_RULE_H_
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_UVM_MACRO_SEMICOLON_RULE_H_
 
+#include <set>
 #include <string>
 
 #include "common/analysis/lint_rule_status.h"

--- a/verilog/analysis/checkers/void_cast_rule_test.cc
+++ b/verilog/analysis/checkers/void_cast_rule_test.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/analysis/checkers/void_cast_rule.h"
 
+#include <initializer_list>
+
 #include "common/analysis/linter_test_utils.h"
 #include "common/analysis/syntax_tree_linter_test_utils.h"
 #include "common/text/symbol.h"

--- a/verilog/analysis/dependencies.cc
+++ b/verilog/analysis/dependencies.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/dependencies.h"
 
+#include <functional>
 #include <iostream>
 
 #include "common/strings/compare.h"

--- a/verilog/analysis/dependencies_test.cc
+++ b/verilog/analysis/dependencies_test.cc
@@ -14,6 +14,10 @@
 
 #include "verilog/analysis/dependencies.h"
 
+#include <ostream>
+#include <string>
+#include <vector>
+
 #include "absl/status/status.h"
 #include "common/util/file_util.h"
 #include "gmock/gmock.h"

--- a/verilog/analysis/extractors.cc
+++ b/verilog/analysis/extractors.cc
@@ -14,6 +14,7 @@
 
 #include "verilog/analysis/extractors.h"
 
+#include <set>
 #include <string>
 
 #include "verilog/CST/identifier.h"

--- a/verilog/analysis/extractors_test.cc
+++ b/verilog/analysis/extractors_test.cc
@@ -14,6 +14,10 @@
 
 #include "verilog/analysis/extractors.h"
 
+#include <set>
+#include <string>
+#include <utility>
+
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 

--- a/verilog/analysis/flow_tree.h
+++ b/verilog/analysis/flow_tree.h
@@ -16,8 +16,10 @@
 #define VERIBLE_VERILOG_FLOW_TREE_H_
 
 #include <bitset>
+#include <functional>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/analysis/lint_rule_registry.cc
+++ b/verilog/analysis/lint_rule_registry.cc
@@ -15,6 +15,7 @@
 #include "verilog/analysis/lint_rule_registry.h"
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -14,10 +14,14 @@
 
 #include "verilog/analysis/symbol_table.h"
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <sstream>
 #include <stack>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -18,6 +18,11 @@
 #include <functional>
 #include <iosfwd>
 #include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/verilog/analysis/verilog_analyzer.h
+++ b/verilog/analysis/verilog_analyzer.h
@@ -19,6 +19,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"

--- a/verilog/analysis/verilog_equivalence.cc
+++ b/verilog/analysis/verilog_equivalence.cc
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <iostream>
 #include <iterator>
 #include <string>

--- a/verilog/analysis/verilog_equivalence_test.cc
+++ b/verilog/analysis/verilog_equivalence_test.cc
@@ -14,8 +14,10 @@
 
 #include "verilog/analysis/verilog_equivalence.h"
 
+#include <functional>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/analysis/verilog_filelist.cc
+++ b/verilog/analysis/verilog_filelist.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/analysis/verilog_filelist.h
+++ b/verilog/analysis/verilog_filelist.h
@@ -16,6 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_VERILOG_FILELIST_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/analysis/verilog_filelist_test.cc
+++ b/verilog/analysis/verilog_filelist_test.cc
@@ -14,6 +14,9 @@
 
 #include "verilog/analysis/verilog_filelist.h"
 
+#include <string>
+#include <vector>
+
 #include "common/util/file_util.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -17,8 +17,11 @@
 #include <cstddef>
 #include <fstream>
 #include <iomanip>
+#include <ios>
 #include <map>
 #include <memory>
+#include <ostream>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -16,6 +16,7 @@
 #define VERIBLE_VERILOG_ANALYSIS_VERILOG_LINTER_H_
 
 #include <iosfwd>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -16,8 +16,10 @@
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 #include <map>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -24,6 +24,8 @@
 #include <fstream>
 #include <iterator>
 #include <memory>
+#include <ostream>
+#include <set>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>
 #include <utility>

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/analysis/verilog_project.h
+++ b/verilog/analysis/verilog_project.h
@@ -15,9 +15,12 @@
 #ifndef VERIBLE_VERILOG_ANALYSIS_VERILOG_PROJECT_H_
 #define VERIBLE_VERILOG_ANALYSIS_VERILOG_PROJECT_H_
 
+#include <algorithm>
 #include <map>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/analysis/verilog_project_test.cc
+++ b/verilog/analysis/verilog_project_test.cc
@@ -15,6 +15,9 @@
 #include "verilog/analysis/verilog_project.h"
 
 #include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "absl/strings/match.h"
 #include "common/text/text_structure.h"

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <vector>
 

--- a/verilog/formatting/comment_controls.cc
+++ b/verilog/formatting/comment_controls.cc
@@ -14,7 +14,9 @@
 
 #include "verilog/formatting/comment_controls.h"
 
+#include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <vector>
 
 #include "absl/strings/match.h"

--- a/verilog/formatting/comment_controls.h
+++ b/verilog/formatting/comment_controls.h
@@ -15,6 +15,8 @@
 #ifndef VERIBLE_VERILOG_FORMATTING_COMMENT_CONTROLS_H_
 #define VERIBLE_VERILOG_FORMATTING_COMMENT_CONTROLS_H_
 
+#include <ostream>
+
 #include "absl/strings/string_view.h"
 #include "common/strings/line_column_map.h"
 #include "common/strings/position.h"  // for ByteOffsetSet, LineNumberSet

--- a/verilog/formatting/comment_controls_test.cc
+++ b/verilog/formatting/comment_controls_test.cc
@@ -15,6 +15,8 @@
 #include "verilog/formatting/comment_controls.h"
 
 #include <initializer_list>
+#include <sstream>
+#include <utility>
 
 #include "absl/strings/str_join.h"
 #include "common/strings/line_column_map.h"

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -16,8 +16,13 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
+#include <functional>
 #include <iostream>
 #include <iterator>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/formatting/formatter.h
+++ b/verilog/formatting/formatter.h
@@ -16,6 +16,7 @@
 #define VERIBLE_VERILOG_FORMATTING_FORMATTER_H_
 
 #include <iosfwd>
+#include <string>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/formatting/formatter_test.cc
+++ b/verilog/formatting/formatter_test.cc
@@ -20,6 +20,7 @@
 
 #include "verilog/formatting/formatter.h"
 
+#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -14,7 +14,9 @@
 
 #include "verilog/formatting/token_annotator.h"
 
+#include <algorithm>
 #include <iterator>
+#include <utility>
 #include <vector>
 
 #include "absl/strings/match.h"

--- a/verilog/formatting/tree_unwrapper.cc
+++ b/verilog/formatting/tree_unwrapper.cc
@@ -15,9 +15,12 @@
 #include "verilog/formatting/tree_unwrapper.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <functional>
 #include <initializer_list>
 #include <iterator>
 #include <ostream>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/verilog/parser/verilog_lexer.cc
+++ b/verilog/parser/verilog_lexer.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/parser/verilog_lexer.h"
 
+#include <functional>
+
 #include "absl/strings/string_view.h"
 #include "common/text/token_info.h"
 #include "verilog/parser/verilog_token_enum.h"

--- a/verilog/parser/verilog_lexer.h
+++ b/verilog/parser/verilog_lexer.h
@@ -29,6 +29,8 @@
 #  undef yyFlexLexer  // this is how FlexLexer.h says to do things
 #  define yyFlexLexer verilogFlexLexer
 #  include <FlexLexer.h>
+
+#include <functional>
 #endif
 // clang-format on
 

--- a/verilog/parser/verilog_lexer_unittest.cc
+++ b/verilog/parser/verilog_lexer_unittest.cc
@@ -17,6 +17,7 @@
 
 #include <initializer_list>
 #include <utility>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "common/lexer/lexer_test_util.h"

--- a/verilog/preprocessor/verilog_preprocess.cc
+++ b/verilog/preprocessor/verilog_preprocess.cc
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <functional>
 #include <iterator>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/verilog/preprocessor/verilog_preprocess_test.cc
+++ b/verilog/preprocessor/verilog_preprocess_test.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/tools/diff/verilog_diff.cc
+++ b/verilog/tools/diff/verilog_diff.cc
@@ -21,7 +21,9 @@
 // Example usage:
 // verilog_diff [options] file1 file2
 
+#include <functional>
 #include <iostream>
+#include <map>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>   // for string, allocator, etc
 

--- a/verilog/tools/kythe/indexing_facts_tree.cc
+++ b/verilog/tools/kythe/indexing_facts_tree.cc
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 #include <iostream>
+#include <string>
+#include <tuple>
 
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"

--- a/verilog/tools/kythe/indexing_facts_tree.h
+++ b/verilog/tools/kythe/indexing_facts_tree.h
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -15,7 +15,10 @@
 #include "verilog/tools/kythe/indexing_facts_tree_extractor.h"
 
 #include <iostream>
+#include <iterator>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
@@ -16,6 +16,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "common/analysis/syntax_tree_search_test_utils.h"

--- a/verilog/tools/kythe/indexing_facts_tree_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_test.cc
@@ -15,6 +15,7 @@
 #include "verilog/tools/kythe/indexing_facts_tree.h"
 
 #include <sstream>
+#include <string>
 
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"

--- a/verilog/tools/kythe/kythe_facts.cc
+++ b/verilog/tools/kythe/kythe_facts.cc
@@ -20,6 +20,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "absl/hash/hash.h"
 #include "absl/log/check.h"

--- a/verilog/tools/kythe/kythe_proto_output.cc
+++ b/verilog/tools/kythe/kythe_proto_output.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/tools/kythe/kythe_proto_output.h"
 
+#include <string>
+
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "third_party/proto/kythe/storage.pb.h"

--- a/verilog/tools/kythe/scope_resolver.cc
+++ b/verilog/tools/kythe/scope_resolver.cc
@@ -15,6 +15,7 @@
 #include "verilog/tools/kythe/scope_resolver.h"
 
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"

--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <optional>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -15,7 +15,9 @@
 #include <deque>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <string>
+#include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/status/status.h"

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -18,6 +18,7 @@
 // Example usage:
 // verilog_lint files...
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <memory>

--- a/verilog/tools/ls/autoexpand.cc
+++ b/verilog/tools/ls/autoexpand.cc
@@ -17,6 +17,16 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"

--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -14,7 +14,13 @@
 
 #include "verilog/tools/ls/autoexpand.h"
 
+#include <algorithm>
 #include <deque>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "common/lsp/lsp-protocol.h"
 #include "gtest/gtest.h"

--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -14,6 +14,8 @@
 
 #include "verilog/tools/ls/document-symbol-filler.h"
 
+#include <string>
+
 #include "absl/flags/flag.h"
 #include "common/lsp/lsp-protocol-enums.h"
 #include "common/lsp/lsp-protocol.h"

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -15,6 +15,12 @@
 
 #include "verilog/tools/ls/lsp-parse-buffer.h"
 
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "absl/status/status.h"
 #include "common/lsp/lsp-file-utils.h"
 #include "common/util/logging.h"

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -17,6 +17,11 @@
 #define VERILOG_TOOLS_LS_LSP_PARSE_BUFFER_H
 
 #include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "common/lsp/lsp-text-buffer.h"
 #include "verilog/analysis/verilog_analyzer.h"

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -16,6 +16,10 @@
 #include "verilog/tools/ls/symbol-table-handler.h"
 
 #include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/time/clock.h"

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -18,6 +18,8 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -15,6 +15,8 @@
 #include "verilog/tools/ls/symbol-table-handler.h"
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "common/util/file_util.h"

--- a/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verilog/tools/ls/verible-lsp-adapter.cc
@@ -15,6 +15,10 @@
 
 #include "verilog/tools/ls/verible-lsp-adapter.h"
 
+#include <iterator>
+#include <string>
+#include <vector>
+
 #include "common/lsp/lsp-protocol-enums.h"
 #include "common/lsp/lsp-protocol-operators.h"
 #include "common/lsp/lsp-protocol.h"

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -15,7 +15,9 @@
 #include "verilog/tools/ls/verilog-language-server.h"
 
 #include <functional>
+#include <iostream>
 #include <memory>
+#include <string>
 
 #include "absl/flags/flag.h"
 #include "absl/strings/string_view.h"

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -15,6 +15,8 @@
 #ifndef VERILOG_TOOLS_LS_LS_WRAPPER_H
 #define VERILOG_TOOLS_LS_LS_WRAPPER_H
 
+#include <string>
+
 #include "absl/status/status.h"
 #include "common/lsp/json-rpc-dispatcher.h"
 #include "common/lsp/lsp-text-buffer.h"

--- a/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verilog/tools/ls/verilog-language-server_test.cc
@@ -14,7 +14,12 @@
 
 #include "verilog/tools/ls/verilog-language-server.h"
 
+#include <algorithm>
 #include <filesystem>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"

--- a/verilog/tools/preprocessor/verilog_preprocessor.cc
+++ b/verilog/tools/preprocessor/verilog_preprocessor.cc
@@ -15,6 +15,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/flags/flag.h"

--- a/verilog/tools/project/project_tool.cc
+++ b/verilog/tools/project/project_tool.cc
@@ -16,6 +16,8 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/usage.h"

--- a/verilog/tools/syntax/export_json_examples/BUILD
+++ b/verilog/tools/syntax/export_json_examples/BUILD
@@ -1,4 +1,6 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_library")
+load("@rules_python//python:defs.bzl", "py_test")
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -19,12 +19,14 @@
 // verilog_syntax --verilog_trace_parser files...
 
 #include <algorithm>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <memory>
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>   // for string, allocator, etc
+#include <utility>
 #include <vector>
 
 #include "absl/flags/flag.h"

--- a/verilog/transform/obfuscate.cc
+++ b/verilog/transform/obfuscate.cc
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"

--- a/verilog/transform/obfuscate.h
+++ b/verilog/transform/obfuscate.h
@@ -16,6 +16,7 @@
 #define VERIBLE_VERILOG_TRANSFORM_OBFUSCATE_H_
 
 #include <iosfwd>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"

--- a/verilog/transform/obfuscate_test.cc
+++ b/verilog/transform/obfuscate_test.cc
@@ -15,6 +15,8 @@
 #include "verilog/transform/obfuscate.h"
 
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "common/strings/obfuscator.h"
 #include "gmock/gmock.h"


### PR DESCRIPTION
This is adding all the standard headers missing in an attempt to see if this fixes #2013 ... it does not ( #2014 fixed it)
However, can't harm to have this more clean anyway :)

While at it, update the current expectations in the smoke tests.