### PR TITLE
Break out setting log levels by environment variables.

### DIFF
--- a/common/util/init_command_line.cc
+++ b/common/util/init_command_line.cc
@@ -62,17 +62,7 @@ static std::string GetBuildVersion() {
   return result;
 }
 
-// We might want to have argc edited in the future, hence non-const param.
-std::vector<absl::string_view> InitCommandLine(
-    absl::string_view usage,
-    int *argc,  // NOLINT(readability-non-const-parameter)
-    char ***argv) {
-  absl::InitializeSymbolizer(*argv[0]);
-  absl::FlagsUsageConfig usage_config;
-  usage_config.version_string = GetBuildVersion;
-  absl::SetFlagsUsageConfig(usage_config);
-  absl::SetProgramUsageMessage(usage);  // copies usage string
-
+void SetLoggingLevelsFromEnvironment() {
   // To avoid confusing and rarely used flags, we just enable logging via
   // environment variables.
   const char *const stderr_log_level = getenv("VERIBLE_LOGTHRESHOLD");
@@ -92,7 +82,20 @@ std::vector<absl::string_view> InitCommandLine(
   } else {
     VERIBLE_INTERNAL_SET_VLOGLEVEL(0);
   }
+}
 
+// We might want to have argc edited in the future, hence non-const param.
+std::vector<absl::string_view> InitCommandLine(
+    absl::string_view usage,
+    int *argc,  // NOLINT(readability-non-const-parameter)
+    char ***argv) {
+  absl::InitializeSymbolizer(*argv[0]);
+  absl::FlagsUsageConfig usage_config;
+  usage_config.version_string = GetBuildVersion;
+  absl::SetFlagsUsageConfig(usage_config);
+  absl::SetProgramUsageMessage(usage);  // copies usage string
+
+  SetLoggingLevelsFromEnvironment();
   absl::InitializeLog();
 
   // Print stacktrace on issue, but not if --config=asan

--- a/common/util/init_command_line.h
+++ b/common/util/init_command_line.h
@@ -25,6 +25,12 @@ namespace verible {
 // Get a one-line build version string that based on the repository version.
 std::string GetRepositoryVersion();
 
+// Set logging thresholds from environment variables.
+//  * VERIBLE_LOGTHRESHOLD corresponds to absl::LogSeverityAtLeast()
+//  * VERIBLE_VLOG_DETAIL  corresponds to absl::SetGlobalVLogLevel()
+// Called in InitCommandLine(), so usually not needed to be called separately.
+void SetLoggingLevelsFromEnvironment();
+
 // Initializes command-line tool, including parsing flags.
 // The recognized flags are initialized and their text removed from the
 // input command line, returning the remaining positional parameters.


### PR DESCRIPTION
This mostly clarifies functionality (though not necessarily be needed to be called by the user, as it already happens in InitCommandLine()).