### PR TITLE
Module file name rule autofix

### DIFF
--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -430,6 +430,7 @@ cc_library(
         "//common/analysis:lint-rule-status",
         "//common/analysis:syntax-tree-search",
         "//common/analysis:text-structure-lint-rule",
+        "//common/text:concrete-syntax-leaf",
         "//common/text:config-utils",
         "//common/text:symbol",
         "//common/text:text-structure",

--- a/verilog/analysis/checkers/module_filename_rule.cc
+++ b/verilog/analysis/checkers/module_filename_rule.cc
@@ -124,8 +124,13 @@ void ModuleFilenameRule::Lint(const TextStructureView &text_structure,
   const auto *last_module_id = GetModuleName(*module_cleaned.back().match);
   if (!last_module_id) LOG(ERROR) << "Couldn't extract module name";
   if (last_module_id) {
-    violations_.insert(verible::LintViolation(
-        last_module_id->get(), absl::StrCat(kMessage, "\"", unitname, "\"")));
+    std::string autofix_msg =
+        absl::StrCat("Rename module to '", unitname, "' to match filename");
+    verible::LintViolation violation = verible::LintViolation(
+        last_module_id->get(), absl::StrCat(kMessage, "\"", unitname, "\""),
+        {verible::AutoFix(autofix_msg, {last_module_id->get(), unitname})});
+
+    violations_.insert(violation);
   }
 }
 

--- a/verilog/analysis/checkers/module_filename_rule.cc
+++ b/verilog/analysis/checkers/module_filename_rule.cc
@@ -120,17 +120,32 @@ void ModuleFilenameRule::Lint(const TextStructureView &text_structure,
     return;
   }
 
-  // Only report a violation on the last module declaration.
-  const auto *last_module_id = GetModuleName(*module_cleaned.back().match);
-  if (!last_module_id) LOG(ERROR) << "Couldn't extract module name";
-  if (last_module_id) {
-    std::string autofix_msg =
-        absl::StrCat("Rename module to '", unitname, "' to match filename");
-    verible::LintViolation violation = verible::LintViolation(
-        last_module_id->get(), absl::StrCat(kMessage, "\"", unitname, "\""),
-        {verible::AutoFix(autofix_msg, {last_module_id->get(), unitname})});
+  // Because we can't be certain which module the autofix should be applied to,
+  // raise a violation for all found modules in the clean list and let the user
+  // decide.
+  for (const auto &module_match : module_cleaned) {
+    const verible::Symbol *module_symbol = module_match.match;
+    const auto *module_id = GetModuleName(*module_symbol);
+    if (!module_id) LOG(ERROR) << "Couldn't extract module name";
+    if (module_id) {
+      const std::string autofix_msg =
+          absl::StrCat("Rename module to '", unitname, "' to match filename");
 
-    violations_.insert(violation);
+      auto autofix =
+          verible::AutoFix(autofix_msg, {module_id->get(), unitname});
+
+      const verible::SyntaxTreeLeaf *module_end_label =
+          GetModuleEndLabel(*module_symbol);
+      if (module_end_label) {
+        autofix.AddEdits({{module_end_label->get(), unitname}});
+      }
+
+      verible::LintViolation violation = verible::LintViolation(
+          module_id->get(), absl::StrCat(kMessage, "\"", unitname, "\""),
+          {autofix});
+
+      violations_.insert(violation);
+    }
   }
 }
 

--- a/verilog/analysis/checkers/module_filename_rule_test.cc
+++ b/verilog/analysis/checkers/module_filename_rule_test.cc
@@ -116,11 +116,7 @@ TEST(ModuleFilenameRuleTest, NoModuleMatchesFilenameAbsPath) {
       {""},
       {"package q; endpackage\n"},
       {"module ", {kToken, "m"}, "; endmodule"},
-      {"module ",
-       {kToken, "m"},
-       "; endmodule\nmodule ",
-       {kToken, "n"},
-       "; endmodule"},
+      {"module m; endmodule\nmodule ", {kToken, "n"}, "; endmodule"},
       {"module ",
        {kToken, "m"},
        ";\n"
@@ -157,11 +153,7 @@ TEST(ModuleFilenameRuleTest, NoModuleMatchesFilenameRelPath) {
   const std::initializer_list<LintTestCase> kTestCases = {
       {""},
       {"module ", {kToken, "m"}, "; endmodule"},
-      {"module ",
-       {kToken, "m"},
-       "; endmodule\nmodule ",
-       {kToken, "n"},
-       "; endmodule"},
+      {"module m; endmodule\nmodule ", {kToken, "n"}, "; endmodule"},
       {"module ",
        {kToken, "m"},
        ";\n"

--- a/verilog/analysis/checkers/module_filename_rule_test.cc
+++ b/verilog/analysis/checkers/module_filename_rule_test.cc
@@ -116,7 +116,11 @@ TEST(ModuleFilenameRuleTest, NoModuleMatchesFilenameAbsPath) {
       {""},
       {"package q; endpackage\n"},
       {"module ", {kToken, "m"}, "; endmodule"},
-      {"module m; endmodule\nmodule ", {kToken, "n"}, "; endmodule"},
+      {"module ",
+       {kToken, "m"},
+       "; endmodule\nmodule ",
+       {kToken, "n"},
+       "; endmodule"},
       {"module ",
        {kToken, "m"},
        ";\n"
@@ -153,7 +157,11 @@ TEST(ModuleFilenameRuleTest, NoModuleMatchesFilenameRelPath) {
   const std::initializer_list<LintTestCase> kTestCases = {
       {""},
       {"module ", {kToken, "m"}, "; endmodule"},
-      {"module m; endmodule\nmodule ", {kToken, "n"}, "; endmodule"},
+      {"module ",
+       {kToken, "m"},
+       "; endmodule\nmodule ",
+       {kToken, "n"},
+       "; endmodule"},
       {"module ",
        {kToken, "m"},
        ";\n"
@@ -187,6 +195,14 @@ TEST(ModuleFilenameRuleTest, AutoFixModuleFilenameRule) {
       {"module some_name1;\n\nendmodule", "module r;\n\nendmodule"},
       {"module some_name2();\n\nendmodule", "module r();\n\nendmodule"},
       {"module some_name3#()();\n\nendmodule", "module r#()();\n\nendmodule"},
+      {"module a;\n\nendmodule : a", "module r;\n\nendmodule : r"},
+      {"module some_name1;\n\nendmodule: some_name1",
+       "module r;\n\nendmodule: r"},
+      {"module some_name2();\n\nendmodule :some_name2",
+       "module r();\n\nendmodule :r"},
+      {"module some_name3#()();\n\nendmodule:some_name3",
+       "module r#()();\n\nendmodule:r"},
+
   };
   const std::string filename = "path/to/r.sv";
   RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(kTestCases, "",
@@ -202,6 +218,14 @@ TEST(ModuleFilenameRuleTest, AutoFixModuleFilenameRuleWithDashes) {
        "module file_with_dashes();\n\nendmodule"},
       {"module some_name3#()();\n\nendmodule",
        "module file_with_dashes#()();\n\nendmodule"},
+      {"module a;\n\nendmodule : a",
+       "module file_with_dashes;\n\nendmodule : file_with_dashes"},
+      {"module some_name1;\n\nendmodule :some_name1",
+       "module file_with_dashes;\n\nendmodule :file_with_dashes"},
+      {"module some_name2();\n\nendmodule: some_name2",
+       "module file_with_dashes();\n\nendmodule: file_with_dashes"},
+      {"module some_name3#()();\n\nendmodule:some_name3",
+       "module file_with_dashes#()();\n\nendmodule:file_with_dashes"},
   };
   const std::string filename = "path/to/file-with-dashes.sv";
   RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(
@@ -217,6 +241,14 @@ TEST(ModuleFilenameRuleTest, AutoFixModuleFilenameRuleWithUnderscore) {
        "module file_no_dashes();\n\nendmodule"},
       {"module some_name3#()();\n\nendmodule",
        "module file_no_dashes#()();\n\nendmodule"},
+      {"module a;\n\nendmodule : a",
+       "module file_no_dashes;\n\nendmodule : file_no_dashes"},
+      {"module some_name1;\n\nendmodule :some_name1",
+       "module file_no_dashes;\n\nendmodule :file_no_dashes"},
+      {"module some_name2();\n\nendmodule: some_name2",
+       "module file_no_dashes();\n\nendmodule: file_no_dashes"},
+      {"module some_name3#()();\n\nendmodule:some_name3",
+       "module file_no_dashes#()();\n\nendmodule:file_no_dashes"},
   };
   const std::string filename = "path/to/file_no_dashes.sv";
   RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(

--- a/verilog/analysis/checkers/module_filename_rule_test.cc
+++ b/verilog/analysis/checkers/module_filename_rule_test.cc
@@ -29,6 +29,7 @@ namespace analysis {
 namespace {
 
 using verible::LintTestCase;
+using verible::RunApplyFixCases;
 using verible::RunConfiguredLintTestCases;
 using verible::RunLintTestCases;
 
@@ -178,6 +179,50 @@ TEST(ModuleFilenameRuleTest, NoModuleMatchesFilenameRelPath) {
   };
   const std::string filename = "path/to/r.sv";
   RunLintTestCases<VerilogAnalyzer, ModuleFilenameRule>(kTestCases, filename);
+}
+
+TEST(ModuleFilenameRuleTest, AutoFixModuleFilenameRule) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module a;\n\nendmodule", "module r;\n\nendmodule"},
+      {"module some_name1;\n\nendmodule", "module r;\n\nendmodule"},
+      {"module some_name2();\n\nendmodule", "module r();\n\nendmodule"},
+      {"module some_name3#()();\n\nendmodule", "module r#()();\n\nendmodule"},
+  };
+  const std::string filename = "path/to/r.sv";
+  RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(kTestCases, "",
+                                                        filename);
+}
+
+TEST(ModuleFilenameRuleTest, AutoFixModuleFilenameRuleWithDashes) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module a;\n\nendmodule", "module file_with_dashes;\n\nendmodule"},
+      {"module some_name1;\n\nendmodule",
+       "module file_with_dashes;\n\nendmodule"},
+      {"module some_name2();\n\nendmodule",
+       "module file_with_dashes();\n\nendmodule"},
+      {"module some_name3#()();\n\nendmodule",
+       "module file_with_dashes#()();\n\nendmodule"},
+  };
+  const std::string filename = "path/to/file-with-dashes.sv";
+  RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(
+      kTestCases, "allow-dash-for-underscore:on", filename);
+}
+
+TEST(ModuleFilenameRuleTest, AutoFixModuleFilenameRuleWithUnderscore) {
+  const std::initializer_list<verible::AutoFixInOut> kTestCases = {
+      {"module a;\n\nendmodule", "module file_no_dashes;\n\nendmodule"},
+      {"module some_name1;\n\nendmodule",
+       "module file_no_dashes;\n\nendmodule"},
+      {"module some_name2();\n\nendmodule",
+       "module file_no_dashes();\n\nendmodule"},
+      {"module some_name3#()();\n\nendmodule",
+       "module file_no_dashes#()();\n\nendmodule"},
+  };
+  const std::string filename = "path/to/file_no_dashes.sv";
+  RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(
+      kTestCases, "allow-dash-for-underscore:off", filename);
+  RunApplyFixCases<VerilogAnalyzer, ModuleFilenameRule>(
+      kTestCases, "allow-dash-for-underscore:on", filename);
 }
 
 }  // namespace


### PR DESCRIPTION
Added a simple autofix for [module-filename] lint rule to rename the module to match the filename.