### PR TITLE
Fix some standard headers missed in the last PR.

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -135,7 +135,7 @@ ExpectedFailCount[preprocessor:ibex]=368
 ExpectedFailCount[syntax:opentitan]=35
 ExpectedFailCount[lint:opentitan]=35
 ExpectedFailCount[project:opentitan]=739
-ExpectedFailCount[preprocessor:opentitan]=1978
+ExpectedFailCount[preprocessor:opentitan]=1981
 
 ExpectedFailCount[syntax:sv-tests]=77
 ExpectedFailCount[lint:sv-tests]=76
@@ -152,10 +152,10 @@ ExpectedFailCount[lint:Cores-VeeR-EH2]=2
 ExpectedFailCount[project:Cores-VeeR-EH2]=42
 ExpectedFailCount[preprocessor:Cores-VeeR-EH2]=43
 
-ExpectedFailCount[syntax:cva6]=5
-ExpectedFailCount[lint:cva6]=5
-ExpectedFailCount[project:cva6]=76
-ExpectedFailCount[preprocessor:cva6]=98
+ExpectedFailCount[syntax:cva6]=6
+ExpectedFailCount[lint:cva6]=6
+ExpectedFailCount[project:cva6]=77
+ExpectedFailCount[preprocessor:cva6]=103
 
 ExpectedFailCount[syntax:uvm]=1
 ExpectedFailCount[lint:uvm]=1

--- a/common/analysis/command_file_lexer.h
+++ b/common/analysis/command_file_lexer.h
@@ -15,6 +15,8 @@
 #ifndef VERIBLE_CONFIG_FILE_LEXER_H_
 #define VERIBLE_CONFIG_FILE_LEXER_H_
 
+#include <vector>
+
 // lint_waiver_config.lex has "%prefix=verible", meaning the class flex
 // creates is veribleFlexLexer. Unfortunately, FlexLexer.h doesn't have proper
 // ifdefs around its inclusion, so we have to put a bar around it here.
@@ -27,8 +29,6 @@
 #  undef yyFlexLexer  // this is how FlexLexer.h says to do things
 #  define yyFlexLexer veribleCommandFileFlexLexer
 #  include <FlexLexer.h>
-
-#include <vector>
 #endif
 // clang-format on
 

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -17,7 +17,10 @@
 #include <charconv>
 #include <initializer_list>
 #include <list>
+#include <ostream>
+#include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "absl/strings/str_cat.h"

--- a/external_libs/editscript_test.cc
+++ b/external_libs/editscript_test.cc
@@ -14,10 +14,12 @@
 
 #include "external_libs/editscript.h"
 
+#include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "absl/strings/str_join.h"

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -2126,9 +2126,8 @@ absl::StatusOr<SymbolTableNode*> DependentReferences::ResolveOnlyBaseLocally(
   SymbolTableNode& resolved = found->second;
 
   // If metatype doesn't match what is expected, then fail.
-  const auto resolve_status = base.ResolveSymbol(resolved);
-  if (!resolve_status.ok()) {
-    return resolve_status;
+  if (absl::Status status = base.ResolveSymbol(resolved); !status.ok()) {
+    return status;
   }
   return &resolved;
 }

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -17,8 +17,10 @@
 #include <algorithm>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "absl/base/attributes.h"

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -315,9 +315,8 @@ absl::StatusOr<std::vector<LintRuleStatus>> VerilogLintTextStructure(
     const TextStructureView& text_structure) {
   // Create the linter, add rules, and run it.
   VerilogLinter linter;
-  const absl::Status configuration_status = linter.Configure(config, filename);
-  if (!configuration_status.ok()) {
-    return configuration_status;
+  if (absl::Status status = linter.Configure(config, filename); !status.ok()) {
+    return status;
   }
 
   linter.Lint(text_structure, filename);

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -106,7 +106,7 @@ std::ostream& operator<<(std::ostream& stream,
   stream << "referenced path: " << source.ReferencedPath() << std::endl;
   stream << "resolved path: " << source.ResolvedPath() << std::endl;
   stream << "corpus: " << source.Corpus() << std::endl;
-  const auto status = source.Status();
+  const absl::Status status = source.Status();
   stream << "status: " << (status.ok() ? "ok" : status.message()) << std::endl;
   const auto content = source.GetContent();
   stream << "have content? " << (!content.empty() ? "yes" : "no") << std::endl;
@@ -150,8 +150,9 @@ absl::StatusOr<VerilogSourceFile*> VerilogProject::OpenFile(
   VerilogSourceFile& file(*file_iter->second);
 
   // Read the file's contents.
-  const absl::Status status = file.Open();
-  if (!status.ok()) return status;
+  if (absl::Status status = file.Open(); !status.ok()) {
+    return status;
+  }
 
   // NOTE: string view maps don't support removal operation. The following block
   // is valid only if files won't be removed from the project.
@@ -250,8 +251,9 @@ absl::optional<absl::StatusOr<VerilogSourceFile*>>
 VerilogProject::FindOpenedFile(absl::string_view filename) const {
   const auto found = files_.find(filename);
   if (found != files_.end()) {
-    const auto status = found->second->Status();
-    if (!status.ok()) return status;
+    if (absl::Status status = found->second->Status(); !status.ok()) {
+      return status;
+    }
     return found->second.get();
   }
   return absl::nullopt;

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -209,9 +209,10 @@ bool VerifyUnwrappedLines(std::ostream* stream,
     const auto right_children = diff.right->Children().size();
     EXPECT_EQ(left_children, right_children) << "code:\n"
                                              << test_case.source_code;
-    if (first_diff_stream.str().length()) {
+    const std::string first_diff = first_diff_stream.str();
+    if (!first_diff.empty()) {
       // The Value()s at these nodes are different.
-      *stream << "value difference: " << first_diff_stream.str();
+      *stream << "value difference: " << first_diff;
     }
     return false;
   }


### PR DESCRIPTION
Make absl::Status that is to be returned non-const, so that the compiler can apply move.

Remove an unnecessary double-copy of a ostream string.