### PR TITLE
lint: remove false positives from uvm-macro-semicolon

### DIFF
--- a/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
+++ b/verilog/analysis/checkers/uvm_macro_semicolon_rule_test.cc
@@ -43,6 +43,15 @@ TEST(UvmMacroSemicolonRuleTest, BaseTests) {
   RunLintTestCases<VerilogAnalyzer, UvmMacroSemicolonRule>(kTestCases);
 }
 
+TEST(UvmMacroSemicolonRuleTest, NoFalsePositivesTest) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+      {"module m;\nint k = `UVM_DEFAULT_TIMEOUT; endmodule\n"},
+      {"module m;\nbit [63:0] k = `UVM_REG_ADDR_WIDTH'(0); endmodule\n"},
+  };
+
+  RunLintTestCases<VerilogAnalyzer, UvmMacroSemicolonRule>(kTestCases);
+}
+
 TEST(UvmMacroSemicolonRuleTest, AcceptedUvmMacroCallTests) {
   const std::initializer_list<LintTestCase> kTestCases = {
       // Function/Task scope


### PR DESCRIPTION
Macros like `UVM_REG_DATA_WIDTH were being flagged by the rule when they shouldn't.

To the best of my knowledge, the only UVM macros that are parsed like `MacroIdentifier` and should be flagged are the ones ending with `_end`:

  uvm_component_utils_end,
  uvm_error_context_end,
  ...

More context: https://github.com/chipsalliance/verible/issues/2107 