### PR TITLE
Simplify clang-tidy; read directly from .clang-tidy config file.

### DIFF
--- a/.github/bin/check-potential-problems.sh
+++ b/.github/bin/check-potential-problems.sh
@@ -26,7 +26,8 @@ EXIT_CODE=0
 #
 # So, until these assumptions are fixed, we need to use absl::string_view that
 # comes with the same implementation everywhere.
-find . -name "*.h" -o -name "*.cc" | xargs grep -n "std::string_view"
+find common verilog -name "*.h" -o -name "*.cc" | \
+  xargs grep -n "std::string_view"
 if [ $? -eq 0 ]; then
   echo "::error:: use absl::string_view instead of std::string_view"
   echo

--- a/.github/bin/run-clang-tidy-cached.cc
+++ b/.github/bin/run-clang-tidy-cached.cc
@@ -1,7 +1,7 @@
 #if 0  // Invoke with /bin/sh or simply add executable bit on this file on Unix.
 B=${0%%.cc}; [ "$B" -nt "$0" ] || c++ -std=c++17 -o"$B" "$0" && exec "$B" "$@";
 #endif
-// Copyright 2023 The Verible Authors.
+// Copyright 2023 Henner Zeller <h.zeller@acm.org>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,13 +24,20 @@ B=${0%%.cc}; [ "$B" -nt "$0" ] || c++ -std=c++17 -o"$B" "$0" && exec "$B" "$@";
 // all *.{cc,h} files. Additional parameters passed to this script are passed
 // to clang-tidy as-is. Typical use could be for instance
 //   run-clang-tidy-cached.cc --checks="-*,modernize-use-override" --fix
+//
+// Note: usefule environment variables to configure are
+//  CLANG_TIDY = binary to run; default would just be clang-tidy.
+//  CACHE_DIR  = where to put the cached content; default ~/.cache
 
+// This file shall be self-contained, so we don't use any re2 or absl niceties
 #include <algorithm>
+#include <cerrno>
 #include <cinttypes>
 #include <csignal>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -38,29 +45,57 @@ B=${0%%.cc}; [ "$B" -nt "$0" ] || c++ -std=c++17 -o"$B" "$0" && exec "$B" "$@";
 #include <list>
 #include <map>
 #include <mutex>
-#include <optional>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
 
+// Some configuration for this project.
+static const std::string kProjectCachePrefix = "verible_";
+static constexpr std::string_view kWorkspaceFile = "MODULE.bazel";
+
+static constexpr std::string_view kSearchDir = ".";
+static const std::string kFileExcludeRe =
+    ".git/|.github/"         // stuff we're not interested in
+    "|vscode/"               // some generated code in there
+    "|tree_operations_test"  // very slow
+    "|symbol_table_test";
+
+static constexpr std::string_view kClangConfigFile = ".clang-tidy";
+static constexpr std::string_view kExtraArgs[] = {"-Wno-unknown-pragmas"};
+
 namespace fs = std::filesystem;
-using filepath_contenthash_t = std::pair<fs::path, uint64_t>;
+using file_time = std::filesystem::file_time_type;
 using ReIt = std::sregex_iterator;
+using filepath_contenthash_t = std::pair<fs::path, uint64_t>;
 
 // Some helpers
 std::string GetContent(FILE *f) {
   std::string result;
+  if (!f) return result;  // ¯\_(ツ)_/¯ best effort.
   char buf[4096];
-  while (size_t r = fread(buf, 1, sizeof(buf), f)) result.append(buf, r);
+  while (const size_t r = fread(buf, 1, sizeof(buf), f)) {
+    result.append(buf, r);
+  }
   fclose(f);
   return result;
 }
 
 std::string GetContent(const fs::path &f) {
-  return GetContent(fopen(f.string().c_str(), "r"));
+  FILE *file_to_read = fopen(f.string().c_str(), "r");
+  if (!file_to_read) {
+    fprintf(stderr, "%s: can't open: %s\n", f.string().c_str(),
+            strerror(errno));
+    return {};  // ¯\_(ツ)_/¯ best effort.
+  }
+  return GetContent(file_to_read);
+}
+
+std::string GetCommandOutput(const std::string &prog) {
+  return GetContent(popen(prog.c_str(), "r"));  // NOLINT
 }
 
 using hash_t = uint64_t;
@@ -71,102 +106,248 @@ std::string toHex(uint64_t value, int show_lower_nibbles = 16) {
   return out + (16 - show_lower_nibbles);
 }
 
-std::optional<std::string> ReadAndVerifyTidyConfig(const fs::path &config) {
-  auto content = GetContent(config);
-  auto start_config = content.find("\nChecks:");
-  if (start_config == std::string::npos) {
-    std::cerr << "Not seen 'Checks:' in config " << config << "\n";
-    return std::nullopt;
+// Mapping filepath_contenthash_t to an actual location in the file system.
+class ContentAddressedStore {
+ public:
+  explicit ContentAddressedStore(const fs::path &project_base_dir)
+      : content_dir(project_base_dir / "contents") {
+    fs::create_directories(content_dir);
   }
-  if (content.find('#', start_config) != std::string::npos) {
-    std::cerr << "Comment found in check section of " << config << "\n";
-    return std::nullopt;
+
+  // Given filepath contenthash, return the path to read/write from.
+  fs::path PathFor(const filepath_contenthash_t &c) const {
+    // Name is human readable, the content hash makes it unique.
+    std::string name_with_contenthash = c.first.filename().string();
+    name_with_contenthash.append("-").append(toHex(c.second));
+    return content_dir / name_with_contenthash;
   }
-  return content.substr(start_config);
-}
 
-fs::path GetCacheDir() {
-  if (const char *from_env = getenv("CACHE_DIR")) return fs::path(from_env);
-  if (const char *home = getenv("HOME")) {
-    if (auto cdir = fs::path(home) / ".cache/"; fs::exists(cdir)) return cdir;
+  std::string GetContentFor(const filepath_contenthash_t &c) const {
+    return GetContent(PathFor(c));
   }
-  return fs::path(getenv("TMPDIR") ?: "/tmp");
-}
 
-// Fix filename paths that are not emitted relative to project root.
-void CanonicalizeSourcePaths(const fs::path &infile, const fs::path &outfile) {
-  static const std::regex sFixPathsRe = []() {
-    std::string canonicalize_expr = "(^|\\n)(";  // fix names at start of line
-    auto root = GetContent(popen("bazel info execution_root 2>/dev/null", "r"));
-    if (!root.empty()) {
-      root.pop_back();  // remove newline.
-      canonicalize_expr += root + "/|";
-    }
-    canonicalize_expr += fs::current_path().string() + "/";  // $(pwd)/
-    canonicalize_expr += ")?(\\./)?";  // Some start with, or have a trailing ./
-    return std::regex{canonicalize_expr};
-  }();
-  const auto in_content = GetContent(infile);
-  std::fstream out_stream(outfile, std::ios::out);
-  out_stream << std::regex_replace(in_content, sFixPathsRe, "$1");
-}
+  // Check if this needs to be recreated, either because it is not there,
+  // or is not empty and does not fit freshness requirements.
+  bool NeedsRefresh(const filepath_contenthash_t &c,
+                    file_time min_freshness) const {
+    const fs::path content_hash_file = PathFor(c);
+    // Recreate if we don't have it yet or if it contains messages but is
+    // older than WORKSPACE or compilation db. Maybe something got fixed.
+    return (!fs::exists(content_hash_file) ||
+            (fs::file_size(content_hash_file) > 0 &&
+             fs::last_write_time(content_hash_file) < min_freshness));
+  }
 
-// Given a work-queue in/out-file, process it. Using system() for portability.
-void ClangTidyProcessFiles(const fs::path &content_dir, const std::string &cmd,
-                           std::list<filepath_contenthash_t> *work_queue) {
-  if (work_queue->empty()) return;
-  const int kJobs = std::thread::hardware_concurrency();
-  std::cerr << work_queue->size() << " files to process...";
+ private:
+  const fs::path content_dir;
+};
 
-  std::mutex queue_access_lock;
-  auto clang_tidy_runner = [&]() {
-    for (;;) {
-      filepath_contenthash_t work;
-      {
-        const std::lock_guard<std::mutex> lock(queue_access_lock);
-        if (work_queue->empty()) return;
-        fprintf(stderr, "%5d\b\b\b\b\b", static_cast<int>(work_queue->size()));
-        work = work_queue->front();
-        work_queue->pop_front();
-      }
-      const fs::path final_out = content_dir / toHex(work.second);
-      const std::string tmp_out = final_out.string() + ".tmp";
-      const std::string command = cmd + " '" + work.first.string() + "'" +
-                                  "> '" + tmp_out + "' 2>/dev/null";
-      const int r = system(command.c_str());
+class ClangTidyRunner {
+ public:
+  ClangTidyRunner(int argc, char **argv)
+      : clang_tidy_(getenv("CLANG_TIDY") ?: "clang-tidy"),
+        clang_tidy_args_(AssembleArgs(argc, argv)) {
+    project_cache_dir_ = AssembleProjectCacheDir();
+  }
+
+  const fs::path &project_cache_dir() const { return project_cache_dir_; }
+
+  // Given a work-queue in/out-file, process it. Using system() for portability.
+  void RunClangTidyOn(ContentAddressedStore &output_store,
+                      std::list<filepath_contenthash_t> work_queue) {
+    if (work_queue.empty()) return;
+    const int kJobs = std::thread::hardware_concurrency();
+    std::cerr << work_queue.size() << " files to process...";
+
+    std::mutex queue_access_lock;
+    auto clang_tidy_runner = [&]() {
+      for (;;) {
+        filepath_contenthash_t work;
+        {
+          const std::lock_guard<std::mutex> lock(queue_access_lock);
+          if (work_queue.empty()) return;
+          fprintf(stderr, "%5d\b\b\b\b\b", static_cast<int>(work_queue.size()));
+          work = work_queue.front();
+          work_queue.pop_front();
+        }
+        const fs::path final_out = output_store.PathFor(work);
+        const std::string tmp_out = final_out.string() + ".tmp";
+        // Putting the file to clang-tidy early in the command line so that
+        // it is easy to find with `ps` or `top`.
+        const std::string command = clang_tidy_ + " '" + work.first.string() +
+                                    "'" + clang_tidy_args_ + "> '" + tmp_out +
+                                    "' 2>/dev/null";
+        const int r = system(command.c_str());
 #ifdef WIFSIGNALED
-      // NOLINTBEGIN
-      if (WIFSIGNALED(r) && (WTERMSIG(r) == SIGINT || WTERMSIG(r) == SIGQUIT)) {
-        break;  // got Ctrl-C
-      }
-      // NOLINTEND
+        // NOLINTBEGIN
+        if (WIFSIGNALED(r) &&
+            (WTERMSIG(r) == SIGINT || WTERMSIG(r) == SIGQUIT)) {
+          break;  // got Ctrl-C
+        }
+        // NOLINTEND
 #endif
-      CanonicalizeSourcePaths(tmp_out, tmp_out);
-      fs::rename(tmp_out, final_out);  // atomic replacement
+        RepairFilenameOccurences(tmp_out, tmp_out);
+        fs::rename(tmp_out, final_out);  // atomic replacement
+      }
+    };
+
+    std::vector<std::thread> workers;
+    for (auto i = 0; i < kJobs; ++i) {
+      workers.emplace_back(clang_tidy_runner);  // NOLINT
     }
-  };
-  std::vector<std::thread> workers;
-  for (auto i = 0; i < kJobs; ++i) {
-    workers.emplace_back(clang_tidy_runner);  // NOLINT
+    for (auto &t : workers) t.join();
+    fprintf(stderr, "     \n");  // Clean out progress counter.
   }
-  for (auto &t : workers) t.join();
-  fprintf(stderr, "     \n");  // Clean out progress counter.
-}
+
+ private:
+  static fs::path GetCacheBaseDir() {
+    if (const char *from_env = getenv("CACHE_DIR")) return fs::path{from_env};
+    if (const char *home = getenv("HOME")) {
+      if (auto cdir = fs::path(home) / ".cache/"; fs::exists(cdir)) return cdir;
+    }
+    return fs::path{getenv("TMPDIR") ?: "/tmp"};
+  }
+
+  static std::string AssembleArgs(int argc, char **argv) {
+    std::string result = " --quiet";
+    result.append(" '--config-file=").append(kClangConfigFile).append("'");
+    for (const std::string_view arg : kExtraArgs) {
+      result.append(" --extra-arg='").append(arg).append("'");
+    }
+    for (int i = 1; i < argc; ++i) {
+      result.append(" '").append(argv[i]).append("'");
+    }
+    return result;
+  }
+
+  fs::path AssembleProjectCacheDir() const {
+    const fs::path cache_dir = GetCacheBaseDir() / "clang-tidy";
+
+    // Use major version as part of name of our configuration specific dir.
+    auto version = GetCommandOutput(clang_tidy_ + " --version");
+    std::smatch version_match;
+    const std::string major_version =
+        std::regex_search(version, version_match,
+                          std::regex{"version ([0-9]+)"})
+            ? version_match[1].str()
+            : "UNKNOWN";
+    // Make sure directory filename depends on .clang-tidy content.
+    return cache_dir /
+           fs::path(kProjectCachePrefix + "v" + major_version + "_" +
+                    toHex(hash(version + clang_tidy_ + clang_tidy_args_) ^
+                              hash(GetContent(kClangConfigFile)),
+                          8));
+  }
+
+  // Fix filename paths found in logfiles that are not emitted relative to
+  // project root in the log (bazel has its own)
+  static void RepairFilenameOccurences(const fs::path &infile,
+                                       const fs::path &outfile) {
+    static const std::regex sFixPathsRe = []() {
+      std::string canonicalize_expr = "(^|\\n)(";  // fix names at start of line
+      auto root = GetCommandOutput("bazel info execution_root 2>/dev/null");
+      if (!root.empty()) {
+        root.pop_back();  // remove newline.
+        canonicalize_expr += root + "/|";
+      }
+      canonicalize_expr += fs::current_path().string() + "/";  // $(pwd)/
+      canonicalize_expr +=
+          ")?(\\./)?";  // Some start with, or have a trailing ./
+      return std::regex{canonicalize_expr};
+    }();
+
+    const auto in_content = GetContent(infile);
+    std::fstream out_stream(outfile, std::ios::out);
+    out_stream << std::regex_replace(in_content, sFixPathsRe, "$1");
+  }
+
+  const std::string clang_tidy_;
+  const std::string clang_tidy_args_;
+  fs::path project_cache_dir_;
+};
+
+class FileGatherer {
+ public:
+  FileGatherer(ContentAddressedStore &store, std::string_view search_dir)
+      : store_(store), root_dir_(search_dir) {}
+
+  // Find all the files we're interested in, and assemble a list of
+  // paths that need refreshing.
+  std::list<filepath_contenthash_t> BuildWorkList(file_time min_freshness) {
+    // Gather all *.cc and *.h files; remember content hashes of includes.
+    const std::regex exclude_re(kFileExcludeRe);
+    std::map<std::string, hash_t> header_hashes;
+    for (const auto &dir_entry : fs::recursive_directory_iterator(root_dir_)) {
+      const fs::path &p = dir_entry.path().lexically_normal();
+      if (!fs::is_regular_file(p)) continue;
+      if (!kFileExcludeRe.empty() &&
+          std::regex_search(p.string(), exclude_re)) {
+        continue;
+      }
+      if (auto ext = p.extension(); ext == ".cc" || ext == ".h") {
+        files_of_interest_.emplace_back(p, 0);  // <- hash to be filled later.
+        if (ext == ".h") header_hashes[p.string()] = hash(GetContent(p));
+      }
+    }
+    std::cerr << files_of_interest_.size() << " files of interest.\n";
+
+    // Create content hash address. If any header a file depends on changes, we
+    // want to reprocess. So we make the hash dependent on header content as
+    // well.
+    std::list<filepath_contenthash_t> work_queue;
+    const std::regex inc_re("\"([0-9a-zA-Z_/-]+\\.h)\"");  // match include
+    for (filepath_contenthash_t &f : files_of_interest_) {
+      const auto content = GetContent(f.first);
+      f.second = hash(content);
+      for (ReIt it(content.begin(), content.end(), inc_re); it != ReIt();
+           ++it) {
+        const std::string &header_path = (*it)[1].str();
+        f.second ^= header_hashes[header_path];
+      }
+      // Recreate if we don't have it yet or if it contains messages but is
+      // older than WORKSPACE or compilation db. Maybe something got fixed.
+      if (store_.NeedsRefresh(f, min_freshness)) {
+        work_queue.emplace_back(f);
+      }
+    }
+    return work_queue;
+  }
+
+  // Tally up findings for files of interest and assemble in one file.
+  // (BuildWorkList() needs to be called first).
+  std::map<std::string, int> CreateReport(const fs::path &project_dir,
+                                          std::string_view symlink_to) {
+    const fs::path tidy_outfile = project_dir / "tidy.out";
+    // Assemble the separate outputs into a single file. Tally up per-check
+    const std::regex check_re("(\\[[a-zA-Z.-]+\\])\n");
+    std::map<std::string, int> checks_seen;
+    std::ofstream tidy_collect(tidy_outfile);
+    for (const filepath_contenthash_t &f : files_of_interest_) {
+      const auto tidy = store_.GetContentFor(f);
+      if (!tidy.empty()) tidy_collect << f.first.string() << ":\n" << tidy;
+      for (ReIt it(tidy.begin(), tidy.end(), check_re); it != ReIt(); ++it) {
+        checks_seen[(*it)[1].str()]++;
+      }
+    }
+
+    std::error_code ignored_error;
+    fs::remove(symlink_to, ignored_error);
+    fs::create_symlink(tidy_outfile, symlink_to, ignored_error);
+    return checks_seen;
+  }
+
+ private:
+  ContentAddressedStore &store_;
+  const std::string root_dir_;
+  std::vector<filepath_contenthash_t> files_of_interest_;
+};
 
 int main(int argc, char *argv[]) {
-  const std::string kProjectPrefix = "verible_";
-  const std::string kSearchDir = ".";
-  const std::string kFileExcludeRe =
-      "vscode/|external_libs/|.github/"
-      "|tree_operations_test"  // very slow
-      "|symbol_table_test";
-
-  const std::string kTidySymlink = kProjectPrefix + "clang-tidy.out";
-  const fs::path cache_dir = GetCacheDir() / "clang-tidy";
+  const std::string kTidySymlink = kProjectCachePrefix + "clang-tidy.out";
 
   // Test that key files exist and remember their last change.
   std::error_code ec;
-  const auto workspace_ts = fs::last_write_time("WORKSPACE", ec);
+  const auto workspace_ts = fs::last_write_time(kWorkspaceFile, ec);
   if (ec.value() != 0) {
     std::cerr << "Script needs to be executed in toplevel bazel project dir\n";
     return EXIT_FAILURE;
@@ -178,89 +359,15 @@ int main(int argc, char *argv[]) {
   }
   const auto build_env_latest_change = std::max(workspace_ts, compdb_ts);
 
-  const auto config = ReadAndVerifyTidyConfig(".clang-tidy");
-  if (!config) return EXIT_FAILURE;
+  ClangTidyRunner runner(argc, argv);
+  ContentAddressedStore store(runner.project_cache_dir());
+  std::cerr << "Cache dir " << runner.project_cache_dir() << "\n";
 
-  // We'll invoke clang-tidy with all the additional flags user provides.
-  const std::string clang_tidy = getenv("CLANG_TIDY") ?: "clang-tidy";
-  std::string clang_tidy_invocation = clang_tidy + " --quiet";
-  clang_tidy_invocation.append(" \"--config=").append(*config).append("\"");
-  for (int i = 1; i < argc; ++i) {
-    clang_tidy_invocation.append(" \"").append(argv[i]).append("\"");
-  }
-
-  // Use major version as part of name of our configuration specific dir.
-  auto version = GetContent(popen((clang_tidy + " --version").c_str(), "r"));
-  std::smatch version_match;
-  const std::string major_version =
-      std::regex_search(version, version_match, std::regex{"version ([0-9]+)"})
-          ? version_match[1].str()
-          : "UNKNOWN";
-
-  // Cache directory name based on configuration.
-  const fs::path project_base_dir =
-      cache_dir / fs::path(kProjectPrefix + "v" + major_version + "_" +
-                           toHex(hash(version + clang_tidy_invocation), 8));
-  const fs::path tidy_outfile = project_base_dir / "tidy.out";
-  const fs::path content_dir = project_base_dir / "contents";
-  fs::create_directories(content_dir);
-  std::cerr << "Cache dir " << project_base_dir << "\n";
-
-  // Gather all *.cc and *.h files; remember content hashes of includes.
-  std::vector<filepath_contenthash_t> files_of_interest;
-  std::map<std::string, hash_t> header_hashes;
-  const std::regex exclude_re(kFileExcludeRe);
-  for (const auto &dir_entry : fs::recursive_directory_iterator(kSearchDir)) {
-    const fs::path &p = dir_entry.path().lexically_normal();
-    if (!fs::is_regular_file(p)) continue;
-    if (!kFileExcludeRe.empty() && std::regex_search(p.string(), exclude_re)) {
-      continue;
-    }
-    if (auto ext = p.extension(); ext == ".cc" || ext == ".h") {
-      files_of_interest.emplace_back(p, 0);
-      if (ext == ".h") header_hashes[p.string()] = hash(GetContent(p));
-    }
-  }
-  std::cerr << files_of_interest.size() << " files of interest.\n";
-
-  // Create content hash address. If any header a file depends on changes, we
-  // want to reprocess. So we make the hash dependent on header content as well.
-  std::list<filepath_contenthash_t> work_queue;
-  const std::regex inc_re("\"([0-9a-zA-Z_/-]+\\.h)\"");  // match include
-  for (filepath_contenthash_t &f : files_of_interest) {
-    const auto content = GetContent(f.first);
-    f.second = hash(content);
-    for (ReIt it(content.begin(), content.end(), inc_re); it != ReIt(); ++it) {
-      const std::string &header_path = (*it)[1].str();
-      f.second ^= header_hashes[header_path];
-    }
-    const fs::path content_hash_file = content_dir / toHex(f.second);
-    // Recreate if we don't have it yet or if it contains messages but is
-    // older than WORKSPACE or compilation db. Maybe something got fixed.
-    if (!fs::exists(content_hash_file) ||
-        (fs::file_size(content_hash_file) > 0 &&
-         fs::last_write_time(content_hash_file) < build_env_latest_change)) {
-      work_queue.emplace_back(f);
-    }
-  }
-
-  // Run clang tidy in parallel on the files to process.
-  ClangTidyProcessFiles(content_dir, clang_tidy_invocation, &work_queue);
-
-  // Assemble the separate outputs into a single file. Tally up per-check stats.
-  const std::regex check_re("(\\[[a-zA-Z.-]+\\])\n");
-  std::map<std::string, int> checks_seen;
-  std::ofstream tidy_collect(tidy_outfile);
-  for (const filepath_contenthash_t &f : files_of_interest) {
-    const auto tidy = GetContent(content_dir / toHex(f.second));
-    if (!tidy.empty()) tidy_collect << f.first.string() << ":\n" << tidy;
-    for (ReIt it(tidy.begin(), tidy.end(), check_re); it != ReIt(); ++it) {
-      checks_seen[(*it)[1].str()]++;
-    }
-  }
-  std::error_code ignored_error;
-  fs::remove(kTidySymlink, ignored_error);
-  fs::create_symlink(tidy_outfile, kTidySymlink, ignored_error);
+  FileGatherer cc_file_gatherer(store, kSearchDir);
+  auto work_list = cc_file_gatherer.BuildWorkList(build_env_latest_change);
+  runner.RunClangTidyOn(store, work_list);
+  auto checks_seen =
+      cc_file_gatherer.CreateReport(runner.project_cache_dir(), kTidySymlink);
 
   if (checks_seen.empty()) {
     std::cerr << "No clang-tidy complaints. 😎\n";

--- a/external_libs/editscript.h
+++ b/external_libs/editscript.h
@@ -29,10 +29,8 @@
 #define EDITSCRIPT_H_
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <iterator>
-#include <map>
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/external_libs/editscript_test.cc
+++ b/external_libs/editscript_test.cc
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <set>
+#include <iterator>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Older clang-tidy did not have --config-file yet, these days they have, which simplifies things.

Fix issues found in editscript* which is now included in clang-tidy runs.