### PR TITLE
Move installer to the bazel/ subdir, but provide a toplevel alias.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,6 @@
 # Run tests with
 #  bazel test ...
 
-load("@com_github_google_rules_install//installer:def.bzl", "installer")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
@@ -47,12 +46,10 @@ filegroup(
     ],
 )
 
-installer(
+# Installing; see README.md
+alias(
     name = "install",
-    data = [
-        ":install-binaries",
-        ":install-scripts",
-    ],
+    actual = "//bazel:install",
 )
 
 genrule(
@@ -63,19 +60,4 @@ genrule(
     tools = [
         "//verilog/tools/lint:verible-verilog-lint",
     ],
-)
-
-extra_action(
-    name = "extractor",
-    cmd = ("/opt/kythe/extractors/bazel_cxx_extractor " +
-           "$(EXTRA_ACTION_FILE) $(output $(ACTION_ID).cxx.kzip) $(location :vnames.json)"),
-    data = [":vnames.json"],
-    out_templates = ["$(ACTION_ID).cxx.kzip"],
-)
-
-action_listener(
-    name = "extract_cxx",
-    extra_actions = [":extractor"],
-    mnemonics = ["CppCompile"],
-    visibility = ["//visibility:public"],
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -3,6 +3,7 @@ Rules for adding './configure && make' style dependencies.
 """
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@com_github_google_rules_install//installer:def.bzl", "installer")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -44,4 +45,14 @@ bool_flag(
 config_setting(
     name = "static_linked_executables",
     flag_values = {":create_static_linked_executables": "true"},
+)
+
+# This installer is here, so that the toplevel BUILD file does not have
+# to pull in the full rules_install to keep that light of dependencies.
+installer(
+    name = "install",
+    data = [
+        "//:install-binaries",
+        "//:install-scripts",
+    ],
 )


### PR DESCRIPTION
Someone importing the project thus does not need that pull in that dependency directly.