### PR TITLE
Fix string view index in UpdateFileContents()

### DIFF
--- a/common/strings/string_memory_map.h
+++ b/common/strings/string_memory_map.h
@@ -65,6 +65,9 @@ class StringViewSuperRangeMap {
     return string_map_.find({substring.begin(), substring.end()});
   }
 
+  // Erase given range.
+  const_iterator erase(const_iterator pos) { return string_map_.erase(pos); }
+
   // Similar to find(), but asserts that a superstring range is found,
   // and converts the result directly to a string_view.
   absl::string_view must_find(absl::string_view substring) const {

--- a/common/strings/string_memory_map_test.cc
+++ b/common/strings/string_memory_map_test.cc
@@ -106,6 +106,28 @@ TEST(StringViewSuperRangeMapTest, TwoStrings) {
   });
 }
 
+TEST(StringViewSuperRangeMapTest, EraseString) {
+  constexpr absl::string_view text1("onestring");
+  constexpr absl::string_view text2("another");
+  StringViewSuperRangeMap svmap;
+  svmap.must_emplace(text1);
+  svmap.must_emplace(text2);
+
+  auto found = svmap.find(text1);
+  EXPECT_NE(found, svmap.end());
+  svmap.erase(found);
+
+  // should be gone now
+  found = svmap.find(text1);
+  EXPECT_EQ(found, svmap.end());
+
+  found = svmap.find(text2);
+  EXPECT_NE(found, svmap.end());
+  svmap.erase(found);
+
+  EXPECT_TRUE(svmap.empty());
+}
+
 // Function to get the owned address range of the underlying string.
 static absl::string_view StringViewKey(
     const std::unique_ptr<const std::string> &owned) {

--- a/common/util/interval_set.h
+++ b/common/util/interval_set.h
@@ -625,6 +625,9 @@ class DisjointIntervalSet : private internal::IntervalSetImpl {
     return p;
   }
 
+  // Erase given interval.
+  const_iterator erase(const_iterator pos) { return intervals_.erase(pos); }
+
   // Same as emplace(), but fails fatally if emplacement fails,
   // and only returns the iterator to the new map entry (which should have
   // consumed 'value').

--- a/common/util/interval_set_test.cc
+++ b/common/util/interval_set_test.cc
@@ -1123,6 +1123,26 @@ TEST(DisjointIntervalSetTest, MustEmplaceOverlapsUpper) {
   EXPECT_DEATH(iset.must_emplace(45, 55), "Failed to emplace");
 }
 
+TEST(DisjointIntervalSetTest, EraseRange) {
+  IntIntervalSet iset;
+  iset.must_emplace(30, 40);
+  iset.must_emplace(50, 60);
+
+  auto found = iset.find(35);
+  EXPECT_NE(found, iset.end());
+  iset.erase(found);
+
+  // ... should be gone now.
+  found = iset.find(35);
+  EXPECT_EQ(found, iset.end());
+
+  found = iset.find(55);
+  EXPECT_NE(found, iset.end());
+  iset.erase(found);
+
+  EXPECT_TRUE(iset.empty());
+}
+
 TEST(DisjointIntervalMapTest, FindInterval) {
   IntIntervalSet iset;
   iset.must_emplace(20, 25);

--- a/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
@@ -101,7 +101,7 @@ class SimpleTestProject : public TempDir, public VerilogProject {
   explicit SimpleTestProject(absl::string_view code_text,
                              const std::vector<std::string> &include_paths = {})
       : VerilogProject(temp_dir_, include_paths, /*corpus=*/"unittest",
-                       /*populate_string_maps=*/false),
+                       /*provide_lookup_file_origin=*/false),
         code_text_(code_text),
         translation_unit_(code_text, temp_dir_,
                           [this](absl::string_view full_file_name)

--- a/verilog/tools/kythe/verilog_kythe_extractor.cc
+++ b/verilog/tools/kythe/verilog_kythe_extractor.cc
@@ -211,7 +211,7 @@ Output: Produces Indexing Facts for kythe (http://kythe.io).
                            file_list.preprocessing.include_dirs.end());
   verilog::VerilogProject project(file_list_root, include_dir_paths,
                                   absl::GetFlag(FLAGS_verilog_project_name),
-                                  /*populate_string_maps=*/false);
+                                  /*provide_lookup_file_origin=*/false);
 
   const std::vector<absl::Status> errors(
       verilog::kythe::ExtractTranslationUnits(file_list_path, &project,

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -52,6 +52,17 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "lsp-parse-buffer_test",
+    srcs = ["lsp-parse-buffer_test.cc"],
+    deps = [
+        ":lsp-parse-buffer",
+        "//common/lsp:lsp-text-buffer",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "verible-lsp-adapter",
     srcs = ["verible-lsp-adapter.cc"],

--- a/verilog/tools/ls/autoexpand_test.cc
+++ b/verilog/tools/ls/autoexpand_test.cc
@@ -142,7 +142,7 @@ void TestTextEditsWithProject(
   SymbolTableHandler symbol_table_handler;
   symbol_table_handler.SetProject(proj);
   symbol_table_handler.UpdateFileContent(TESTED_FILENAME,
-                                         &tracker.current()->parser().Data());
+                                         &tracker.current()->parser());
   symbol_table_handler.BuildProjectSymbolTable();
   // Run the tested edit function
   std::vector<TextEdit> edits = run.edit_fn(&symbol_table_handler, &tracker);

--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -50,20 +50,19 @@ ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
           content, uri)) {
   VLOG(1) << "Analyzed " << uri << " lex:" << parser_->LexStatus()
           << "; parser:" << parser_->ParseStatus() << std::endl;
-  // TODO(hzeller): we should use a filename not URI; strip prefix.
+  // TODO(hzeller): should we use a filename not URI ?
   if (auto lint_result = RunLinter(uri, *parser_); lint_result.ok()) {
     lint_statuses_ = std::move(lint_result.value());
   }
 }
 
-void BufferTracker::Update(const std::string &filename,
+void BufferTracker::Update(const std::string &uri,
                            const verible::lsp::EditTextBuffer &txt) {
   if (current_ && current_->version() == txt.last_global_version()) {
     return;  // Nothing to do (we don't really expect this to happen)
   }
-  txt.RequestContent([&txt, &filename, this](absl::string_view content) {
-    current_ = std::make_shared<ParsedBuffer>(txt.last_global_version(),
-                                              filename, content);
+  txt.RequestContent([&txt, &uri, this](absl::string_view content) {
+    current_.reset(new ParsedBuffer(txt.last_global_version(), uri, content));
   });
   if (current_->parsed_successfully()) {
     last_good_ = current_;
@@ -74,9 +73,19 @@ verible::lsp::BufferCollection::UriBufferCallback
 BufferTrackerContainer::GetSubscriptionCallback() {
   return
       [this](const std::string &uri, const verible::lsp::EditTextBuffer *txt) {
+        // The Update() might replace, thus discard, old parsed buffers.
+        // However, the change listeners we're about to inform might
+        // expect them to be still alive while the update takes place.
+        // So hold on to them here until all updates are performed.
+        // (this copy is cheap as it is just reference counted pointers).
+        BufferTracker remember_previous;
+        if (const BufferTracker *tracker = FindBufferTrackerOrNull(uri)) {
+          remember_previous = *tracker;
+        }
+
         if (txt) {
           const BufferTracker *tracker = Update(uri, *txt);
-          // Now inform our listeners.
+          // Updated current() and last_good(); Now inform our listeners.
           for (const auto &change_listener : change_listeners_) {
             change_listener(uri, tracker);
           }

--- a/verilog/tools/ls/lsp-parse-buffer.h
+++ b/verilog/tools/ls/lsp-parse-buffer.h
@@ -63,13 +63,16 @@ class ParsedBuffer {
   std::vector<verible::LintRuleStatus> lint_statuses_;
 };
 
-// A buffer tracker tracks the EditTextBuffer content and keeps up to
-// two versions of ParsedBuffers - the latest, that might have parse errors,
-// and the last known good that parsed without errors (if available).
+// A buffer tracker tracks of a single file EditTextBuffer content and stores
+// a parsed version.
+// It keeps up to two versions of ParsedBuffers - the latest, that might have
+// parse errors,  and the last known good that parsed without errors
+// (if available).
 class BufferTracker {
  public:
-  void Update(const std::string &filename,
-              const verible::lsp::EditTextBuffer &txt);
+  // Update with a changed text buffer from the LSP subsystem. Triggers
+  // re-parsing and updating our current() and potentially last_good().
+  void Update(const std::string &uri, const verible::lsp::EditTextBuffer &txt);
 
   // ---
   // Thread guarantee for the following functions.
@@ -80,10 +83,10 @@ class BufferTracker {
   // ---
 
   // Get the current ParsedBuffer from the last text update we received
-  // from the editor. This can be nullptr if it could not be parsed.
+  // from the editor.
   //
-  // Use in operations that only really makes sense on the latest view and
-  // only if it was parseable, e.g. suggesting edits.
+  // Use in operations that only really makes sense on the latest view,
+  // e.g. suggesting edits.
   std::shared_ptr<const ParsedBuffer> current() const { return current_; }
 
   // Get the ParsedBuffer that represents that last time we were able to
@@ -91,8 +94,9 @@ class BufferTracker {
   // as current() if the last text update was fully parseable, or nullptr
   // if we never received a buffer that was parseable.
   //
-  // Use in operations that focus on returning something even it it is slightly
-  // outdated, e.g. finding a particular symbol.
+  // Use in operations that focus on returning something that requires a
+  // valid parsed file even it it is slightly outdated, e.g. finding
+  // a particular symbol.
   std::shared_ptr<const ParsedBuffer> last_good() const { return last_good_; }
 
  private:
@@ -107,9 +111,10 @@ class BufferTracker {
   std::shared_ptr<const ParsedBuffer> last_good_;
 };
 
-// Container holding all buffer trackers keyed by file uri.
+// Container holding a buffer tracker per file uri.
 // This is the correspondent to verible::lsp::BufferCollection that
-// internally stores
+// internally stores file content by uri. Here we keep parsed files per uri,
+// whenever we're informed of a change in the buffer collection.
 class BufferTrackerContainer {
  public:
   // Return a callback that allows to subscribe to an lsp::BufferCollection

--- a/verilog/tools/ls/lsp-parse-buffer_test.cc
+++ b/verilog/tools/ls/lsp-parse-buffer_test.cc
@@ -1,0 +1,120 @@
+// Copyright 2024 The Verible Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "verilog/tools/ls/lsp-parse-buffer.h"
+
+#include "common/lsp/lsp-text-buffer.h"
+#include "gtest/gtest.h"
+
+namespace verilog {
+namespace {
+TEST(BufferTraccker, ParseGoodDocument) {
+  verible::lsp::EditTextBuffer good_document("module foo(); endmodule");
+  BufferTracker tracker;
+  EXPECT_EQ(tracker.current().get(), nullptr);
+  tracker.Update("foo.sv", good_document);
+
+  ASSERT_NE(tracker.current().get(), nullptr);
+
+  // Successfully parsed, so last_good() == current()
+  EXPECT_EQ(tracker.last_good().get(), tracker.current().get());
+}
+
+TEST(BufferTraccker, ParseParseErrorDocument) {
+  verible::lsp::EditTextBuffer bad_document("moduleinvalid foo(); endmodule");
+  BufferTracker tracker;
+  tracker.Update("foo.sv", bad_document);
+
+  ASSERT_NE(tracker.current().get(), nullptr);  // a current document, maybe bad
+
+  // Not successfully parsed, so last_good() is still null.
+  ASSERT_EQ(tracker.last_good().get(), nullptr);
+}
+
+TEST(BufferTrackerConatainer, PopulateBufferCollection) {
+  BufferTrackerContainer container;
+  auto feed_callback = container.GetSubscriptionCallback();
+
+  verible::lsp::EditTextBuffer foo_doc("module foo(); endmodule");
+  feed_callback("foo.sv", &foo_doc);
+  const BufferTracker *tracker = container.FindBufferTrackerOrNull("foo.sv");
+  ASSERT_NE(tracker, nullptr);
+  EXPECT_NE(tracker->last_good().get(), nullptr);
+
+  verible::lsp::EditTextBuffer bar_doc("modulebroken bar(); endmodule");
+  feed_callback("bar.sv", &bar_doc);
+  tracker = container.FindBufferTrackerOrNull("bar.sv");
+  ASSERT_NE(tracker, nullptr);
+  EXPECT_NE(tracker->current().get(), nullptr);    // Current always there
+  EXPECT_EQ(tracker->last_good().get(), nullptr);  // Was a bad parse
+
+  feed_callback("bar.sv", nullptr);  // Remove.
+  tracker = container.FindBufferTrackerOrNull("bar.sv");
+  EXPECT_EQ(tracker, nullptr);
+}
+
+TEST(BufferTrackerConatainer, ParseUpdateNotification) {
+  BufferTrackerContainer container;
+
+  const verible::TextStructureView *last_text_structure = nullptr;
+  int update_remove_count = 0;  // track these
+  container.AddChangeListener([&update_remove_count, &last_text_structure](
+                                  const std::string &,
+                                  const BufferTracker *tracker) {
+    if (tracker != nullptr) {
+      ++update_remove_count;
+    } else {
+      --update_remove_count;
+    };
+
+    // attempt to access the previous text structure if it was not null to
+    // make sure it was not deleted. If it was, then this UB might only be
+    // detected in the ASAN test.
+    if (last_text_structure) {
+      // Accessing the content and see if it is alive and well, not corrupted.
+      EXPECT_TRUE(absl::StartsWith(last_text_structure->Contents(), "module"));
+    }
+
+    // Remember current text structure for last time.
+    if (tracker) {
+      last_text_structure = &tracker->current()->parser().Data();
+    } else {
+      last_text_structure = nullptr;
+    }
+  });
+
+  EXPECT_EQ(update_remove_count, 0);
+
+  auto feed_callback = container.GetSubscriptionCallback();
+  // Put one document in there.
+  verible::lsp::EditTextBuffer foo_doc("module foo(); endmodule");
+  feed_callback("foo.sv", &foo_doc);
+
+  EXPECT_EQ(update_remove_count, 1);
+
+  const BufferTracker *tracker = container.FindBufferTrackerOrNull("foo.sv");
+  ASSERT_NE(tracker, nullptr);
+  EXPECT_NE(tracker->last_good().get(), nullptr);
+
+  verible::lsp::EditTextBuffer updated_foo_doc("module foobar(); endmodule");
+  feed_callback("foo.sv", &updated_foo_doc);
+  EXPECT_EQ(update_remove_count, 2);
+
+  // Remove doc
+  feed_callback("foo.sv", nullptr);
+  EXPECT_EQ(update_remove_count, 1);
+}
+
+}  // namespace
+}  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -365,9 +365,9 @@ void SymbolTableHandler::CollectReferences(
 }
 
 void SymbolTableHandler::UpdateFileContent(
-    absl::string_view path, const verible::TextStructureView *content) {
+    absl::string_view path, const verilog::VerilogAnalyzer *parsed) {
   files_dirty_ = true;
-  curr_project_->UpdateFileContents(path, content);
+  curr_project_->UpdateFileContents(path, parsed);
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -70,7 +70,7 @@ class SymbolTableHandler {
   // Provide new parsed content for the given path. If "content" is nullptr,
   // opens the given file instead.
   void UpdateFileContent(absl::string_view path,
-                         const verible::TextStructureView *content);
+                         const verilog::VerilogAnalyzer *parsed);
 
   // Creates a symbol table for entire project (public: needed in unit-test)
   std::vector<absl::Status> BuildProjectSymbolTable();

--- a/verilog/tools/ls/verilog-language-server.cc
+++ b/verilog/tools/ls/verilog-language-server.cc
@@ -253,7 +253,7 @@ void VerilogLanguageServer::UpdateEditedFileInProject(
   }
   if (!buffer_tracker->last_good()) return;
   symbol_table_handler_.UpdateFileContent(
-      path, &buffer_tracker->last_good()->parser().Data());
+      path, &buffer_tracker->last_good()->parser());
   VLOG(1) << "Updated file:  " << uri << " (" << path << ")";
 }
 


### PR DESCRIPTION
This fixes #2078.
Since some changes are somewhat independent, they are in three different commits.

This also fixes the misfeature that the string view index had to be disabled in cases the `VerilogProject` is used where it needs to remove files. So instead of a fractured class use, this is now merely a feature that can be enabled.