### PR TITLE
Fix Windows LLVM to version 15 until bazel 6.4

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -500,7 +500,8 @@ jobs:
         restore-keys: bazelcache_windows2_
 
     - name: Install dependencies
-      run: choco install llvm
+      # Bazel breaks on Windows with LLVM 16. Will be fixed in bazel 6.4
+      run: choco install llvm --force --version=15.0.7
 
     - name: Debug bazel directory settings
       run: bazel info


### PR DESCRIPTION
Bazel fails with LLVM 16, which is now installed on Windows CI.

Fix version 15 for now.

The issue is [resolved in bazel](https://github.com/bazelbuild/bazel/pull/19430), but not released yet.