### PR TITLE
Document a strange situation in which we find end() iterators in toke…

### DIFF
--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -431,8 +431,11 @@ absl::Status TextStructureView::InternalConsistencyCheck() const {
   return SyntaxTreeConsistencyCheck();
 }
 
-// TokenRange can be a container reference or iterator range.
-// TokenViewRange can be a container reference or iterator range.
+// "token_source" is a sequence of tokens.
+// The TokenRange can be a container reference or iterator range.
+//
+// "view_source" is a sequence of iterators pointing to token_source content.
+// The TokenViewRange can be a container reference or iterator range.
 template <typename TokenRange, typename TokenViewRange>
 static void CopyTokensAndView(TokenSequence* destination,
                               std::vector<int>* view_indices,
@@ -440,8 +443,15 @@ static void CopyTokensAndView(TokenSequence* destination,
                               const TokenViewRange& view_source) {
   // Translate token_view's iterators into array indices, adjusting for the
   // number of pre-existing tokens.
+  const auto pre_existing_start_index = destination->size();
   for (const auto& token_iter : view_source) {
-    view_indices->push_back(destination->size() +
+    // TODO: something is wrong here, the view should never have iterators
+    // pointing outside the range of the source. Needs to be explored.
+#if 0
+    CHECK(token_iter >= token_source.begin() &&
+          token_iter < token_source.end());
+#endif
+    view_indices->push_back(pre_existing_start_index +
                             std::distance(token_source.begin(), token_iter));
   }
   // Copy tokens up to this expansion point.


### PR DESCRIPTION
…n-views.

Needs to be explored more, but I think the view should only contain dereferencable iterators.
If CHECK() is enabled (`#if 1`), the formatter_test will fail.