### PR TITLE
For unit tests: add gtest libraries explicitly not only gtest_main.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,11 +152,9 @@ http_archive(
     ],
 )
 
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
 rules_proto_dependencies()
-
-rules_proto_toolchains()
 
 http_archive(
     name = "rules_python",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -206,6 +206,7 @@ http_archive(
 )
 
 load("@rules_compdb//:deps.bzl", "rules_compdb_deps")
+
 rules_compdb_deps()
 
 # zlib is imported through protobuf. Make the dependency explicit considering

--- a/common/analysis/BUILD
+++ b/common/analysis/BUILD
@@ -107,6 +107,7 @@ cc_test(
         "//common/lexer:lexer-test-util",
         "//common/text:token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -368,6 +369,7 @@ cc_test(
         "//common/text:token-info",
         "//common/text:tree-builder-test-util",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -382,6 +384,7 @@ cc_test(
         "//common/text:token-info",
         "//common/text:token-stream-view",
         "//common/util:iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -395,6 +398,7 @@ cc_test(
         "//common/text:token-info",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -407,6 +411,7 @@ cc_test(
         ":linter-test-utils",
         "//common/util:range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -420,6 +425,7 @@ cc_test(
         ":lint-rule-status",
         "//common/text:token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -437,6 +443,7 @@ cc_test(
         "//common/text:syntax-tree-context",
         "//common/text:token-info",
         "//common/text:tree-builder-test-util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -452,6 +459,7 @@ cc_test(
         "//common/text:syntax-tree-context",
         "//common/text:tree-builder-test-util",
         "//common/text:tree-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -464,6 +472,7 @@ cc_test(
         "//common/text:tree-builder-test-util",
         "//common/util:range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -478,6 +487,7 @@ cc_test(
         "//common/text:text-structure",
         "//common/text:token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -492,6 +502,7 @@ cc_test(
         "//common/text:token-info",
         "//common/text:token-stream-view",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/analysis/matcher/BUILD
+++ b/common/analysis/matcher/BUILD
@@ -45,6 +45,7 @@ cc_test(
         "//common/text:concrete-syntax-tree",
         "//common/text:symbol",
         "//common/text:tree-builder-test-util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -70,6 +71,7 @@ cc_test(
         ":matcher-test-utils",
         "//common/text:symbol",
         "//common/text:tree-builder-test-util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -109,6 +111,7 @@ cc_test(
         "//common/text:concrete-syntax-tree",
         "//common/text:symbol",
         "//common/text:tree-builder-test-util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -133,6 +136,7 @@ cc_test(
         "//common/text:symbol",
         "//common/text:token-info",
         "//common/text:tree-builder-test-util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -50,6 +50,7 @@ cc_test(
         "//common/util:spacer",
         "//common/util:value-saver",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -79,6 +80,7 @@ cc_test(
     srcs = ["basic_format_style_test.cc"],
     deps = [
         ":basic-format-style",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -112,6 +114,7 @@ cc_test(
         "//common/text:token-info",
         "//common/util:range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -157,6 +160,7 @@ cc_test(
         "//common/util:vector-tree",
         "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -197,6 +201,7 @@ cc_library(
         ":token-partition-tree",
         ":unwrapped-line",
         "//common/util:tree-operations",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -214,6 +219,7 @@ cc_test(
         "//common/util:tree-operations",
         "//common/util:vector-tree",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -257,6 +263,7 @@ cc_test(
         ":unwrapped-line-test-utils",
         "//common/text:tree-builder-test-util",
         "//common/util:container-iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -288,6 +295,7 @@ cc_test(
         "//common/text:token-info",
         "//common/text:tree-builder-test-util",
         "//common/util:iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -332,6 +340,7 @@ cc_test(
         "//common/util:container-iterator-range",
         "//common/util:range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -385,6 +394,7 @@ cc_test(
         "//common/util:logging",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -399,6 +409,7 @@ cc_test(
         ":unwrapped-line",
         ":unwrapped-line-test-utils",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -421,6 +432,7 @@ cc_test(
     deps = [
         ":verification",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/lexer/BUILD
+++ b/common/lexer/BUILD
@@ -76,6 +76,7 @@ cc_test(
         "//common/text:token-info",
         "//common/util:logging",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -89,6 +90,7 @@ cc_test(
         ":token-stream-adapter",
         "//common/text:token-info",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -34,6 +34,7 @@ cc_test(
         ":message-stream-splitter",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -66,6 +67,7 @@ cc_test(
         ":json-rpc-dispatcher",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -93,6 +95,7 @@ cc_test(
     srcs = ["lsp-protocol-operators_test.cc"],
     deps = [
         ":lsp-protocol-operators",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -117,6 +120,7 @@ cc_test(
         ":json-rpc-dispatcher",
         ":lsp-text-buffer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -136,6 +140,7 @@ cc_test(
     deps = [
         ":lsp-file-utils",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/parser/BUILD
+++ b/common/parser/BUILD
@@ -88,6 +88,7 @@ cc_test(
         "//common/text:symbol",
         "//common/text:token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -20,6 +20,7 @@ cc_test(
     srcs = ["compare_test.cc"],
     deps = [
         ":compare",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -42,6 +43,7 @@ cc_test(
         ":comment-utils",
         "//common/util:range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -65,6 +67,7 @@ cc_test(
     deps = [
         ":diff",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -83,6 +86,7 @@ cc_test(
     srcs = ["display_utils_test.cc"],
     deps = [
         ":display-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -108,6 +112,7 @@ cc_test(
         ":random",
         "//common/util:bijective-map",
         "//common/util:logging",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -132,6 +137,7 @@ cc_test(
     srcs = ["naming_utils_test.cc"],
     deps = [
         ":naming-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -167,6 +173,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -186,6 +193,7 @@ cc_test(
     srcs = ["position_test.cc"],
     deps = [
         ":position",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -207,6 +215,7 @@ cc_test(
     srcs = ["random_test.cc"],
     deps = [
         ":random",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -228,6 +237,7 @@ cc_test(
     deps = [
         ":range",
         "//common/util:range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -248,6 +258,7 @@ cc_test(
         ":range",
         ":split",
         "//common/util:range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -270,6 +281,7 @@ cc_test(
         "//common/util:range",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -304,6 +316,7 @@ cc_test(
     srcs = ["utf8_test.cc"],
     deps = [
         ":utf8",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -314,6 +327,7 @@ cc_test(
     deps = [
         ":line-column-map",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -338,6 +352,7 @@ cc_test(
         ":string-memory-map",
         "//common/util:range",
         "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -98,6 +98,7 @@ cc_test(
         ":concrete-syntax-leaf",
         ":token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -135,6 +136,7 @@ cc_test(
         ":config-utils",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -176,6 +178,7 @@ cc_test(
         ":concrete-syntax-tree",
         ":tree-builder-test-util",
         ":tree-compare",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -197,6 +200,7 @@ cc_test(
     deps = [
         ":tree-builder-test-util",
         ":tree-context-visitor",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -241,6 +245,7 @@ cc_test(
     deps = [
         ":tree-builder-test-util",
         ":tree-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -340,6 +345,7 @@ cc_test(
         "//common/util:casts",
         "//common/util:logging",
         "//common/util:range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -354,6 +360,7 @@ cc_test(
         ":tree-builder-test-util",
         ":tree-compare",
         "//common/util:logging",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -367,6 +374,7 @@ cc_test(
         "//common/util:range",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -379,6 +387,7 @@ cc_test(
         ":token-info",
         ":token-info-json",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -391,6 +400,7 @@ cc_test(
         ":token-info-test-util",
         "//common/util:logging",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -404,6 +414,7 @@ cc_test(
         ":token-info",
         ":token-stream-view",
         "//common/util:iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -415,6 +426,7 @@ cc_test(
         ":concrete-syntax-tree",
         ":syntax-tree-context",
         "//common/util:iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -440,6 +452,7 @@ cc_test(
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -452,6 +465,7 @@ cc_test(
         ":token-info",
         "//common/util:container-util",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -466,6 +480,7 @@ cc_test(
         ":token-stream-view",
         ":tree-builder-test-util",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -94,6 +94,7 @@ cc_test(
     deps = [
         ":jcxxgen-testfile",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -335,6 +335,7 @@ cc_test(
         ":algorithm",
         ":iterator-range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -344,6 +345,7 @@ cc_test(
     srcs = ["auto_iterator_test.cc"],
     deps = [
         ":auto-iterator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -354,6 +356,7 @@ cc_test(
     deps = [
         ":auto-pop-stack",
         ":iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -365,6 +368,7 @@ cc_test(
         ":file-util",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -374,6 +378,7 @@ cc_test(
     srcs = ["interval_test.cc"],
     deps = [
         ":interval",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -385,6 +390,7 @@ cc_test(
         ":interval-map",
         ":range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -394,6 +400,7 @@ cc_test(
     srcs = ["interval_set_test.cc"],
     deps = [
         ":interval-set",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -404,6 +411,7 @@ cc_test(
     deps = [
         ":forward",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -415,6 +423,7 @@ cc_test(
         ":iterator-range",
         ":range",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -430,6 +439,7 @@ cc_test(
     deps = [
         ":thread-pool",
         "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -439,6 +449,7 @@ cc_test(
     srcs = ["container_iterator_range_test.cc"],
     deps = [
         ":container-iterator-range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -448,6 +459,7 @@ cc_test(
     srcs = ["iterator_adaptors_test.cc"],
     deps = [
         ":iterator-adaptors",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -458,6 +470,7 @@ cc_test(
     deps = [
         ":iterator-range",
         ":range",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -467,6 +480,7 @@ cc_test(
     srcs = ["spacer_test.cc"],
     deps = [
         ":spacer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -477,6 +491,7 @@ cc_test(
     deps = [
         ":subcommand",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -486,6 +501,7 @@ cc_test(
     srcs = ["top_n_test.cc"],
     deps = [
         ":top-n",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -495,6 +511,7 @@ cc_test(
     srcs = ["type_traits_test.cc"],
     deps = [
         ":type-traits",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -504,6 +521,7 @@ cc_test(
     srcs = ["value_saver_test.cc"],
     deps = [
         ":value-saver",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -514,6 +532,7 @@ cc_test(
     deps = [
         ":enum-flags",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -525,6 +544,7 @@ cc_test(
         ":bijective-map",
         ":logging",
         "//common/strings:compare",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -537,6 +557,7 @@ cc_test(
         ":vector-tree",
         ":vector-tree-test-util",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -552,6 +573,7 @@ cc_test(
                 ":tree-operations",
                 "@com_google_absl//absl/strings",
                 "@com_google_absl//absl/strings:str_format",
+                "@com_google_googletest//:gtest",
                 "@com_google_googletest//:gtest_main",
             ],
         ),
@@ -574,6 +596,7 @@ cc_test(
         ":vector-tree",
         ":vector-tree-test-util",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -586,6 +609,7 @@ cc_test(
         ":vector-tree",
         ":vector-tree-iterators",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -601,6 +625,7 @@ cc_test(
         ":map-tree",
         ":spacer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -611,6 +636,7 @@ cc_test(
     deps = [
         ":with-reason",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -621,6 +647,7 @@ cc_test(
     deps = [
         ":user-interaction",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -632,6 +659,7 @@ cc_test(
         ":container-proxy",
         ":type-traits",
         "//common/strings:display-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -654,6 +682,7 @@ cc_test(
         ":file-util",
         ":simple-zip",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -673,6 +702,7 @@ cc_test(
     deps = [
         ":sha256",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/external_libs/BUILD
+++ b/external_libs/BUILD
@@ -21,6 +21,7 @@ cc_test(
     deps = [
         ":editscript",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ let
 
   # Testing with specific compilers
   #verible_used_stdenv = pkgs.gcc13Stdenv;
-  #verible_used_stdenv = pkgs.clang13Stdenv;
+  #verible_used_stdenv = pkgs.clang17Stdenv;
 in
 verible_used_stdenv.mkDerivation {
   name = "verible-build-environment";

--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -49,6 +49,7 @@ cc_test(
     deps = [
         ":verilog-nonterminals",
         "//common/text:constants",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -82,6 +83,7 @@ cc_test(
         "//common/analysis/matcher:matcher-builders",
         "//common/analysis/matcher:matcher-test-utils",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -108,6 +110,7 @@ cc_test(
         ":verilog-treebuilder-utils",
         "//common/text:tree-builder-test-util",
         "//common/text:tree-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -168,6 +171,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -203,6 +207,7 @@ cc_test(
         "//common/text:tree-utils",
         "//common/util:range",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -238,6 +243,7 @@ cc_test(
         "//common/analysis:syntax-tree-search-test-utils",
         "//common/text:text-structure",
         "//common/text:tree-utils",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -275,6 +281,7 @@ cc_test(
         "//common/util:casts",
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -315,6 +322,7 @@ cc_test(
         "//common/text:tree-utils",
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -361,6 +369,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -399,6 +408,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -432,6 +442,7 @@ cc_test(
         "//common/text:token-info-test-util",
         "//common/util:range",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -470,6 +481,7 @@ cc_test(
         "//common/util:logging",
         "//common/util:range",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -510,6 +522,7 @@ cc_test(
         "//common/util:logging",
         "//common/util:range",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -546,6 +559,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -579,6 +593,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -616,6 +631,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -662,6 +678,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -702,6 +719,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -736,6 +754,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -780,6 +799,7 @@ cc_test(
         "//common/util:logging",
         "//common/util:range",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -821,6 +841,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -861,6 +882,7 @@ cc_test(
         "//common/text:tree-utils",
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -931,6 +953,7 @@ cc_test(
         "//common/text:syntax-tree-context",
         "//common/text:tree-builder-test-util",
         "//common/util:casts",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -941,6 +964,7 @@ cc_test(
     deps = [
         ":numbers",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -953,6 +977,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -966,6 +991,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -25,6 +25,7 @@ cc_test(
         ":default-rules",
         ":lint-rule-registry",
         "//verilog/analysis/checkers:verilog-lint-rules",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -56,6 +57,7 @@ cc_test(
     deps = [
         ":extractors",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -96,6 +98,7 @@ cc_test(
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -126,6 +129,7 @@ cc_test(
         ":verilog-analyzer",
         "//common/util:logging",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
         "@jsonhpp",
     ],
@@ -148,6 +152,7 @@ cc_test(
         "//common/text:text-structure",
         "//common/text:token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -298,6 +303,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -324,6 +330,7 @@ cc_test(
         "//common/text:token-info",
         "//common/text:tree-builder-test-util",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -342,6 +349,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -356,6 +364,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -378,6 +387,7 @@ cc_test(
     deps = [
         ":verilog-filelist",
         "//common/util:file-util",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -412,6 +422,7 @@ cc_test(
         "//common/util:range",
         "//verilog/CST:module",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -476,6 +487,7 @@ cc_test(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -501,6 +513,7 @@ cc_test(
         ":dependencies",
         "//common/util:file-util",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -107,6 +107,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -137,6 +138,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -167,6 +169,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -205,6 +208,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -236,6 +240,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -278,6 +283,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -313,6 +319,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -347,6 +354,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -386,6 +394,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -420,6 +429,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -456,6 +466,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -490,6 +501,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -533,6 +545,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -568,6 +581,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -599,6 +613,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -631,6 +646,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -667,6 +683,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -724,6 +741,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -739,6 +757,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -776,6 +795,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -812,6 +832,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -850,6 +871,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -889,6 +911,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -929,6 +952,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -968,6 +992,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1008,6 +1033,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1053,6 +1079,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1089,6 +1116,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1124,6 +1152,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1150,6 +1179,7 @@ cc_test(
         ":suggest-parentheses-rule",
         "//common/analysis:syntax-tree-linter-test-utils",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1187,6 +1217,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1225,6 +1256,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1263,6 +1295,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1302,6 +1335,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1341,6 +1375,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1379,6 +1414,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1418,6 +1454,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1454,6 +1491,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1492,6 +1530,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1530,6 +1569,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1563,6 +1603,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1593,6 +1634,7 @@ cc_test(
         "//common/analysis:token-stream-linter-test-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1626,6 +1668,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1665,6 +1708,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1703,6 +1747,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1740,6 +1785,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1776,6 +1822,7 @@ cc_test(
         "//verilog/CST:verilog-treebuilder-utils",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1815,6 +1862,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1853,6 +1901,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1896,6 +1945,7 @@ cc_test(
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1938,6 +1988,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -1976,6 +2027,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -2013,6 +2065,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -2050,6 +2103,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -2086,6 +2140,7 @@ cc_test(
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -2121,6 +2176,7 @@ cc_test(
         "//common/text:symbol",
         "//verilog/CST:verilog-nonterminals",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -2154,6 +2210,7 @@ cc_test(
         "//common/analysis:linter-test-utils",
         "//common/analysis:syntax-tree-linter-test-utils",
         "//verilog/analysis:verilog-analyzer",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -100,6 +100,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -123,6 +124,7 @@ cc_test(
         "//common/formatting:format-token",
         "//common/text:token-info",
         "//verilog/parser:verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -186,6 +188,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -200,6 +203,7 @@ cc_test(
         "//common/util:logging",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -234,6 +238,7 @@ cc_test(
         "//common/text:token-info-test-util",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -303,6 +308,7 @@ cc_test(
         "//verilog/parser:verilog-parser",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/parser/BUILD
+++ b/verilog/parser/BUILD
@@ -53,6 +53,7 @@ cc_test(
         "//common/lexer:lexer-test-util",
         "//common/text:token-info",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -198,6 +199,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -215,6 +217,7 @@ cc_test(
         "//common/util:logging",
         "//verilog/analysis:verilog-analyzer",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -234,6 +237,7 @@ cc_test(
     deps = [
         ":verilog-token-classifications",
         ":verilog-token-enum",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/preprocessor/BUILD
+++ b/verilog/preprocessor/BUILD
@@ -49,6 +49,7 @@ cc_test(
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -39,6 +39,7 @@ cc_test(
     srcs = ["kythe_facts_test.cc"],
     deps = [
         ":kythe-facts",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -64,6 +65,7 @@ cc_test(
         ":kythe-facts",
         ":scope-resolver",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -145,6 +147,7 @@ cc_test(
         "//common/util:range",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -202,6 +205,7 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "//verilog/analysis:verilog-project",
         "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -60,6 +60,7 @@ cc_test(
         "//common/lsp:lsp-text-buffer",
         "//common/text:text-structure",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -155,6 +156,7 @@ cc_test(
         "//common/util:file-util",
         "//verilog/analysis:verilog-project",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -192,6 +194,7 @@ cc_test(
         "//verilog/analysis:verilog-linter",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -233,6 +236,7 @@ cc_test(
         "//common/lsp:lsp-protocol",
         "//verilog/formatting:format-style-init",
         "//verilog/formatting:formatter",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/verilog/transform/BUILD
+++ b/verilog/transform/BUILD
@@ -34,6 +34,7 @@ cc_test(
     deps = [
         ":obfuscate",
         "//common/strings:obfuscator",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )
@@ -61,6 +62,7 @@ cc_test(
     deps = [
         ":strip-comments",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
The layering_check feature of bazel complained that the direct dependency for using the header was not included.

Doesn't matter much in practice, but being explicit about the dependencies is also nice.

(It will then eventually be possible to run the layering check in the CI, so that things are not forgotten accidentally)