### PR TITLE
Reduce unnecessary visibility.

### DIFF
--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -7,9 +7,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 
 package(
     default_applicable_licenses = ["//:license"],
-    default_visibility = [
-        "//:__subpackages__",
-    ],
+    default_visibility = ["//visibility:private"],
 )
 
 cc_library(


### PR DESCRIPTION
The only relevant visible part is the binary, that is already marked public.

Context: cl/580583239