### PR TITLE
Remove explicit copy constructors with default implementation.

### DIFF
--- a/common/text/token_info.h
+++ b/common/text/token_info.h
@@ -73,8 +73,6 @@ class TokenInfo {
     Context(absl::string_view b,
             std::function<void(std::ostream&, int)> translator)
         : base(b), token_enum_translator(std::move(translator)) {}
-
-    Context(const Context&) = default;
   };
 
   int token_enum() const { return token_enum_; }

--- a/verilog/analysis/verilog_linter_configuration.h
+++ b/verilog/analysis/verilog_linter_configuration.h
@@ -188,9 +188,6 @@ class LinterConfiguration {
   // Constructor has no rules enabled by default;
   LinterConfiguration() = default;
 
-  // This is copy-able.
-  LinterConfiguration(const LinterConfiguration &) = default;
-
   void TurnOn(const analysis::LintRuleId &rule) {
     configuration_[rule] = {true, ""};
   }


### PR DESCRIPTION
If there is a copy constructor, we also would have to define an assignment operator. Since these are default anyway, just use the default as-is.