### PR TITLE
Resolve "Rejected valid signal name"

### DIFF
--- a/verible/verilog/parser/verilog-parser_test.cc
+++ b/verible/verilog/parser/verilog-parser_test.cc
@@ -1839,6 +1839,7 @@ static constexpr ParserTestCaseArray kModuleTests = {
     // keyword tests
     "module keyword_identifiers;\n"
     "reg branch;  // branch is a Verilog-AMS keyword\n"
+    "reg analog;  // analog is a Verilog-AMS keyword\n"
     "input from;  // from is a Verilog-AMS keyword\n"
     "wire access;  // access is a Verilog-AMS keyword\n"
     "wire exclude;  // exclude is a Verilog-AMS keyword\n"

--- a/verible/verilog/parser/verilog-parser_test.cc
+++ b/verible/verilog/parser/verilog-parser_test.cc
@@ -4749,6 +4749,18 @@ static constexpr ParserTestCaseArray kModuleMemberTests = {
     "    `MACRO();\n"  // macro as item
     "  }\n"
     "endgroup",
+    // Verilog-AMS analog_construct, which starts with the same "analog" that is
+    // also accepted as a plain identifier.
+    "module mymodule;\n"
+    "  analog V(a, b) <+ 1;\n"
+    "endmodule",
+    "module mymodule;\n"
+    "  analog I(x) <+ y + 1;\n"
+    "endmodule",
+    "module mymodule;\n"
+    "  reg analog;\n"  // analog as identifier, next to the construct
+    "  analog V(a, b) <+ analog;\n"
+    "endmodule",
 };
 
 static constexpr ParserTestCaseArray kClassMemberTests = {

--- a/verible/verilog/parser/verilog.y
+++ b/verible/verilog/parser/verilog.y
@@ -773,6 +773,8 @@ KeywordIdentifier
     { $$ = std::move($1); }
   | TK_discrete
     { $$ = std::move($1); }
+  | TK_analog
+    { $$ = std::move($1); }
   /* TK_sample is in SystemVerilog coverage_event */
   | TK_sample
     { $$ = std::move($1); }

--- a/verible/verilog/parser/verilog.y
+++ b/verible/verilog/parser/verilog.y
@@ -730,7 +730,13 @@ is not locally defined, so the grammar here uses only generic identifiers.
 %nonassoc TK_else
 /* to resolve exclude (... ambiguity */
 %nonassoc '('
+/* resolve the `analog <identifier>` ambiguity.
+ * after "analog" a following identifier can start either an analog_construct or a declaration in which "analog" is itself the identifier.
+ * Ranking TK_analog below every token that can follow it there */
+%right TK_analog
 %nonassoc TK_exclude
+%precedence SymbolIdentifier EscapedIdentifier MacroIdentifier
+%precedence TK_access TK_continuous TK_discrete TK_flow TK_from TK_infinite TK_sample
 
 /* root of syntax tree: */
 %start source_text


### PR DESCRIPTION
Close #2076: add `analog` as potential AMS-dialect word in parser according to https://github.com/chipsalliance/verible/issues/2076#issuecomment-1919763868
