### PR TITLE
Avoid comparison against nullptr, instead use it as boolean identity.

### DIFF
--- a/.github/bin/check-potential-problems.sh
+++ b/.github/bin/check-potential-problems.sh
@@ -71,10 +71,22 @@ if [ $? -eq 0 ]; then
   EXIT_CODE=1
 fi
 
+# Improve readability of pointer comparisons. We always use pointers in a
+# 'does this thing (not) exist' context, and comparing it as boolean makes
+# such expressions read more naturally.
+find common verilog -name "*.h" -o -name "*.cc" | \
+  xargs egrep -n ' [=!]= nullptr' | grep -v "// NOLINT"
+if [ $? -eq 0 ]; then
+  echo "::error:: Avoid comparing against nullptr, use boolean identiy instead."
+  echo
+  EXIT_CODE=1
+fi
+
 # bazelbuild/rules_python is broken as it downloads a dynamically
 # linked pre-built binary - This makes it _very_ platform specific.
 # This should either compile Python from scratch or use the local system Python.
-# So before rules_python() is added here, this needs to be fixed first upstream.
+# So if Python is ever needed and before rules_python() is added here, this
+# needs to be fixed first upstream.
 # https://github.com/bazelbuild/rules_python/issues/1211
 grep rules_python WORKSPACE* MODULE.bazel
 if [ $? -eq 0 ]; then

--- a/common/analysis/lint_waiver.cc
+++ b/common/analysis/lint_waiver.cc
@@ -84,7 +84,7 @@ void LintWaiver::RegexToLines(absl::string_view contents,
 bool LintWaiver::RuleIsWaivedOnLine(absl::string_view rule_name,
                                     int line_number) const {
   const auto *line_set = verible::container::FindOrNull(waiver_map_, rule_name);
-  return line_set != nullptr && LineNumberSetContains(*line_set, line_number);
+  return line_set && LineNumberSetContains(*line_set, line_number);
 }
 
 bool LintWaiver::Empty() const {

--- a/common/analysis/matcher/matcher_test_utils.h
+++ b/common/analysis/matcher/matcher_test_utils.h
@@ -53,7 +53,7 @@ void RunRawMatcherTestCase(const RawMatcherTestCase &test) {
   EXPECT_TRUE(status.ok()) << "code with error:\n" << test.code;
 
   auto *tree = analyzer.SyntaxTree().get();
-  EXPECT_TRUE(tree != nullptr);
+  EXPECT_TRUE(tree);
 
   ExpectMatchesInAST(*tree, test.matcher, test.num_matches, test.code);
 }

--- a/common/analysis/syntax_tree_search_test_utils.cc
+++ b/common/analysis/syntax_tree_search_test_utils.cc
@@ -75,7 +75,7 @@ bool SyntaxTreeSearchTestCase::ExactMatchFindings(
   // Convert actual_findings into string ranges.  Ignore matches' context.
   StringRangeSet actual_findings_ranges;
   for (const auto &finding : actual_findings) {
-    if (finding.match == nullptr) continue;
+    if (!finding.match) continue;
     const auto &match_symbol(*finding.match);
     const absl::string_view spanned_text = StringSpanOfSymbol(match_symbol);
     // Spanned text can be empty when a subtree is devoid of leaves.

--- a/common/formatting/align.cc
+++ b/common/formatting/align.cc
@@ -325,8 +325,8 @@ struct AlignedColumnConfiguration {
   // constructs.
   const SyntaxTreeLeaf* leaf = GetLeftmostLeaf(symbol);
   // It is possible for a node to be empty, in which case, ignore.
-  if (leaf == nullptr) return nullptr;
-  if (parent_column->Parent() != nullptr && parent_column->Children().empty()) {
+  if (!leaf) return nullptr;
+  if (parent_column->Parent() && parent_column->Children().empty()) {
     // Starting token of a column and its first subcolumn must be the same.
     // (subcolumns overlap their parent column).
     CHECK_EQ(parent_column->Value().starting_token, leaf->get());
@@ -559,7 +559,7 @@ static void FillAlignmentRow(
       CHECK(token_iter != remaining_tokens_range.end());
       remaining_tokens_range.set_begin(token_iter);
 
-      if (prev_cell_tokens != nullptr) prev_cell_tokens->set_end(token_iter);
+      if (prev_cell_tokens) prev_cell_tokens->set_end(token_iter);
 
       AlignmentRow& row_cell = verible::DescendPath(
           *row, column_loc_iter->second.begin(), column_loc_iter->second.end());

--- a/common/formatting/align.h
+++ b/common/formatting/align.h
@@ -343,7 +343,7 @@ ColumnPositionTree ScanPartitionForAlignmentCells(
   // this 'row', and detect the sparse set of columns found by the scanner.
   ScannerType scanner = scanner_factory();
   const Symbol *origin = unwrapped_line.Origin();
-  if (origin != nullptr) origin->Accept(&scanner);
+  if (origin) origin->Accept(&scanner);
   return scanner.SparseColumns();
 }
 
@@ -385,7 +385,7 @@ ColumnPositionTree ScanPartitionForAlignmentCells_WithNonTreeTokens(
 
   FormatTokenRange leading_tokens(ftokens.begin(), ftokens.begin());
   FormatTokenRange trailing_tokens(ftokens.end(), ftokens.end());
-  if (origin != nullptr) {
+  if (origin) {
     // Identify the last token covered by the origin tree.
     const SyntaxTreeLeaf *first_leaf = GetLeftmostLeaf(*origin);
     const SyntaxTreeLeaf *last_leaf = GetRightmostLeaf(*origin);

--- a/common/formatting/align_test.cc
+++ b/common/formatting/align_test.cc
@@ -1089,7 +1089,7 @@ class SubcolumnsTreeAlignmentTest : public MatrixTreeAlignmentTestFixture {
       const std::vector<verible::PreFormatToken>::iterator& end) {
     SymbolPtr list = TNode(0);
     SymbolPtr item;
-    while ((item = ParseItem(it, end)) != nullptr) {
+    while ((item = ParseItem(it, end))) {
       SymbolCastToNode(*list).AppendChild(std::move(item));
     }
     return list;

--- a/common/formatting/format_token_test.cc
+++ b/common/formatting/format_token_test.cc
@@ -151,7 +151,7 @@ TEST(PreFormatTokenTest, OriginalLeadingSpaces) {
 TEST(PreFormatTokenTest, ExcessSpacesNoNewline) {
   const absl::string_view text("abcdefgh");
   const TokenInfo tok(1, text.substr(1, 3));
-  PreFormatToken p(&tok);  // before.preserved_space_start == nullptr
+  PreFormatToken p(&tok);  //! before.preserved_space_start
   EXPECT_EQ(p.ExcessSpaces(), 0);
 
   p.before.preserved_space_start = text.begin();
@@ -165,7 +165,7 @@ TEST(PreFormatTokenTest, ExcessSpacesNoNewline) {
 TEST(PreFormatTokenTest, ExcessSpacesNewline) {
   const absl::string_view text("\nbcdefgh");
   const TokenInfo tok(1, text.substr(1, 3));
-  PreFormatToken p(&tok);  // before.preserved_space_start == nullptr
+  PreFormatToken p(&tok);  //! before.preserved_space_start
   EXPECT_EQ(p.ExcessSpaces(), 0);
 
   p.before.preserved_space_start = text.begin();

--- a/common/formatting/layout_optimizer.cc
+++ b/common/formatting/layout_optimizer.cc
@@ -678,14 +678,14 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
   // Setting indentation for a line that is going to be appended is invalid and
   // probably has been done for some reason that is not going to work as
   // intended.
-  LOG_IF(WARNING, ((relative_indentation > 0) && (current_node_ != nullptr)))
+  LOG_IF(WARNING, ((relative_indentation > 0) && current_node_))
       << "Discarding indentation of a line that's going to be appended.";
 
   switch (layout.Type()) {
     case LayoutType::kLine: {
       CHECK(layout_tree.Children().empty());
 
-      if (current_node_ == nullptr) {
+      if (!current_node_) {
         auto uwline = UnwrappedLine(current_indentation_spaces_,
                                     layout.TokensRange().begin(),
                                     PartitionPolicyEnum::kAlreadyFormatted);
@@ -744,7 +744,7 @@ void TreeReconstructor::TraverseTree(const LayoutTree& layout_tree) {
 
       // Calculate indent for 2nd and further lines.
       int indentation = current_indentation_spaces_;
-      if (current_node_ != nullptr) {
+      if (current_node_) {
         indentation = AlreadyFormattedPartitionLength(*current_node_) +
                       layout.SpacesBefore();
       }

--- a/common/formatting/layout_optimizer_test.cc
+++ b/common/formatting/layout_optimizer_test.cc
@@ -108,7 +108,7 @@ void ExpectLayoutFunctionsEqual(const LayoutFunction& actual,
                                expected[i].span, 2);
     }
     auto layout_diff = DeepEqual(actual[i].layout, expected[i].layout);
-    if (layout_diff.left != nullptr) {
+    if (layout_diff.left) {
       PrintInvalidValueMessage(segment_msg, "layout (fragment)",
                                *layout_diff.left, *layout_diff.right, 2, true);
     }

--- a/common/formatting/state_node.h
+++ b/common/formatting/state_node.h
@@ -113,7 +113,7 @@ struct StateNode {
 
   // Returns true if this state was initialized with an unwrapped line and
   // has no parent state.
-  bool IsRootState() const { return prev_state == nullptr; }
+  bool IsRootState() const { return !prev_state; }
 
   // Returns the total number of nodes in state ancestry, including itself.
   // This occurs in O(N) time, and is only suitable for testing/debug.

--- a/common/formatting/token_partition_tree.cc
+++ b/common/formatting/token_partition_tree.cc
@@ -153,7 +153,7 @@ std::ostream& TokenPartitionTreePrinter::PrintTree(std::ostream& stream,
            // <auto> just means the concatenation of all subpartitions
            << "[<auto>], policy: " << value.PartitionPolicy() << ") @"
            << NodePath(node);
-    if (value.Origin() != nullptr) {
+    if (value.Origin()) {
       stream << ", (origin: ";
       origin_printer(stream, value.Origin());
       stream << ")";
@@ -384,8 +384,7 @@ void MergeConsecutiveSiblings(TokenPartitionTree* tree, size_t pos) {
 static void UpdateTokenRangeLowerBound(TokenPartitionTree* leaf,
                                        TokenPartitionTree* last,
                                        format_token_iterator token_iter) {
-  for (auto* node = leaf; node != nullptr && node != last;
-       node = node->Parent()) {
+  for (auto* node = leaf; node && node != last; node = node->Parent()) {
     node->Value().SpanBackToToken(token_iter);
   }
 }
@@ -395,8 +394,7 @@ static void UpdateTokenRangeLowerBound(TokenPartitionTree* leaf,
 static void UpdateTokenRangeUpperBound(TokenPartitionTree* leaf,
                                        TokenPartitionTree* last,
                                        format_token_iterator token_iter) {
-  for (auto* node = leaf; node != nullptr && node != last;
-       node = node->Parent()) {
+  for (auto* node = leaf; node && node != last; node = node->Parent()) {
     node->Value().SpanUpToToken(token_iter);
   }
 }
@@ -405,7 +403,7 @@ TokenPartitionTree* GroupLeafWithPreviousLeaf(TokenPartitionTree* leaf) {
   CHECK_NOTNULL(leaf);
   VLOG(4) << "origin leaf:\n" << *leaf;
   auto* previous_leaf = PreviousLeaf(*leaf);
-  if (previous_leaf == nullptr) return nullptr;
+  if (!previous_leaf) return nullptr;
   VLOG(4) << "previous leaf:\n" << *previous_leaf;
 
   // If there is no common ancestor, do nothing and return.
@@ -455,7 +453,7 @@ TokenPartitionTree* MergeLeafIntoPreviousLeaf(TokenPartitionTree* leaf) {
   CHECK_NOTNULL(leaf);
   VLOG(4) << "origin leaf:\n" << *leaf;
   auto* target_leaf = PreviousLeaf(*leaf);
-  if (target_leaf == nullptr) return nullptr;
+  if (!target_leaf) return nullptr;
   VLOG(4) << "target leaf:\n" << *target_leaf;
 
   // If there is no common ancestor, do nothing and return.
@@ -501,7 +499,7 @@ TokenPartitionTree* MergeLeafIntoNextLeaf(TokenPartitionTree* leaf) {
   CHECK_NOTNULL(leaf);
   VLOG(4) << "origin leaf:\n" << *leaf;
   auto* target_leaf = NextLeaf(*leaf);
-  if (target_leaf == nullptr) return nullptr;
+  if (!target_leaf) return nullptr;
   VLOG(4) << "target leaf:\n" << *target_leaf;
 
   // If there is no common ancestor, do nothing and return.
@@ -565,7 +563,7 @@ class TokenPartitionTreeWrapper {
   TokenPartitionTreeWrapper() = delete;
 
   TokenPartitionTreeWrapper(const TokenPartitionTreeWrapper& other) {
-    CHECK((other.node_ != nullptr) || (other.unwrapped_line_ != nullptr));
+    CHECK(other.node_ || other.unwrapped_line_);
 
     if (other.node_) {
       node_ = other.node_;
@@ -582,7 +580,7 @@ class TokenPartitionTreeWrapper {
 
   // Concatenate subnodes value with other node value
   UnwrappedLine Value(const TokenPartitionTree& other) const {
-    CHECK((node_ == nullptr) && (unwrapped_line_ != nullptr));
+    CHECK(!node_ && unwrapped_line_);
     UnwrappedLine uw = *unwrapped_line_;
     uw.SpanUpToToken(other.Value().TokensRange().end());
     return uw;
@@ -598,7 +596,7 @@ class TokenPartitionTreeWrapper {
 
   // Fix concatenated value indentation
   void SetIndentationSpaces(int indent) {
-    CHECK((node_ == nullptr) && (unwrapped_line_ != nullptr));
+    CHECK(!node_ && unwrapped_line_);
     unwrapped_line_->SetIndentationSpaces(indent);
   }
 

--- a/common/formatting/token_partition_tree_test.cc
+++ b/common/formatting/token_partition_tree_test.cc
@@ -450,9 +450,9 @@ TEST_F(GroupLeafWithPreviousLeafTest, RootOnly) {
 
   // Expect no change.
   const auto diff = DeepEqual(tree, saved_tree, PropertiesEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(GroupLeafWithPreviousLeafTest, OneChild) {
@@ -474,9 +474,9 @@ TEST_F(GroupLeafWithPreviousLeafTest, OneChild) {
 
   // Expect no change.
   const auto diff = DeepEqual(tree, saved_tree, PropertiesEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(GroupLeafWithPreviousLeafTest, TwoChild) {
@@ -520,9 +520,9 @@ TEST_F(GroupLeafWithPreviousLeafTest, TwoChild) {
   EXPECT_EQ(group, &tree.Children().back());
 
   const auto diff = DeepEqual(tree, expected_tree, PropertiesEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(GroupLeafWithPreviousLeafTest, TwoGenerations) {
@@ -571,9 +571,9 @@ TEST_F(GroupLeafWithPreviousLeafTest, TwoGenerations) {
   EXPECT_EQ(group, &tree.Children().back().Children().back());
 
   const auto diff = DeepEqual(tree, expected_tree, PropertiesEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(GroupLeafWithPreviousLeafTest, Cousins) {
@@ -637,9 +637,9 @@ TEST_F(GroupLeafWithPreviousLeafTest, Cousins) {
   EXPECT_EQ(group, &tree.Children().front().Children().back());
 
   const auto diff = DeepEqual(tree, expected_tree, PropertiesEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(GroupLeafWithPreviousLeafTest, ExtendCommonAncestor) {
@@ -682,9 +682,9 @@ TEST_F(GroupLeafWithPreviousLeafTest, ExtendCommonAncestor) {
   EXPECT_EQ(group, &tree.Children().back());
 
   const auto diff = DeepEqual(tree, expected_tree, PropertiesEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 static bool TokenRangeEqual(const UnwrappedLine& left,
@@ -712,9 +712,9 @@ TEST_F(MergeLeafIntoPreviousLeafTest, RootOnly) {
 
   // Expect no change.
   const auto diff = DeepEqual(tree, saved_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoPreviousLeafTest, OneChild) {
@@ -736,9 +736,9 @@ TEST_F(MergeLeafIntoPreviousLeafTest, OneChild) {
 
   // Expect no change.
   const auto diff = DeepEqual(tree, saved_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoPreviousLeafTest, TwoChild) {
@@ -769,9 +769,9 @@ TEST_F(MergeLeafIntoPreviousLeafTest, TwoChild) {
   EXPECT_EQ(parent, &tree);
 
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoPreviousLeafTest, TwoGenerations) {
@@ -816,9 +816,9 @@ TEST_F(MergeLeafIntoPreviousLeafTest, TwoGenerations) {
   EXPECT_EQ(parent, &tree);
 
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoPreviousLeafTest, Cousins) {
@@ -878,9 +878,9 @@ TEST_F(MergeLeafIntoPreviousLeafTest, Cousins) {
   EXPECT_EQ(parent, &tree.Children().back());
 
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 class MergeLeafIntoNextLeafTest : public TokenPartitionTreeTestFixture {};
@@ -903,9 +903,9 @@ TEST_F(MergeLeafIntoNextLeafTest, RootOnly) {
 
   // Expect no change.
   const auto diff = DeepEqual(tree, saved_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoNextLeafTest, OneChild) {
@@ -927,9 +927,9 @@ TEST_F(MergeLeafIntoNextLeafTest, OneChild) {
 
   // Expect no change.
   const auto diff = DeepEqual(tree, saved_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoNextLeafTest, TwoChild) {
@@ -960,9 +960,9 @@ TEST_F(MergeLeafIntoNextLeafTest, TwoChild) {
   EXPECT_EQ(parent, &tree);
 
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoNextLeafTest, TwoGenerations) {
@@ -1009,9 +1009,9 @@ TEST_F(MergeLeafIntoNextLeafTest, TwoGenerations) {
   EXPECT_EQ(parent, &tree.Children().front());
 
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeLeafIntoNextLeafTest, Cousins) {
@@ -1072,9 +1072,9 @@ TEST_F(MergeLeafIntoNextLeafTest, Cousins) {
   EXPECT_EQ(parent, &tree.Children().front());
 
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 class MergeConsecutiveSiblingsTest : public TokenPartitionTreeTestFixture {};
@@ -1120,9 +1120,9 @@ TEST_F(MergeConsecutiveSiblingsTest, TwoChild) {
 
   MergeConsecutiveSiblings(&tree, 0);
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 TEST_F(MergeConsecutiveSiblingsTest, TwoGenerations) {
@@ -1174,9 +1174,9 @@ TEST_F(MergeConsecutiveSiblingsTest, TwoGenerations) {
 
   MergeConsecutiveSiblings(&tree, 0);
   const auto diff = DeepEqual(tree, expected_tree, TokenRangeEqual);
-  EXPECT_TRUE(diff.left == nullptr) << "First differing node at:\n"
-                                    << *diff.left << "\nand:\n"
-                                    << *diff.right << '\n';
+  EXPECT_FALSE(diff.left) << "First differing node at:\n"
+                          << *diff.left << "\nand:\n"
+                          << *diff.right << '\n';
 }
 
 class AnyPartitionSubRangeIsDisabledTest

--- a/common/formatting/token_partition_tree_test_utils.cc
+++ b/common/formatting/token_partition_tree_test_utils.cc
@@ -67,7 +67,7 @@ TokenPartitionTree TokenPartitionTreeBuilder::build(
     const char* actual_expr, const char* expected_expr,
     const TokenPartitionTree& actual, const TokenPartitionTree& expected) {
   const auto diff = DeepEqual(actual, expected, PartitionsEqual);
-  if (diff.left != nullptr) {
+  if (diff.left) {
     return ::testing::AssertionFailure()
            << "Expected equality of these trees:\n"
               "Actual:\n"

--- a/common/formatting/tree_annotator.cc
+++ b/common/formatting/tree_annotator.cc
@@ -89,7 +89,7 @@ void TreeAnnotator::Annotate() {
 
   // Visit the tokens from the beginning of the token stream through
   // the last syntax tree node.
-  if (syntax_tree_root_ != nullptr) {
+  if (syntax_tree_root_) {
     syntax_tree_root_->Accept(this);
   }
   // Else without a syntax tree, the following code will still annotate

--- a/common/formatting/unwrapped_line.cc
+++ b/common/formatting/unwrapped_line.cc
@@ -95,7 +95,7 @@ std::ostream *UnwrappedLine::AsCode(
                              TokenFormatter(out, token, verbose);
                            })
           << "], policy: " << partition_policy_;
-  if (origin_ != nullptr) {
+  if (origin_) {
     *stream << ", (origin: ";
     origin_printer(*stream, origin_);
     *stream << ")";

--- a/common/lsp/jcxxgen.cc
+++ b/common/lsp/jcxxgen.cc
@@ -249,7 +249,7 @@ void GenerateCode(const std::string &filename,
       is_first = false;
     }
     fprintf(out, " {\n");
-    for (const auto &p : obj->properties) {
+    for (const Property &p : obj->properties) {
       std::string type;
       if (p.object_type) {
         type = p.object_type->name;
@@ -290,7 +290,7 @@ void GenerateCode(const std::string &filename,
     for (const auto &e : obj->extends) {
       fprintf(out, "    %s::Deserialize(j);\n", e.c_str());
     }
-    for (const auto &p : obj->properties) {
+    for (const Property &p : obj->properties) {
       int indent = 4;
       std::string access_call = "j.at(\"" + p.name + "\")";
       std::string access_deref = access_call + ".";
@@ -304,7 +304,7 @@ void GenerateCode(const std::string &filename,
         access_call = "*found";
         access_deref = "found->";
       }
-      if (p.object_type == nullptr || p.is_array) {
+      if (!p.object_type || p.is_array) {
         fprintf(out, "%*s%sget_to(%s);\n", indent, "", access_deref.c_str(),
                 p.name.c_str());
       } else {
@@ -327,7 +327,7 @@ void GenerateCode(const std::string &filename,
         fprintf(out, "%*sif (has_%s)", indent, "", p.name.c_str());
         indent = 1;
       }
-      if (p.object_type == nullptr || p.is_array) {
+      if (!p.object_type || p.is_array) {
         fprintf(out, "%*s(*j)[\"%s\"] = %s;\n", indent, "", p.name.c_str(),
                 p.name.c_str());
       } else {

--- a/common/parser/parser_test_util.h
+++ b/common/parser/parser_test_util.h
@@ -127,7 +127,7 @@ void TestParserAllMatched(absl::string_view code, int i) {
 
   const Symbol *tree_ptr = analyzer.SyntaxTree().get();
   EXPECT_NE(tree_ptr, nullptr) << "Missing syntax tree with input:\n" << code;
-  if (tree_ptr == nullptr) return;  // Already failed, abort this test case.
+  if (!tree_ptr) return;  // Already failed, abort this test case.
   const Symbol &root = *tree_ptr;
 
   ParserVerifier verifier(root, analyzer.Data().GetTokenStreamView());

--- a/common/strings/obfuscator.cc
+++ b/common/strings/obfuscator.cc
@@ -34,7 +34,7 @@ bool Obfuscator::encode(absl::string_view key, absl::string_view value) {
 absl::string_view Obfuscator::operator()(absl::string_view input) {
   if (decode_mode_) {
     const auto *p = translator_.find_reverse(input);
-    return (p != nullptr) ? *p : input;
+    return (p) ? *p : input;
   }
   const std::string *str = translator_.insert_using_value_generator(
       std::string(input), [this, input]() { return generator_(input); });

--- a/common/strings/patch.cc
+++ b/common/strings/patch.cc
@@ -251,7 +251,7 @@ class HunkSplitter {
   HunkSplitter() = default;
 
   bool operator()(const MarkedLine &line) {
-    if (previous_line_ == nullptr) {
+    if (!previous_line_) {
       // first line
       previous_line_ = &line;
       return true;

--- a/common/text/concrete_syntax_tree.cc
+++ b/common/text/concrete_syntax_tree.cc
@@ -69,7 +69,7 @@ const SymbolPtr &SyntaxTreeNode::operator[](const size_t i) const {
 void SyntaxTreeNode::Accept(TreeVisitorRecursive *visitor) const {
   visitor->Visit(*this);
   for (const auto &child : children_) {
-    if (child != nullptr) child->Accept(visitor);
+    if (child) child->Accept(visitor);
   }
 }
 
@@ -78,7 +78,7 @@ void SyntaxTreeNode::Accept(MutableTreeVisitorRecursive *visitor,
   CHECK_EQ(ABSL_DIE_IF_NULL(this_owned)->get(), this);
   visitor->Visit(*this, this_owned);
   for (auto &child : children_) {
-    if (child != nullptr) child->Accept(visitor, &child);
+    if (child) child->Accept(visitor, &child);
   }
 }
 
@@ -89,11 +89,11 @@ void SyntaxTreeNode::Accept(SymbolVisitor *visitor) const {
 void SetChild_(const SymbolPtr &parent, int child_index, SymbolPtr new_child) {
   CHECK_EQ(ABSL_DIE_IF_NULL(parent)->Kind(), SymbolKind::kNode);
 
-  auto *parent_node = down_cast<SyntaxTreeNode *>(parent.get());
-  CHECK_LT(child_index, static_cast<int>(parent_node->size()));
-  CHECK((*parent_node)[child_index] == nullptr);
+  SyntaxTreeNode &parent_node = down_cast<SyntaxTreeNode &>(*parent);
+  CHECK_LT(child_index, static_cast<int>(parent_node.size()));
+  CHECK(!parent_node[child_index]);
 
-  (*parent_node)[child_index] = std::move(new_child);
+  parent_node[child_index] = std::move(new_child);
 }
 
 }  // namespace verible

--- a/common/text/concrete_syntax_tree.h
+++ b/common/text/concrete_syntax_tree.h
@@ -91,7 +91,7 @@ class SyntaxTreeNode final : public Symbol {
   // Call MakeNode or ExtendNode instead of calling this directly.
   // If node is actually a leaf, just append the leaf.
   void AppendChild(ForwardChildren forwarded_children) {
-    if (forwarded_children.node == nullptr) return;
+    if (!forwarded_children.node) return;
     if (forwarded_children.node->Kind() != SymbolKind::kNode) {
       children_.emplace_back(std::move(forwarded_children.node));
       return;

--- a/common/text/text_structure.cc
+++ b/common/text/text_structure.cc
@@ -202,7 +202,7 @@ void TextStructureView::FocusOnSubtreeSpanningSubstring(int left_offset,
   // Don't let the syntax tree be empty.
   // Always return a tree with one node.
   // This can happen when TrimSyntaxTree() yields a nullptr syntax tree
-  if (syntax_tree_ == nullptr) {
+  if (!syntax_tree_) {
     syntax_tree_ = MakeNode();
   }
   TrimTokensToSubstring(left_offset, right_offset);
@@ -319,7 +319,7 @@ void TextStructureView::MutateTokens(const LeafMutator& mutator) {
   }
   // No need to touch tokens_view_, all transformations are in-place.
 
-  if (syntax_tree_ != nullptr) {
+  if (syntax_tree_) {
     // The tokens at the leaves of the tree are their own copies, and thus
     // need to re-apply the same transformation.
     MutateLeaves(&syntax_tree_, mutator);
@@ -349,7 +349,7 @@ absl::Status TextStructureView::FastTokenRangeConsistencyCheck() const {
           std::distance(first.text().cbegin(), lower_bound)));
     }
     const TokenInfo* last = FindLastNonEOFToken(tokens_);
-    if (last != nullptr && last->text().cend() > upper_bound) {
+    if (last && last->text().cend() > upper_bound) {
       return absl::InternalError(absl::StrCat(
           "Token offset points past end of string contents.  delta=",
           std::distance(upper_bound, last->text().cend())));
@@ -410,7 +410,7 @@ absl::Status TextStructureView::SyntaxTreeConsistencyCheck() const {
   // inside contents_.
   const char* const lower_bound = contents_.data();
   const char* const upper_bound = lower_bound + contents_.length();
-  if (syntax_tree_ != nullptr) {
+  if (syntax_tree_) {
     const SyntaxTreeLeaf* left = GetLeftmostLeaf(*syntax_tree_);
     if (!left) return absl::OkStatus();
     const SyntaxTreeLeaf* right = GetRightmostLeaf(*syntax_tree_);

--- a/common/text/tree_compare.cc
+++ b/common/text/tree_compare.cc
@@ -22,10 +22,10 @@ namespace verible {
 
 bool EqualTrees(const Symbol *lhs, const Symbol *rhs,
                 const TokenComparator &compare_tokens) {
-  if (lhs == nullptr && rhs == nullptr) {
+  if (!lhs && !rhs) {
     return true;
   }
-  if (lhs == nullptr || rhs == nullptr) {
+  if (!lhs || !rhs) {
     return false;
   }
   const Symbol *rhs_pointer = rhs;

--- a/common/text/tree_utils.h
+++ b/common/text/tree_utils.h
@@ -141,7 +141,7 @@ const SyntaxTreeLeaf &CheckSymbolAsLeaf(const Symbol &symbol, E token_enum) {
 // Succeeds if symbol is a node, or nullptr (returning nullptr).
 template <typename SPtr>
 const SyntaxTreeNode *CheckOptionalSymbolAsNode(const SPtr &symbol) {
-  if (symbol == nullptr) return nullptr;
+  if (!symbol) return nullptr;
   return &SymbolCastToNode(*symbol);
 }
 
@@ -150,7 +150,7 @@ const SyntaxTreeNode *CheckOptionalSymbolAsNode(const SPtr &symbol) {
 template <typename SPtr, typename E>
 const SyntaxTreeNode *CheckOptionalSymbolAsNode(const SPtr &symbol,
                                                 E node_enum) {
-  if (symbol == nullptr) return nullptr;
+  if (!symbol) return nullptr;
   return &CheckSymbolAsNode(*symbol, node_enum);
 }
 
@@ -166,7 +166,7 @@ const SyntaxTreeNode *CheckOptionalSymbolAsNode(const std::nullptr_t &symbol,
 template <typename SPtr, typename E>
 const SyntaxTreeLeaf *CheckOptionalSymbolAsLeaf(const SPtr &symbol,
                                                 E token_enum) {
-  if (symbol == nullptr) return nullptr;
+  if (!symbol) return nullptr;
   return &CheckSymbolAsLeaf(*symbol, token_enum);
 }
 

--- a/common/util/casts.h
+++ b/common/util/casts.h
@@ -26,7 +26,7 @@ inline To down_cast(From *f) {
 
   // We skip the assert and hence the dynamic_cast if RTTI is disabled.
 #if !defined(__GNUC__) || defined(__GXX_RTTI)
-  assert(f == nullptr || dynamic_cast<To>(f) != nullptr);
+  assert(!f || dynamic_cast<To>(f));
 #endif  // !defined(__GNUC__) || defined(__GXX_RTTI)
 
   return static_cast<To>(f);

--- a/common/util/enum_flags.h
+++ b/common/util/enum_flags.h
@@ -128,7 +128,7 @@ class EnumNameMap {
   bool Parse(key_type text, EnumType *enum_value, std::ostream &errstream,
              absl::string_view type_name) const {
     const EnumType *found_value = enum_name_map_.find_forward(text);
-    if (found_value != nullptr) {
+    if (found_value) {
       *enum_value = *found_value;
       return true;
     }
@@ -151,7 +151,7 @@ class EnumNameMap {
   // Returns the string representation of an enum.
   absl::string_view EnumName(EnumType value) const {
     const auto *key = enum_name_map_.find_reverse(value);
-    if (key == nullptr) return "???";
+    if (!key) return "???";
     return *key;
   }
 

--- a/common/util/expandable_tree_view.h
+++ b/common/util/expandable_tree_view.h
@@ -112,7 +112,7 @@ class ExpandableTreeView {
               return node_type(other);
             })) {
     // Guarantee structural equivalence with original tree.
-    CHECK(StructureEqual(view_, tree).left == nullptr);
+    CHECK(!StructureEqual(view_, tree).left);
   }
 
   // TODO(fangism): implement later as needed
@@ -171,7 +171,7 @@ class ExpandableTreeView {
   // \precondition this->parent_->expand_ is true (for all ancestors),
   //   otherwise we would have never reached this node.
   static const impl_type *next_sibling(const impl_type &current) {
-    if (current.Parent() == nullptr) return nullptr;
+    if (!current.Parent()) return nullptr;
 
     // Find the next sibling, if there is one.
     const size_t birth_rank = verible::BirthRank(current);

--- a/common/util/map_tree.h
+++ b/common/util/map_tree.h
@@ -217,8 +217,7 @@ class MapTree {
 
   size_t NumAncestors() const {
     size_t depth = 0;
-    for (const this_type *iter = Parent(); iter != nullptr;
-         iter = iter->Parent()) {
+    for (const this_type *iter = Parent(); iter; iter = iter->Parent()) {
       ++depth;
     }
     return depth;
@@ -230,9 +229,8 @@ class MapTree {
   // nullptr is never considered an ancestor of any node.
   // 'this' node is not considered an ancestor of itself.
   bool HasAncestor(const this_type *other) const {
-    if (other == nullptr) return false;
-    for (const this_type *iter = Parent(); iter != nullptr;
-         iter = iter->Parent()) {
+    if (!other) return false;
+    for (const this_type *iter = Parent(); iter; iter = iter->Parent()) {
       if (iter == other) return true;
     }
     return false;
@@ -241,7 +239,7 @@ class MapTree {
   // Returns pointer to the tree root, the greatest ancestor of this node.
   const this_type *Root() const {
     const this_type *node = this;
-    while (node->Parent() != nullptr) node = node->Parent();
+    while (node->Parent()) node = node->Parent();
     return node;
   }
 
@@ -261,7 +259,7 @@ class MapTree {
 #endif
     // Compute offset of member &key_value_type::second (built-in function).
     static constexpr auto value_offset = offsetof(key_value_type, second);
-    if (Parent() == nullptr) return nullptr;  // Root node has no key
+    if (!Parent()) return nullptr;  // Root node has no key
     // All non-root nodes belong to a parent's map, and thus are
     // pair-co-located with a key.
     // Use pointer arithmetic to recover location of the key-value pair to which
@@ -277,7 +275,7 @@ class MapTree {
   // Returns the key associated with this node (if this is not a root),
   // otherwise return nullptr.
   const key_type *Key() const {
-    if (Parent() == nullptr) return nullptr;  // Root node has no key
+    if (!Parent()) return nullptr;  // Root node has no key
     return &KeyValuePair()->first;
   }
 

--- a/common/util/map_tree_test.cc
+++ b/common/util/map_tree_test.cc
@@ -391,7 +391,7 @@ TEST(MapTreeTest, TraversePrint) {
     std::ostringstream stream;
     m.ApplyPreOrder([&stream](const MapTreeTestType &node) {
       const auto *key = node.Key();
-      stream << (key == nullptr ? 0 : *key) << " ";
+      stream << (key ? *key : 0) << " ";
     });
     EXPECT_EQ(stream.str(), "0 3 2 6 5 1 4 ");
   }
@@ -408,7 +408,7 @@ TEST(MapTreeTest, TraversePrint) {
     std::ostringstream stream;
     m.ApplyPostOrder([&stream](const MapTreeTestType &node) {
       const auto *key = node.Key();
-      stream << (key == nullptr ? 0 : *key) << " ";
+      stream << (key ? *key : 0) << " ";
     });
     EXPECT_EQ(stream.str(), "2 6 3 1 4 5 0 ");
   }

--- a/common/util/tree_operations.h
+++ b/common/util/tree_operations.h
@@ -132,7 +132,7 @@ struct TreeNodeParentTraits : FeatureTraits {};
 // This overload is a linear-time operation.
 template <class T>
 size_t BirthRank(const T& node, std::input_iterator_tag) {
-  if (node.Parent() != nullptr) {
+  if (node.Parent()) {
     size_t index = 0;
     for (const auto& child : node.Parent()->Children()) {
       if (&node == &child) return index;
@@ -145,7 +145,7 @@ size_t BirthRank(const T& node, std::input_iterator_tag) {
 // BirthRank optimized for random access containers.
 template <class T>
 size_t BirthRank(const T& node, std::random_access_iterator_tag) {
-  if (node.Parent() != nullptr) {
+  if (node.Parent()) {
     return std::distance(&*(node.Parent()->Children().begin()), &node);
   }
   return 0;
@@ -378,7 +378,7 @@ template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 size_t NumAncestors(const T& node) {
   size_t depth = 0;
-  for (const T* p = node.Parent(); p != nullptr; p = p->Parent()) {
+  for (const T* p = node.Parent(); p; p = p->Parent()) {
     ++depth;
   }
   return depth;
@@ -394,8 +394,8 @@ size_t NumAncestors(const T& node) {
 template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 bool HasAncestor(const T& node, const T* other) {
-  if (other == nullptr) return false;
-  for (const auto* p = node.Parent(); p != nullptr; p = p->Parent()) {
+  if (!other) return false;
+  for (const auto* p = node.Parent(); p; p = p->Parent()) {
     if (p == other) return true;
   }
   return false;
@@ -419,7 +419,7 @@ template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 T& Root(T& node) {
   T* root = &node;
-  while (root->Parent() != nullptr) {
+  while (root->Parent()) {
     root = root->Parent();
   }
   return *root;
@@ -439,15 +439,15 @@ T* NearestCommonAncestor(T& node_a, T& node_b) {
   // In alternation, insert a/b into its respective set of ancestors,
   // and check for membership in the other ancestor set.
   // Return as soon as one is found in the other's set of ancestors.
-  while (a != nullptr || b != nullptr) {
-    if (a != nullptr) {
+  while (a || b) {
+    if (a) {
       if (ancestors_b.find(a) != ancestors_b.end()) {
         return a;
       }
       ancestors_a.insert(a);
       a = a->Parent();
     }
-    if (b != nullptr) {
+    if (b) {
       if (ancestors_a.find(b) != ancestors_a.end()) {
         return b;
       }
@@ -465,7 +465,7 @@ T* NearestCommonAncestor(T& node_a, T& node_b) {
 template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 bool IsFirstChild(const T& node) {
-  if (node.Parent() == nullptr) return true;
+  if (!node.Parent()) return true;
   return &*node.Parent()->Children().begin() == &node;
 }
 
@@ -479,7 +479,7 @@ template <
     std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr,
     std::void_t<decltype(std::declval<const T>().Children().back())>* = nullptr>
 bool IsLastChild(const T& node) {
-  if (node.Parent() == nullptr) return true;
+  if (!node.Parent()) return true;
   return &node.Parent()->Children().back() == &node;
 }
 
@@ -493,7 +493,7 @@ template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 T* NextLeaf(T& node) {
   auto* parent = node.Parent();
-  if (parent == nullptr) {
+  if (!parent) {
     // Root node has no next sibling, this is the end().
     return nullptr;
   }
@@ -511,7 +511,7 @@ T* NextLeaf(T& node) {
   // Find the nearest parent that has a next child (ascending).
   // TODO(fangism): rewrite without recursion
   auto* next_ancestor = NextLeaf(*parent);
-  if (next_ancestor == nullptr) return nullptr;
+  if (!next_ancestor) return nullptr;
 
   // next_ancestor is the NearestCommonAncestor() to the original
   // node and the resulting node.
@@ -528,7 +528,7 @@ template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 T* PreviousLeaf(T& node) {
   auto* parent = node.Parent();
-  if (parent == nullptr) {
+  if (!parent) {
     // Root node has no previous sibling, this is the reverse-end().
     return nullptr;
   }
@@ -545,7 +545,7 @@ T* PreviousLeaf(T& node) {
   // Find the nearest parent that has a previous child (descending).
   // TODO(fangism): rewrite without recursion
   auto* prev_ancestor = PreviousLeaf(*parent);
-  if (prev_ancestor == nullptr) return nullptr;
+  if (!prev_ancestor) return nullptr;
 
   // prev_ancestor is the NearestCommonAncestor() to the original
   // node and the resulting node.
@@ -560,7 +560,7 @@ T* PreviousLeaf(T& node) {
 template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 T* NextSibling(T& node) {
-  if (node.Parent() == nullptr) {
+  if (!node.Parent()) {
     return nullptr;
   }
   const size_t birth_rank = BirthRank(node);
@@ -580,7 +580,7 @@ T* NextSibling(T& node) {
 template <class T,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 T* PreviousSibling(T& node) {
-  if (node.Parent() == nullptr) {
+  if (!node.Parent()) {
     return nullptr;
   }
   const size_t birth_rank = BirthRank(node);
@@ -772,7 +772,7 @@ void FlattenOnlyChildrenWithChildren(
 
   ReserveIfSupported(new_children, new_children_count);
 
-  if (new_offsets != nullptr) {
+  if (new_offsets) {
     new_offsets->clear();
     new_offsets->reserve(std::size(node.Children()));
   }
@@ -836,7 +836,7 @@ void FlattenOneChild(T& node, size_t i) {
 template <class T, class PathType,  //
           std::enable_if_t<TreeNodeTraits<T>::Parent::available>* = nullptr>
 void Path(const T& node, PathType& path) {
-  if (node.Parent() != nullptr) {
+  if (node.Parent()) {
     Path(*node.Parent(), path);
     path.push_back(verible::BirthRank(node));
   }
@@ -922,7 +922,7 @@ TreeNodePair<LT, RT> DeepEqual(
                       right_children.begin(),
                       [&comp, &first_diff](const LT& l, const RT& r) -> bool {
                         const auto result = DeepEqual(l, r, comp);
-                        if (result.left == nullptr) {
+                        if (!result.left) {
                           return true;
                         }
                         first_diff = result;  // Capture first difference.

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -155,7 +155,7 @@ class SimpleNode {
 
   friend std::ostream& operator<<(std::ostream& stream,
                                   const ThisType* self_ptr) {
-    if (self_ptr == nullptr) {
+    if (!self_ptr) {
       return stream << "nullptr";
     }
     return stream << absl::StreamFormat("%p (%s; parent=%p)\n", self_ptr,
@@ -257,7 +257,7 @@ class IntNode {
 
   friend std::ostream& operator<<(std::ostream& stream,
                                   const IntNode* self_ptr) {
-    if (self_ptr == nullptr) {
+    if (!self_ptr) {
       return stream << "nullptr";
     }
     return stream << absl::StreamFormat("%p (%d)\n", self_ptr,

--- a/verilog/CST/DPI.h
+++ b/verilog/CST/DPI.h
@@ -41,7 +41,7 @@ verible::SymbolPtr MakeDPIImport(T0 &&keyword, T1 &&spec, T2 &&property,
                                  T3 &&id, T4 &&equals, T5 &&proto) {
   verible::CheckSymbolAsLeaf(*keyword, verilog_tokentype::TK_import);
   verible::CheckSymbolAsLeaf(*spec, verilog_tokentype::TK_StringLiteral);
-  if (id != nullptr) {
+  if (id) {
     CHECK(IsIdentifierLike(
         verilog_tokentype(verible::SymbolCastToLeaf(*id).get().token_enum())));
   }

--- a/verilog/CST/class.cc
+++ b/verilog/CST/class.cc
@@ -74,7 +74,7 @@ const verible::SyntaxTreeLeaf *GetClassEndLabel(
     const verible::Symbol &class_declaration) {
   const auto *label_node = verible::GetSubtreeAsSymbol(
       class_declaration, NodeEnum::kClassDeclaration, 3);
-  if (label_node == nullptr) {
+  if (!label_node) {
     return nullptr;
   }
   return verible::GetSubtreeAsLeaf(verible::SymbolCastToNode(*label_node),

--- a/verilog/CST/class_test.cc
+++ b/verilog/CST/class_test.cc
@@ -194,7 +194,7 @@ TEST(FindAllModuleDeclarationTest, FindClassParameters) {
           for (const auto &instance : instances) {
             const auto *decl =
                 GetParamDeclarationListFromClassDeclaration(*instance.match);
-            if (decl == nullptr) {
+            if (!decl) {
               continue;
             }
             params.emplace_back(TreeSearchMatch{decl, {/* ignored context */}});
@@ -224,7 +224,7 @@ TEST(GetClassExtendTest, GetExtendListIdentifiers) {
           std::vector<TreeSearchMatch> identifiers;
           for (const auto &decl : members) {
             const auto *identifier = GetExtendedClass(*decl.match);
-            if (identifier == nullptr) {
+            if (!identifier) {
               continue;
             }
             identifiers.emplace_back(

--- a/verilog/CST/declaration.cc
+++ b/verilog/CST/declaration.cc
@@ -182,7 +182,7 @@ const verible::SyntaxTreeNode *GetPackedDimensionFromDataDeclaration(
   if (!instantiation_type) return nullptr;
   const verible::Symbol *data_type = verible::GetSubtreeAsSymbol(
       *instantiation_type, NodeEnum::kInstantiationType, 0);
-  if (data_type == nullptr) return nullptr;
+  if (!data_type) return nullptr;
 
   return GetPackedDimensionFromDataType(*data_type);
 }
@@ -209,13 +209,13 @@ const verible::Symbol *GetTypeIdentifierFromDataDeclaration(
   if (!instantiation_type) return nullptr;
   const verible::Symbol *identifier =
       GetTypeIdentifierFromInstantiationType(*instantiation_type);
-  if (identifier != nullptr) {
+  if (identifier) {
     return identifier;
   }
 
   const verible::Symbol *base_type =
       GetBaseTypeFromInstantiationType(*instantiation_type);
-  if (base_type == nullptr) return nullptr;
+  if (!base_type) return nullptr;
   return GetTypeIdentifierFromBaseType(*base_type);
 }
 

--- a/verilog/CST/declaration_test.cc
+++ b/verilog/CST/declaration_test.cc
@@ -265,7 +265,7 @@ TEST(GetQualifiersOfDataDeclarationTest, NoQualifiers) {
           // nullptrs.
           for (const auto &decl : decls) {
             const auto *quals = GetQualifiersOfDataDeclaration(*decl.match);
-            if (quals != nullptr) {
+            if (quals) {
               for (const auto &child : quals->children()) {
                 EXPECT_EQ(child, nullptr)
                     << "unexpected qualifiers:\n"
@@ -410,7 +410,7 @@ TEST(GetQualifiersOfDataDeclarationTest, SomeQualifiers) {
           std::vector<TreeSearchMatch> quals;
           for (const auto &decl : decls) {
             const auto *qual = GetQualifiersOfDataDeclaration(*decl.match);
-            if (qual != nullptr) {
+            if (qual) {
               quals.push_back(TreeSearchMatch{qual, {/* ignored context */}});
             } else {
               EXPECT_NE(qual, nullptr) << "decl:\n"
@@ -627,7 +627,7 @@ TEST(GetStructTypeFromDeclaration, GetStructOrUnionOrEnumType) {
           for (const auto &decl : instances) {
             const auto *type =
                 GetStructOrUnionOrEnumTypeFromDataDeclaration(*decl.match);
-            if (type == nullptr) {
+            if (!type) {
               continue;
             }
             types.emplace_back(TreeSearchMatch{type, {/* ignored context */}});
@@ -753,7 +753,7 @@ TEST(FindAllDataDeclarationTest, FindDataDeclarationParameters) {
             VLOG(1) << "decl: " << verible::StringSpanOfSymbol(*decl.match);
             const auto *param_list =
                 GetParamListFromDataDeclaration(*decl.match);
-            if (param_list == nullptr) {
+            if (!param_list) {
               continue;
             }
             params.emplace_back(
@@ -933,7 +933,7 @@ TEST(GetVariableDeclaration, FindPackedDimensionFromDataDeclaration) {
           for (const auto &decl : instances) {
             const auto *packed_dimension =
                 GetPackedDimensionFromDataDeclaration(*decl.match);
-            if (packed_dimension == nullptr) {
+            if (!packed_dimension) {
               continue;
             }
             packed_dimensions.emplace_back(

--- a/verilog/CST/dimensions_test.cc
+++ b/verilog/CST/dimensions_test.cc
@@ -164,11 +164,11 @@ static const MatchTestCase kMatchTestCases[] = {
 };
 
 static size_t ExtractNumDimensions(const verible::Symbol *root) {
-  if (root == nullptr) return 0;
+  if (!root) return 0;
   const auto matches = FindAllDeclarationDimensions(*root);
   if (matches.empty()) return 0;
   // Only extract from the first match.
-  if (matches[0].match == nullptr) return 0;
+  if (!matches[0].match) return 0;
   const auto &s = *matches[0].match;
   return down_cast<const verible::SyntaxTreeNode &>(s).size();
 }

--- a/verilog/CST/expression.cc
+++ b/verilog/CST/expression.cc
@@ -41,7 +41,7 @@ using verible::SyntaxTreeNode;
 using verible::TreeSearchMatch;
 
 bool IsExpression(const verible::SymbolPtr &symbol_ptr) {
-  if (symbol_ptr == nullptr) return false;
+  if (!symbol_ptr) return false;
   if (symbol_ptr->Kind() != SymbolKind::kNode) return false;
   const auto &node = down_cast<const SyntaxTreeNode &>(*symbol_ptr);
   return node.MatchesTag(NodeEnum::kExpression);
@@ -161,9 +161,8 @@ static const verible::TokenInfo *ReferenceBaseIsSimple(
   const auto *params = GetParamListFromUnqualifiedId(unqualified_id);
   // If there are parameters, it is not simple reference.
   // It is most likely a class-qualified static reference.
-  return params == nullptr
-             ? &verible::SymbolCastToLeaf(*unqualified_id.front()).get()
-             : nullptr;
+  return !params ? &verible::SymbolCastToLeaf(*unqualified_id.front()).get()
+                 : nullptr;
 }
 
 const verible::TokenInfo *ReferenceIsSimpleIdentifier(

--- a/verilog/CST/expression_test.cc
+++ b/verilog/CST/expression_test.cc
@@ -239,7 +239,7 @@ TEST(GetConditionExpressionPredicateTest, Various) {
           for (const auto& expr : exprs) {
             const auto* predicate =
                 GetConditionExpressionPredicate(*expr.match);
-            if (predicate != nullptr) {
+            if (predicate) {
               predicates.push_back(
                   TreeSearchMatch{predicate, {/* ignored context */}});
             } else {
@@ -325,7 +325,7 @@ TEST(GetConditionExpressionTrueCaseTest, Various) {
           std::vector<TreeSearchMatch> predicates;
           for (const auto& expr : exprs) {
             const auto* predicate = GetConditionExpressionTrueCase(*expr.match);
-            if (predicate != nullptr) {
+            if (predicate) {
               predicates.push_back(
                   TreeSearchMatch{predicate, {/* ignored context */}});
             } else {
@@ -412,7 +412,7 @@ TEST(GetConditionExpressionFalseCaseTest, Various) {
           for (const auto& expr : exprs) {
             const auto* predicate =
                 GetConditionExpressionFalseCase(*expr.match);
-            if (predicate != nullptr) {
+            if (predicate) {
               predicates.push_back(
                   TreeSearchMatch{predicate, {/* ignored context */}});
             } else {

--- a/verilog/CST/functions_test.cc
+++ b/verilog/CST/functions_test.cc
@@ -204,7 +204,7 @@ TEST(FunctionPrototypesReturnTypesTest, Various) {
           for (const auto &proto : protos) {
             const auto *return_type = GetFunctionHeaderReturnType(
                 *GetFunctionPrototypeHeader(*proto.match));
-            if (return_type == nullptr) continue;
+            if (!return_type) continue;
             if (verible::StringSpanOfSymbol(*return_type).empty()) continue;
             returns.push_back(TreeSearchMatch{return_type, /* no context */});
           }
@@ -252,7 +252,7 @@ TEST(FunctionPrototypesIdsTest, Various) {
           for (const auto &proto : protos) {
             const auto *id =
                 GetFunctionHeaderId(*GetFunctionPrototypeHeader(*proto.match));
-            if (id == nullptr) continue;
+            if (!id) continue;
             if (verible::StringSpanOfSymbol(*id).empty()) continue;
             ids.push_back(TreeSearchMatch{id, /* no context */});
           }
@@ -484,7 +484,7 @@ TEST(GetFunctionReturnTypeTest, VariousReturnTypes) {
             const auto &statement = *decl.match;
             const auto *return_type = GetFunctionReturnType(statement);
             // Expect a type node, even when type is implicit or empty.
-            if (return_type == nullptr) continue;
+            if (!return_type) continue;
             const auto return_type_span =
                 verible::StringSpanOfSymbol(*return_type);
             if (!return_type_span.empty()) {
@@ -526,7 +526,7 @@ TEST(GetFunctionFormalPortsGroupTest, MixedFormalPorts) {
           for (const auto &decl : decls) {
             const auto &statement = *decl.match;
             const auto *port_formals = GetFunctionFormalPortsGroup(statement);
-            if (port_formals == nullptr) continue;
+            if (!port_formals) continue;
             const auto port_formals_span =
                 verible::StringSpanOfSymbol(*port_formals);
             if (port_formals_span.empty()) continue;
@@ -696,7 +696,7 @@ TEST(FunctionCallTest, GetFunctionCallName) {
           for (const auto &call : calls) {
             const auto *identifier =
                 GetIdentifiersFromFunctionCall(*call.match);
-            if (identifier == nullptr) {
+            if (!identifier) {
               continue;
             }
             identifiers.emplace_back(

--- a/verilog/CST/identifier_test.cc
+++ b/verilog/CST/identifier_test.cc
@@ -118,7 +118,7 @@ TEST(GetIdentifierTest, UnqualifiedIds) {
           for (const auto &id : ids) {
             const verible::SyntaxTreeLeaf *base =
                 AutoUnwrapIdentifier(*id.match);
-            if (base == nullptr) continue;
+            if (!base) continue;
             got_ids.push_back(TreeSearchMatch{base, /* ignored context */});
             EXPECT_EQ(AutoUnwrapIdentifier(*base), base);  // check convergence
           }

--- a/verilog/CST/macro.cc
+++ b/verilog/CST/macro.cc
@@ -88,7 +88,7 @@ bool MacroCallArgsIsEmpty(const SyntaxTreeNode &args) {
   // Empty macro args are always constructed with one nullptr child in
   // the semantic actions in verilog.y.
   if (sub.size() != 1) return false;
-  return sub.front() == nullptr;
+  return !sub.front();
 }
 
 const verible::SyntaxTreeLeaf *GetMacroName(

--- a/verilog/CST/macro_test.cc
+++ b/verilog/CST/macro_test.cc
@@ -305,7 +305,7 @@ TEST(FindAllPreprocessorInclude, IncludedFileName) {
           for (const auto &include : includes) {
             const auto *filename =
                 GetFileFromPreprocessorInclude(*include.match);
-            if (filename == nullptr) {
+            if (!filename) {
               continue;
             }
             names.emplace_back(

--- a/verilog/CST/module.cc
+++ b/verilog/CST/module.cc
@@ -114,7 +114,7 @@ const verible::SyntaxTreeLeaf *GetModuleEndLabel(
   CHECK(IsModuleOrInterfaceOrProgramDeclaration(module_node));
 
   const auto *label_node = module_node[3].get();
-  if (label_node == nullptr) {
+  if (!label_node) {
     return nullptr;
   }
   return verible::GetSubtreeAsLeaf(verible::SymbolCastToNode(*label_node),

--- a/verilog/CST/module.h
+++ b/verilog/CST/module.h
@@ -36,7 +36,7 @@ verible::SymbolPtr MakeModuleHeader(T0 &&keyword, T1 &&lifetime, T2 &&id,
                                     T3 &&imports, T4 &&parameters, T5 &&ports,
                                     T6 &&attribute, T7 &&semi) {
   verible::SymbolCastToLeaf(*keyword);
-  if (lifetime != nullptr) verible::SymbolCastToLeaf(*lifetime);
+  if (lifetime) verible::SymbolCastToLeaf(*lifetime);
   verible::SymbolCastToLeaf(*id);  // SymbolIdentifier or other identifier
   verible::CheckOptionalSymbolAsNode(imports, NodeEnum::kPackageImportList);
   verible::CheckOptionalSymbolAsNode(parameters,

--- a/verilog/CST/module_test.cc
+++ b/verilog/CST/module_test.cc
@@ -197,7 +197,7 @@ TEST(GetModulePortDeclarationListTest, ModulePorts) {
           std::vector<TreeSearchMatch> groups;
           for (const auto &instance : modules) {
             const auto *group = GetModulePortParenGroup(*instance.match);
-            if (group == nullptr) {
+            if (!group) {
               continue;
             }
             groups.emplace_back(
@@ -232,7 +232,7 @@ TEST(FindAllModuleDeclarationTest, FindModuleParameters) {
           for (const auto &instance : instances) {
             const auto *decl =
                 GetParamDeclarationListFromModuleDeclaration(*instance.match);
-            if (decl == nullptr) {
+            if (!decl) {
               continue;
             }
             params.emplace_back(TreeSearchMatch{decl, {/* ignored context */}});
@@ -266,7 +266,7 @@ TEST(FindAllInterfaceDeclarationTest, FindInterfaceParameters) {
           for (const auto &instance : instances) {
             const auto *decl = GetParamDeclarationListFromInterfaceDeclaration(
                 *instance.match);
-            if (decl == nullptr) {
+            if (!decl) {
               continue;
             }
             params.emplace_back(TreeSearchMatch{decl, {/* ignored context */}});
@@ -294,7 +294,7 @@ TEST(GetModulePortDeclarationListTest, ModulePortList) {
           std::vector<TreeSearchMatch> lists;
           for (const auto &instance : instances) {
             const auto *list = GetModulePortDeclarationList(*instance.match);
-            if (list == nullptr) {
+            if (!list) {
               continue;
             }
             lists.emplace_back(TreeSearchMatch{list, {/* ignored context */}});
@@ -322,7 +322,7 @@ TEST(GetInterfacePortDeclarationListTest, InterfacePortList) {
           std::vector<TreeSearchMatch> lists;
           for (const auto &instance : instances) {
             const auto *list = GetModulePortDeclarationList(*instance.match);
-            if (list == nullptr) {
+            if (!list) {
               continue;
             }
             lists.emplace_back(TreeSearchMatch{list, {/* ignored context */}});
@@ -350,7 +350,7 @@ TEST(GetProgramPortDeclarationListTest, ProgramPortList) {
           std::vector<TreeSearchMatch> lists;
           for (const auto &instance : instances) {
             const auto *list = GetModulePortDeclarationList(*instance.match);
-            if (list == nullptr) {
+            if (!list) {
               continue;
             }
             lists.emplace_back(TreeSearchMatch{list, {/* ignored context */}});
@@ -381,7 +381,7 @@ TEST(FindModuleEndTest, ModuleEndName) {
           std::vector<TreeSearchMatch> labels;
           for (const auto &instance : instances) {
             const auto *label = GetModuleEndLabel(*instance.match);
-            if (label == nullptr) {
+            if (!label) {
               continue;
             }
             labels.emplace_back(
@@ -413,7 +413,7 @@ TEST(FindInterfaceEndTest, InterfaceEndName) {
           std::vector<TreeSearchMatch> labels;
           for (const auto &instance : instances) {
             const auto *label = GetModuleEndLabel(*instance.match);
-            if (label == nullptr) {
+            if (!label) {
               continue;
             }
             labels.emplace_back(
@@ -445,7 +445,7 @@ TEST(FindProgramEndTest, ProgramEndName) {
           std::vector<TreeSearchMatch> labels;
           for (const auto &instance : instances) {
             const auto *label = GetModuleEndLabel(*instance.match);
-            if (label == nullptr) {
+            if (!label) {
               continue;
             }
             labels.emplace_back(

--- a/verilog/CST/package.cc
+++ b/verilog/CST/package.cc
@@ -52,7 +52,7 @@ const verible::SyntaxTreeLeaf *GetPackageNameEndLabel(
     const verible::Symbol &package_declaration) {
   const auto *label_node = verible::GetSubtreeAsSymbol(
       package_declaration, NodeEnum::kPackageDeclaration, 6);
-  if (label_node == nullptr) {
+  if (!label_node) {
     return nullptr;
   }
   return verible::GetSubtreeAsLeaf(verible::SymbolCastToNode(*label_node),

--- a/verilog/CST/package_test.cc
+++ b/verilog/CST/package_test.cc
@@ -352,7 +352,7 @@ TEST(GetPackageNameTest, GetPackageEndLabelName) {
           std::vector<TreeSearchMatch> names;
           for (const auto &decl : declarations) {
             const auto *package_name = GetPackageNameEndLabel(*decl.match);
-            if (package_name == nullptr) continue;
+            if (!package_name) continue;
             names.push_back(TreeSearchMatch{package_name, {}});
           }
           return names;
@@ -385,7 +385,7 @@ TEST(GetPackageBodyTest, GetPackageItemList) {
           std::vector<TreeSearchMatch> lists;
           for (const auto &decl : declarations) {
             const auto *package_item_list = GetPackageItemList(*decl.match);
-            if (package_item_list == nullptr) continue;
+            if (!package_item_list) continue;
             lists.push_back(TreeSearchMatch{package_item_list, {}});
           }
           return lists;
@@ -458,7 +458,7 @@ TEST(PackageImportTest, GetImportedItemName) {
           for (const auto &decl : decls) {
             const auto *name =
                 GeImportedItemNameFromPackageImportItem(*decl.match);
-            if (name == nullptr) continue;
+            if (!name) continue;
             names.emplace_back(TreeSearchMatch{name, {/* ignored context*/}});
           }
           return names;

--- a/verilog/CST/parameters.cc
+++ b/verilog/CST/parameters.cc
@@ -54,7 +54,7 @@ verilog_tokentype GetParamKeyword(const verible::Symbol &symbol) {
   //
   const auto *param_keyword_symbol =
       verible::GetSubtreeAsSymbol(symbol, NodeEnum::kParamDeclaration, 0);
-  if (param_keyword_symbol == nullptr) return TK_parameter;
+  if (!param_keyword_symbol) return TK_parameter;
   const auto *leaf = down_cast<const SyntaxTreeLeaf *>(param_keyword_symbol);
   return static_cast<verilog_tokentype>(leaf->get().token_enum());
 }
@@ -147,7 +147,7 @@ const verible::SyntaxTreeNode *GetTypeAssignmentFromParamDeclaration(
   // Get the Type AssignmentList or kTypeAssignment symbol.
   const auto *assignment_symbol =
       verible::GetSubtreeAsSymbol(symbol, NodeEnum::kParamDeclaration, 2);
-  if (assignment_symbol == nullptr) {
+  if (!assignment_symbol) {
     return nullptr;
   }
 
@@ -177,8 +177,7 @@ const verible::SyntaxTreeNode *GetExpressionFromTypeAssignment(
     const verible::Symbol &type_assignment) {
   const verible::Symbol *expression = verible::GetSubtreeAsSymbol(
       type_assignment, NodeEnum::kTypeAssignment, 2);
-  if (expression == nullptr ||
-      NodeEnum(expression->Tag().tag) != NodeEnum::kExpression) {
+  if (!expression || NodeEnum(expression->Tag().tag) != NodeEnum::kExpression) {
     return nullptr;
   }
   return &verible::SymbolCastToNode(*expression);
@@ -202,7 +201,7 @@ const verible::Symbol *TryDescentPath(
   for (auto p : path) {
     if (NodeEnum(value->Tag().tag) != p.expected_type) return nullptr;
     value = GetSubtreeAsSymbol(*value, p.expected_type, p.next_index);
-    if (value == nullptr) return nullptr;
+    if (!value) return nullptr;
   }
   return value;
 }
@@ -221,8 +220,7 @@ bool IsTypeInfoEmpty(const verible::Symbol &symbol) {
 
   const auto &type_info_node = verible::SymbolCastToNode(symbol);
 
-  return (type_info_node[0] == nullptr && type_info_node[1] == nullptr &&
-          type_info_node[2] == nullptr);
+  return (!type_info_node[0] && !type_info_node[1] && !type_info_node[2]);
 }
 
 const verible::SyntaxTreeLeaf *GetNamedParamFromActualParam(

--- a/verilog/CST/parameters_test.cc
+++ b/verilog/CST/parameters_test.cc
@@ -363,7 +363,7 @@ TEST(GetTypeAssignmentFromParamDeclarationTests, BasicTests) {
     const auto param_declarations = FindAllParamDeclarations(*root);
     const auto *type_assignment_symbol = GetTypeAssignmentFromParamDeclaration(
         *param_declarations.front().match);
-    if (type_assignment_symbol == nullptr) {
+    if (!type_assignment_symbol) {
       continue;
     }
     const auto t = type_assignment_symbol->Tag();
@@ -554,7 +554,7 @@ TEST(FindAllParamByNameTest, FindParenGroupOfNamedParam) {
           for (const auto &instance : instances) {
             const auto *paren_group =
                 GetParenGroupFromActualParam(*instance.match);
-            if (paren_group == nullptr) {
+            if (!paren_group) {
               continue;
             }
             paren_groups.emplace_back(
@@ -596,12 +596,12 @@ TEST(FindAllParamTest, FindExpressionFromParameterType) {
           for (const auto &type : types) {
             const auto *type_assignment =
                 GetTypeAssignmentFromParamDeclaration(*type.match);
-            if (type_assignment == nullptr) {
+            if (!type_assignment) {
               continue;
             }
             const auto *expression =
                 GetExpressionFromTypeAssignment(*type_assignment);
-            if (expression == nullptr) {
+            if (!expression) {
               continue;
             }
             expressions.emplace_back(

--- a/verilog/CST/port_test.cc
+++ b/verilog/CST/port_test.cc
@@ -468,7 +468,7 @@ TEST(GetActualNamedPort, GetActualNamedPortParenGroup) {
           std::vector<TreeSearchMatch> paren_groups;
           for (const auto &port : ports) {
             const auto *paren_group = GetActualNamedPortParenGroup(*port.match);
-            if (paren_group == nullptr) {
+            if (!paren_group) {
               continue;
             }
             paren_groups.emplace_back(

--- a/verilog/CST/seq_block.cc
+++ b/verilog/CST/seq_block.cc
@@ -68,19 +68,19 @@ static const SyntaxTreeNode *GetBeginLabel(const Symbol &begin) {
 
 static const SyntaxTreeNode *GetEndLabel(const Symbol &end) {
   const auto *label = verible::GetSubtreeAsSymbol(end, NodeEnum::kEnd, 1);
-  if (label == nullptr) return nullptr;
+  if (!label) return nullptr;
   return verible::CheckOptionalSymbolAsNode(label, NodeEnum::kLabel);
 }
 
 const TokenInfo *GetBeginLabelTokenInfo(const Symbol &symbol) {
   const SyntaxTreeNode *label = GetBeginLabel(symbol);
-  if (label == nullptr) return nullptr;
+  if (!label) return nullptr;
   return &GetLabelLeafText(*label).get();
 }
 
 const TokenInfo *GetEndLabelTokenInfo(const Symbol &symbol) {
   const SyntaxTreeNode *label = GetEndLabel(symbol);
-  if (label == nullptr) return nullptr;
+  if (!label) return nullptr;
   return &GetLabelLeafText(*label).get();
 }
 

--- a/verilog/CST/statement.cc
+++ b/verilog/CST/statement.cc
@@ -82,7 +82,7 @@ const SyntaxTreeNode *GetConditionalGenerateElseClause(
       SymbolCastToNode(conditional), NodeEnum::kConditionalGenerateConstruct);
   if (!node || node->size() < 2) return nullptr;
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kGenerateElseClause);
 }
@@ -113,7 +113,7 @@ const SyntaxTreeNode *GetConditionalStatementElseClause(
                                          NodeEnum::kConditionalStatement);
   if (!node || node->size() < 2) return nullptr;
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
@@ -138,7 +138,7 @@ const SyntaxTreeNode *GetAssertionStatementElseClause(
   const auto *node = MatchNodeEnumOrNull(SymbolCastToNode(assertion_statement),
                                          NodeEnum::kAssertionStatement);
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
@@ -164,7 +164,7 @@ const SyntaxTreeNode *GetAssumeStatementElseClause(
                                          NodeEnum::kAssumeStatement);
   if (!node) return nullptr;
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
@@ -208,7 +208,7 @@ const SyntaxTreeNode *GetAssertPropertyStatementElseClause(
                           NodeEnum::kAssertPropertyStatement);
   if (!node) return nullptr;
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
@@ -236,7 +236,7 @@ const SyntaxTreeNode *GetAssumePropertyStatementElseClause(
                           NodeEnum::kAssumePropertyStatement);
   if (!node) return nullptr;
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
@@ -264,7 +264,7 @@ const SyntaxTreeNode *GetExpectPropertyStatementElseClause(
                           NodeEnum::kExpectPropertyStatement);
   if (!node) return nullptr;
   const Symbol *else_ptr = node->back().get();
-  if (else_ptr == nullptr) return nullptr;
+  if (!else_ptr) return nullptr;
   return MatchNodeEnumOrNull(SymbolCastToNode(*else_ptr),
                              NodeEnum::kElseClause);
 }
@@ -446,7 +446,7 @@ const verible::SyntaxTreeNode *GetDataTypeFromForInitialization(
     const verible::Symbol &for_initialization) {
   const auto *data_type = verible::GetSubtreeAsSymbol(
       for_initialization, NodeEnum::kForInitialization, 1);
-  if (data_type == nullptr) {
+  if (!data_type) {
     return nullptr;
   }
   return &verible::SymbolCastToNode(*data_type);

--- a/verilog/CST/statement_test.cc
+++ b/verilog/CST/statement_test.cc
@@ -1207,7 +1207,7 @@ TEST(FindAllForLoopsInitializations, FindForInitializationDataTypes) {
           for (const auto &instance : instances) {
             const auto *type =
                 GetDataTypeFromForInitialization(*instance.match);
-            if (type == nullptr) {
+            if (!type) {
               continue;
             }
             types.emplace_back(TreeSearchMatch{type, {/* ignored context */}});

--- a/verilog/CST/type.cc
+++ b/verilog/CST/type.cc
@@ -154,7 +154,7 @@ std::vector<verible::TreeSearchMatch> FindAllInterfaceTypes(
 
 bool IsStorageTypeOfDataTypeSpecified(const verible::Symbol &symbol) {
   const auto *storage = GetBaseTypeFromDataType(symbol);
-  return (storage != nullptr);
+  return (storage);
 }
 
 const verible::SyntaxTreeLeaf *GetIdentifierFromTypeDeclaration(
@@ -176,7 +176,7 @@ const verible::Symbol *GetBaseTypeFromDataType(
   const auto &children = local_root->children();
   verible::Symbol *last_child = nullptr;
   for (auto &child : children) {
-    if (child != nullptr && child->Kind() == verible::SymbolKind::kNode) {
+    if (child && child->Kind() == verible::SymbolKind::kNode) {
       last_child = child.get();
     }
   }
@@ -239,9 +239,8 @@ const verible::SyntaxTreeNode *GetStructOrUnionOrEnumTypeFromDataType(
     const verible::Symbol &data_type) {
   const verible::Symbol *type = GetBaseTypeFromDataType(data_type);
 
-  if (type == nullptr ||
-      (NodeEnum(type->Tag().tag) != NodeEnum::kDataTypePrimitive &&
-       NodeEnum(type->Tag().tag) != NodeEnum::kLocalRoot)) {
+  if (!type || (NodeEnum(type->Tag().tag) != NodeEnum::kDataTypePrimitive &&
+                NodeEnum(type->Tag().tag) != NodeEnum::kLocalRoot)) {
     return nullptr;
   }
   const verible::Symbol *inner_type =
@@ -258,7 +257,7 @@ const verible::SyntaxTreeNode *GetStructOrUnionOrEnumTypeFromInstantiationType(
     const verible::Symbol &instantiation_type) {
   const verible::Symbol *type =
       GetDataTypeFromInstantiationType(instantiation_type);
-  if (type == nullptr || NodeEnum(type->Tag().tag) != NodeEnum::kDataType) {
+  if (!type || NodeEnum(type->Tag().tag) != NodeEnum::kDataType) {
     return nullptr;
   }
   return GetStructOrUnionOrEnumTypeFromDataType(*type);
@@ -299,7 +298,7 @@ const verible::SyntaxTreeNode *GetParamListFromInstantiationType(
     const verible::Symbol &instantiation_type) {
   const verible::Symbol *base_type =
       GetBaseTypeFromInstantiationType(instantiation_type);
-  if (base_type == nullptr) {
+  if (!base_type) {
     return nullptr;
   }
   return GetParamListFromBaseType(*base_type);
@@ -311,8 +310,7 @@ GetSymbolIdentifierFromDataTypeImplicitIdDimensions(
   // The Identifier can be at index 1 or 2.
   const verible::Symbol *identifier = verible::GetSubtreeAsSymbol(
       struct_union_member, NodeEnum::kDataTypeImplicitIdDimensions, 2);
-  if (identifier != nullptr &&
-      identifier->Kind() == verible::SymbolKind::kLeaf) {
+  if (identifier && identifier->Kind() == verible::SymbolKind::kLeaf) {
     return {&verible::SymbolCastToLeaf(*identifier), 2};
   }
   return {verible::GetSubtreeAsLeaf(struct_union_member,
@@ -331,8 +329,7 @@ const verible::SyntaxTreeLeaf *GetNonprimitiveTypeOfDataTypeImplicitDimensions(
   const verible::Symbol *type_id = GetTypeIdentifierFromBaseType(*base_type);
   if (!type_id) return nullptr;
   const verible::Symbol *identifier = verible::GetLeftmostLeaf(*type_id);
-  if (identifier == nullptr ||
-      identifier->Kind() != verible::SymbolKind::kLeaf) {
+  if (!identifier || identifier->Kind() != verible::SymbolKind::kLeaf) {
     return nullptr;
   }
   return &verible::SymbolCastToLeaf(*identifier);
@@ -389,7 +386,7 @@ const verible::SyntaxTreeNode *GetTypeIdentifierFromDataType(
     return nullptr;
   }
   const verible::Symbol *base_type = GetBaseTypeFromDataType(data_type);
-  if (base_type == nullptr) return nullptr;
+  if (!base_type) return nullptr;
   return GetTypeIdentifierFromBaseType(*base_type);
 }
 

--- a/verilog/CST/type_test.cc
+++ b/verilog/CST/type_test.cc
@@ -337,7 +337,7 @@ TEST(GetVariableDeclaration, FindPackedDimensionFromDataDeclaration) {
             VLOG(1) << "decl: " << verible::StringSpanOfSymbol(*decl.match);
             const auto *packed_dimension =
                 GetPackedDimensionFromDataDeclaration(*decl.match);
-            if (packed_dimension == nullptr) continue;
+            if (!packed_dimension) continue;
             if (packed_dimension->empty()) continue;
             packed_dimensions.emplace_back(
                 TreeSearchMatch{packed_dimension, {/* ignored context */}});
@@ -380,7 +380,7 @@ TEST(GetType, GetStructOrUnionOrEnumType) {
           std::vector<TreeSearchMatch> names;
           for (const auto &decl : types) {
             const auto *name = GetReferencedTypeOfTypeDeclaration(*decl.match);
-            if (name == nullptr) continue;
+            if (!name) continue;
             names.emplace_back(TreeSearchMatch{name, {/* ignored context */}});
           }
           return names;
@@ -405,7 +405,7 @@ TEST(GetTypeIdentifier, GetNameOfDataType) {
           std::vector<TreeSearchMatch> names;
           for (const auto &decl : types) {
             const auto *name = GetTypeIdentifierFromDataType(*decl.match);
-            if (name == nullptr) {
+            if (!name) {
               continue;
             }
             names.emplace_back(TreeSearchMatch{name, {/* ignored context */}});
@@ -437,7 +437,7 @@ TEST(GetDataImplicitIdDimensions, GetTypeOfDataImplicitIdDimensions) {
           for (const auto &decl : types) {
             const auto *inner_type =
                 GetNonprimitiveTypeOfDataTypeImplicitDimensions(*decl.match);
-            if (inner_type == nullptr) {
+            if (!inner_type) {
               continue;
             }
             inner_types.emplace_back(

--- a/verilog/CST/verilog_treebuilder_utils.cc
+++ b/verilog/CST/verilog_treebuilder_utils.cc
@@ -49,7 +49,7 @@ std::string EmbedInClassMethod(absl::string_view text) {
 void ExpectString(const verible::SymbolPtr &symbol,
                   absl::string_view expected) {
   const auto *leaf = down_cast<const verible::SyntaxTreeLeaf *>(symbol.get());
-  CHECK(leaf != nullptr) << "expected: " << expected;
+  CHECK(leaf) << "expected: " << expected;
   CHECK_EQ(leaf->get().text(), expected);
 }
 

--- a/verilog/CST/verilog_treebuilder_utils.h
+++ b/verilog/CST/verilog_treebuilder_utils.h
@@ -57,7 +57,7 @@ template <typename T1, typename T2, typename T3>
 verible::SymbolPtr MakeParenGroup(T1 &&left_paren, T2 &&contents,
                                   T3 &&right_paren) {
   ExpectString(left_paren, "(");
-  if (contents != nullptr) {
+  if (contents != nullptr) {  // NOLINT
     ExpectString(right_paren, ")");
   }  // else right_paren might be dropped due to error-recovery
   return verible::MakeTaggedNode(

--- a/verilog/analysis/checkers/create_object_name_match_rule.cc
+++ b/verilog/analysis/checkers/create_object_name_match_rule.cc
@@ -91,7 +91,7 @@ static bool UnqualifiedIdEquals(const SyntaxTreeNode &node,
       // The one-and-only child is the SymbolIdentifier token
       const auto &leaf_ptr =
           down_cast<const SyntaxTreeLeaf *>(node.front().get());
-      if (leaf_ptr != nullptr) {
+      if (leaf_ptr) {
         const TokenInfo &token = leaf_ptr->get();
         return token.token_enum() == SymbolIdentifier && token.text() == name;
       }
@@ -113,7 +113,7 @@ static bool QualifiedCallIsTypeIdCreate(
         down_cast<const SyntaxTreeNode *>(qualified_id_node.back().get());
     const auto *type_id_leaf_ptr = down_cast<const SyntaxTreeNode *>(
         qualified_id_node[num_children - 3].get());
-    if (create_leaf_ptr != nullptr && type_id_leaf_ptr != nullptr) {
+    if (create_leaf_ptr && type_id_leaf_ptr) {
       return UnqualifiedIdEquals(*create_leaf_ptr, "create") &&
              UnqualifiedIdEquals(*type_id_leaf_ptr, "type_id");
     }
@@ -144,7 +144,7 @@ static const TokenInfo *ExtractStringLiteralToken(
 
   const auto *leaf_ptr =
       down_cast<const SyntaxTreeLeaf *>(expr_node.front().get());
-  if (leaf_ptr != nullptr) {
+  if (leaf_ptr) {
     const TokenInfo &token = leaf_ptr->get();
     if (token.token_enum() == TK_StringLiteral) {
       return &token;
@@ -184,16 +184,16 @@ void CreateObjectNameMatchRule::HandleSymbol(const verible::Symbol &symbol,
   // Extract named bindings for matched nodes within this match.
 
   const auto *lval_ref = manager.GetAs<SyntaxTreeNode>("lval_ref");
-  if (lval_ref == nullptr) return;
+  if (!lval_ref) return;
 
   const TokenInfo *lval_id = ReferenceIsSimpleIdentifier(*lval_ref);
-  if (lval_id == nullptr) return;
+  if (!lval_id) return;
   if (lval_id->token_enum() != SymbolIdentifier) return;
 
   const auto *call = manager.GetAs<SyntaxTreeNode>("func");
   const auto *args = manager.GetAs<SyntaxTreeNode>("args");
-  if (call == nullptr) return;
-  if (args == nullptr) return;
+  if (!call) return;
+  if (!args) return;
   if (!QualifiedCallIsTypeIdCreate(*call)) return;
 
   // The first argument is a string that must match the variable name, lval.

--- a/verilog/analysis/checkers/explicit_function_lifetime_rule.cc
+++ b/verilog/analysis/checkers/explicit_function_lifetime_rule.cc
@@ -76,7 +76,7 @@ void ExplicitFunctionLifetimeRule::HandleSymbol(
     if (IdIsQualified(*function_id)) return;
 
     // Make sure the lifetime was set
-    if (GetFunctionLifetime(symbol) == nullptr) {
+    if (!GetFunctionLifetime(symbol)) {
       // Point to the function id.
       const verible::TokenInfo token(SymbolIdentifier,
                                      verible::StringSpanOfSymbol(*function_id));

--- a/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
+++ b/verilog/analysis/checkers/explicit_parameter_storage_type_rule.cc
@@ -69,7 +69,7 @@ static const Matcher &ParamMatcher() {
 
 static bool HasStringAssignment(const verible::Symbol &param_decl) {
   const auto *s = GetParamAssignExpression(param_decl);
-  if (s == nullptr) return false;
+  if (!s) return false;
   // We can't really do expression evaluation and determine the type of the
   // RHS, so here we focus on the simple case in which the RHS is a
   // string literal.

--- a/verilog/analysis/checkers/explicit_task_lifetime_rule.cc
+++ b/verilog/analysis/checkers/explicit_task_lifetime_rule.cc
@@ -75,7 +75,7 @@ void ExplicitTaskLifetimeRule::HandleSymbol(const verible::Symbol &symbol,
     if (IdIsQualified(*task_id)) return;
 
     // Make sure the lifetime was set
-    if (GetTaskLifetime(symbol) == nullptr) {
+    if (!GetTaskLifetime(symbol)) {
       // Point to the task id.
       const verible::TokenInfo token(SymbolIdentifier,
                                      verible::StringSpanOfSymbol(*task_id));

--- a/verilog/analysis/checkers/generate_label_prefix_rule.cc
+++ b/verilog/analysis/checkers/generate_label_prefix_rule.cc
@@ -82,7 +82,7 @@ void GenerateLabelPrefixRule::HandleSymbol(
           continue;
       }
 
-      if (label != nullptr) {
+      if (label) {
         if (!(absl::StartsWith(label->text(), "g_") ||
               absl::StartsWith(label->text(), "gen_"))) {
           violations_.insert(verible::LintViolation(*label, kMessage, context));

--- a/verilog/analysis/checkers/mismatched_labels_rule.cc
+++ b/verilog/analysis/checkers/mismatched_labels_rule.cc
@@ -67,12 +67,12 @@ void MismatchedLabelsRule::HandleSymbol(
     const auto *end_label = GetEndLabelTokenInfo(*matchingEnd);
 
     // Don't check anything if there is no end label
-    if (end_label == nullptr) {
+    if (!end_label) {
       return;
     }
 
     // Error if there is no begin label
-    if (begin_label == nullptr) {
+    if (!begin_label) {
       violations_.insert(
           verible::LintViolation(symbol, kMessageMissing, context));
 

--- a/verilog/analysis/checkers/module_filename_rule.cc
+++ b/verilog/analysis/checkers/module_filename_rule.cc
@@ -81,7 +81,7 @@ void ModuleFilenameRule::Lint(const TextStructureView &text_structure,
   }
 
   const auto &tree = text_structure.SyntaxTree();
-  if (tree == nullptr) return;
+  if (!tree) return;
 
   // Find all module declarations.
   auto module_matches = FindAllModuleDeclarations(*tree);

--- a/verilog/analysis/checkers/module_instantiation_rules.cc
+++ b/verilog/analysis/checkers/module_instantiation_rules.cc
@@ -192,7 +192,7 @@ void ModulePortRule::HandleSymbol(const verible::Symbol &symbol,
   }
 
   for (const auto &child : port_list_node.children()) {
-    if (child == nullptr) continue;
+    if (!child) continue;
 
     // If child is a node, then it must be a kPort
     if (child->Kind() == verible::SymbolKind::kNode) {

--- a/verilog/analysis/checkers/one_module_per_file_rule.cc
+++ b/verilog/analysis/checkers/one_module_per_file_rule.cc
@@ -55,7 +55,7 @@ const LintRuleDescriptor &OneModulePerFileRule::GetDescriptor() {
 void OneModulePerFileRule::Lint(const TextStructureView &text_structure,
                                 absl::string_view) {
   const auto &tree = text_structure.SyntaxTree();
-  if (tree == nullptr) return;
+  if (!tree) return;
 
   auto module_matches = FindAllModuleDeclarations(*tree);
   if (module_matches.empty()) {

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -71,7 +71,7 @@ void PackageFilenameRule::Lint(const TextStructureView &text_structure,
   }
 
   const auto &tree = text_structure.SyntaxTree();
-  if (tree == nullptr) return;
+  if (!tree) return;
 
   // Find all package declarations.
   auto package_matches = FindAllPackageDeclarations(*tree);

--- a/verilog/analysis/dependencies.cc
+++ b/verilog/analysis/dependencies.cc
@@ -28,8 +28,7 @@ namespace verilog {
 static FileDependencies::symbol_index_type CreateSymbolMapFromSymbolTable(
     const SymbolTableNode &root, const VerilogProject *project) {
   VLOG(1) << __FUNCTION__ << ": collecting definitions";
-  CHECK(project != nullptr)
-      << "VerilogProject* is required for dependency analysis.";
+  CHECK(project) << "VerilogProject* is required for dependency analysis.";
   FileDependencies::symbol_index_type symbols_index;
 
   using SymbolData = FileDependencies::SymbolData;
@@ -38,10 +37,10 @@ static FileDependencies::symbol_index_type CreateSymbolMapFromSymbolTable(
   for (const SymbolTableNode::key_value_type &child : root) {
     const absl::string_view symbol_name(child.first);
     const VerilogSourceFile *file_origin = child.second.Value().file_origin;
-    if (file_origin == nullptr) continue;
+    if (!file_origin) continue;
 
     SymbolData &symbol_data(symbols_index[symbol_name]);
-    if (symbol_data.definer == nullptr) {
+    if (!symbol_data.definer) {
       // Take the first definition, arbitrarily.
       symbol_data.definer = file_origin;
     }
@@ -60,9 +59,9 @@ static FileDependencies::symbol_index_type CreateSymbolMapFromSymbolTable(
 
       const VerilogSourceFile *ref_file_origin =
           project->LookupFileOrigin(ref_id);
-      if (ref_file_origin == nullptr) continue;  // unknown file
+      if (!ref_file_origin) continue;  // unknown file
 
-      if (ref_comp.resolved_symbol != nullptr) {
+      if (ref_comp.resolved_symbol) {
         const VerilogSourceFile *def_file_origin =
             ref_comp.resolved_symbol->Value().file_origin;
         if (ref_file_origin == def_file_origin) {
@@ -102,7 +101,7 @@ CreateFileDependenciesFromSymbolMap(
     const FileDependencies::SymbolData &symbol_info(symbol_entry.second);
     const VerilogSourceFile *def = symbol_info.definer;
     // If no definition is found, then do not create any edges for it.
-    if (def == nullptr) continue;
+    if (!def) continue;
 
     for (const VerilogSourceFile *ref : symbol_info.referencers) {
       // Skip self-edges.

--- a/verilog/analysis/symbol_table.h
+++ b/verilog/analysis/symbol_table.h
@@ -199,7 +199,7 @@ struct DependentReferences {
   DependentReferences& operator=(DependentReferences&&) = delete;
 
   // Returns true of no references were collected.
-  bool Empty() const { return components == nullptr; }
+  bool Empty() const { return !components; }
 
   // Returns the current terminal descendant.
   const ReferenceComponentNode* LastLeaf() const;

--- a/verilog/analysis/verilog_analyzer.cc
+++ b/verilog/analysis/verilog_analyzer.cc
@@ -132,7 +132,7 @@ std::unique_ptr<VerilogAnalyzer> VerilogAnalyzer::AnalyzeAutomaticMode(
   VLOG(2) << __FUNCTION__;
   auto analyzer =
       std::make_unique<VerilogAnalyzer>(text, name, preprocess_config);
-  if (analyzer == nullptr) return analyzer;
+  if (!analyzer) return analyzer;
   const absl::string_view text_base = analyzer->Data().Contents();
   // If there is any lexical error, stop right away.
   const auto lex_status = analyzer->Tokenize();
@@ -146,7 +146,7 @@ std::unique_ptr<VerilogAnalyzer> VerilogAnalyzer::AnalyzeAutomaticMode(
     VLOG(1) << "Analyzing using parse mode directive: " << parse_mode;
     auto mode_analyzer = AnalyzeVerilogWithMode(text->AsStringView(), name,
                                                 parse_mode, preprocess_config);
-    if (mode_analyzer != nullptr) return mode_analyzer;
+    if (mode_analyzer) return mode_analyzer;
     // Silently ignore any unknown parsing modes.
   }
 
@@ -294,7 +294,7 @@ absl::Status VerilogAnalyzer::Analyze() {
   max_used_stack_size_ = parser.MaxUsedStackSize();
 
   // Expand macro arguments that are parseable as expressions.
-  if (parse_status_.ok() && Data().SyntaxTree() != nullptr) {
+  if (parse_status_.ok() && Data().SyntaxTree()) {
     ExpandMacroCallArgExpressions();
   }
 
@@ -363,7 +363,7 @@ class MacroCallArgExpander : public MutableTreeVisitorRecursive {
         // and causing excessive reallocation).
         TextStructureView::DeferredExpansion& analysis_slot =
             InsertKeyOrDie(&subtrees_to_splice_, token.left(full_text_));
-        CHECK(analysis_slot.subanalysis.get() == nullptr)
+        CHECK(!analysis_slot.subanalysis)
             << "Cannot expand the same location twice.  Token: " << token;
         analysis_slot.expansion_point = leaf_owner;
         analysis_slot.subanalysis = expr_analyzer->ReleaseTextStructure();

--- a/verilog/analysis/verilog_analyzer_test.cc
+++ b/verilog/analysis/verilog_analyzer_test.cc
@@ -66,7 +66,7 @@ bool TreeContainsToken(const ConcreteSyntaxTree& tree, const TokenInfo& token) {
         const auto* leaf_ptr = down_cast<const SyntaxTreeLeaf*>(&symbol);
         return leaf_ptr->get() == token;
       });
-  return matching_leaf != nullptr;
+  return matching_leaf;
 }
 
 void DiagnosticMessagesContainFilename(const VerilogAnalyzer& analyzer,

--- a/verilog/analysis/verilog_equivalence.cc
+++ b/verilog/analysis/verilog_equivalence.cc
@@ -70,7 +70,7 @@ static bool LexText(absl::string_view text, TokenSequence *subtokens,
       &lexer, text, subtokens, [&](const TokenInfo &err) { err_tok = err; });
   if (!status.ok()) {
     VLOG(1) << "lex error on: " << err_tok;
-    if (errstream != nullptr) {
+    if (errstream) {
       (*errstream) << "Error lexing text: " << text << std::endl
                    << "subtoken: " << err_tok << std::endl
                    << status.message() << std::endl;
@@ -124,14 +124,14 @@ DiffStatus LexicallyEquivalent(
   {
     const bool left_success = lexer(left_text, &left_tokens);
     if (!left_success) {
-      if (errstream != nullptr) {
+      if (errstream) {
         *errstream << "Lexical error from left input text." << std::endl;
       }
       return DiffStatus::kLeftError;
     }
     const bool right_success = lexer(right_text, &right_tokens);
     if (!right_success) {
-      if (errstream != nullptr) {
+      if (errstream) {
         *errstream << "Lexical error from right input text." << std::endl;
       }
       return DiffStatus::kRightError;
@@ -153,7 +153,7 @@ DiffStatus LexicallyEquivalent(
   const size_t r_size = right_filtered.size();
   const bool size_match = l_size == r_size;
   if (!size_match) {
-    if (errstream != nullptr) {
+    if (errstream) {
       *errstream << "Mismatch in token sequence lengths: " << l_size << " vs. "
                  << r_size << std::endl;
     }
@@ -172,7 +172,7 @@ DiffStatus LexicallyEquivalent(
            r->text() == ")") ||
           (r->token_enum() == verilog_tokentype::MacroCallCloseToEndLine &&
            l->text() == ")"))) {
-      if (errstream != nullptr) {
+      if (errstream) {
         *errstream << "Mismatched token enums.  got: ";
         token_printer(*l, *errstream);
         *errstream << " vs. ";
@@ -227,7 +227,7 @@ DiffStatus LexicallyEquivalent(
     return DiffStatus::kDifferent;
   }
   // else there was a mismatch
-  if (errstream != nullptr) {
+  if (errstream) {
     const size_t mismatch_index =
         std::distance(left_filtered.begin(), mismatch_pair.first);
     const auto &left_token = **mismatch_pair.first;

--- a/verilog/analysis/verilog_linter.cc
+++ b/verilog/analysis/verilog_linter.cc
@@ -243,7 +243,7 @@ void VerilogLinter::Lint(const TextStructureView &text_structure,
 
   // Analyze syntax tree.
   const verible::ConcreteSyntaxTree &syntax_tree = text_structure.SyntaxTree();
-  if (syntax_tree != nullptr) {
+  if (syntax_tree) {
     syntax_tree_linter_.Lint(*syntax_tree);
   }
 }

--- a/verilog/analysis/verilog_linter_configuration.cc
+++ b/verilog/analysis/verilog_linter_configuration.cc
@@ -202,7 +202,7 @@ std::string RuleBundle::UnparseConfiguration(const char separator,
 
 bool LinterConfiguration::RuleIsOn(const analysis::LintRuleId &rule) const {
   const auto *entry = FindOrNull(configuration_, rule);
-  if (entry == nullptr) return false;
+  if (!entry) return false;
   return entry->enabled;
 }
 
@@ -288,7 +288,7 @@ static absl::StatusOr<std::vector<std::unique_ptr<T>>> CreateRules(
     if (!setting.enabled) continue;
 
     std::unique_ptr<T> rule_ptr = factory(rule_pair.first);
-    if (rule_ptr == nullptr) continue;
+    if (!rule_ptr) continue;
 
     if (!setting.configuration.empty()) {
       if (absl::Status status = rule_ptr->Configure(setting.configuration);

--- a/verilog/analysis/verilog_linter_configuration_test.cc
+++ b/verilog/analysis/verilog_linter_configuration_test.cc
@@ -181,7 +181,7 @@ TEST(ProjectPolicyTest, MatchesAnyPath) {
   };
   for (const auto &test : kTestCases) {
     const char *match = test.policy.MatchesAnyPath(test.filename);
-    if (test.expected_match != nullptr) {
+    if (test.expected_match) {
       EXPECT_EQ(absl::string_view(match), test.expected_match);
     } else {
       EXPECT_EQ(match, nullptr);
@@ -206,7 +206,7 @@ TEST(ProjectPolicyTest, MatchesAnyExclusions) {
   };
   for (const auto &test : kTestCases) {
     const char *match = test.policy.MatchesAnyExclusions(test.filename);
-    if (test.expected_match != nullptr) {
+    if (test.expected_match) {
       EXPECT_EQ(absl::string_view(match), test.expected_match);
     } else {
       EXPECT_EQ(match, nullptr);

--- a/verilog/analysis/verilog_project.cc
+++ b/verilog/analysis/verilog_project.cc
@@ -92,7 +92,7 @@ absl::Status VerilogSourceFile::Parse() {
 }
 
 const verible::TextStructureView *VerilogSourceFile::GetTextStructure() const {
-  if (analyzed_structure_ == nullptr) return nullptr;
+  if (!analyzed_structure_) return nullptr;
   return &analyzed_structure_->Data();
 }
 

--- a/verilog/formatting/align.cc
+++ b/verilog/formatting/align.cc
@@ -152,7 +152,7 @@ static bool IgnoreWithinStructUnionMemberPartitionGroup(
           partition.Value().Origin(), [](const Symbol& symbol) {
             return symbol.Tag() ==
                    verible::NodeTag(NodeEnum::kStructUnionMemberList);
-          }) != nullptr) {
+          })) {
     return true;
   }
 
@@ -605,7 +605,7 @@ static std::vector<TaggedTokenPartitionRange> GetConsecutiveModuleItemGroups(
       [](const TokenPartitionTree& partition)
           -> AlignedPartitionClassification {
         const Symbol* origin = partition.Value().Origin();
-        if (origin == nullptr) return {AlignmentGroupAction::kIgnore};
+        if (!origin) return {AlignmentGroupAction::kIgnore};
         const verible::SymbolTag symbol_tag = origin->Tag();
         if (symbol_tag.kind != verible::SymbolKind::kNode) {
           return AlignClassify(AlignmentGroupAction::kIgnore);
@@ -633,7 +633,7 @@ static std::vector<TaggedTokenPartitionRange> GetConsecutiveClassItemGroups(
       [](const TokenPartitionTree& partition)
           -> AlignedPartitionClassification {
         const Symbol* origin = partition.Value().Origin();
-        if (origin == nullptr) return {AlignmentGroupAction::kIgnore};
+        if (!origin) return {AlignmentGroupAction::kIgnore};
         const verible::SymbolTag symbol_tag = origin->Tag();
         if (symbol_tag.kind != verible::SymbolKind::kNode) {
           return {AlignmentGroupAction::kIgnore};
@@ -655,7 +655,7 @@ static std::vector<TaggedTokenPartitionRange> GetAlignableStatementGroups(
       [](const TokenPartitionTree& partition)
           -> AlignedPartitionClassification {
         const Symbol* origin = partition.Value().Origin();
-        if (origin == nullptr) return {AlignmentGroupAction::kIgnore};
+        if (!origin) return {AlignmentGroupAction::kIgnore};
         const verible::SymbolTag symbol_tag = origin->Tag();
         if (symbol_tag.kind != verible::SymbolKind::kNode) {
           return AlignClassify(AlignmentGroupAction::kIgnore);
@@ -1548,11 +1548,11 @@ void TabularAlignTokenPartitions(const FormatStyle& style,
   auto& partition = *partition_ptr;
   auto& uwline = partition.Value();
   const auto* origin = uwline.Origin();
-  VLOG(2) << "origin is nullptr? " << (origin == nullptr);
-  if (origin == nullptr) return;
+  VLOG(2) << "origin is nullptr? " << (!origin);
+  if (!origin) return;
   const auto* node = down_cast<const SyntaxTreeNode*>(origin);
-  VLOG(2) << "origin is node? " << (node != nullptr);
-  if (node == nullptr) return;
+  VLOG(2) << "origin is node? " << (node);
+  if (!node) return;
   // Dispatch aligning function based on syntax tree node type.
 
   static const auto* const kAlignHandlers =

--- a/verilog/formatting/formatter.cc
+++ b/verilog/formatting/formatter.cc
@@ -608,7 +608,7 @@ static void PrintLargestPartitions(
 }
 
 std::ostream& ExecutionControl::Stream() const {
-  return (stream != nullptr) ? *stream : std::cout;
+  return (stream) ? *stream : std::cout;
 }
 
 void Formatter::SelectLines(const LineNumberSet& lines) {
@@ -742,7 +742,7 @@ class ContinuationCommentAligner {
       const verible::FormattedToken& token, int* column) {
     switch (token.before.action) {
       case verible::SpacingDecision::kPreserve: {
-        if (token.before.preserved_space_start != nullptr) {
+        if (token.before.preserved_space_start) {
           *column += token.OriginalLeadingSpaces().length();
         } else {
           *column += token.before.spaces;

--- a/verilog/formatting/token_annotator.cc
+++ b/verilog/formatting/token_annotator.cc
@@ -965,7 +965,7 @@ void AnnotateFormattingInformation(
     return;
   }
 
-  if (buffer_start != nullptr) {
+  if (buffer_start) {
     // For unit testing, tokens' text snippets don't necessarily originate
     // from the same contiguous string buffer, so skip this step.
     ConnectPreFormatTokensPreservedSpaceStarts(buffer_start, format_tokens);

--- a/verilog/formatting/token_annotator_test.cc
+++ b/verilog/formatting/token_annotator_test.cc
@@ -148,7 +148,7 @@ class InitializedSyntaxTreeContext : public verible::SyntaxTreeContext {
     std::vector<verible::SyntaxTreeNode *> parents;
     parents.reserve(ancestors.size());
     for (const auto ancestor : verible::reversed_view(ancestors)) {
-      if (root_ == nullptr) {
+      if (!root_) {
         root_ = verible::MakeTaggedNode(ancestor);
       } else {
         root_ = verible::MakeTaggedNode(ancestor, root_);

--- a/verilog/formatting/tree_unwrapper_test.cc
+++ b/verilog/formatting/tree_unwrapper_test.cc
@@ -198,7 +198,7 @@ bool VerifyUnwrappedLines(std::ostream* stream,
         return expect.EqualsUnwrappedLine(&first_diff_stream, actual);
       });
 
-  if (diff.left != nullptr) {
+  if (diff.left) {
     *stream << "error: test case: " << test_case.test_name << std::endl;
     *stream << "first difference at subnode " << verible::NodePath(*diff.left)
             << std::endl;

--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -8089,9 +8089,10 @@ sequence_expr_match_primary
 sequence_repetition_expr
   /* Highest precedence sequence_expr. */
   : expression_or_dist boolean_abbrev_opt
-    { $$ = ($2 == nullptr) ? std::move($1) :
-                             MakeTaggedNode(N::kSequenceRepetitionExpression,
-                                            $1, $2); }
+    { $$ = ($2)
+        ? MakeTaggedNode(N::kSequenceRepetitionExpression, $1, $2)
+        : std::move($1);
+    }
   /* This covers a simple expression.
    *
    * More importantly, this also covers sequence_expr_match_primary without conflict:
@@ -8109,7 +8110,7 @@ expression_or_dist
     {
       // If dist_opt is nullptr, then we can just forward expression
       // without introducing another layer
-      if ($2 == nullptr)  {
+      if (!$2)  {
         $$ = std::move($1);
       } else {
         SetChild($2, 0, $1);

--- a/verilog/parser/verilog_lexical_context.cc
+++ b/verilog/parser/verilog_lexical_context.cc
@@ -427,8 +427,7 @@ void LastSemicolonStateMachine::UpdateState(verible::TokenInfo* token) {
         semicolons_.push(token);
       } else if (token->token_enum() == finish_token_enum_) {
         // Replace the desired ';' and return to dormant state.
-        if (previous_token_ != nullptr &&
-            previous_token_->token_enum() == ';') {
+        if (previous_token_ && previous_token_->token_enum() == ';') {
           // Discard the optional ';' right before the end-keyword.
           // <jedi>This is not the semicolon you are looking for.</jedi>
           semicolons_.pop();
@@ -724,7 +723,7 @@ WithReason<bool> LexicalContext::ExpectingBodyItemStart() const {
   if (InFlowControlHeader()) return {false, "in flow control header"};
   if (InAnyDeclarationHeader()) return {false, "in other declaration header"};
   if (!balance_stack_.empty()) return {false, "balance stack not empty"};
-  if (previous_token_ == nullptr) {
+  if (!previous_token_) {
     // First token should be start of a description/package item.
     return {true, "first token"};
   }

--- a/verilog/parser/verilog_parser_unittest.cc
+++ b/verilog/parser/verilog_parser_unittest.cc
@@ -6319,7 +6319,7 @@ static void TestVerilogLibraryParserMatchAll(const ParserTestCaseArray& data) {
 
     const Symbol* tree_ptr = analyzer->SyntaxTree().get();
     EXPECT_NE(tree_ptr, nullptr) << "Missing syntax tree with input:\n" << code;
-    if (tree_ptr == nullptr) return;  // Already failed, abort this test case.
+    if (!tree_ptr) return;  // Already failed, abort this test case.
     const Symbol& root = *tree_ptr;
 
     verible::ParserVerifier verifier(root,

--- a/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
+++ b/verilog/tools/kythe/indexing_facts_tree_extractor_test.cc
@@ -78,12 +78,12 @@ struct TestFileEntry {
 
   // Returns the string_view of text owned by this->source_file.
   absl::string_view SourceText() const {
-    CHECK(source_file != nullptr);
+    CHECK(source_file);
     return source_file->GetContent();
   }
 
   T::value_type ExpectedFileData() const {
-    CHECK(source_file != nullptr);
+    CHECK(source_file);
     return {
         IndexingFactType::kFile,
         Anchor(source_file->ResolvedPath()),

--- a/verilog/tools/kythe/kythe_facts_extractor.cc
+++ b/verilog/tools/kythe/kythe_facts_extractor.cc
@@ -311,7 +311,7 @@ void KytheFactsExtractor::ExtractFile(const IndexingFactNode &root) {
 std::optional<SignatureDigest> KytheFactsExtractor::GetParentTypeScope(
     const IndexingFactNode &node) const {
   absl::string_view node_name = node.Value().Anchors()[0].Text();
-  if (node.Parent() == nullptr) {
+  if (!node.Parent()) {
     return std::nullopt;
   }
   const auto &parent_anchors = node.Parent()->Value().Anchors();

--- a/verilog/tools/kythe/scope_resolver.cc
+++ b/verilog/tools/kythe/scope_resolver.cc
@@ -134,9 +134,8 @@ std::optional<ScopedVname> ScopeResolver::FindScopeAndDefinition(
   for (auto &scope_member : scope->second) {
     SignatureDigest digest = scope_member.instantiation_scope;
     if (scope_focus.rolling_hash.size() < digest.rolling_hash.size() ||
-        (match != nullptr &&
-         digest.rolling_hash.size() <
-             match->instantiation_scope.rolling_hash.size())) {
+        (match && digest.rolling_hash.size() <
+                      match->instantiation_scope.rolling_hash.size())) {
       // Mismatch, or not interesting (worse match).
       VLOG(2) << "Scope resolution mismatch for '" << name << "' at scope "
               << ScopeDebug(digest);
@@ -147,7 +146,7 @@ std::optional<ScopedVname> ScopeResolver::FindScopeAndDefinition(
       match = &scope_member;
     }
   }
-  if (match != nullptr) {
+  if (match) {
     VLOG(2) << "Found definition for '" << name << "' within scope "
             << ScopeDebug(scope_focus);
     return *match;

--- a/verilog/tools/ls/document-symbol-filler.cc
+++ b/verilog/tools/ls/document-symbol-filler.cc
@@ -172,7 +172,7 @@ void DocumentSymbolFiller::Visit(const verible::SyntaxTreeNode &node) {
       if (child) child->Accept(this);
     }
     // Update our parent with what we found
-    if (parent->children == nullptr) {
+    if (parent->children.is_null()) {
       if (parent->range.start.line == kUninitializedStartLine) {
         parent->range.start = node_symbol.range.start;
       }

--- a/verilog/tools/ls/lsp-parse-buffer_test.cc
+++ b/verilog/tools/ls/lsp-parse-buffer_test.cc
@@ -77,7 +77,7 @@ TEST(BufferTrackerConatainer, ParseUpdateNotification) {
   container.AddChangeListener([&update_remove_count, &last_text_structure](
                                   const std::string &,
                                   const BufferTracker *tracker) {
-    if (tracker != nullptr) {
+    if (tracker) {
       ++update_remove_count;
     } else {
       --update_remove_count;

--- a/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verilog/tools/ls/symbol-table-handler_test.cc
@@ -256,8 +256,8 @@ TEST(SymbolTableHandlerTest,
   parsed_buffers.GetSubscriptionCallback()(
       verible::lsp::PathToLSPUri(sources_dir + "/a.sv"), &a_buffer);
   symbol_table_handler.BuildProjectSymbolTable();
-  ASSERT_FALSE(parsed_buffers.FindBufferTrackerOrNull(
-                   parameters.textDocument.uri) != nullptr);
+  ASSERT_FALSE(
+      parsed_buffers.FindBufferTrackerOrNull(parameters.textDocument.uri));
 
   std::optional<verible::lsp::Range> edit_range =
       symbol_table_handler.FindRenameableRangeAtCursor(parameters,
@@ -306,8 +306,8 @@ TEST(SymbolTableHandlerTest,
   parsed_buffers.GetSubscriptionCallback()(parameters.textDocument.uri,
                                            &b_buffer);
   symbol_table_handler.BuildProjectSymbolTable();
-  ASSERT_TRUE(parsed_buffers.FindBufferTrackerOrNull(
-                  parameters.textDocument.uri) != nullptr);
+  ASSERT_TRUE(
+      parsed_buffers.FindBufferTrackerOrNull(parameters.textDocument.uri));
 
   std::optional<verible::lsp::Range> edit_range =
       symbol_table_handler.FindRenameableRangeAtCursor(parameters,
@@ -356,8 +356,8 @@ TEST(SymbolTableHandlerTest, FindRenamableRangeAtCursorReturnsLocation) {
   parsed_buffers.GetSubscriptionCallback()(parameters.textDocument.uri,
                                            &a_buffer);
   symbol_table_handler.BuildProjectSymbolTable();
-  ASSERT_TRUE(parsed_buffers.FindBufferTrackerOrNull(
-                  parameters.textDocument.uri) != nullptr);
+  ASSERT_TRUE(
+      parsed_buffers.FindBufferTrackerOrNull(parameters.textDocument.uri));
 
   std::optional<verible::lsp::Range> edit_range =
       symbol_table_handler.FindRenameableRangeAtCursor(parameters,
@@ -408,8 +408,8 @@ TEST(SymbolTableHandlerTest,
   parsed_buffers.GetSubscriptionCallback()(parameters.textDocument.uri,
                                            &a_buffer);
   symbol_table_handler.BuildProjectSymbolTable();
-  ASSERT_TRUE(parsed_buffers.FindBufferTrackerOrNull(
-                  parameters.textDocument.uri) != nullptr);
+  ASSERT_TRUE(
+      parsed_buffers.FindBufferTrackerOrNull(parameters.textDocument.uri));
 
   verible::lsp::WorkspaceEdit edit_range =
       symbol_table_handler.FindRenameLocationsAndCreateEdits(parameters,
@@ -461,8 +461,8 @@ TEST(SymbolTableHandlerTest,
   parsed_buffers.GetSubscriptionCallback()(parameters.textDocument.uri,
                                            &a_buffer);
   symbol_table_handler.BuildProjectSymbolTable();
-  ASSERT_TRUE(parsed_buffers.FindBufferTrackerOrNull(
-                  parameters.textDocument.uri) != nullptr);
+  ASSERT_TRUE(
+      parsed_buffers.FindBufferTrackerOrNull(parameters.textDocument.uri));
 
   verible::lsp::WorkspaceEdit edit_range =
       symbol_table_handler.FindRenameLocationsAndCreateEdits(parameters,

--- a/verilog/tools/syntax/verilog_syntax.cc
+++ b/verilog/tools/syntax/verilog_syntax.cc
@@ -145,7 +145,7 @@ static std::unique_ptr<VerilogAnalyzer> ParseWithLanguageMode(
 // Prints all tokens in view that are not matched in root.
 static void VerifyParseTree(const TextStructureView &text_structure) {
   const ConcreteSyntaxTree &root = text_structure.SyntaxTree();
-  if (root == nullptr) return;
+  if (!root) return;
   // TODO(fangism): this seems like a good method for TextStructureView.
   ParserVerifier verifier(*root, text_structure.GetTokenStreamView());
   auto unmatched = verifier.Verify();
@@ -256,7 +256,7 @@ static int AnalyzeOneFile(
   const auto &syntax_tree = text_structure.SyntaxTree();
 
   // check for printtree flag, and print tree if on
-  if (absl::GetFlag(FLAGS_printtree) && syntax_tree != nullptr) {
+  if (absl::GetFlag(FLAGS_printtree) && syntax_tree) {
     if (!absl::GetFlag(FLAGS_export_json)) {
       std::cout << std::endl
                 << "Parse Tree"


### PR DESCRIPTION
Readability improvement.

We never use pointers as an artifact of a low-level memory implementation, we always use it in the context of things that can exist or not.

For these, comparing against nullptr uses a low-level technical aspect about the implementation, but not what we _mean_.

Using the boolean evaluation is more expressive as it reads more naturally like an existence check `if (thing) thing->dosomething()`

C/C++ gives us the improved expressiveness, let's use it.