### PR TITLE
Less leakage of container type in concrete syntax tree.

### DIFF
--- a/common/analysis/matcher/matcher_test.cc
+++ b/common/analysis/matcher/matcher_test.cc
@@ -156,8 +156,8 @@ TEST(MatcherTest, BindMatcherNested) {
 static std::vector<const Symbol *> GetFirstChild(const Symbol &symbol) {
   if (symbol.Kind() == SymbolKind::kNode) {
     const auto &node = down_cast<const SyntaxTreeNode &>(symbol);
-    if (node.children().empty()) return {};
-    return {node.children()[0].get()};
+    if (node.empty()) return {};
+    return {node[0].get()};
   }
 
   return {};

--- a/common/text/concrete_syntax_tree.cc
+++ b/common/text/concrete_syntax_tree.cc
@@ -41,13 +41,13 @@ bool SyntaxTreeNode::equals(const Symbol *symbol,
 bool SyntaxTreeNode::equals(const SyntaxTreeNode *node,
                             const TokenComparator &compare_tokens) const {
   if (Tag().tag != node->Tag().tag) return false;
-  if (children_.size() != node->children().size()) {
+  if (children_.size() != node->size()) {
     return false;
   }
-  int size = children_.size();
-  for (int i = 0; i < size; i++) {
-    if (!EqualTrees(children_[i].get(), node->children()[i].get(),
-                    compare_tokens)) {
+  auto this_it = children_.begin();
+  auto other_it = node->children().begin();
+  for (/**/; this_it != children_.end(); ++this_it, ++other_it) {
+    if (!EqualTrees(this_it->get(), other_it->get(), compare_tokens)) {
       return false;
     }
   }
@@ -89,10 +89,10 @@ void SetChild_(const SymbolPtr &parent, int child_index, SymbolPtr new_child) {
   CHECK_EQ(ABSL_DIE_IF_NULL(parent)->Kind(), SymbolKind::kNode);
 
   auto *parent_node = down_cast<SyntaxTreeNode *>(parent.get());
-  CHECK_LT(child_index, static_cast<int>(parent_node->children().size()));
-  CHECK(parent_node->children()[child_index] == nullptr);
+  CHECK_LT(child_index, static_cast<int>(parent_node->size()));
+  CHECK((*parent_node)[child_index] == nullptr);
 
-  parent_node->mutable_children()[child_index] = std::move(new_child);
+  (*parent_node)[child_index] = std::move(new_child);
 }
 
 }  // namespace verible

--- a/common/text/concrete_syntax_tree_test.cc
+++ b/common/text/concrete_syntax_tree_test.cc
@@ -68,7 +68,7 @@ TEST(SyntaxTreeNodeMatchesTagAnyOf, Matches) {
 TEST(SyntaxTreeNodeAppend, AppendVoid) {
   SyntaxTreeNode node;
   node.Append();
-  EXPECT_THAT(node.children(), IsEmpty());
+  EXPECT_THAT(node, IsEmpty());
 }
 
 // Test that std::move is automated.
@@ -76,7 +76,7 @@ TEST(SyntaxTreeNodeAppend, AppendChildReference) {
   SyntaxTreeNode node;
   SymbolPtr child;
   node.Append(child);
-  EXPECT_THAT(node.children(), SizeIs(1));
+  EXPECT_THAT(node, SizeIs(1));
 }
 
 // Test that redundant move is accepted.
@@ -84,21 +84,21 @@ TEST(SyntaxTreeNodeAppend, AppendChildMoved) {
   SyntaxTreeNode node;
   SymbolPtr child;
   node.Append(std::move(child));
-  EXPECT_THAT(node.children(), SizeIs(1));
+  EXPECT_THAT(node, SizeIs(1));
 }
 
 // Test that temporary value is properly forwarded.
 TEST(SyntaxTreeNodeAppend, AppendChildTemporary) {
   SyntaxTreeNode node;
   node.Append(SymbolPtr());
-  EXPECT_THAT(node.children(), SizeIs(1));
+  EXPECT_THAT(node, SizeIs(1));
 }
 
 // Test that nullptrs can be appended.
 TEST(SyntaxTreeNodeAppend, AppendChildNullPtr) {
   SyntaxTreeNode node;
   node.Append(nullptr);
-  EXPECT_THAT(node.children(), SizeIs(1));
+  EXPECT_THAT(node, SizeIs(1));
 }
 
 // Test that ownership is transferred to sink functions.
@@ -128,14 +128,14 @@ TEST(MakeNodeTest, TaggedEmptyConstructor) {
   const int tag = 10;
   auto node = MakeTaggedNode(tag);
   ASSERT_THAT(node, NotNull());
-  EXPECT_THAT(CheckTree(node)->children(), IsEmpty());
+  EXPECT_THAT(*CheckTree(node), IsEmpty());
 }
 
 // Test construction of tagged node.
 TEST(MakeNodeTest, ImmediateTaggedEmptyConstructor) {
   auto node = MakeTaggedNode(20);
   ASSERT_THAT(node, NotNull());
-  EXPECT_THAT(CheckTree(node)->children(), IsEmpty());
+  EXPECT_THAT(*CheckTree(node), IsEmpty());
 }
 
 // Test construction of untagged node with one child.
@@ -145,14 +145,14 @@ TEST(MakeNodeTest, SingleChild) {
   auto parent = MakeNode(child);
   EXPECT_THAT(parent, NotNull());
   EXPECT_THAT(child, IsNull());
-  EXPECT_THAT(CheckTree(parent)->children(), SizeIs(1));
+  EXPECT_THAT(*CheckTree(parent), SizeIs(1));
 }
 
 // Test construction of untagged node with one (temporary) child.
 TEST(MakeNodeTest, SingleChildTemporary) {
   auto parent = MakeNode(MakeNode());
   EXPECT_THAT(parent, NotNull());
-  EXPECT_THAT(CheckTree(parent)->children(), SizeIs(1));
+  EXPECT_THAT(*CheckTree(parent), SizeIs(1));
 }
 
 // Test construction of untagged node with multiple children.
@@ -168,7 +168,7 @@ TEST(MakeNodeTest, MultiChild) {
   EXPECT_THAT(child1, IsNull());
   EXPECT_THAT(child2, IsNull());
   EXPECT_THAT(child3, IsNull());
-  EXPECT_THAT(CheckTree(parent)->children(), SizeIs(3));
+  EXPECT_THAT(*CheckTree(parent), SizeIs(3));
 }
 
 // Test ExtendNode with nothing to extend (base case).
@@ -178,7 +178,7 @@ TEST(ExtendNodeTest, ExtendNone) {
   auto seq2 = ExtendNode(seq);
   EXPECT_THAT(seq2, NotNull());
   EXPECT_THAT(seq, IsNull());
-  EXPECT_THAT(CheckTree(seq2)->children(), IsEmpty());
+  EXPECT_THAT(*CheckTree(seq2), IsEmpty());
 }
 
 // Test extending node with one child.
@@ -191,7 +191,7 @@ TEST(ExtendNodeTest, ExtendOne) {
   EXPECT_THAT(seq2, NotNull());
   EXPECT_THAT(seq, IsNull());
   EXPECT_THAT(item, IsNull());
-  EXPECT_THAT(CheckTree(seq2)->children(), SizeIs(1));
+  EXPECT_THAT(*CheckTree(seq2), SizeIs(1));
 }
 
 // Test extending node with multiple children.
@@ -210,7 +210,7 @@ TEST(ExtendNodeTest, ExtendMulti) {
   EXPECT_THAT(item1, IsNull());
   EXPECT_THAT(item2, IsNull());
   EXPECT_THAT(item3, IsNull());
-  EXPECT_THAT(CheckTree(seq2)->children(), SizeIs(3));
+  EXPECT_THAT(*CheckTree(seq2), SizeIs(3));
 }
 
 // Test extending node with multiple (temporary) children.
@@ -220,21 +220,21 @@ TEST(ExtendNodeTest, ExtendMultiTemporary) {
   auto seq2 = ExtendNode(seq, MakeNode(), MakeNode());
   ASSERT_THAT(seq2, NotNull());
   EXPECT_THAT(seq, IsNull());
-  EXPECT_THAT(CheckTree(seq2)->children(), SizeIs(2));
+  EXPECT_THAT(*CheckTree(seq2), SizeIs(2));
 }
 
 // Test extending node with temporary parent.
 TEST(ExtendNodeTest, ExtendTemporaryNodeNoChildren) {
   auto seq = ExtendNode(MakeNode());
   ASSERT_THAT(seq, NotNull());
-  EXPECT_THAT(CheckTree(seq)->children(), IsEmpty());
+  EXPECT_THAT(*CheckTree(seq), IsEmpty());
 }
 
 // Test extending node with temporary parent with temporary children.
 TEST(ExtendNodeTest, ExtendTemporaryNode) {
   auto seq = ExtendNode(MakeNode(), MakeNode(), MakeNode());
   ASSERT_THAT(seq, NotNull());
-  EXPECT_THAT(CheckTree(seq)->children(), SizeIs(2));
+  EXPECT_THAT(*CheckTree(seq), SizeIs(2));
 }
 
 // Test forwarding empty set of children to new node.
@@ -242,7 +242,7 @@ TEST(SyntaxTreeNodeAppend, AdoptChildrenNone) {
   auto seq = MakeNode();
   auto parent = MakeNode(ForwardChildren(seq));
   EXPECT_THAT(seq, IsNull());
-  EXPECT_THAT(CheckTree(parent)->children(), IsEmpty());
+  EXPECT_THAT(*CheckTree(parent), IsEmpty());
 }
 
 // Test forwarding empty set of children to new node.
@@ -250,7 +250,7 @@ TEST(SyntaxTreeNodeAppend, AdoptLeaf) {
   SymbolPtr leaf(new SyntaxTreeLeaf(0, "abc"));
   auto parent = MakeNode(ForwardChildren(leaf));
   EXPECT_THAT(leaf, IsNull());
-  EXPECT_THAT(CheckTree(parent)->children(), SizeIs(1));
+  EXPECT_THAT(*CheckTree(parent), SizeIs(1));
 }
 
 // Test forwarding set of children to new node, transferring ownership.
@@ -259,7 +259,7 @@ TEST(SyntaxTreeNodeAppend, AdoptChildren) {
   auto parent = MakeNode(ForwardChildren(seq));
   EXPECT_THAT(seq, IsNull());
   auto parentnode = CheckTree(parent);
-  EXPECT_THAT(parentnode->children(), SizeIs(3));
+  EXPECT_THAT(*parentnode, SizeIs(3));
   for (const auto &child : parentnode->children()) {
     EXPECT_THAT(child, NotNull());
   }
@@ -271,7 +271,7 @@ TEST(SyntaxTreeNodeAppend, AdoptNullChildren) {
   auto parent = MakeNode(ForwardChildren(seq));
   EXPECT_THAT(seq, IsNull());
   auto parentnode = CheckTree(parent);
-  EXPECT_THAT(parentnode->children(), SizeIs(2));
+  EXPECT_THAT(*parentnode, SizeIs(2));
   for (const auto &child : parentnode->children()) {
     EXPECT_THAT(child, IsNull());
   }
@@ -303,7 +303,7 @@ TEST(SyntaxTreeNodeAppend, AdoptChildrenMixed) {
   EXPECT_THAT(seq, IsNull());
   auto parentnode = CheckTree(parent);
   ASSERT_THAT(parentnode, NotNull());
-  EXPECT_THAT(parentnode->children(), SizeIs(5));
+  EXPECT_THAT(*parentnode, SizeIs(5));
   for (const auto &child : parentnode->children()) {
     EXPECT_THAT(child, NotNull());
   }
@@ -318,7 +318,7 @@ TEST(SyntaxTreeNodeAppend, AdoptChildrenMultiple) {
   EXPECT_THAT(seq2, IsNull());
   auto parentnode = CheckTree(parent);
   ASSERT_THAT(parentnode, NotNull());
-  EXPECT_THAT(parentnode->children(), SizeIs(7));
+  EXPECT_THAT(*parentnode, SizeIs(7));
   for (const auto &child : parentnode->children()) {
     EXPECT_THAT(child, NotNull());
   }
@@ -330,7 +330,7 @@ TEST(ExtendNodeTest, AdoptChildren) {
   auto parent = MakeNode(ForwardChildren(seq));
   EXPECT_THAT(seq, IsNull());
   auto parentnode = CheckTree(parent);
-  EXPECT_THAT(parentnode->children(), SizeIs(2));
+  EXPECT_THAT(*parentnode, SizeIs(2));
   for (const auto &child : parentnode->children()) {
     EXPECT_THAT(child, NotNull());
   }
@@ -342,7 +342,7 @@ TEST(ExtendNodeTest, AdoptChildrenMixed) {
   auto parent = ExtendNode(MakeNode(), ForwardChildren(seq), MakeNode());
   EXPECT_THAT(seq, IsNull());
   auto parentnode = CheckTree(parent);
-  EXPECT_THAT(parentnode->children(), SizeIs(4));
+  EXPECT_THAT(*parentnode, SizeIs(4));
   for (const auto &child : parentnode->children()) {
     EXPECT_THAT(child, NotNull());
   }
@@ -357,7 +357,7 @@ TEST(ExtendNodeTest, SetChild0Size1) {
   SetChild(node1, 0, node2);
   EXPECT_THAT(node1, NotNull());
   EXPECT_THAT(node2, IsNull());
-  EXPECT_THAT(CheckTree(node1)->children(), SizeIs(1));
+  EXPECT_THAT(*CheckTree(node1), SizeIs(1));
   EXPECT_TRUE(EqualTreesByEnum(expected.get(), node1.get()));
 }
 
@@ -370,7 +370,7 @@ TEST(ExtendNodeTest, SetChild1Size2) {
   SetChild(node1, 1, node2);
   EXPECT_THAT(node1, NotNull());
   EXPECT_THAT(node2, IsNull());
-  EXPECT_THAT(CheckTree(node1)->children(), SizeIs(2));
+  EXPECT_THAT(*CheckTree(node1), SizeIs(2));
   EXPECT_TRUE(EqualTreesByEnum(expected.get(), node1.get()));
 }
 

--- a/common/text/text_structure_test.cc
+++ b/common/text/text_structure_test.cc
@@ -484,9 +484,8 @@ TEST_F(TextStructureViewPublicTest, ExpandSubtreesOneLeaf) {
   std::string subtext(tokens_[0].text().data(), tokens_[0].text().length());
   std::unique_ptr<TextStructure> subanalysis(new TextStructure(subtext));
   FakeParseToken(&subanalysis->MutableData(), divide, new_node_tag);
-  auto &replacement_node = down_cast<SyntaxTreeNode *>(syntax_tree_.get())
-                               ->mutable_children()
-                               .front();
+  auto &replacement_node =
+      down_cast<SyntaxTreeNode *>(syntax_tree_.get())->front();
   TextStructureView::DeferredExpansion expansion{&replacement_node,
                                                  std::move(subanalysis)};
   // Expect tree must be built using substrings of contents_.
@@ -518,9 +517,8 @@ TEST_F(TextStructureViewPublicTest, ExpandSubtreesMultipleLeaves) {
     std::string subtext(tokens_[0].text().data(), tokens_[0].text().length());
     std::unique_ptr<TextStructure> subanalysis(new TextStructure(subtext));
     FakeParseToken(&subanalysis->MutableData(), divide1, new_node_tag1);
-    auto &replacement_node = down_cast<SyntaxTreeNode *>(syntax_tree_.get())
-                                 ->mutable_children()
-                                 .front();
+    auto &replacement_node =
+        down_cast<SyntaxTreeNode *>(syntax_tree_.get())->front();
     TextStructureView::DeferredExpansion expansion{&replacement_node,
                                                    std::move(subanalysis)};
     expansion_map[tokens_[0].left(contents_)] = std::move(expansion);
@@ -530,9 +528,8 @@ TEST_F(TextStructureViewPublicTest, ExpandSubtreesMultipleLeaves) {
     std::string subtext(tokens_[3].text().data(), tokens_[3].text().length());
     std::unique_ptr<TextStructure> subanalysis(new TextStructure(subtext));
     FakeParseToken(&subanalysis->MutableData(), divide2, new_node_tag2);
-    auto &replacement_node = down_cast<SyntaxTreeNode *>(syntax_tree_.get())
-                                 ->mutable_children()
-                                 .back();
+    auto &replacement_node =
+        down_cast<SyntaxTreeNode *>(syntax_tree_.get())->back();
     TextStructureView::DeferredExpansion expansion{&replacement_node,
                                                    std::move(subanalysis)};
     expansion_map[offset2] = std::move(expansion);

--- a/common/text/tree_builder_test_util.cc
+++ b/common/text/tree_builder_test_util.cc
@@ -28,13 +28,13 @@ SymbolPtr XLeaf(int token_enum) { return Leaf(token_enum, kDontCareText); }
 
 const Symbol *DescendPath(const Symbol &symbol,
                           std::initializer_list<size_t> path) {
-  const Symbol *node = &symbol;
+  const Symbol *node_symbol = &symbol;
   for (const auto &index : path) {
-    const auto &children = SymbolCastToNode(*ABSL_DIE_IF_NULL(node)).children();
-    CHECK_LT(index, children.size());  // bounds check, like ::at()
-    node = children[index].get();
+    const auto &node = SymbolCastToNode(*ABSL_DIE_IF_NULL(node_symbol));
+    CHECK_LT(index, node.size());  // bounds check, like ::at()
+    node_symbol = node[index].get();
   }
-  return node;
+  return node_symbol;
 }
 
 }  // namespace verible

--- a/common/text/tree_utils.cc
+++ b/common/text/tree_utils.cc
@@ -43,10 +43,9 @@ const Symbol *DescendThroughSingletons(const Symbol &symbol) {
   }
   // else is a kNode
   const auto &node = SymbolCastToNode(symbol);
-  const auto &children = node.children();
-  if (children.size() == 1 && children.front() != nullptr) {
+  if (node.size() == 1 && node.front() != nullptr) {
     // If only child is non-null, descend.
-    return DescendThroughSingletons(*children.front());
+    return DescendThroughSingletons(*node.front());
     // TODO(fangism): rewrite non-recursively.
   }
   return &symbol;

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -188,7 +188,7 @@ typename match_const<Symbol, S>::type *GetSubtreeAsSymbol(
   if (symbol.Kind() != SymbolKind::kNode) return nullptr;
   auto &node = SymbolCastToNode(symbol);
   if (!MatchNodeEnumOrNull(node, parent_must_be_node_enum)) return nullptr;
-  if (node.children().size() <= child_position) return nullptr;
+  if (node.size() <= child_position) return nullptr;
   return node[child_position].get();
 }
 

--- a/common/text/tree_utils_test.cc
+++ b/common/text/tree_utils_test.cc
@@ -36,7 +36,7 @@ namespace {
 
 // Helper function for reaching only-child node.
 const Symbol *ExpectOnlyChild(const Symbol &node) {
-  return down_cast<const SyntaxTreeNode &>(node).children()[0].get();
+  return down_cast<const SyntaxTreeNode &>(node)[0].get();
 }
 
 // Tests that leaf is considered an only-child when descending.

--- a/verilog/CST/dimensions_test.cc
+++ b/verilog/CST/dimensions_test.cc
@@ -173,7 +173,7 @@ static size_t ExtractNumDimensions(const verible::Symbol *root) {
   // Only extract from the first match.
   if (matches[0].match == nullptr) return 0;
   const auto &s = *matches[0].match;
-  return (down_cast<const verible::SyntaxTreeNode &>(s).children()).size();
+  return down_cast<const verible::SyntaxTreeNode &>(s).size();
 }
 
 // Test that number of sets of packed dimensions found is correct.

--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -79,8 +79,7 @@ const verible::Symbol *UnwrapExpression(const verible::Symbol &expr) {
 
   if (tag != NodeEnum::kExpression) return &expr;
 
-  const auto &children = node.children();
-  return children.front().get();
+  return node.front().get();
 }
 
 const verible::Symbol *GetConditionExpressionPredicate(
@@ -106,7 +105,7 @@ const verible::TokenInfo *GetUnaryPrefixOperator(
   if (!node || !MatchNodeEnumOrNull(*node, NodeEnum::kUnaryPrefixExpression)) {
     return nullptr;
   }
-  const verible::Symbol *leaf_symbol = node->children().front().get();
+  const verible::Symbol *leaf_symbol = node->front().get();
   return &verible::down_cast<const verible::SyntaxTreeLeaf *>(leaf_symbol)
               ->get();
 }
@@ -118,7 +117,7 @@ const verible::Symbol *GetUnaryPrefixOperand(const verible::Symbol &symbol) {
   if (!node || !MatchNodeEnumOrNull(*node, NodeEnum::kUnaryPrefixExpression)) {
     return nullptr;
   }
-  return node->children().back().get();
+  return node->back().get();
 }
 
 std::vector<verible::TreeSearchMatch> FindAllBinaryOperations(
@@ -164,8 +163,7 @@ static const verible::TokenInfo *ReferenceBaseIsSimple(
   // If there are parameters, it is not simple reference.
   // It is most likely a class-qualified static reference.
   return params == nullptr
-             ? &verible::SymbolCastToLeaf(*unqualified_id.children().front())
-                    .get()
+             ? &verible::SymbolCastToLeaf(*unqualified_id.front()).get()
              : nullptr;
 }
 
@@ -178,8 +176,8 @@ const verible::TokenInfo *ReferenceIsSimpleIdentifier(
       verible::CheckSymbolAsNode(reference, NodeEnum::kReference));
   // A simple reference contains one component without hierarchy, indexing, or
   // calls; it looks like just an identifier.
-  if (reference_node.children().size() > 1) return nullptr;
-  const auto &base_symbol = reference_node.children().front();
+  if (reference_node.size() > 1) return nullptr;
+  const auto &base_symbol = reference_node.front();
   if (!base_symbol) return nullptr;
   const auto &base_node = verible::SymbolCastToNode(*base_symbol);
   if (!base_node.MatchesTag(NodeEnum::kLocalRoot)) return nullptr;

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -177,7 +177,6 @@ TEST(AssociativeBinaryExpressionsTest, ThreeFlatOperands) {
           for (const auto& match : matches) {
             // "A op B op C" is 5 sibling tokens, due to flattening
             EXPECT_EQ(verible::SymbolCastToNode(*ABSL_DIE_IF_NULL(match.match))
-                          .children()
                           .size(),
                       5);
           }

--- a/verilog/CST/macro.cc
+++ b/verilog/CST/macro.cc
@@ -79,8 +79,7 @@ const SyntaxTreeNode *GetMacroCallArgs(const Symbol &s) {
 
 bool MacroCallArgsIsEmpty(const SyntaxTreeNode &args) {
   const auto &sub =
-      ABSL_DIE_IF_NULL(MatchNodeEnumOrNull(args, NodeEnum::kMacroArgList))
-          ->children();
+      *ABSL_DIE_IF_NULL(MatchNodeEnumOrNull(args, NodeEnum::kMacroArgList));
   // Empty macro args are always constructed with one nullptr child in
   // the semantic actions in verilog.y.
   if (sub.size() != 1) return false;

--- a/verilog/CST/module.cc
+++ b/verilog/CST/module.cc
@@ -63,7 +63,7 @@ const SyntaxTreeNode *GetModuleHeader(const Symbol &module_declaration) {
   const SyntaxTreeNode &module_node =
       verible::SymbolCastToNode(module_declaration);
   if (!IsModuleOrInterfaceOrProgramDeclaration(module_node)) return nullptr;
-  if (module_node.children().empty()) return nullptr;
+  if (module_node.empty()) return nullptr;
   return &verible::SymbolCastToNode(*module_node[0].get());
 }
 
@@ -127,7 +127,7 @@ const verible::SyntaxTreeNode *GetModuleItemList(
   const SyntaxTreeNode &module_node =
       verible::SymbolCastToNode(module_declaration);
   if (!IsModuleOrInterfaceOrProgramDeclaration(module_node)) return nullptr;
-  if (module_node.children().size() < 2) return nullptr;
+  if (module_node.size() < 2) return nullptr;
   verible::Symbol *item = module_node[1].get();
   return item ? &verible::SymbolCastToNode(*item) : nullptr;
 }

--- a/verilog/CST/port.cc
+++ b/verilog/CST/port.cc
@@ -150,7 +150,7 @@ const SyntaxTreeLeaf *GetIdentifierFromTaskFunctionPortItem(
   const auto *type_id_dimensions =
       GetTypeIdDimensionsFromTaskFunctionPortItem(symbol);
   if (!type_id_dimensions) return nullptr;
-  if (type_id_dimensions->children().size() <= 1) return nullptr;
+  if (type_id_dimensions->size() <= 1) return nullptr;
   const auto *port_item = (*type_id_dimensions)[1].get();
   return port_item ? AutoUnwrapIdentifier(*port_item) : nullptr;
 }

--- a/verilog/CST/seq_block.cc
+++ b/verilog/CST/seq_block.cc
@@ -33,17 +33,17 @@ using verible::TokenInfo;
 // kLabel could be prefix "label :" or suffix ": label".  Handle both cases.
 static const verible::SyntaxTreeLeaf &GetLabelLeafText(const Symbol &label) {
   const auto &node = CheckSymbolAsNode(label, NodeEnum::kLabel);
-  CHECK_EQ(node.children().size(), 2);
-  if (node.children().front()->Tag() ==
+  CHECK_EQ(node.size(), 2);
+  if (node.front()->Tag() ==
       verible::SymbolTag{verible::SymbolKind::kLeaf, ':'}) {
-    return verible::SymbolCastToLeaf(*node.children().back());
+    return verible::SymbolCastToLeaf(*node.back());
   }
-  CHECK((node.children().back()->Tag() ==
+  CHECK((node.back()->Tag() ==
          verible::SymbolTag{verible::SymbolKind::kLeaf, ':'}));
   // in verilog.y, a prefix label could be an unqualified_id (to avoid grammar
   // conflicts), so descend to the leftmost leaf.
   return verible::SymbolCastToLeaf(
-      *ABSL_DIE_IF_NULL(verible::GetLeftmostLeaf(*node.children().front())));
+      *ABSL_DIE_IF_NULL(verible::GetLeftmostLeaf(*node.front())));
 }
 
 // Return tehe optional label node from a kBegin node.
@@ -52,17 +52,16 @@ static const verible::SyntaxTreeLeaf &GetLabelLeafText(const Symbol &label) {
 //   label : begin  (shaped as [[label :] begin])
 static const SyntaxTreeNode *GetBeginLabel(const Symbol &begin) {
   const auto &node = CheckSymbolAsNode(begin, NodeEnum::kBegin);
-  CHECK_EQ(node.children().size(), 2);
-  if (node.children().front()->Tag() ==
-      verible::SymbolTag{verible::SymbolKind::kLeaf,
-                         verilog_tokentype::TK_begin}) {
-    return verible::CheckOptionalSymbolAsNode(node.children().back().get(),
+  CHECK_EQ(node.size(), 2);
+  if (node.front()->Tag() == verible::SymbolTag{verible::SymbolKind::kLeaf,
+                                                verilog_tokentype::TK_begin}) {
+    return verible::CheckOptionalSymbolAsNode(node.back().get(),
                                               NodeEnum::kLabel);
   }
-  CHECK((node.children().back()->Tag() ==
-         verible::SymbolTag{verible::SymbolKind::kLeaf,
-                            verilog_tokentype::TK_begin}));
-  return verible::CheckOptionalSymbolAsNode(node.children().front().get(),
+  CHECK(
+      (node.back()->Tag() == verible::SymbolTag{verible::SymbolKind::kLeaf,
+                                                verilog_tokentype::TK_begin}));
+  return verible::CheckOptionalSymbolAsNode(node.front().get(),
                                             NodeEnum::kLabel);
 }
 
@@ -87,7 +86,7 @@ const TokenInfo *GetEndLabelTokenInfo(const Symbol &symbol) {
 const Symbol *GetMatchingEnd(const Symbol &symbol,
                              const SyntaxTreeContext &context) {
   CHECK_EQ(NodeEnum(symbol.Tag().tag), NodeEnum::kBegin);
-  return context.top().children().back().get();
+  return context.top().back().get();
 }
 
 }  // namespace verilog

--- a/verilog/CST/statement.cc
+++ b/verilog/CST/statement.cc
@@ -50,7 +50,7 @@ static const SyntaxTreeNode *GetGenericStatementBody(
   if (!node) return node;
   // In most controlled constructs, the controlled statement body is
   // in tail position.  Exceptions include: DoWhile.
-  return &SymbolCastToNode(*node->children().back());
+  return &SymbolCastToNode(*node->back());
 }
 
 const SyntaxTreeNode *GetIfClauseGenerateBody(const Symbol &if_clause) {
@@ -82,8 +82,8 @@ const SyntaxTreeNode *GetConditionalGenerateElseClause(
     const Symbol &conditional) {
   const auto *node = MatchNodeEnumOrNull(
       SymbolCastToNode(conditional), NodeEnum::kConditionalGenerateConstruct);
-  if (!node || node->children().size() < 2) return nullptr;
-  const Symbol *else_ptr = node->children().back().get();
+  if (!node || node->size() < 2) return nullptr;
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kGenerateElseClause);
@@ -113,8 +113,8 @@ const SyntaxTreeNode *GetConditionalStatementElseClause(
     const Symbol &conditional) {
   const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(conditional),
                                          NodeEnum::kConditionalStatement);
-  if (!node || node->children().size() < 2) return nullptr;
-  const Symbol *else_ptr = node->children().back().get();
+  if (!node || node->size() < 2) return nullptr;
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
@@ -139,7 +139,7 @@ const SyntaxTreeNode *GetAssertionStatementElseClause(
     const Symbol &assertion_statement) {
   const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(assertion_statement),
                                          NodeEnum::kAssertionStatement);
-  const Symbol *else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
@@ -165,7 +165,7 @@ const SyntaxTreeNode *GetAssumeStatementElseClause(
   const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(assume_statement),
                                          NodeEnum::kAssumeStatement);
   if (!node) return nullptr;
-  const Symbol *else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
@@ -209,7 +209,7 @@ const SyntaxTreeNode *GetAssertPropertyStatementElseClause(
       MatchNodeEnumOrNull(SymbolCastToNode(assert_property_statement),
                           NodeEnum::kAssertPropertyStatement);
   if (!node) return nullptr;
-  const Symbol *else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
@@ -237,7 +237,7 @@ const SyntaxTreeNode *GetAssumePropertyStatementElseClause(
       MatchNodeEnumOrNull(SymbolCastToNode(assume_property_statement),
                           NodeEnum::kAssumePropertyStatement);
   if (!node) return nullptr;
-  const Symbol *else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
@@ -265,7 +265,7 @@ const SyntaxTreeNode *GetExpectPropertyStatementElseClause(
       MatchNodeEnumOrNull(SymbolCastToNode(expect_property_statement),
                           NodeEnum::kExpectPropertyStatement);
   if (!node) return nullptr;
-  const Symbol *else_ptr = node->children().back().get();
+  const Symbol *else_ptr = node->back().get();
   if (else_ptr == nullptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);

--- a/verilog/CST/type_test.cc
+++ b/verilog/CST/type_test.cc
@@ -339,7 +339,7 @@ TEST(GetVariableDeclaration, FindPackedDimensionFromDataDeclaration) {
             const auto *packed_dimension =
                 GetPackedDimensionFromDataDeclaration(*decl.match);
             if (packed_dimension == nullptr) continue;
-            if (packed_dimension->children().empty()) continue;
+            if (packed_dimension->empty()) continue;
             packed_dimensions.emplace_back(
                 TreeSearchMatch{packed_dimension, {/* ignored context */}});
           }

--- a/verilog/CST/verilog_treebuilder_utils_test.cc
+++ b/verilog/CST/verilog_treebuilder_utils_test.cc
@@ -27,14 +27,14 @@ using verible::Leaf;
 TEST(MakeParenGroupTest, Normal) {
   const auto node =
       MakeParenGroup(Leaf('(', "("), Leaf(1, "1"), Leaf(')', ")"));
-  EXPECT_EQ(verible::SymbolCastToNode(*node).children().size(), 3);
+  EXPECT_EQ(verible::SymbolCastToNode(*node).size(), 3);
 }
 
 TEST(MakeParenGroupTest, ErrorRecovered) {
   const auto node1 = MakeParenGroup(Leaf('(', "("), nullptr, Leaf(')', ")"));
-  EXPECT_EQ(verible::SymbolCastToNode(*node1).children().size(), 3);
+  EXPECT_EQ(verible::SymbolCastToNode(*node1).size(), 3);
   const auto node2 = MakeParenGroup(Leaf('(', "("), nullptr, nullptr);
-  EXPECT_EQ(verible::SymbolCastToNode(*node2).children().size(), 3);
+  EXPECT_EQ(verible::SymbolCastToNode(*node2).size(), 3);
 }
 
 TEST(MakeParenGroupTest, MissingOpenParen) {

--- a/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
+++ b/verilog/analysis/checkers/always_ff_non_blocking_rule.cc
@@ -109,7 +109,7 @@ void AlwaysFFNonBlockingRule::HandleSymbol(const verible::Symbol &symbol,
             verible::down_cast<const verible::SyntaxTreeNode *>(&symbol)) {
       check_root =
           /* lhs */ verible::down_cast<const verible::SyntaxTreeNode *>(
-              node->children()[0].get());
+              node->front().get());
     }
   } else {
     // Not interested in any other blocking assignments unless flagged
@@ -120,7 +120,7 @@ void AlwaysFFNonBlockingRule::HandleSymbol(const verible::Symbol &symbol,
               verible::down_cast<const verible::SyntaxTreeNode *>(&symbol)) {
         check_root =
             /* lhs */ verible::down_cast<const verible::SyntaxTreeNode *>(
-                node->children()[0].get());
+                node->front().get());
       }
     } else if (asgn_incdec_matcher.Matches(symbol, &symbol_man)) {
       check_root = &symbol;
@@ -145,7 +145,7 @@ void AlwaysFFNonBlockingRule::HandleSymbol(const verible::Symbol &symbol,
               verible::down_cast<const verible::SyntaxTreeNode *>(var.match)) {
         if (const auto *const ident =
                 verible::down_cast<const verible::SyntaxTreeLeaf *>(
-                    varn->children()[0].get())) {
+                    varn->front().get())) {
           found = std::find(locals_.begin(), locals_.end(),
                             ident->get().text()) != locals_.end();
           VLOG(4) << "LHS='" << ident->get().text() << "' FOUND=" << found
@@ -211,7 +211,7 @@ bool AlwaysFFNonBlockingRule::LocalDeclaration(const verible::Symbol &symbol) {
               verible::down_cast<const verible::SyntaxTreeNode *>(var.match)) {
         if (const auto *const ident =
                 verible::down_cast<const verible::SyntaxTreeLeaf *>(
-                    node->children()[0].get())) {
+                    node->front().get())) {
           const absl::string_view name = ident->get().text();
           VLOG(4) << "Registering '" << name << '\'' << std::endl;
           locals_.emplace_back(name);

--- a/verilog/analysis/checkers/create_object_name_match_rule.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule.cc
@@ -88,10 +88,10 @@ static const Matcher &CreateAssignmentMatcher() {
 static bool UnqualifiedIdEquals(const SyntaxTreeNode &node,
                                 absl::string_view name) {
   if (node.MatchesTag(NodeEnum::kUnqualifiedId)) {
-    if (!node.children().empty()) {
+    if (!node.empty()) {
       // The one-and-only child is the SymbolIdentifier token
       const auto &leaf_ptr =
-          down_cast<const SyntaxTreeLeaf *>(node.children().front().get());
+          down_cast<const SyntaxTreeLeaf *>(node.front().get());
       if (leaf_ptr != nullptr) {
         const TokenInfo &token = leaf_ptr->get();
         return token.token_enum() == SymbolIdentifier && token.text() == name;
@@ -105,16 +105,15 @@ static bool UnqualifiedIdEquals(const SyntaxTreeNode &node,
 // TODO(fangism): Refactor into QualifiedCallEndsWith().
 static bool QualifiedCallIsTypeIdCreate(
     const SyntaxTreeNode &qualified_id_node) {
-  const auto &children = qualified_id_node.children();
-  const size_t num_children = children.size();
+  const size_t num_children = qualified_id_node.size();
   // Allow for more than 3 segments, in case of package qualification, e.g.
   // my_pkg::class_type::type_id::create.
   // 5: 3 segments + 2 separators (in alternation), e.g. A::B::C
-  if (qualified_id_node.children().size() >= 5) {
+  if (qualified_id_node.size() >= 5) {
     const auto *create_leaf_ptr =
-        down_cast<const SyntaxTreeNode *>(children.back().get());
-    const auto *type_id_leaf_ptr =
-        down_cast<const SyntaxTreeNode *>(children[num_children - 3].get());
+        down_cast<const SyntaxTreeNode *>(qualified_id_node.back().get());
+    const auto *type_id_leaf_ptr = down_cast<const SyntaxTreeNode *>(
+        qualified_id_node[num_children - 3].get());
     if (create_leaf_ptr != nullptr && type_id_leaf_ptr != nullptr) {
       return UnqualifiedIdEquals(*create_leaf_ptr, "create") &&
              UnqualifiedIdEquals(*type_id_leaf_ptr, "type_id");
@@ -140,13 +139,12 @@ static const TokenInfo *ExtractStringLiteralToken(
   if (!expr_node.MatchesTag(NodeEnum::kExpression)) return nullptr;
 
   // this check is limited to only checking string literal leaf tokens
-  if (expr_node.children().front().get()->Kind() !=
-      verible::SymbolKind::kLeaf) {
+  if (expr_node.front().get()->Kind() != verible::SymbolKind::kLeaf) {
     return nullptr;
   }
 
   const auto *leaf_ptr =
-      down_cast<const SyntaxTreeLeaf *>(expr_node.children().front().get());
+      down_cast<const SyntaxTreeLeaf *>(expr_node.front().get());
   if (leaf_ptr != nullptr) {
     const TokenInfo &token = leaf_ptr->get();
     if (token.token_enum() == TK_StringLiteral) {
@@ -159,8 +157,8 @@ static const TokenInfo *ExtractStringLiteralToken(
 // Returns the first expression from an argument list, if it exists.
 static const SyntaxTreeNode *GetFirstExpressionFromArgs(
     const SyntaxTreeNode &args_node) {
-  if (!args_node.children().empty()) {
-    const auto &first_arg = args_node.children().front();
+  if (!args_node.empty()) {
+    const auto &first_arg = args_node.front();
     if (const auto *first_expr =
             down_cast<const SyntaxTreeNode *>(first_arg.get())) {
       return first_expr;

--- a/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
+++ b/verilog/analysis/checkers/truncated_numeric_literal_rule.cc
@@ -158,11 +158,10 @@ void TruncatedNumericLiteralRule::HandleSymbol(
   size_t width;
   if (!absl::SimpleAtoi(width_text, &width)) return;
 
-  const auto &base_digit_part = literal_node->children();
   const auto *base_leaf =
-      down_cast<const SyntaxTreeLeaf *>(base_digit_part[0].get());
+      down_cast<const SyntaxTreeLeaf *>((*literal_node)[0].get());
   const auto *digits_leaf =
-      down_cast<const SyntaxTreeLeaf *>(base_digit_part[1].get());
+      down_cast<const SyntaxTreeLeaf *>((*literal_node)[1].get());
 
   const auto base_text = base_leaf->get().text();
   const auto digits_text = digits_leaf->get().text();

--- a/verilog/analysis/checkers/undersized_binary_literal_rule.cc
+++ b/verilog/analysis/checkers/undersized_binary_literal_rule.cc
@@ -96,11 +96,10 @@ void UndersizedBinaryLiteralRule::HandleSymbol(
   size_t width;
   if (!absl::SimpleAtoi(width_text, &width)) return;
 
-  const auto& base_digit_part = literal_node->children();
   const auto* base_leaf =
-      down_cast<const SyntaxTreeLeaf*>(base_digit_part[0].get());
+      down_cast<const SyntaxTreeLeaf*>((*literal_node)[0].get());
   const auto* digits_leaf =
-      down_cast<const SyntaxTreeLeaf*>(base_digit_part[1].get());
+      down_cast<const SyntaxTreeLeaf*>((*literal_node)[1].get());
 
   const auto base_text = base_leaf->get().text();
   const auto digits_text = digits_leaf->get().text();

--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -873,8 +873,7 @@ class SymbolTable::Builder : public TreeContextVisitor {
         Context().NearestParentWithTag(NodeEnum::kQualifiedId);
     const SyntaxTreeNode* unqualified_id =
         Context().NearestParentWithTag(NodeEnum::kUnqualifiedId);
-    return ABSL_DIE_IF_NULL(qualified_id)->children().back().get() ==
-           unqualified_id;
+    return ABSL_DIE_IF_NULL(qualified_id)->back().get() == unqualified_id;
   }
 
   bool ExtendedCallIsLast() const {

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -359,7 +359,7 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
       case NodeEnum::kDimensionRange:
       case NodeEnum::kDimensionSlice: {
         CHECK_NOTNULL(current_dimensions_group_);
-        CHECK_EQ(node.children().size(), 5);
+        CHECK_EQ(node.size(), 5);
 
         SyntaxTreePath dimension_path = Path();
         const bool right_align =
@@ -367,8 +367,7 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
                 ? style_.port_declarations_right_align_packed_dimensions
                 : style_.port_declarations_right_align_unpacked_dimensions;
         if (right_align) {
-          dimension_path.back() +=
-              kMaxPathIndex - Context().top().children().size();
+          dimension_path.back() += kMaxPathIndex - Context().top().size();
         }
 
         const verible::AlignmentColumnProperties no_border(false, 0);
@@ -385,7 +384,7 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
       case NodeEnum::kDimensionScalar:
       case NodeEnum::kDimensionAssociativeType: {
         CHECK_NOTNULL(current_dimensions_group_);
-        CHECK_EQ(node.children().size(), 3);
+        CHECK_EQ(node.size(), 3);
 
         SyntaxTreePath dimension_path = Path();
         const bool right_align =
@@ -393,8 +392,7 @@ class PortDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
                 ? style_.port_declarations_right_align_packed_dimensions
                 : style_.port_declarations_right_align_unpacked_dimensions;
         if (right_align) {
-          dimension_path.back() +=
-              kMaxPathIndex - Context().top().children().size();
+          dimension_path.back() += kMaxPathIndex - Context().top().size();
         }
 
         const verible::AlignmentColumnProperties no_border(false, 0);
@@ -731,7 +729,7 @@ class DataDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
         break;
       }
       case NodeEnum::kDimensionScalar: {
-        CHECK_EQ(node.children().size(), 3);
+        CHECK_EQ(node.size(), 3);
         auto* column = ABSL_DIE_IF_NULL(ReserveNewColumn(node, FlushLeft));
 
         ReserveNewColumn(column, *node[0], FlushLeft);   // '['
@@ -740,7 +738,7 @@ class DataDeclarationColumnSchemaScanner : public VerilogColumnSchemaScanner {
         return;
       }
       case NodeEnum::kDimensionRange: {
-        CHECK_EQ(node.children().size(), 5);
+        CHECK_EQ(node.size(), 5);
         auto* column = ABSL_DIE_IF_NULL(ReserveNewColumn(node, FlushRight));
 
         // The value returned from this call can be used to
@@ -859,7 +857,7 @@ class ClassPropertyColumnSchemaScanner : public VerilogColumnSchemaScanner {
         break;
       }
       case NodeEnum::kDimensionScalar: {
-        CHECK_EQ(node.children().size(), 3);
+        CHECK_EQ(node.size(), 3);
         auto* column = ABSL_DIE_IF_NULL(ReserveNewColumn(node, FlushLeft));
 
         ReserveNewColumn(column, *node[0], FlushLeft);   // '['
@@ -868,7 +866,7 @@ class ClassPropertyColumnSchemaScanner : public VerilogColumnSchemaScanner {
         return;
       }
       case NodeEnum::kDimensionRange: {
-        CHECK_EQ(node.children().size(), 5);
+        CHECK_EQ(node.size(), 5);
         auto* column = ABSL_DIE_IF_NULL(ReserveNewColumn(node, FlushLeft));
 
         SyntaxTreePath np;
@@ -1229,7 +1227,7 @@ class DistItemColumnSchemaScanner : public VerilogColumnSchemaScanner {
         if (!Context().DirectParentIs(NodeEnum::kDistributionItem)) {
           break;
         }
-        CHECK_EQ(node.children().size(), 5);
+        CHECK_EQ(node.size(), 5);
         CHECK_NOTNULL(item_column_);
         ReserveNewColumn(item_column_, *node[0], FlushLeft,
                          GetSubpath(Path(), {0}));  // '['

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -103,7 +103,7 @@ static SymbolPtr ExtendFirstSublist(SymbolPtr& pair, SymbolPtr item) {
 static SymbolPtr ExtendLastSublist(SymbolPtr& list, SymbolPtr& item) {
   auto& list_node = down_cast<SyntaxTreeNode&>(*list);
   auto& last_sublist = down_cast<SyntaxTreeNode&>(
-      *list_node.mutable_children().back());
+      *list_node.back());
   last_sublist.Append(std::move(item));
   return std::move(list);
 }
@@ -117,8 +117,7 @@ static SymbolPtr ExtendLastSublistWithSeparator(
   auto& separator = pair_node[1];
   /* Extend the last sublist. */
   auto& list_node = down_cast<SyntaxTreeNode&>(*list);
-  auto& sublist_node = down_cast<SyntaxTreeNode&>(
-      *list_node.mutable_children().back());
+  auto& sublist_node = down_cast<SyntaxTreeNode&>(*list_node.back());
   sublist_node.Append(std::move(separator), std::move(item));
   return std::move(list);
 }

--- a/verilog/tools/kythe/indexing_facts_tree_extractor.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor.cc
@@ -906,10 +906,10 @@ void IndexingFactsTreeExtractor::ExtractModuleInstantiation(
       const verible::Symbol *reference =
           GetSubtreeAsSymbol(*type, NodeEnum::kInstantiationType, 0);
       if (reference->Tag().tag == (int)NodeEnum::kReference &&
-          SymbolCastToNode(*reference).children().size() > 1) {
+          SymbolCastToNode(*reference).size() > 1) {
         const auto &children = SymbolCastToNode(*reference).children();
         for (auto &child :
-             verible::make_range(children.begin() + 1, children.end())) {
+             verible::make_range(++children.begin(), children.end())) {
           if (child->Tag().tag == (int)NodeEnum::kHierarchyExtension) {
             Visit(verible::SymbolCastToNode(*child));
           }
@@ -1298,8 +1298,8 @@ void IndexingFactsTreeExtractor::ExtractFunctionOrTaskOrConstructorPort(
 void IndexingFactsTreeExtractor::ExtractFunctionOrTaskCall(
     const SyntaxTreeNode &function_call_node) {
   // check if this node contains an actual call
-  if (!function_call_node.children().empty() &&
-      SymbolCastToNode(*function_call_node.children()[0])
+  if (!function_call_node.empty() &&
+      SymbolCastToNode(*function_call_node[0])
           .MatchesTagAnyOf({NodeEnum::kReference, NodeEnum::kMacroCall})) {
     TreeContextVisitor::Visit(function_call_node);
     return;
@@ -1325,10 +1325,10 @@ void IndexingFactsTreeExtractor::ExtractFunctionOrTaskCall(
     const verible::Symbol *reference = GetSubtreeAsSymbol(
         *reference_call_base, NodeEnum::kReferenceCallBase, 0);
     if (reference->Tag().tag == (int)NodeEnum::kReference) {
-      if (SymbolCastToNode(*reference).children().size() > 1) {
+      if (SymbolCastToNode(*reference).size() > 1) {
         const auto &children = SymbolCastToNode(*reference).children();
         for (auto &child :
-             verible::make_range(children.begin() + 1, children.end())) {
+             verible::make_range(++children.begin(), children.end())) {
           if (child->Tag().tag == (int)NodeEnum::kHierarchyExtension) {
             Visit(verible::SymbolCastToNode(*child));
           }

--- a/verilog/tools/ls/autoexpand.cc
+++ b/verilog/tools/ls/autoexpand.cc
@@ -962,8 +962,7 @@ std::vector<AutoExpander::Dimension> GetDimensionsFromNodes(
     for (const auto &scalar :
          SearchSyntaxTree(*dimension.match, NodekDimensionScalar())) {
       size_t size;
-      const Symbol &scalar_value =
-          *SymbolCastToNode(*scalar.match).children()[1];
+      const Symbol &scalar_value = *SymbolCastToNode(*scalar.match)[1];
       const absl::string_view span = StringSpanOfSymbol(scalar_value);
       const bool result = absl::SimpleAtoi(span, &size);
       dimensions.push_back(result ? Dimension{size} : Dimension{span});

--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -88,8 +88,8 @@ void DocumentSymbolFiller::Visit(const verible::SyntaxTreeNode &node) {
 
     case verilog::NodeEnum::kSeqBlock:
     case verilog::NodeEnum::kGenerateBlock:
-      if (!node.children().empty()) {
-        const auto &begin = node.children().front().get();
+      if (!node.empty()) {
+        const auto &begin = node.front().get();
         if (begin) {
           if (const auto *token = GetBeginLabelTokenInfo(*begin); token) {
             is_visible_node = true;


### PR DESCRIPTION
Reduces the leaky abstraction of handing out children() by `SyntaxTreeNode`, but provide operations to work on them: `front()`, `back()`, `operator[]`.

This change does not get rid of handing out `children()` entirely yet, as they are used in range loops, this will be a separate change.

Reducing the abstraction leak will make it easier to change that implementation later (e.g. for issue #1523)