### PR TITLE
SymbolTable: Gracefully handle current CHECK-fail

### DIFF
--- a/verilog/analysis/symbol_table.cc
+++ b/verilog/analysis/symbol_table.cc
@@ -2017,7 +2017,12 @@ static void ResolveReferenceComponentNode(
   switch (component.ref_type) {
     case ReferenceType::kUnqualified: {
       // root node: lookup this symbol from its context upward
-      CHECK(node->Parent() == nullptr);
+      if (node->Parent() != nullptr) {
+        // TODO(hzeller): Is this a situation that should never happen thus
+        // be dealt with further up-stream ? (changed from a CHECK()).
+        LOG(WARNING) << *node << ": Parent exists " << *node->Parent() << "\n";
+        return;
+      }
       ResolveUnqualifiedName(&component, context, diagnostics);
       break;
     }


### PR DESCRIPTION
This situation seems to arise if we have possibly multiple parent references when fed a bunch of possibly unrelated files with naming overlap. Don't crash in this case.