### PR TITLE
Since we use zlib, don't rely on protobuf implicitly providing it.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,6 @@
 workspace(name = "com_google_verible")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 http_archive(
     name = "rules_license",
@@ -126,6 +125,18 @@ load("@rules_bison//bison:bison.bzl", "bison_register_toolchains")
 
 bison_register_toolchains()
 
+# We, but also protobuf needs zlib. Make sure we define it first.
+http_archive(
+    name = "zlib",
+    build_file = "//bazel:zlib.BUILD",
+    sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
+    strip_prefix = "zlib-1.3.1",
+    urls = [
+        "https://zlib.net/zlib-1.3.1.tar.gz",
+        "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
+    ],
+)
+
 http_archive(
     name = "com_google_protobuf",
     patch_args = ["-p1"],
@@ -177,17 +188,3 @@ http_archive(
 load("@rules_compdb//:deps.bzl", "rules_compdb_deps")
 
 rules_compdb_deps()
-
-# zlib is imported through protobuf. Make the dependency explicit considering
-# it's used outside protobuf.
-maybe(
-    http_archive,
-    name = "zlib",
-    build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
-    sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
-    strip_prefix = "zlib-1.3.1",
-    urls = [
-        "https://zlib.net/zlib-1.3.1.tar.gz",
-        "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
-    ],
-)

--- a/bazel/zlib.BUILD
+++ b/bazel/zlib.BUILD
@@ -1,0 +1,73 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+exports_files(["zlib.BUILD"])
+
+_ZLIB_HEADERS = [
+    "crc32.h",
+    "deflate.h",
+    "gzguts.h",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.h",
+    "inftrees.h",
+    "trees.h",
+    "zconf.h",
+    "zlib.h",
+    "zutil.h",
+]
+
+_ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_HEADERS]
+
+# In order to limit the damage from the `includes` propagation
+# via `:zlib`, copy the public headers to a subdirectory and
+# expose those.
+genrule(
+    name = "copy_public_headers",
+    srcs = _ZLIB_HEADERS,
+    outs = _ZLIB_PREFIXED_HEADERS,
+    cmd_bash = "cp $(SRCS) $(@D)/zlib/include/",
+    cmd_bat = " && ".join(
+        ["@copy /Y $(location %s) $(@D)\\zlib\\include\\  >NUL" %
+         s for s in _ZLIB_HEADERS],
+    ),
+)
+
+cc_library(
+    name = "zlib",
+    srcs = [
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+        # Include the un-prefixed headers in srcs to work
+        # around the fact that zlib isn't consistent in its
+        # choice of <> or "" delimiter when including itself.
+    ] + _ZLIB_HEADERS,
+    hdrs = [  # _ZLIB_PREFIXED_HEADERS, but we only need a few.
+        "zlib/include/zconf.h",
+        "zlib/include/zlib.h",
+    ],
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": [
+            "-Wno-deprecated-non-prototype",
+            "-Wno-unused-variable",
+            "-Wno-implicit-function-declaration",
+        ],
+    }),
+    includes = ["zlib/include/"],
+    visibility = ["//visibility:public"],
+)

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -680,7 +680,6 @@ cc_library(
     hdrs = ["simple_zip.h"],
     deps = [
         "//third_party/portable_endian",
-        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
         "@zlib",
     ],


### PR DESCRIPTION
The way WORKSPACE processes dependencies, we need to define before proto.