### PR TITLE
[proper-parameter-declaration] change default behaviour

### DIFF
--- a/verilog/analysis/checkers/proper_parameter_declaration_rule.cc
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule.cc
@@ -70,13 +70,13 @@ const LintRuleDescriptor &ProperParameterDeclarationRule::GetDescriptor() {
       .param = {
           {
               .name = "package_allow_parameter",
-              .default_value = "true",
+              .default_value = "false",
               .description = "Allow parameters in packages (treated as a "
                              "synonym for localparam).",
           },
           {
               .name = "package_allow_localparam",
-              .default_value = "false",
+              .default_value = "true",
               .description = "Allow localparams in packages.",
           },
       }};

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule.h
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule.h
@@ -47,8 +47,8 @@ class ProperParameterDeclarationRule : public verible::SyntaxTreeLintRule {
  private:
   std::set<verible::LintViolation> violations_;
 
-  bool package_allow_parameter_ = true;
-  bool package_allow_localparam_ = false;
+  bool package_allow_parameter_ = false;
+  bool package_allow_localparam_ = true;
 };
 
 }  // namespace analysis

--- a/verilog/analysis/checkers/proper_parameter_declaration_rule_test.cc
+++ b/verilog/analysis/checkers/proper_parameter_declaration_rule_test.cc
@@ -89,9 +89,7 @@ TEST(ProperParameterDeclarationRuleTest, RejectPackageParameters) {
        "endmodule"},
   };
 
-  RunConfiguredLintTestCases<VerilogAnalyzer, ProperParameterDeclarationRule>(
-      kTestCases,
-      "package_allow_parameter:false;package_allow_localparam:true");
+  RunLintTestCases<VerilogAnalyzer, ProperParameterDeclarationRule>(kTestCases);
 }
 
 // Tests that the expected number of localparam usage violations are found.
@@ -221,7 +219,9 @@ TEST(ProperParameterDeclarationRuleTest, AllowPackageParameters) {
        "endpackage"},
   };
 
-  RunLintTestCases<VerilogAnalyzer, ProperParameterDeclarationRule>(kTestCases);
+  RunConfiguredLintTestCases<VerilogAnalyzer, ProperParameterDeclarationRule>(
+      kTestCases,
+      "package_allow_parameter:true;package_allow_localparam:false");
 }
 
 }  // namespace

--- a/verilog/tools/lint/testdata/endif_comment.sv
+++ b/verilog/tools/lint/testdata/endif_comment.sv
@@ -1,5 +1,5 @@
 package endif_comment;
 `ifdef FOOBAR
-  parameter int P = 4;
+  localparam int P = 4;
 `endif
 endpackage


### PR DESCRIPTION
As discussed in #2160 and #2190, this follow up PR changes the default behaviour of the proper-parameter-declaration to raise a violation if a parameter is declared in a package, and allow localparam's instead. The use of localparam's in packages is preferred as it is more in line with the System Verilog LRM IEEE Std 1800™-2017. 

Section 6.20.4  (LRM 2017 and older) states "parameters" in packages are treated as a synonym for a localparam, so tools should treat parameters as localparam's in a package. More intuitively, as parameters are overidable, a parameter in a package doesn't make sense in that packages are constant and not parameterisable.

Users can revert to the old behaviour by adding the following to their '.rules.verible_lint' file:
`package_allow_parameter:true;package_allow_localparam:false`

<details><summary>System Verilog LRM IEEE Std 1800™-2017: 6.20.4 Local parameters (localparam)</summary>
<p>
<p>Local parameters are identical to parameters except that they cannot directly be modified by defparam statements (see 23.10.1) or instance parameter value assignments (see 23.10.2). Local parameters can be assigned constant expressions (see 11.2.1) containing parameters, which in turn can be modified with defparam statements or instance parameter value assignments.</p>

<p>Unlike nonlocal parameters, local parameters can be declared in a generate block, package, class body, or compilation-unit scope. In these contexts, the parameter keyword shall be a synonym for the localparam keyword.</p>

<p>Local parameters may be declared in a module’s parameter_port_list. Any parameter declaration appearing in such a list between a localparam keyword and the next parameter keyword (or the end of the list, if there is no next parameter keyword) shall be a local parameter. Any other parameter declaration in such a list shall be a nonlocal parameter that may be overridden as described in 23.10.
</p>

If you got this far, thanks for reading :+1: 
</p>
</details>