### PR TITLE
Use Windows CI runner 2019 (2022 has issues).

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -476,7 +476,7 @@ jobs:
         apt -qq -y install npm nodejs
 
   WindowsBuild:
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
Issues #2193