### PR TITLE
Always pass `-xc++`: Tell the compiler the language to compile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,13 +10,15 @@ build:openbsd --workspace_status_command="bazel/build-version.py"
 build:macos --workspace_status_command="bazel/build-version.py"
 build:windows --workspace_status_command="python bazel/build-version.py"
 
-common:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
-common:freebsd --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17 --linkopt=-lm --host_linkopt=-lm
-common:openbsd --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17 --linkopt=-lm --host_linkopt=-lm
+# Systems with gcc or clang
+common:linux   --cxxopt=-xc++ --host_cxxopt=-xc++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+common:freebsd --cxxopt=-xc++ --host_cxxopt=-xc++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17 --linkopt=-lm --host_linkopt=-lm
+common:openbsd --cxxopt=-xc++ --host_cxxopt=-xc++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17 --linkopt=-lm --host_linkopt=-lm
+common:macos   --cxxopt=-xc++ --host_cxxopt=-xc++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
 
 # https://github.com/abseil/abseil-cpp/issues/848
 # https://github.com/bazelbuild/bazel/issues/4341#issuecomment-758361769
-common:macos --features=-supports_dynamic_linker --linkopt=-framework --linkopt=CoreFoundation --host_linkopt=-framework --host_linkopt=CoreFoundation --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+common:macos --features=-supports_dynamic_linker --linkopt=-framework --linkopt=CoreFoundation --host_linkopt=-framework --host_linkopt=CoreFoundation
 
 # Force the use clang-cl on Windows instead of MSVC. MSVC has some issues with
 # the codebase, so we focus the effort for now is to have a Windows Verible

--- a/shell.nix
+++ b/shell.nix
@@ -16,9 +16,6 @@ let
 
   # Testing with specific compilers
   #verible_used_stdenv = pkgs.gcc13Stdenv;
-
-  # Using clang stdenv does not work yet out of the box yet
-  # https://github.com/NixOS/nixpkgs/issues/216047
   #verible_used_stdenv = pkgs.clang13Stdenv;
 in
 verible_used_stdenv.mkDerivation {


### PR DESCRIPTION
Bazel just invokes the compiler (gcc or clang) in its basic form and expects it to figure out if the language is C or C++.

Make sure it always is told that it is C++; not all compiler installatins are set-up to auto-detect (looking at you, clang-installation-on-NixOS...).

Works around
  Issue https://github.com/NixOS/nixpkgs/issues/216047
  Issue https://github.com/NixOS/nixpkgs/issues/150655