### PR TITLE
Make scope_to_vnames_ absl::node_hash_map instead of absl::flat_hash_…

### DIFF
--- a/verilog/tools/kythe/scope_resolver.h
+++ b/verilog/tools/kythe/scope_resolver.h
@@ -140,8 +140,8 @@ class ScopeResolver {
   absl::flat_hash_map<std::string, absl::flat_hash_set<ScopedVname>>
       variable_to_scoped_vname_;
 
-  // Mapping from scope to all its members.
-  absl::flat_hash_map<SignatureDigest, absl::flat_hash_set<VName>>
+  // Mapping from scope to all its members. NOTE: requires pointer stability!
+  absl::node_hash_map<SignatureDigest, absl::flat_hash_set<VName>>
       scope_to_vnames_;
 
   // Maps the scope to the human readable description. Available only when debug


### PR DESCRIPTION
…map as ScopeResolver::AppendScopeToScope() requires pointer stability (scope_to_vnames_ is iterated and modified at the same time).