### PR TITLE
Updated platforms dependency to support bazel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ guide and the [development resources](./doc/development.md).
 
 Verible's code base is written in C++.
 
-To build, you need the [bazel] (>= 5.0 and < 7) build system and a C++17
-compatible compiler (e.g. >= g++-10), as well as python3. Note, Verible
-is _not_ yet compatible with bazel-7, so you have to use an older version
-5 or 6. A lot of users of Verible have to work on pretty old installations,
+To build, you need the [bazel] (>= 5.0 and <= 7) build system and a C++17
+compatible compiler (e.g. >= g++-10), as well as python3. Note, to build
+Verible with bazel-7, so you need to add `--noenable_bzlmod` to every bazel
+command. A lot of users of Verible have to work on pretty old installations,
 so we try to keep the requirements as minimal as possible.
 
 Use your package manager to install the dependencies; on a system with
@@ -183,7 +183,10 @@ the nix package manager simply run `nix-shell` to get a build environment.
 
 ```bash
 # Build all tools and libraries
+# bazel 5/6
 bazel build -c opt //...
+# bazel 7
+bazel build --noenable_bzlmod -c opt //...
 ```
 
 You can access the generated artifacts under `bazel-bin/`. For instance the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,10 +15,10 @@ http_archive(
 # Bazel platform rules, needed as dependency to absl.
 http_archive(
     name = "platforms",
-    sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+    sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
     ],
 )
 


### PR DESCRIPTION
When we drop bazel 5, we will be able to either switch to bzlmod or move the options "--noenable_bzlmod" to the .bazelrc.