### PR TITLE
Fix potential double-update of a buffer in Verilog Projecdt

### DIFF
--- a/verilog/tools/ls/lsp-parse-buffer.cc
+++ b/verilog/tools/ls/lsp-parse-buffer.cc
@@ -59,6 +59,7 @@ ParsedBuffer::ParsedBuffer(int64_t version, absl::string_view uri,
 void BufferTracker::Update(const std::string &uri,
                            const verible::lsp::EditTextBuffer &txt) {
   if (current_ && current_->version() == txt.last_global_version()) {
+    LOG(DFATAL) << "Testing: Forgot to update version number ?";
     return;  // Nothing to do (we don't really expect this to happen)
   }
   txt.RequestContent([&txt, &uri, this](absl::string_view content) {

--- a/verilog/tools/ls/lsp-parse-buffer_test.cc
+++ b/verilog/tools/ls/lsp-parse-buffer_test.cc
@@ -98,9 +98,11 @@ TEST(BufferTrackerConatainer, ParseUpdateNotification) {
 
   EXPECT_EQ(update_remove_count, 0);
 
+  int64_t version_number = 0;
   auto feed_callback = container.GetSubscriptionCallback();
   // Put one document in there.
   verible::lsp::EditTextBuffer foo_doc("module foo(); endmodule");
+  foo_doc.set_last_global_version(++version_number);
   feed_callback("foo.sv", &foo_doc);
 
   EXPECT_EQ(update_remove_count, 1);
@@ -110,6 +112,7 @@ TEST(BufferTrackerConatainer, ParseUpdateNotification) {
   EXPECT_NE(tracker->last_good().get(), nullptr);
 
   verible::lsp::EditTextBuffer updated_foo_doc("module foobar(); endmodule");
+  updated_foo_doc.set_last_global_version(++version_number);
   feed_callback("foo.sv", &updated_foo_doc);
   EXPECT_EQ(update_remove_count, 2);
 

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -155,6 +155,7 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
     }
     filelist_path_ = projectpath;
   }
+
   if (!last_filelist_update_) {
     last_filelist_update_ = std::filesystem::last_write_time(filelist_path_);
   } else if (*last_filelist_update_ ==
@@ -162,6 +163,7 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
     // filelist file is unchanged, keeping it
     return true;
   }
+
   VLOG(1) << "Updating the filelist";
   // fill the FileList object
   FileList filelist;
@@ -174,6 +176,7 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
     last_filelist_update_ = {};
     return false;
   }
+
   // add directory containing filelist to includes
   // TODO (glatosinski): should we do this?
   const absl::string_view filelist_dir = verible::file::Dirname(filelist_path_);
@@ -184,6 +187,7 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
     VLOG(1) << "Adding include path:  " << incdir;
     curr_project_->AddIncludePath(incdir);
   }
+
   // Add files from file list to the project
   VLOG(1) << "Resolving " << filelist.file_paths.size() << " files.";
   int actually_opened = 0;
@@ -201,6 +205,11 @@ bool SymbolTableHandler::LoadProjectFileList(absl::string_view current_dir) {
     }
     ++actually_opened;
   }
+
+  // It could be that we just (re-) opened all the exactly same files, so
+  // setting files_dirty_ here might overstate it. However, good conservative
+  // estimate.
+  files_dirty_ |= (actually_opened > 0);
 
   VLOG(1) << "Successfully opened " << actually_opened
           << " files from file-list: " << (absl::Now() - start);
@@ -254,9 +263,7 @@ const SymbolTableNode *SymbolTableHandler::ScanSymbolTreeForDefinition(
 
 void SymbolTableHandler::Prepare() {
   LoadProjectFileList(curr_project_->TranslationUnitRoot());
-  if (files_dirty_) {
-    BuildProjectSymbolTable();
-  }
+  if (files_dirty_) BuildProjectSymbolTable();
 }
 
 std::optional<verible::TokenInfo>
@@ -383,9 +390,7 @@ std::vector<verible::lsp::Location> SymbolTableHandler::FindDefinitionLocation(
 
 const verible::Symbol *SymbolTableHandler::FindDefinitionSymbol(
     absl::string_view symbol) {
-  if (files_dirty_) {
-    BuildProjectSymbolTable();
-  }
+  Prepare();
   const SymbolTableNode *symbol_table_node =
       ScanSymbolTreeForDefinition(&symbol_table_->Root(), symbol);
   if (symbol_table_node) return symbol_table_node->Value().syntax_origin;
@@ -413,9 +418,7 @@ SymbolTableHandler::FindRenameableRangeAtCursor(
     const verible::lsp::PrepareRenameParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
   Prepare();
-  if (files_dirty_) {
-    BuildProjectSymbolTable();
-  }
+
   std::optional<verible::TokenInfo> symbol =
       GetTokenInfoAtTextDocumentPosition(params, parsed_buffers);
   if (symbol) {
@@ -434,10 +437,8 @@ verible::lsp::WorkspaceEdit
 SymbolTableHandler::FindRenameLocationsAndCreateEdits(
     const verible::lsp::RenameParams &params,
     const verilog::BufferTrackerContainer &parsed_buffers) {
-  if (files_dirty_) {
-    BuildProjectSymbolTable();
-  }
   Prepare();
+
   absl::string_view symbol =
       GetTokenAtTextDocumentPosition(params, parsed_buffers);
   const SymbolTableNode &root = symbol_table_->Root();
@@ -513,6 +514,24 @@ void SymbolTableHandler::UpdateFileContent(
     absl::string_view path, const verilog::VerilogAnalyzer *parsed) {
   files_dirty_ = true;
   curr_project_->UpdateFileContents(path, parsed);
+}
+
+BufferTrackerContainer::ChangeCallback
+SymbolTableHandler::CreateBufferTrackerListener() {
+  return [this](const std::string &uri,
+                const verilog::BufferTracker *buffer_tracker) {
+    const std::string path = verible::lsp::LSPUriToPath(uri);
+    if (path.empty()) {
+      LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
+      return;
+    }
+    if (!buffer_tracker) {
+      UpdateFileContent(path, nullptr);
+      return;
+    }
+    if (!buffer_tracker->last_good()) return;
+    UpdateFileContent(path, &buffer_tracker->last_good()->parser());
+  };
 }
 
 };  // namespace verilog

--- a/verilog/tools/ls/symbol-table-handler.cc
+++ b/verilog/tools/ls/symbol-table-handler.cc
@@ -525,12 +525,11 @@ SymbolTableHandler::CreateBufferTrackerListener() {
       LOG(ERROR) << "Could not convert LS URI to path:  " << uri;
       return;
     }
-    if (!buffer_tracker) {
-      UpdateFileContent(path, nullptr);
-      return;
-    }
-    if (!buffer_tracker->last_good()) return;
-    UpdateFileContent(path, &buffer_tracker->last_good()->parser());
+    // Note, if we actually got any result we must use it here to update
+    // the file content, as the old one will be deleted.
+    // So must use current() as last_good() might be nullptr.
+    UpdateFileContent(
+        path, buffer_tracker ? &buffer_tracker->current()->parser() : nullptr);
   };
 }
 

--- a/verilog/tools/ls/symbol-table-handler.h
+++ b/verilog/tools/ls/symbol-table-handler.h
@@ -71,10 +71,6 @@ class SymbolTableHandler {
   std::optional<verible::lsp::Range> FindRenameableRangeAtCursor(
       const verible::lsp::PrepareRenameParams &params,
       const verilog::BufferTrackerContainer &parsed_buffers);
-  // Provide new parsed content for the given path. If "content" is nullptr,
-  // opens the given file instead.
-  void UpdateFileContent(absl::string_view path,
-                         const verilog::VerilogAnalyzer *parsed);
 
   verible::lsp::WorkspaceEdit FindRenameLocationsAndCreateEdits(
       const verible::lsp::RenameParams &params,
@@ -82,6 +78,15 @@ class SymbolTableHandler {
 
   // Creates a symbol table for entire project (public: needed in unit-test)
   std::vector<absl::Status> BuildProjectSymbolTable();
+
+  // Provide new parsed content for the given path. If "content" is nullptr,
+  // opens the given file instead.
+  void UpdateFileContent(absl::string_view path,
+                         const verilog::VerilogAnalyzer *parsed);
+
+  // Create a listener to be wired up to a buffer tracker. Whenever we
+  // there is a change in the editor, this will update our internal project.
+  BufferTrackerContainer::ChangeCallback CreateBufferTrackerListener();
 
  private:
   // prepares structures for symbol-based requests

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -242,19 +242,7 @@ TEST(SymbolTableHandlerTest,
 
   verilog::BufferTrackerContainer parsed_buffers;
   parsed_buffers.AddChangeListener(
-      [&symbol_table_handler, parameters](
-          const std::string &uri,
-          const verilog::BufferTracker *buffer_tracker) {
-        if (!buffer_tracker) {
-          symbol_table_handler.UpdateFileContent(
-              verible::lsp::LSPUriToPath(parameters.textDocument.uri), nullptr);
-          return;
-        }
-        if (!buffer_tracker->last_good()) return;
-        symbol_table_handler.UpdateFileContent(
-            verible::lsp::LSPUriToPath(parameters.textDocument.uri),
-            &buffer_tracker->last_good()->parser());
-      });
+      symbol_table_handler.CreateBufferTrackerListener());
 
   // Add trackers for the files we're going to process - normally done by the
   // LSP but we don't have one
@@ -304,19 +292,7 @@ TEST(SymbolTableHandlerTest,
 
   verilog::BufferTrackerContainer parsed_buffers;
   parsed_buffers.AddChangeListener(
-      [&symbol_table_handler, parameters](
-          const std::string &uri,
-          const verilog::BufferTracker *buffer_tracker) {
-        if (!buffer_tracker) {
-          symbol_table_handler.UpdateFileContent(
-              verible::lsp::LSPUriToPath(parameters.textDocument.uri), nullptr);
-          return;
-        }
-        if (!buffer_tracker->last_good()) return;
-        symbol_table_handler.UpdateFileContent(
-            verible::lsp::LSPUriToPath(parameters.textDocument.uri),
-            &buffer_tracker->last_good()->parser());
-      });
+      symbol_table_handler.CreateBufferTrackerListener());
 
   // Add trackers for the files we're going to process - normally done by the
   // LSP but we don't have one
@@ -366,19 +342,7 @@ TEST(SymbolTableHandlerTest, FindRenamableRangeAtCursorReturnsLocation) {
 
   verilog::BufferTrackerContainer parsed_buffers;
   parsed_buffers.AddChangeListener(
-      [&symbol_table_handler, parameters](
-          const std::string &uri,
-          const verilog::BufferTracker *buffer_tracker) {
-        if (!buffer_tracker) {
-          symbol_table_handler.UpdateFileContent(
-              verible::lsp::LSPUriToPath(parameters.textDocument.uri), nullptr);
-          return;
-        }
-        if (!buffer_tracker->last_good()) return;
-        symbol_table_handler.UpdateFileContent(
-            verible::lsp::LSPUriToPath(parameters.textDocument.uri),
-            &buffer_tracker->last_good()->parser());
-      });
+      symbol_table_handler.CreateBufferTrackerListener());
 
   // Add trackers for the files we're going to process - normally done by the
   // LSP but we don't have one
@@ -430,19 +394,7 @@ TEST(SymbolTableHandlerTest,
 
   verilog::BufferTrackerContainer parsed_buffers;
   parsed_buffers.AddChangeListener(
-      [&symbol_table_handler, parameters](
-          const std::string &uri,
-          const verilog::BufferTracker *buffer_tracker) {
-        if (!buffer_tracker) {
-          symbol_table_handler.UpdateFileContent(
-              verible::lsp::LSPUriToPath(parameters.textDocument.uri), nullptr);
-          return;
-        }
-        if (!buffer_tracker->last_good()) return;
-        symbol_table_handler.UpdateFileContent(
-            verible::lsp::LSPUriToPath(parameters.textDocument.uri),
-            &buffer_tracker->last_good()->parser());
-      });
+      symbol_table_handler.CreateBufferTrackerListener());
 
   // Add trackers for the files we're going to process - normally done by the
   // LSP but we don't have one
@@ -495,19 +447,7 @@ TEST(SymbolTableHandlerTest,
 
   verilog::BufferTrackerContainer parsed_buffers;
   parsed_buffers.AddChangeListener(
-      [&symbol_table_handler, parameters](
-          const std::string &uri,
-          const verilog::BufferTracker *buffer_tracker) {
-        if (!buffer_tracker) {
-          symbol_table_handler.UpdateFileContent(
-              verible::lsp::LSPUriToPath(parameters.textDocument.uri), nullptr);
-          return;
-        }
-        if (!buffer_tracker->last_good()) return;
-        symbol_table_handler.UpdateFileContent(
-            verible::lsp::LSPUriToPath(parameters.textDocument.uri),
-            &buffer_tracker->last_good()->parser());
-      });
+      symbol_table_handler.CreateBufferTrackerListener());
 
   // Add trackers for the files we're going to process - normally done by the
   // LSP but we don't have one

--- a/verilog/tools/ls/verilog-language-server.h
+++ b/verilog/tools/ls/verilog-language-server.h
@@ -73,10 +73,6 @@ class VerilogLanguageServer {
   void SendDiagnostics(const std::string &uri,
                        const verilog::BufferTracker &buffer_tracker);
 
-  // Updates file contents in the project on change in Language Server Client
-  void UpdateEditedFileInProject(const std::string &uri,
-                                 const verilog::BufferTracker *buffer_tracker);
-
   // Stream splitter splits the input stream into messages (header/body).
   verible::lsp::MessageStreamSplitter stream_splitter_;
 


### PR DESCRIPTION
The VerilogProject is sensitive to adding the exact same file content twice, as it buildls a string index mapping back to the file.

The symbol table was ignnoring updates with files that might not be parseable, where the `last_good()` was essentially not changing, i.e. it was pushing the same `last_good()` content (with the exact same string view content) to the project which made it not happy. This problematic handling was probably highlighted by the recent fix of #2078 which made sure all registering and unregistering of files is accounted for.

The actual fix is small, so split into two commits
  * https://github.com/chipsalliance/verible/commit/75463fff739668dd75500b0bff9be4aacf747c06 is refactoring the current notification and moves from the language server to handled more locally in the symbol table.
  * https://github.com/chipsalliance/verible/commit/fd195a5460ac4c9abd00e161b6b011336849ba30 fixes the issue at hand. Essentially passing the `current()` parse instead of `last_good()` to verilog project.