### PR TITLE
Get ready for ABSL providing a VLOG() implementation.

### DIFF
--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -82,12 +82,15 @@ std::vector<absl::string_view> InitCommandLine(
         static_cast<absl::LogSeverityAtLeast>(std::clamp(log_level, 0, 3)));
   }
 
-  // Until vlog is provided in absl, we use our own global variable, defined
-  // in logging.cc
+  // Set vlog-level with environment variable. The definition of
+  // VERIBLE_INTERNAL_SET_VLOGLEVEL() might be different depending on if we
+  // have an absl implementation or not.
   const char *const vlog_level_env = getenv("VERIBLE_VLOG_DETAIL");
-  if (!vlog_level_env ||
-      !absl::SimpleAtoi(vlog_level_env, &verible::global_vlog_level_)) {
-    global_vlog_level_ = 0;
+  int vlog_level = 0;
+  if (vlog_level_env && absl::SimpleAtoi(vlog_level_env, &vlog_level)) {
+    VERIBLE_INTERNAL_SET_VLOGLEVEL(vlog_level);
+  } else {
+    VERIBLE_INTERNAL_SET_VLOGLEVEL(0);
   }
 
   absl::InitializeLog();


### PR DESCRIPTION
In the unreleased head of absl, a
[VLOG()](https://github.com/abseil/abseil-cpp/blob/bae260199fffe782d5a5414bb80cfe49abb1436f/absl/log/absl_vlog_is_on.h) implementation is available now.
Make sure we can compile with the current and future absl.