### PR TITLE
Update protobuf in bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,32 +51,16 @@ flex.repository(
 use_repo(flex, "flex")
 register_toolchains("@flex//:toolchain")
 
-bazel_dep(name = "abseil-cpp", version = "20240116.1", repo_name="com_google_absl")
+bazel_dep(name = "abseil-cpp", version = "20240116.2", repo_name="com_google_absl")
 single_version_override(
     module_name = "abseil-cpp",
     patch_strip = 1,
-    version = "20240116.1",
+    version = "20240116.2",
     patches = ["//bazel:absl.patch"],
 )
 
 bazel_dep(name = "re2", version = "2023-09-01", repo_name="com_googlesource_code_re2")
 bazel_dep(name = "googletest", version = "1.14.0.bcr.1", repo_name="com_google_googletest")
-
-bazel_dep(name = "protobuf", version = "25.2", repo_name="com_google_protobuf")
-# This override can be removed once https://registry.bazel.build/modules/protobuf
-# supports a compatible protobuf version for abseil.
-archive_override(
-    module_name = "protobuf",
-    urls = [
-        "https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protobuf-25.2.tar.gz",
-    ],
-    strip_prefix="protobuf-25.2",
-    integrity = "sha256-j/URpk/EbueS0/5JpaG8rW99xQ37uloosOW5ecF/mHE=",
-    patches = [
-        "//bazel:proto-add-module-bazel.patch",
-    ],
-    patch_strip = 1,
-)
-
+bazel_dep(name = "protobuf", version = "26.0", repo_name="com_google_protobuf")
 bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name="jsonhpp")
 bazel_dep(name = "zlib", version = "1.3.1")


### PR DESCRIPTION
The latest version in the bzlmod repo does have the absl dependency, so we can simplify the import.