### PR TITLE
Use a deleter type insteadl of function pointer to close FILE.

### DIFF
--- a/verilog/tools/kythe/kzip_creator.cc
+++ b/verilog/tools/kythe/kzip_creator.cc
@@ -38,7 +38,7 @@ constexpr int kKZipCompressionLevel = 9;
 }  // namespace
 
 KzipCreator::KzipCreator(absl::string_view output_path)
-    : zip_file_(fopen(std::string(output_path).c_str(), "wb"), &fclose),
+    : zip_file_(fopen(std::string(output_path).c_str(), "wb")),
       archive_(kKZipCompressionLevel, [this](absl::string_view s) {
         return fwrite(s.data(), 1, s.size(), zip_file_.get()) == s.size();
       }) {

--- a/verilog/tools/kythe/kzip_creator.h
+++ b/verilog/tools/kythe/kzip_creator.h
@@ -42,7 +42,10 @@ class KzipCreator final {
       const ::kythe::proto::IndexedCompilation &unit);
 
  private:
-  std::unique_ptr<FILE, decltype(&fclose)> zip_file_;
+  struct file_closer {
+    void operator()(FILE *f) const noexcept { fclose(f); }
+  };
+  std::unique_ptr<FILE, file_closer> zip_file_;
   verible::zip::Encoder archive_;
 };
 


### PR DESCRIPTION
gcc12 complains that some attribute of fclose() is not kept ('ignoring attributes on template argument 'int (*)(FILE*)'). Changing this to a deleter type which is anyway more clean.