### PR TITLE
Adding feature to print the lint rules in a format suitable to be used as '.rules.verible_lint' @see #2148

### DIFF
--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
@@ -100,7 +100,7 @@ void ExplicitParameterStorageTypeRule::HandleSymbol(
 // a common type that can't be handled well in some old tools.
 absl::Status ExplicitParameterStorageTypeRule::Configure(
     absl::string_view configuration) {
-  static const std::vector<absl::string_view> allowed = {"string"};
+  static const std::vector<absl::string_view> allowed = {"", "string"};
   using verible::config::SetStringOneOf;
   std::string value;
   auto s = verible::ParseNameValues(

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule_test.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule_test.cc
@@ -44,8 +44,7 @@ TEST(ExplicitParameterStorageTypeRuleTest, Configuration) {
 
   EXPECT_FALSE((status = rule.Configure("exempt_type:int")).ok());
   EXPECT_EQ(status.message(),
-            "exempt_type: Value can only be 'string'; "
-            "got 'int'");
+            "exempt_type: Value can only be one of ['', 'string']; got 'int'");
 }
 
 // Tests that ExplicitParameterStorageTypeRule correctly accepts

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -83,11 +83,11 @@ using verible::TextStructureView;
 using verible::TokenInfo;
 
 std::set<LintViolationWithStatus> GetSortedViolations(
-    const std::vector<LintRuleStatus>& statuses) {
+    const std::vector<LintRuleStatus> &statuses) {
   std::set<LintViolationWithStatus> violations;
 
-  for (const auto& status : statuses) {
-    for (const auto& violation : status.violations) {
+  for (const auto &status : statuses) {
+    for (const auto &violation : status.violations) {
       violations.insert(LintViolationWithStatus(&violation, &status));
     }
   }
@@ -99,9 +99,9 @@ std::set<LintViolationWithStatus> GetSortedViolations(
 //  0: success
 //  1: linting error (if parse_fatal == true)
 //  2..: other fatal issues such as file not found.
-int LintOneFile(std::ostream* stream, absl::string_view filename,
-                const LinterConfiguration& config,
-                verible::ViolationHandler* violation_handler, bool check_syntax,
+int LintOneFile(std::ostream *stream, absl::string_view filename,
+                const LinterConfiguration &config,
+                verible::ViolationHandler *violation_handler, bool check_syntax,
                 bool parse_fatal, bool lint_fatal, bool show_context) {
   const absl::StatusOr<std::string> content_or =
       verible::file::GetContentAsString(filename);
@@ -126,7 +126,7 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
     if (!lex_status.ok() || !parse_status.ok()) {
       const std::vector<std::string> syntax_error_messages(
           analyzer->LinterTokenErrorMessages(show_context));
-      for (const auto& message : syntax_error_messages) {
+      for (const auto &message : syntax_error_messages) {
         *stream << message << std::endl;
       }
       if (parse_fatal) {
@@ -138,7 +138,7 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
   }
 
   // Analyze the parsed structure for lint violations.
-  const auto& text_structure = analyzer->Data();
+  const auto &text_structure = analyzer->Data();
   const auto linter_result =
       VerilogLintTextStructure(filename, config, text_structure);
   if (!linter_result.ok()) {
@@ -147,10 +147,10 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
     return 2;
   }
 
-  const std::vector<LintRuleStatus>& linter_statuses = linter_result.value();
+  const std::vector<LintRuleStatus> &linter_statuses = linter_result.value();
 
   size_t total_violations = 0;
-  for (const auto& rule_status : linter_statuses) {
+  for (const auto &rule_status : linter_statuses) {
     total_violations += rule_status.violations.size();
   }
 
@@ -174,45 +174,45 @@ int LintOneFile(std::ostream* stream, absl::string_view filename,
 
 VerilogLinter::VerilogLinter()
     : lint_waiver_(
-          [](const TokenInfo& t) {
+          [](const TokenInfo &t) {
             return IsComment(verilog_tokentype(t.token_enum()));
           },
-          [](const TokenInfo& t) {
+          [](const TokenInfo &t) {
             return IsWhitespace(verilog_tokentype(t.token_enum()));
           },
           kLinterTrigger, kLinterWaiveLineCommand, kLinterWaiveStartCommand,
           kLinterWaiveStopCommand) {}
 
-absl::Status VerilogLinter::Configure(const LinterConfiguration& configuration,
+absl::Status VerilogLinter::Configure(const LinterConfiguration &configuration,
                                       absl::string_view lintee_filename) {
   if (VLOG_IS_ON(2)) {
-    for (const auto& name : configuration.ActiveRuleIds()) {
+    for (const auto &name : configuration.ActiveRuleIds()) {
       LOG(INFO) << "active rule: '" << name << '\'';
     }
   }
   auto text_rules = configuration.CreateTextStructureRules();
   if (!text_rules.ok()) return text_rules.status();
-  for (auto& rule : *text_rules) {
+  for (auto &rule : *text_rules) {
     text_structure_linter_.AddRule(std::move(rule));
   }
   auto line_rules = configuration.CreateLineRules();
   if (!line_rules.ok()) return line_rules.status();
-  for (auto& rule : *line_rules) {
+  for (auto &rule : *line_rules) {
     line_linter_.AddRule(std::move(rule));
   }
   auto token_rules = configuration.CreateTokenStreamRules();
   if (!token_rules.ok()) return token_rules.status();
-  for (auto& rule : *token_rules) {
+  for (auto &rule : *token_rules) {
     token_stream_linter_.AddRule(std::move(rule));
   }
   auto syntax_rules = configuration.CreateSyntaxTreeRules();
   if (!syntax_rules.ok()) return syntax_rules.status();
-  for (auto& rule : *syntax_rules) {
+  for (auto &rule : *syntax_rules) {
     syntax_tree_linter_.AddRule(std::move(rule));
   }
 
   absl::Status rc = absl::OkStatus();
-  for (const auto& waiver_file :
+  for (const auto &waiver_file :
        absl::StrSplit(configuration.external_waivers, ',', absl::SkipEmpty())) {
     auto content_or = verible::file::GetContentAsString(waiver_file);
     if (!content_or.ok()) continue;  // Couldn't read lint file: ignore
@@ -227,7 +227,7 @@ absl::Status VerilogLinter::Configure(const LinterConfiguration& configuration,
   return rc;
 }
 
-void VerilogLinter::Lint(const TextStructureView& text_structure,
+void VerilogLinter::Lint(const TextStructureView &text_structure,
                          absl::string_view filename) {
   // Collect all lint waivers in an initial pass.
   lint_waiver_.ProcessTokenRangesByLine(text_structure);
@@ -242,24 +242,24 @@ void VerilogLinter::Lint(const TextStructureView& text_structure,
   token_stream_linter_.Lint(text_structure.TokenStream());
 
   // Analyze syntax tree.
-  const verible::ConcreteSyntaxTree& syntax_tree = text_structure.SyntaxTree();
+  const verible::ConcreteSyntaxTree &syntax_tree = text_structure.SyntaxTree();
   if (syntax_tree != nullptr) {
     syntax_tree_linter_.Lint(*syntax_tree);
   }
 }
 
 static void AppendLintRuleStatuses(
-    const std::vector<LintRuleStatus>& new_statuses,
-    const verible::LintWaiver& waivers, const LineColumnMap& line_map,
+    const std::vector<LintRuleStatus> &new_statuses,
+    const verible::LintWaiver &waivers, const LineColumnMap &line_map,
     absl::string_view text_base,
-    std::vector<LintRuleStatus>* cumulative_statuses) {
-  for (const auto& status : new_statuses) {
+    std::vector<LintRuleStatus> *cumulative_statuses) {
+  for (const auto &status : new_statuses) {
     cumulative_statuses->push_back(status);
-    const auto* waived_lines =
+    const auto *waived_lines =
         waivers.LookupLineNumberSet(status.lint_rule_name);
     if (waived_lines) {
       cumulative_statuses->back().WaiveViolations(
-          [&](const verible::LintViolation& violation) {
+          [&](const verible::LintViolation &violation) {
             // Lookup the line number on which the offending token resides.
             const size_t offset = violation.token.left(text_base);
             const size_t line = line_map.LineAtOffset(offset);
@@ -276,9 +276,9 @@ static void AppendLintRuleStatuses(
 }
 
 std::vector<LintRuleStatus> VerilogLinter::ReportStatus(
-    const LineColumnMap& line_map, absl::string_view text_base) {
+    const LineColumnMap &line_map, absl::string_view text_base) {
   std::vector<LintRuleStatus> statuses;
-  const verible::LintWaiver& waivers = lint_waiver_.GetLintWaiver();
+  const verible::LintWaiver &waivers = lint_waiver_.GetLintWaiver();
   AppendLintRuleStatuses(line_linter_.ReportStatus(), waivers, line_map,
                          text_base, &statuses);
   AppendLintRuleStatuses(text_structure_linter_.ReportStatus(), waivers,
@@ -309,8 +309,8 @@ absl::StatusOr<LinterConfiguration> LinterConfigurationFromFlags(
 }
 
 absl::StatusOr<std::vector<LintRuleStatus>> VerilogLintTextStructure(
-    absl::string_view filename, const LinterConfiguration& config,
-    const TextStructureView& text_structure) {
+    absl::string_view filename, const LinterConfiguration &config,
+    const TextStructureView &text_structure) {
   // Create the linter, add rules, and run it.
   VerilogLinter linter;
   if (absl::Status status = linter.Configure(config, filename); !status.ok()) {
@@ -324,8 +324,8 @@ absl::StatusOr<std::vector<LintRuleStatus>> VerilogLintTextStructure(
   return linter.ReportStatus(text_structure.GetLineColumnMap(), text_base);
 }
 
-absl::Status PrintRuleInfo(std::ostream* os,
-                           const analysis::LintRuleDescriptionsMap& rule_map,
+absl::Status PrintRuleInfo(std::ostream *os,
+                           const analysis::LintRuleDescriptionsMap &rule_map,
                            absl::string_view rule_name) {
   constexpr int kRuleWidth = 35;
   constexpr int kParamIndent = kRuleWidth + 4;
@@ -338,14 +338,14 @@ absl::Status PrintRuleInfo(std::ostream* os,
         "\' not found. Please specify a rule name or \"all\" for help on "
         "the rules.\n"));
   }
-  const auto& d = it->second.descriptor;
+  const auto &d = it->second.descriptor;
   // Print description.
   *os << std::left << std::setw(kRuleWidth) << std::setfill(kFill) << rule_name
       << d.desc << "\n";
   if (!d.param.empty()) {
     *os << std::left << std::setw(kRuleWidth) << std::setfill(kFill) << " "
         << "Parameter" << (d.param.size() > 1 ? "s" : "") << ":\n";
-    for (const auto& p : d.param) {
+    for (const auto &p : d.param) {
       *os << std::left << std::setw(kParamIndent) << std::setfill(kFill) << " "
           << "* `" << p.name << "` Default: `" << p.default_value << "` "
           << p.description << "\n";
@@ -359,11 +359,11 @@ absl::Status PrintRuleInfo(std::ostream* os,
   return absl::OkStatus();
 }
 
-void GetLintRuleDescriptionsHelpFlag(std::ostream* os,
+void GetLintRuleDescriptionsHelpFlag(std::ostream *os,
                                      absl::string_view flag_value) {
   // Set up the map.
   auto rule_map = analysis::GetAllRuleDescriptions();
-  for (const auto& rule_id : analysis::kDefaultRuleSet) {
+  for (const auto &rule_id : analysis::kDefaultRuleSet) {
     rule_map[rule_id].default_enabled = true;
   }
 
@@ -374,7 +374,7 @@ void GetLintRuleDescriptionsHelpFlag(std::ostream* os,
   }
 
   // Print all rules.
-  for (const auto& rule : rule_map) {
+  for (const auto &rule : rule_map) {
     const auto status = PrintRuleInfo(os, rule_map, rule.first);
     if (!status.ok()) {
       *os << status.message();
@@ -383,22 +383,47 @@ void GetLintRuleDescriptionsHelpFlag(std::ostream* os,
   }
 }
 
-void GetLintRuleDescriptionsMarkdown(std::ostream* os) {
+void GetLintRuleFile(std::ostream *os) {
+  // Set up the map.
   auto rule_map = analysis::GetAllRuleDescriptions();
-  for (const auto& rule_id : analysis::kDefaultRuleSet) {
+  for (const auto &rule_id : analysis::kDefaultRuleSet) {
     rule_map[rule_id].default_enabled = true;
   }
 
-  for (const auto& rule : rule_map) {
+  // Print all the rules
+  for (const auto &rule : rule_map) {
+    *os << (rule.second.default_enabled ? "+" : "-");
+    *os << rule.second.descriptor.name;
+
+    bool first = true;
+    for (const auto &rule_param : rule.second.descriptor.param) {
+      *os << (first ? "=" : ";");
+      *os << rule_param.name << ":";
+      *os << rule_param.default_value;
+
+      first = false;
+    }
+
+    *os << "\n";
+  }
+}
+
+void GetLintRuleDescriptionsMarkdown(std::ostream *os) {
+  auto rule_map = analysis::GetAllRuleDescriptions();
+  for (const auto &rule_id : analysis::kDefaultRuleSet) {
+    rule_map[rule_id].default_enabled = true;
+  }
+
+  for (const auto &rule : rule_map) {
     // Print the rule, description and if it is enabled by default.
-    const auto& d = rule.second.descriptor;
+    const auto &d = rule.second.descriptor;
     *os << "### " << rule.first << "\n";
     *os << d.desc;
     *os << " See " << verible::GetStyleGuideCitation(d.topic) << ".\n\n";
 
     if (!d.param.empty()) {
       *os << "##### Parameter" << (d.param.size() > 1 ? "s" : "") << "\n";
-      for (const auto& p : d.param) {
+      for (const auto &p : d.param) {
         *os << "  * `" << p.name << "` Default: `" << p.default_value << "` "
             << p.description << "\n";
       }

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -144,6 +144,10 @@ void GetLintRuleDescriptionsHelpFlag(std::ostream*, absl::string_view);
 // Outputs the descriptions for every rule, formatted for markdown.
 void GetLintRuleDescriptionsMarkdown(std::ostream*);
 
+// Outputs the default linting rules in a format suitable to produce a
+// .rules.verible_lint file
+void GetLintRuleFile(std::ostream* os);
+
 }  // namespace verilog
 
 #endif  // VERIBLE_VERILOG_ANALYSIS_VERILOG_LINTER_H_

--- a/verilog/analysis/verilog_linter.h
+++ b/verilog/analysis/verilog_linter.h
@@ -44,7 +44,7 @@ namespace verilog {
 // Returns violations from multiple `LintRuleStatus`es sorted by position
 // of their occurrence in source code.
 std::set<verible::LintViolationWithStatus> GetSortedViolations(
-    const std::vector<verible::LintRuleStatus>& statuses);
+    const std::vector<verible::LintRuleStatus> &statuses);
 
 // Checks a single file for Verilog style lint violations.
 // This is suitable for calling from main().
@@ -63,9 +63,9 @@ std::set<verible::LintViolationWithStatus> GetSortedViolations(
 // TODO(hzeller): the options to this function are a lot and many of them
 //   the same type does not help. Make at least the bool options a struct with
 //   names parameters.
-int LintOneFile(std::ostream* stream, absl::string_view filename,
-                const LinterConfiguration& config,
-                verible::ViolationHandler* violation_handler, bool check_syntax,
+int LintOneFile(std::ostream *stream, absl::string_view filename,
+                const LinterConfiguration &config,
+                verible::ViolationHandler *violation_handler, bool check_syntax,
                 bool parse_fatal, bool lint_fatal, bool show_context = false);
 
 // VerilogLinter analyzes a TextStructureView of Verilog source code.
@@ -75,16 +75,16 @@ class VerilogLinter {
   VerilogLinter();
 
   // Configures the internal linters, enabling select rules.
-  absl::Status Configure(const LinterConfiguration& configuration,
+  absl::Status Configure(const LinterConfiguration &configuration,
                          absl::string_view lintee_filename);
 
   // Analyzes text structure.
-  void Lint(const verible::TextStructureView& text_structure,
+  void Lint(const verible::TextStructureView &text_structure,
             absl::string_view filename);
 
   // Reports lint findings.
   std::vector<verible::LintRuleStatus> ReportStatus(
-      const verible::LineColumnMap&, absl::string_view text_base);
+      const verible::LineColumnMap &, absl::string_view text_base);
 
  private:
   // Line based linter.
@@ -111,7 +111,7 @@ absl::StatusOr<LinterConfiguration> LinterConfigurationFromFlags(
 
 // Expands linter configuration from a text file
 absl::Status AppendLinterConfigurationFromFile(
-    LinterConfiguration* config, absl::string_view config_filename);
+    LinterConfiguration *config, absl::string_view config_filename);
 
 // VerilogLintTextStructure analyzes Verilog syntax tree for style violations
 // and syntactically detectable pitfalls.
@@ -130,23 +130,26 @@ absl::Status AppendLinterConfigurationFromFile(
 // Returns:
 //   Vector of LintRuleStatuses on success, otherwise error code.
 absl::StatusOr<std::vector<verible::LintRuleStatus>> VerilogLintTextStructure(
-    absl::string_view filename, const LinterConfiguration& config,
-    const verible::TextStructureView& text_structure);
+    absl::string_view filename, const LinterConfiguration &config,
+    const verible::TextStructureView &text_structure);
 
 // Prints the rule, description and default_enabled.
-absl::Status PrintRuleInfo(std::ostream*,
-                           const analysis::LintRuleDescriptionsMap&,
+absl::Status PrintRuleInfo(std::ostream *,
+                           const analysis::LintRuleDescriptionsMap &,
                            absl::string_view);
 
 // Outputs the descriptions for every rule for the --help_rules flag.
-void GetLintRuleDescriptionsHelpFlag(std::ostream*, absl::string_view);
+// TODO(sconwayaus): These are really printers and not getters. Consider renaming
+void GetLintRuleDescriptionsHelpFlag(std::ostream *, absl::string_view);
 
 // Outputs the descriptions for every rule, formatted for markdown.
-void GetLintRuleDescriptionsMarkdown(std::ostream*);
+// TODO(sconwayaus): These are really printers and not getters. Consider renaming
+void GetLintRuleDescriptionsMarkdown(std::ostream *);
 
 // Outputs the default linting rules in a format suitable to produce a
 // .rules.verible_lint file
-void GetLintRuleFile(std::ostream* os);
+// TODO(sconwayaus): These are really printers and not getters. Consider renaming
+void GetLintRuleFile(std::ostream *os, const LinterConfiguration &config);
 
 }  // namespace verilog
 

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -178,7 +178,8 @@ bool RuleBundle::ParseConfiguration(absl::string_view text, char separator,
 }
 
 // Parse and unparse for RuleBundle (for commandlineflags)
-std::string RuleBundle::UnparseConfiguration(const char separator) const {
+std::string RuleBundle::UnparseConfiguration(const char separator,
+                                             const bool reverse) const {
   std::vector<std::string> switches;
   switches.reserve(rules.size());
   for (const auto &rule : rules) {
@@ -190,7 +191,12 @@ std::string RuleBundle::UnparseConfiguration(const char separator) const {
         rule.second.configuration));
   }
   // Concatenates all of rules into text.
-  return absl::StrJoin(switches.rbegin(), switches.rend(),
+  if (reverse) {
+    return absl::StrJoin(switches.rbegin(), switches.rend(),
+                         std::string(1, separator));
+  }
+
+  return absl::StrJoin(switches.begin(), switches.end(),
                        std::string(1, separator));
 }
 
@@ -262,6 +268,15 @@ std::set<analysis::LintRuleId> LinterConfiguration::ActiveRuleIds() const {
   return result;
 }
 
+void LinterConfiguration::GetRuleBundle(RuleBundle *rule_bundle) const {
+  // Clear the vector to overwrite any existing value.
+  rule_bundle->rules.clear();
+
+  for (const auto &rule_pair : configuration_) {
+    rule_bundle->rules[rule_pair.first] = rule_pair.second;
+  }
+}
+
 // Iterates through all rules that are mentioned and enabled
 // in the "config" map. Constructs instances using the
 // "factory"-function, and configures them if a configuration string is
@@ -283,7 +298,12 @@ static absl::StatusOr<std::vector<std::unique_ptr<T>>> CreateRules(
     if (!setting.configuration.empty()) {
       if (absl::Status status = rule_ptr->Configure(setting.configuration);
           !status.ok()) {
-        return status;
+        std::string error_msg;
+
+        error_msg.append(std::string(rule_pair.first));
+        error_msg.append(" ");
+        error_msg.append(std::string(status.message()));
+        return absl::InvalidArgumentError(error_msg);
       }
     }
 
@@ -334,8 +354,9 @@ absl::Status LinterConfiguration::AppendFromFile(
     // Log warnings and errors
     if (!error.empty()) {
       std::cerr << "Using a partial version from " << config_filename
-                << ". Found the following issues: " << error;
+                << ". Found the following issues: " << error << std::endl;
     }
+
     UseRuleBundle(local_rules_bundle);
     return absl::OkStatus();
   }

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -298,11 +298,8 @@ static absl::StatusOr<std::vector<std::unique_ptr<T>>> CreateRules(
     if (!setting.configuration.empty()) {
       if (absl::Status status = rule_ptr->Configure(setting.configuration);
           !status.ok()) {
-        std::string error_msg;
-
-        error_msg.append(std::string(rule_pair.first));
-        error_msg.append(" ");
-        error_msg.append(std::string(status.message()));
+        std::string error_msg =
+            absl::StrCat(rule_pair.first, " ", status.message());
         return absl::InvalidArgumentError(error_msg);
       }
     }

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -82,7 +82,7 @@ struct RuleBundle {
   // typically that would be a comma or newline.
   bool ParseConfiguration(absl::string_view text, char separator,
                           std::string *error);
-  std::string UnparseConfiguration(char separator) const;
+  std::string UnparseConfiguration(char separator, bool reverse = true) const;
 };
 
 // Pair of functions that perform stringification and destringification
@@ -211,6 +211,9 @@ class LinterConfiguration {
   // Updates LinterConfiguration to enabled/disable all lint rules
   // in rule_bundle
   void UseRuleBundle(const RuleBundle &rule_bundle);
+
+  // Gets a rule_bundle of the LinterConfiguration
+  void GetRuleBundle(RuleBundle *rule_bundle) const;
 
   // Adjust set of active rules based on the filename.
   void UseProjectPolicy(const ProjectPolicy &policy,

--- a/verilog/analysis/verilog_linter_test.cc
+++ b/verilog/analysis/verilog_linter_test.cc
@@ -439,6 +439,17 @@ TEST(VerilogLinterDocumentationTest, AllRulesMarkdown) {
   EXPECT_TRUE(absl::StrContains(stream.str(), "Enabled by default:"));
 }
 
+TEST(VerilogLinterDocumentationTest, PrintLintRuleFile) {
+  std::ostringstream stream;
+  verilog::GetLintRuleFile(&stream);
+  // Spot-check a few patterns, must mostly make sure generation
+  // works without any fatal errors.
+  EXPECT_TRUE(absl::StrContains(stream.str(), "+always-comb"));
+  EXPECT_TRUE(absl::StrContains(
+      stream.str(), "+module-filename=allow-dash-for-underscore:false"));
+  EXPECT_TRUE(absl::StrContains(stream.str(), "-forbid-negative-array-dim"));
+}
+
 class ViolationFixerTest : public testing::Test {
  public:
   ViolationFixerTest() {

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -49,7 +49,7 @@ enum class AutofixMode {
   kGenerateWaiver,      // Generate waiver file for violations
 };
 
-static const verible::EnumNameMap<AutofixMode>& AutofixModeEnumStringMap() {
+static const verible::EnumNameMap<AutofixMode> &AutofixModeEnumStringMap() {
   static const verible::EnumNameMap<AutofixMode> kAutofixModeEnumStringMap({
       {"no", AutofixMode::kNo},
       {"patch-interactive", AutofixMode::kPatchInteractive},
@@ -61,18 +61,18 @@ static const verible::EnumNameMap<AutofixMode>& AutofixModeEnumStringMap() {
   return kAutofixModeEnumStringMap;
 }
 
-std::ostream& operator<<(std::ostream& stream, AutofixMode mode) {
+std::ostream &operator<<(std::ostream &stream, AutofixMode mode) {
   return AutofixModeEnumStringMap().Unparse(mode, stream);
 }
 
-std::string AbslUnparseFlag(const AutofixMode& mode) {
+std::string AbslUnparseFlag(const AutofixMode &mode) {
   std::ostringstream stream;
   AutofixModeEnumStringMap().Unparse(mode, stream);
   return stream.str();
 }
 
-bool AbslParseFlag(absl::string_view text, AutofixMode* mode,
-                   std::string* error) {
+bool AbslParseFlag(absl::string_view text, AutofixMode *mode,
+                   std::string *error) {
   return AutofixModeEnumStringMap().Parse(text, mode, error, "--autofix value");
 }
 
@@ -94,14 +94,13 @@ ABSL_FLAG(
     "to a snippet of Markdown.");
 ABSL_FLAG(
     bool, print_rules_file, false,
-    "Print the default lint rules in a format that can be used to create a "
-    "lint rules configuration file (i.e. .rules.verible_lint) and exit "
+    "Print the current set of lint rules in a format that can be used to create "
+    "a lint rules configuration file (i.e. .rules.verible_lint) and exit "
     "immediately.");
 ABSL_FLAG(bool, show_diagnostic_context, false,
           "prints an additional "
           "line on which the diagnostic was found,"
           "followed by a line with a position marker");
-
 ABSL_FLAG(
     AutofixMode, autofix, AutofixMode::kNo,
     "autofix mode; one of "
@@ -118,7 +117,7 @@ using verilog::LinterConfiguration;
 // LintOneFile returns 0, 1, or 2
 static const int kAutofixErrorExitStatus = 3;
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   const auto usage =
       absl::StrCat("usage: ", argv[0], " [options] <file> [<file>...]");
   const auto args = verible::InitCommandLine(usage, &argc, &argv);
@@ -136,14 +135,6 @@ int main(int argc, char** argv) {
     return 0;
   }
 
-  // In documentation generation mode, print lint rule file and exit
-  // immediately.
-  bool print_rules_file_flag = absl::GetFlag(FLAGS_print_rules_file);
-  if (print_rules_file_flag) {
-    verilog::GetLintRuleFile(&std::cout);
-    return 0;
-  }
-
   int exit_status = 0;
 
   AutofixMode autofix_mode = absl::GetFlag(FLAGS_autofix);
@@ -151,7 +142,7 @@ int main(int argc, char** argv) {
       absl::GetFlag(FLAGS_autofix_output_file);
 
   std::unique_ptr<std::ostream> stream_closer;
-  std::ostream* autofix_output_stream = nullptr;
+  std::ostream *autofix_output_stream = nullptr;
 
   if (autofix_mode == AutofixMode::kPatch ||
       autofix_mode == AutofixMode::kPatchInteractive ||
@@ -178,7 +169,7 @@ int main(int argc, char** argv) {
   }
 
   const verible::ViolationFixer::AnswerChooser applyAllFixes =
-      [](const verible::LintViolation&,
+      [](const verible::LintViolation &,
          absl::string_view) -> verible::ViolationFixer::Answer {
     return {verible::ViolationFixer::AnswerChoice::kApplyAll, 0};
   };
@@ -211,6 +202,21 @@ int main(int argc, char** argv) {
       break;
   }
 
+  // In documentation generation mode, print lint rule file and exit
+  // immediately.
+  bool print_rules_file_flag = absl::GetFlag(FLAGS_print_rules_file);
+  if (print_rules_file_flag) {
+    auto config_status = verilog::LinterConfigurationFromFlags("");
+    if (!config_status.ok()) {
+      std::cerr << config_status.status().message() << std::endl;
+      return 1;
+    }
+    const LinterConfiguration &config = *config_status;
+
+    verilog::GetLintRuleFile(&std::cout, config);
+    return 0;
+  }
+
   // All positional arguments are file names.  Exclude program name.
   for (const absl::string_view filename :
        verible::make_range(args.begin() + 1, args.end())) {
@@ -221,7 +227,7 @@ int main(int argc, char** argv) {
       exit_status = 1;
       continue;
     }
-    const LinterConfiguration& config = *config_status;
+    const LinterConfiguration &config = *config_status;
 
     const int lint_status = verilog::LintOneFile(
         &std::cout, filename, config, violation_handler.get(),

--- a/verilog/tools/lint/verilog_lint.cc
+++ b/verilog/tools/lint/verilog_lint.cc
@@ -92,7 +92,11 @@ ABSL_FLAG(
     "If true, print the description of every rule formatted for the "
     "Markdown and exit immediately. Intended for the output to be written "
     "to a snippet of Markdown.");
-
+ABSL_FLAG(
+    bool, print_rules_file, false,
+    "Print the default lint rules in a format that can be used to create a "
+    "lint rules configuration file (i.e. .rules.verible_lint) and exit "
+    "immediately.");
 ABSL_FLAG(bool, show_diagnostic_context, false,
           "prints an additional "
           "line on which the diagnostic was found,"
@@ -129,6 +133,14 @@ int main(int argc, char** argv) {
   bool generate_markdown_flag = absl::GetFlag(FLAGS_generate_markdown);
   if (generate_markdown_flag) {
     verilog::GetLintRuleDescriptionsMarkdown(&std::cout);
+    return 0;
+  }
+
+  // In documentation generation mode, print lint rule file and exit
+  // immediately.
+  bool print_rules_file_flag = absl::GetFlag(FLAGS_print_rules_file);
+  if (print_rules_file_flag) {
+    verilog::GetLintRuleFile(&std::cout);
     return 0;
   }
 


### PR DESCRIPTION
Adding feature to print the lint rules in a format suitable to be used as '.rules.verible_lint' as mentioned in #2148

Execute 'verible-verilog-lint --print_rules_file' to print the default rules to stdout. Users can then pipe/copy&paste the output to a file for latter use ('.rules.verible_lint' for example).

Example output:
~/git/verible/bazel-bin/verilog/tools/lint$ ./verible-verilog-lint --print_rules_file
+always-comb
+always-comb-blocking
+always-ff-non-blocking=catch_modifying_assignments:false;waive_for_locals:false
-banned-declared-name-patterns
+case-missing-default
+constraint-name-style
+create-object-name-match
-disable-statement
-endif-comment
...
