### PR TITLE
Enable layering check in most of the packages.

### DIFF
--- a/.github/bin/check-potential-problems.sh
+++ b/.github/bin/check-potential-problems.sh
@@ -62,9 +62,8 @@ if [ $? -eq 0 ]; then
 fi
 
 # Always use fully qualified include paths.
-# Exclude zlib.h, which is the only allowed header.
 find common verilog -name "*.h" -o -name "*.cc" | \
-  xargs egrep -n '#include "[^/]*"' | grep -v zlib.h
+  xargs egrep -n '#include "[^/]*"'
 if [ $? -eq 0 ]; then
   echo "::error:: always use a fully qualified name for #includes"
   echo

--- a/BUILD
+++ b/BUILD
@@ -10,6 +10,7 @@ load("@rules_license//rules:license.bzl", "license")
 package(
     default_applicable_licenses = [":license"],
     default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
 )
 
 # Machine-readable license specification.

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -9,6 +9,7 @@ package(
     default_visibility = [
         "//:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/analysis/BUILD
+++ b/common/analysis/BUILD
@@ -10,6 +10,8 @@ package(
         "//verilog/tools/kythe:__pkg__",
         "//verilog/tools/lint:__subpackages__",
     ],
+    # Not yet enabled, lexer does not find FlexLexer.
+    #features = ["layering_check"],
 )
 
 cc_library(

--- a/common/analysis/matcher/BUILD
+++ b/common/analysis/matcher/BUILD
@@ -8,6 +8,7 @@ package(
         "//verilog/CST:__subpackages__",
         "//verilog/analysis:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/formatting/BUILD
+++ b/common/formatting/BUILD
@@ -5,6 +5,7 @@ package(
     default_visibility = [
         "//verilog/formatting:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/lexer/BUILD
+++ b/common/lexer/BUILD
@@ -10,6 +10,7 @@ package(
         "//verilog/parser:__subpackages__",
         "//verilog/preprocessor:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -14,6 +14,7 @@ package(
     default_visibility = [
         "//verilog/tools/ls:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/parser/BUILD
+++ b/common/parser/BUILD
@@ -7,6 +7,7 @@ package(
         "//common/analysis:__subpackages__",
         "//verilog/parser:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/strings/BUILD
+++ b/common/strings/BUILD
@@ -5,6 +5,7 @@ package(
     default_visibility = [
         "//:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -13,6 +13,7 @@ package(
         "//common/parser:__subpackages__",
         "//verilog:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -9,6 +9,7 @@ package(
     default_visibility = [
         "//:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 exports_files([

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -6,6 +6,7 @@ package(
     default_visibility = [
         "//:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/common/util/simple_zip.cc
+++ b/common/util/simple_zip.cc
@@ -23,7 +23,7 @@
 
 #include "absl/strings/string_view.h"
 #include "third_party/portable_endian/portable_endian.h"
-#include "zlib.h"  // WORKSPACE imported project header
+#include "zlib/include/zlib.h"
 
 namespace verible {
 namespace zip {

--- a/external_libs/BUILD
+++ b/external_libs/BUILD
@@ -8,6 +8,7 @@ package(
     default_visibility = [
         "//:__subpackages__",
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/third_party/proto/kythe/BUILD
+++ b/third_party/proto/kythe/BUILD
@@ -1,7 +1,10 @@
 load("@rules_cc//cc:defs.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+)
 
 proto_library(
     name = "storage_proto",

--- a/third_party/py/dataclasses/BUILD
+++ b/third_party/py/dataclasses/BUILD
@@ -2,7 +2,10 @@
 #   dataclasses module from the Python 3.7 standard library.
 #   For backporting to Python 3.6 and below.
 
-package(default_visibility = ["//visibility:public"])
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+)
 
 licenses(["notice"])  # Python Software Foundation
 

--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -13,6 +13,7 @@ package(
         "//verilog/tools/ls:__pkg__",  # DocumentSymbol
         "//verilog/tools/syntax:__pkg__",  # for printing
     ],
+    features = ["layering_check"],
 )
 
 # Generate foreach list for nonterminal enums.

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -8,6 +8,7 @@ default_visibility = [
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = default_visibility,
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -8,6 +8,7 @@ default_visibility = [
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = default_visibility,
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/verilog/formatting/BUILD
+++ b/verilog/formatting/BUILD
@@ -8,6 +8,7 @@ default_visibility = [
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = default_visibility,
+    features = ["layering_check"],
 )
 
 # libraries

--- a/verilog/parser/BUILD
+++ b/verilog/parser/BUILD
@@ -13,6 +13,8 @@ package(
     default_visibility = [
         "//verilog:__subpackages__",
     ],
+    # Not yet enabled, lexer does not find FlexLexer.h
+    #features = ["layering_check"],
 )
 
 genlex(

--- a/verilog/preprocessor/BUILD
+++ b/verilog/preprocessor/BUILD
@@ -6,6 +6,7 @@ package(
         "//verilog:__subpackages__",
         # TODO(b/130113490): standalone preprocessor tool
     ],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/verilog/tools/diff/BUILD
+++ b/verilog/tools/diff/BUILD
@@ -7,6 +7,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_binary(

--- a/verilog/tools/formatter/BUILD
+++ b/verilog/tools/formatter/BUILD
@@ -7,6 +7,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_binary(

--- a/verilog/tools/kythe/BUILD
+++ b/verilog/tools/kythe/BUILD
@@ -8,6 +8,7 @@ package(
     default_visibility = [
         "//visibility:private",
     ],
+    features = ["layering_check"],
 )
 
 # Generates foreach list for IndexingFactType enum.

--- a/verilog/tools/lint/BUILD
+++ b/verilog/tools/lint/BUILD
@@ -11,6 +11,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 # Integration tests for different flags and configurations

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -8,6 +8,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_library(

--- a/verilog/tools/obfuscator/BUILD
+++ b/verilog/tools/obfuscator/BUILD
@@ -7,6 +7,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_binary(

--- a/verilog/tools/preprocessor/BUILD
+++ b/verilog/tools/preprocessor/BUILD
@@ -7,6 +7,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_binary(

--- a/verilog/tools/project/BUILD
+++ b/verilog/tools/project/BUILD
@@ -7,6 +7,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_binary(

--- a/verilog/tools/syntax/BUILD
+++ b/verilog/tools/syntax/BUILD
@@ -6,6 +6,7 @@ load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 cc_binary(

--- a/verilog/tools/syntax/export_json_examples/BUILD
+++ b/verilog/tools/syntax/export_json_examples/BUILD
@@ -5,6 +5,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],  # public examples
+    features = ["layering_check"],
 )
 
 py_library(

--- a/verilog/transform/BUILD
+++ b/verilog/transform/BUILD
@@ -8,6 +8,7 @@ default_visibility = [
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = default_visibility,
+    features = ["layering_check"],
 )
 
 cc_library(


### PR DESCRIPTION
The packages using flex can't yet be enabled as it seems that the flex target does not expose the FlexLexer.h header we use. To be tested separately.

zlib.h was considered a 'private header', so including the fqn zlib/include/zlib.h