### PR TITLE
Vscode is binary found

### DIFF
--- a/verilog/tools/ls/vscode/src/extension.ts
+++ b/verilog/tools/ls/vscode/src/extension.ts
@@ -10,6 +10,8 @@ async function initLanguageClient() {
     const config = vscode.workspace.getConfiguration('verible');
     const binary_path: string = await checkAndDownloadBinaries(config.get('path') as string, output);
 
+    output.appendLine(`Using executable from path: ${binary_path}`);
+
     const verible_ls: vscodelc.Executable = {
         command: binary_path,
         args: await config.get<string[]>('arguments')
@@ -26,6 +28,7 @@ async function initLanguageClient() {
     };
 
     // Create the language client and start the client.
+    output.appendLine("Starting Language Server");
     client = new vscodelc.LanguageClient(
         'verible',
         'Verible Language Server',


### PR DESCRIPTION
Resolves #2154 

Fixes several issues with the VSCode extension
1. Fixes issue on windows where users are unable to set an absolute (or relative) path to the language server.
2. Fixes issue on Linux preventing users to use ~/ paths to language server.
3. Fixed issue found while testing the above where the extension on windows dosn't extract the langauge server out of the downloaded zip file. 