### PR TITLE
Enable suspicious-semicolon_rule by default

### DIFF
--- a/verilog/analysis/default_rules.h
+++ b/verilog/analysis/default_rules.h
@@ -65,6 +65,7 @@ inline constexpr const char* kDefaultRuleSet[] = {
     "positive-meaning-parameter-name",
     "constraint-name-style",
     "suggest-parentheses",
+    "suspicious-semicolon",
     "truncated-numeric-literal",
     // TODO(fangism): enable in production:
     // TODO(b/155128436): "uvm-macro-semicolon"

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -69,7 +69,7 @@ _linter_test_configs = [
     ("signal-name-style", "signal_name_style", False),
     ("struct-union-name-style", "struct_name_style", True),
     ("struct-union-name-style", "union_name_style", True),
-    ("suspicious-semicolon", "suspicious_semicolon", False),
+    ("suspicious-semicolon", "suspicious_semicolon", True),
     ("v2001-generate-begin", "generate_begin_module", True),
     ("void-cast", "void-cast", True),
     ("undersized-binary-literal", "undersized_binary_literal", True),


### PR DESCRIPTION
This recently added rule inspired by a [clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/suspicious-semicolon.html) seems a good candidate for being enabled by default. Only one "possible" false positive, and could potentially save hours of staring at a screen (don't ask me how I know)