### PR TITLE
Initial version of a devcontainer for Verible

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# Available versions: https://github.com/devcontainers/images/tree/main/src/ruby
+# Available versions: https://github.com/devcontainers/images/tree/main/src/cpp
 FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04
 RUN apt update && apt install -y clang-format clang-tidy
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel && chmod a+rx /usr/local/bin/bazel && /usr/local/bin/bazel --version

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+# Available versions: https://github.com/devcontainers/images/tree/main/src/ruby
+FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-22.04
+RUN apt update && apt install -y clang-format clang-tidy
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64 -O /usr/local/bin/bazel && chmod a+rx /usr/local/bin/bazel && /usr/local/bin/bazel --version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,39 +1,21 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+
+// If you are behind a proxy, set the http_proxy and https_proxy environment variables
+// in the container environment. For example:
+///
+// "containerEnv": {
+// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
+// 	"https_proxy": "http://proxy-dmz.intel.com:912/"
+// },
+
 {
 	"name": "Verible Dev",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Add any proxy settings if the build of the
-		// container is behind a proxy
-		//
-		// "args" : {
-		// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-		// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-		// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
-		// 	"https_proxy": "http://proxy-dmz.intel.com:912/"
-		// }
 	},
-
-	// Add any proxy settings if connecting to a container on
-	// a remote machine
-	//
-	// "remoteEnv": {
-	// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-	// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-	// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
-	// 	"https_proxy": "http://proxy-dmz.intel.com:912/",
-	// },
-
-	// Add any proxy settings if the container is behind
-	// a proxy
-	///
-	// "containerEnv": {
-	// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-	// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-	// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
-	// 	"https_proxy": "http://proxy-dmz.intel.com:912/"
-	// },
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,44 +3,40 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
 	"name": "Verible Dev",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	// "image": "amr-registry.caas.intel.com/fpga-simics/devenv/ubuntu22-dev:1.0",
-	//"image": "mcr.microsoft.com/devcontainers/base:jammy",
-	//"image": "mcr.microsoft.com/devcontainers/universal:2-linux",
 
 	"build": {
 	    "dockerfile": "Dockerfile",
-    	"args" : {
-			"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-			"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-			"http_proxy": "http://proxy-dmz.intel.com:912/",
-			"https_proxy": "http://proxy-dmz.intel.com:912/"
-		}
+		// Add any proxy settings if the build of the
+		// container is behind a proxy
+		//
+		// "args" : {
+		// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+		// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+		// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
+		// 	"https_proxy": "http://proxy-dmz.intel.com:912/"
+		// }
 	},
 
+// Add any proxy settings if connecting to a container on
+// a remote machine
+//
+//   "remoteEnv": {
+//     "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+//     "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+//     "http_proxy": "http://proxy-dmz.intel.com:912/",
+//     "https_proxy": "http://proxy-dmz.intel.com:912/",
+//   },
 
-  "remoteEnv": {
-    "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-    "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-    "http_proxy": "http://proxy-dmz.intel.com:912/",
-    "https_proxy": "http://proxy-dmz.intel.com:912/",
-	"npm_config_proxy": "http://proxy-dmz.intel.com:912/",
-	"npm_config_https_proxy": "http://proxy-dmz.intel.com:912/"
-  },
+// Add any proxy settings if the container is behind
+// a proxy
+///
+//   "containerEnv": {
+//     "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+//     "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+//     "http_proxy": "http://proxy-dmz.intel.com:912/",
+//     "https_proxy": "http://proxy-dmz.intel.com:912/"
+//   },
 
-
-  "containerEnv": {
-    "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-    "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-    "http_proxy": "http://proxy-dmz.intel.com:912/",
-    "https_proxy": "http://proxy-dmz.intel.com:912/"
-  },
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// devcontainer.json
-//	"features": {
-//		"ghcr.io/devcontainers-community/features/bazel:1": {}
-//	},
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -51,16 +47,6 @@
 				"ms-vscode.cpptools-extension-pack"
 			]
 		}
-	},
+	}
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [3000],
-
-	// Use 'portsAttributes' to set default properties for specific forwarded ports.
-	// More info: https://containers.dev/implementors/json_reference/#port-attributes
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,66 @@
+
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Verible Dev",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "amr-registry.caas.intel.com/fpga-simics/devenv/ubuntu22-dev:1.0",
+	//"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	//"image": "mcr.microsoft.com/devcontainers/universal:2-linux",
+
+	"build": {
+	    "dockerfile": "Dockerfile",
+    	"args" : {
+			"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+			"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+			"http_proxy": "http://proxy-dmz.intel.com:912/",
+			"https_proxy": "http://proxy-dmz.intel.com:912/"
+		}
+	},
+
+
+  "remoteEnv": {
+    "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+    "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+    "http_proxy": "http://proxy-dmz.intel.com:912/",
+    "https_proxy": "http://proxy-dmz.intel.com:912/",
+	"npm_config_proxy": "http://proxy-dmz.intel.com:912/",
+	"npm_config_https_proxy": "http://proxy-dmz.intel.com:912/"
+  },
+
+
+  "containerEnv": {
+    "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+    "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+    "http_proxy": "http://proxy-dmz.intel.com:912/",
+    "https_proxy": "http://proxy-dmz.intel.com:912/"
+  },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// devcontainer.json
+//	"features": {
+//		"ghcr.io/devcontainers-community/features/bazel:1": {}
+//	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [3000],
+
+	// Use 'portsAttributes' to set default properties for specific forwarded ports.
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,9 @@
-
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
 	"name": "Verible Dev",
-
 	"build": {
-	    "dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile",
 		// Add any proxy settings if the build of the
 		// container is behind a proxy
 		//
@@ -17,26 +15,25 @@
 		// }
 	},
 
-// Add any proxy settings if connecting to a container on
-// a remote machine
-//
-//   "remoteEnv": {
-//     "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-//     "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-//     "http_proxy": "http://proxy-dmz.intel.com:912/",
-//     "https_proxy": "http://proxy-dmz.intel.com:912/",
-//   },
+	// Add any proxy settings if connecting to a container on
+	// a remote machine
+	//
+	// "remoteEnv": {
+	// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+	// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+	// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
+	// 	"https_proxy": "http://proxy-dmz.intel.com:912/",
+	// },
 
-// Add any proxy settings if the container is behind
-// a proxy
-///
-//   "containerEnv": {
-//     "HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
-//     "HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
-//     "http_proxy": "http://proxy-dmz.intel.com:912/",
-//     "https_proxy": "http://proxy-dmz.intel.com:912/"
-//   },
-
+	// Add any proxy settings if the container is behind
+	// a proxy
+	///
+	// "containerEnv": {
+	// 	"HTTP_PROXY": "http://proxy-dmz.intel.com:912/",
+	// 	"HTTPS_PROXY": "http://proxy-dmz.intel.com:912/",
+	// 	"http_proxy": "http://proxy-dmz.intel.com:912/",
+	// 	"https_proxy": "http://proxy-dmz.intel.com:912/"
+	// },
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -48,5 +45,4 @@
 			]
 		}
 	}
-
 }


### PR DESCRIPTION
Initial version of the .devcontainer/ directory and configuration.

This devcontainer uses a Dockerfile based on the Microsoft CPP container, augmented to install Bazel, clang-format, and clang-tidy.

With the devcontainer, developers can clone the repo, and open it within a standard container definition.