### PR TITLE
Integrate `bant` BUILD dependency cleaner into CI

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -124,6 +124,47 @@ jobs:
         name: "diag"
         path: "**/plot_*.svg"
 
+  RunBantBuildCleaneer:
+    # Running http://bant.build/ to check all dependencies in BUILD files.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build Project genrules
+        run: |
+          # Fetch all dependency and run genrules for bant to see every file
+          # that makes it into the compile.
+          bazel fetch ...
+          bazel build \
+              //common/analysis:command-file-lexer \
+              //common/lsp:jcxxgen-testfile-gen \
+              //common/lsp:lsp-protocol-gen \
+              //common/util:version-header \
+              //verilog/CST:verilog-nonterminals-foreach-gen  \
+              //verilog/parser:gen-verilog-token-enum \
+              //verilog/parser:verilog-lex \
+              //verilog/parser:verilog-parse-interface \
+              //verilog/parser:verilog-y \
+              //verilog/parser:verilog-y-final \
+              //verilog/tools/kythe:verilog-extractor-indexing-fact-type-foreach-gen
+
+      - name: Get Bant
+        run: |
+          # TODO: provide this as action where we simply say with version=...
+          VERSION="v0.1.3"
+          STATIC_VERSION="bant-${VERSION}-linux-static-x86_64"
+          wget "https://github.com/hzeller/bant/releases/download/${VERSION}/${STATIC_VERSION}.tar.gz"
+          tar xvzf "${STATIC_VERSION}.tar.gz"
+          mkdir -p bin
+          ln -sf ../"${STATIC_VERSION}/bin/bant" bin/
+          bin/bant -V
+
+      - name: Run bant build-cleaner
+        run: |
+          bin/bant dwyu ...
 
   Check:
     container: ubuntu:jammy

--- a/common/analysis/BUILD
+++ b/common/analysis/BUILD
@@ -199,7 +199,6 @@ cc_library(
         "//common/util:algorithm",
         "//common/util:logging",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest",  # for library testonly
     ],
 )
 
@@ -266,7 +265,6 @@ cc_library(
         "//common/text:text-structure",
         "//common/util:logging",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest",  # for library testonly
     ],
 )
 
@@ -322,7 +320,6 @@ cc_library(
         "//common/text:text-structure",
         "//common/util:logging",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest",  # for library testonly
     ],
 )
 


### PR DESCRIPTION
This adds the http://bant.build/ tool in the CI checking, for missing and superfluous dependencies in BUILD files and emitting a `buildozer`[^1] script to fix (The CI just checks the cleanness, the user has to run the buildozer commands and update the PR).

Fixes #655

(There is an open feature request issue on bazel for such a tool, but none exists as of now (https://github.com/bazelbuild/bazel/issues/6871).

The `bant` utility generally helps to explore targets and dependencies in bazel projects, and it has a `dwyu` (_Depend-on What You Use_)  feature which helps with clean-ups, so it pretty much provides `build_cleaner` functionality.
The `bant dwyu` works very well on the C++ projects I have tested in on (Verible is so clean as I used an earlier development version of bant on it already; there were tens of findings)).

[^1]: https://github.com/bazelbuild/buildtools/tree/master/buildozer