### PR TITLE
Don't declare lint_waiver.h to be exported by two different targets.

### DIFF
--- a/common/analysis/BUILD
+++ b/common/analysis/BUILD
@@ -63,7 +63,6 @@ cc_library(
     ],
     hdrs = [
         "command_file_lexer.h",
-        "lint_waiver.h",
     ],
     copts = select({
         "@platforms//os:windows": [],

--- a/common/analysis/command_file_lexer.cc
+++ b/common/analysis/command_file_lexer.cc
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "absl/strings/string_view.h"
-#include "common/analysis/lint_waiver.h"
 #include "common/lexer/token_stream_adapter.h"
 #include "common/text/token_info.h"
 #include "common/util/logging.h"

--- a/common/analysis/command_file_lexer.h
+++ b/common/analysis/command_file_lexer.h
@@ -20,9 +20,9 @@
 // lint_waiver_config.lex has "%prefix=verible", meaning the class flex
 // creates is veribleFlexLexer. Unfortunately, FlexLexer.h doesn't have proper
 // ifdefs around its inclusion, so we have to put a bar around it here.
-#include "common/analysis/lint_waiver.h"
 #include "common/lexer/flex_lexer_adapter.h"
 #include "common/text/token_info.h"
+#include "common/text/token_stream_view.h"
 
 // clang-format off
 #ifndef _COMMANDFILE_FLEXLEXER_H_

--- a/common/analysis/lint_waiver.h
+++ b/common/analysis/lint_waiver.h
@@ -26,7 +26,6 @@
 #include "absl/strings/string_view.h"
 #include "common/strings/position.h"
 #include "common/text/text_structure.h"
-#include "common/text/token_stream_view.h"
 #include "common/util/container_util.h"
 #include "common/util/interval_set.h"
 


### PR DESCRIPTION
It was exported by `common/analysis:command-file-lexer` and `common/analysis:lint-waiver`

Found by github.com/hzeller/bant.