### PR TITLE
Make installer work with bazel 7

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,7 +81,10 @@ http_archive(
     # it is benign to leave out.
     # Upstream bug https://github.com/google/bazel_rules_install/issues/31
     patch_args = ["-p1"],
-    patches = ["//bazel:installer.patch"],
+    patches = [
+            "//bazel:installer.patch",
+            #"//bazel:installer-bazel7.patch",  # TODO: if-magic for if bazel7
+    ],
     sha256 = "880217b21dbd40928bbe3bca3d97bd4de7d70d5383665ec007d7e1aac41d9739",
     strip_prefix = "bazel_rules_install-5ae7c2a8d22de2558098e3872fc7f3f7edc61fb4",
     urls = ["https://github.com/google/bazel_rules_install/archive/5ae7c2a8d22de2558098e3872fc7f3f7edc61fb4.zip"],

--- a/bazel/installer-bazel7.patch
+++ b/bazel/installer-bazel7.patch
@@ -1,0 +1,13 @@
+diff --git a/installer/def.bzl b/installer/def.bzl
+index 381127e..4dc0e7a 100644
+--- a/installer/def.bzl
++++ b/installer/def.bzl
+@@ -118,7 +118,7 @@ _gen_installer = rule(
+             allow_single_file = True,
+             default = Label(_TEMPLATE_TARGET),
+         ),
+-        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
++        #"_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+     },
+     executable = True,
+     outputs = {


### PR DESCRIPTION
This is work in progress, playing with what needs to be done.

One of the issues to get things to work with bazel7 is that the installer does not work, it creates this error message:

```
verible/BUILD:49:10: in (an implicit dependency) attribute of _gen_installer rule //:_install_gen: in $whitelist_function_transition attribute of _gen_installer rule //:_install_gen: package group '@@bazel_tools//tools/whitelists/function_transition_whitelist:function_transition_whitelist' is misplaced here (they are only allowed in the visibility attribute).
```

I hacked around here by adding a patch that removes that line :)

Things to work on
  * Make the choice if the patch is applied depending on the bazel version either in WORKSPACE or maybe in the installer file itself. I have no experience with Skylark (or, Python for that matter) to know what to do. Hopefully reviewers on this PR can help.
  * This is a hack of course, but once we know what needs to be done, we could upstream it. The upstream project is kind-of dormant, but it might be possible to get things in (I might have commit permission)
  * Also, given the unmaintained state of the installler, we could consider not using the installer and providing that manually.

There are other issues with bazel 7: for some reason the protocol buffers are completely borked, but that is for another day :)