### PR TITLE
[LINT] Allow interconnection net or port (Syntax 6-2)

### DIFF
--- a/verilog/parser/verilog.y
+++ b/verilog/parser/verilog.y
@@ -5586,9 +5586,10 @@ net_declaration
                           MakePackedDimensionsNode($3),
                           $5, $6); }
   | net_type delay3 net_variable_or_decl_assigns ';'
-  { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType(nullptr, $1, $2, nullptr), nullptr, nullptr, $3, $4); }
+    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType(nullptr, $1, $2, nullptr), nullptr, nullptr, $3, $4); }
   /* TODO(fangism): net_type_identifer [ delay_control ] list_of_net_decl_assignments */
-  /* TODO(fangism): TK_interconnect ... */
+  | TK_interconnect net_variable_or_decl_assigns ';'
+    { $$ = MakeTaggedNode(N::kNetDeclaration, MakeDataType($1), nullptr, $2, $3); }
   ;
 
 module_port_declaration


### PR DESCRIPTION
In _Syntax 6-2_ of the SystemVerilog (exert from _A.2.1.3 Type declarations_) the generic net `interconnect` is allowed but currently this is still flagged by the linter as a syntax error.

```verilog
module mod_a (output wire logic [4:0] net_a);
endmodule

module mod_b (input wire logic [4:0] net_b);
endmodule

module mod_c ();
    interconnect net_interconnect;

    mod_a mod_a (
        .net_a(net_interconnect);
    );

    mod_b mod_b (
        .net_b(net_interconnect);
    );
endmodule
```