### PR TITLE
linter: configuration: emit warnings user configuration overrides itself

### DIFF
--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -158,6 +158,17 @@ bool RuleBundle::ParseConfiguration(absl::string_view text, char separator,
       parsed_correctly = false;
       continue;
     }
+
+    // If we are about to override a rule which was previously configured in the
+    // same configuration file, warn the user about it.
+    // NOTE: ignore producing a warning if there is no configuration, just
+    // disabing/enabling
+    if (!setting.configuration.empty() && rules.count(*rule_iter)) {
+      absl::StrAppend(error, error->empty() ? "" : "\n", kRepeatedFlagMessage,
+                      " \"", rule_name, "\" = ", setting.configuration);
+      parsed_correctly = false;
+    }
+
     // Map keys must use canonical registered string_views for guaranteed
     // lifetime, not just any string-equivalent copy.
     rules[*rule_iter] = setting;

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -43,6 +43,12 @@ struct RuleSetting {
 // encountered while parsing a configuration
 inline constexpr absl::string_view kInvalidFlagMessage = "[ERR] Invalid flag";
 
+// Warning to be shown when we parse a configuration file that configures the
+// same rule more than once.
+inline constexpr absl::string_view kRepeatedFlagMessage =
+    "[WARN] Repeated flag in the configuration. Last provided value will be "
+    "used";
+
 // Warning to be shown when an stray comma is
 // encountered while parsing a configuration
 inline constexpr absl::string_view kStrayCommaWarning =

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -835,6 +835,33 @@ TEST(RuleBundleTest, ParseRuleBundleIgnoreExtraComma) {
   }
 }
 
+TEST(RuleBundleTest, ParseRuleBundleDontWarnIfNoConfig) {
+  constexpr absl::string_view text = "test-rule-1,\ntest-rule-1";
+  {
+    RuleBundle bundle;
+    std::string error;
+    bool success = bundle.ParseConfiguration(text, '\n', &error);
+    ASSERT_TRUE(success) << error;
+    EXPECT_THAT(error, testing::Not(testing::HasSubstr(kRepeatedFlagMessage)))
+        << error;  // don't warn about overriden config if there is no value
+    EXPECT_TRUE(bundle.rules["test-rule-1"].enabled);
+  }
+}
+
+TEST(RuleBundleTest, ParseRuleBundleWarnConfigOverride) {
+  constexpr absl::string_view text = "test-rule-1=a,\ntest-rule-1=b";
+  {
+    RuleBundle bundle;
+    std::string error;
+    bool success = bundle.ParseConfiguration(text, '\n', &error);
+    ASSERT_TRUE(!success) << error;
+    EXPECT_THAT(error, testing::HasSubstr(kRepeatedFlagMessage))
+        << error;  // warning: configuration being overriden
+    EXPECT_TRUE(bundle.rules["test-rule-1"].enabled);
+    EXPECT_EQ("b", bundle.rules["test-rule-1"].configuration);
+  }
+}
+
 // ConfigureFromOptions Tests
 TEST(ConfigureFromOptionsTest, Basic) {
   LinterConfiguration config;

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -771,6 +771,20 @@ TEST(RuleBundleTest, ParseRuleBundleReject) {
   EXPECT_EQ(error, absl::StrCat(kInvalidFlagMessage, " \"bad-flag\""));
 }
 
+TEST(RuleBundleTest, ParseRuleBundleAcceptGoodRulesEvenWhenRejecting) {
+  constexpr absl::string_view text = "test-rule-unknown-rules\ntest-rule-1";
+  {
+    RuleBundle bundle;
+    std::string error;
+    bool success = bundle.ParseConfiguration(text, '\n', &error);
+    ASSERT_TRUE(!success) << error;
+    EXPECT_THAT(error, testing::HasSubstr(kInvalidFlagMessage))
+        << error;  // invalid flag report
+    // Enable test-rule-1 even though we saw an invalid flag
+    EXPECT_TRUE(bundle.rules["test-rule-1"].enabled);
+  }
+}
+
 TEST(RuleBundleTest, ParseRuleBundleAcceptMultiline) {
   constexpr absl::string_view text = "test-rule-1\n-test-rule-2";
   RuleBundle bundle;


### PR DESCRIPTION
When parsing a configuration file, if the user provides more than one configuration for the same rule, the last value will be used.

As this can be confusing, let's emit a warning whenever this happens.

See https://github.com/chipsalliance/verible/issues/2136 for context.

I'd argue that this isn't **crucial** but it is pretty cheap to do and it might save a lot of time for some users