### PR TITLE
Change name of "@jsonhpp" to "@jsonhpp//:json" for WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -168,10 +168,14 @@ http_archive(
 http_archive(
     name = "jsonhpp",
     build_file = "//bazel:jsonhpp.BUILD",
-    sha256 = "081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c",
-    strip_prefix = "json-3.10.2",
+    patch_args = ["-p1"],
+    patches = [
+        "//bazel:nlohmann-libname.patch",
+    ],
+    sha256 = "0d8ef5af7f9794e3263480193c491549b2ba6cc74bb018906202ada498a79406",
+    strip_prefix = "json-3.11.3",
     urls = [
-        "https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz",
+        "https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz",
     ],
 )
 

--- a/bazel/nlohmann-libname.patch
+++ b/bazel/nlohmann-libname.patch
@@ -1,0 +1,11 @@
+--- a/BUILD.bazel	2024-02-25 09:22:53.424710790 -0800
++++ b/BUILD.bazel	2024-02-25 09:24:49.771990947 -0800
+@@ -5,7 +5,7 @@
+ exports_files(["LICENSE"])
+ 
+ cc_library(
+-    name = "jsonhpp",
++    name = "json",  # Be the same for WORKSPACE and MODULE.bazel
+     hdrs = [
+         "single_include/nlohmann/json.hpp",
+     ],

--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -54,7 +54,7 @@ cc_library(
     deps = [
         "//common/util:logging",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -71,7 +71,7 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -161,7 +161,7 @@ cc_binary(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -175,7 +175,7 @@ cc_binary(
         ":message-stream-splitter",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 

--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -36,7 +36,7 @@ cc_library(
     hdrs = ["token_info_json.h"],
     deps = [
         ":token-info",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -412,7 +412,7 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 

--- a/common/tools/BUILD
+++ b/common/tools/BUILD
@@ -99,6 +99,6 @@ cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )

--- a/common/tools/jcxxgen.bzl
+++ b/common/tools/jcxxgen.bzl
@@ -41,5 +41,5 @@ def jcxxgen(name, src, out, namespace = ""):
     native.cc_library(
         name = name,
         hdrs = [out],
-        deps = ["@jsonhpp"],
+        deps = ["@jsonhpp//:json"],
     )

--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -899,7 +899,7 @@ cc_library(
         "//verilog/parser:verilog-token-classifications",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -952,6 +952,6 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -75,7 +75,7 @@ cc_library(
         "//common/analysis:file-analyzer",
         "//common/strings:line-column-map",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -132,7 +132,7 @@ cc_test(
         "//common/util:logging",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -109,7 +109,7 @@ cc_library(
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -142,7 +142,7 @@ cc_library(
         "//verilog/CST:seq-block",
         "//verilog/CST:verilog-nonterminals",
         "@com_google_absl//absl/flags:flag",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -248,7 +248,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -269,7 +269,7 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 
@@ -322,6 +322,6 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )

--- a/verilog/tools/syntax/BUILD
+++ b/verilog/tools/syntax/BUILD
@@ -39,7 +39,7 @@ cc_binary(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp",
+        "@jsonhpp//:json",
     ],
 )
 


### PR DESCRIPTION
These seem to be different otherwise in WORKSPACE and MODULE.bazel.