### PR TITLE
Fixing the Read The Docs action

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,10 @@ build:
 sphinx:
   configuration:
 
+python:
+  install:
+    - requirements: doc/requirements.txt
+
 formats:
   - pdf
   - epub

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  formats:
+   - pdf
+   - epub

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-  formats:
-   - pdf
-   - epub
+  
+formats:
+  - pdf
+  - epub

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,6 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
   
 formats:
   - pdf

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,8 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  
+  configuration:
+
 formats:
   - pdf
   - epub

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, unicode_literals
-
 from datetime import datetime
 
-from recommonmark.parser import CommonMarkParser
-
-extensions = []
+extensions = ['myst_parser']
 templates_path = ['templates', '_templates', '.templates']
 source_suffix = ['.rst', '.md']
 source_parsers = {
-            '.md': CommonMarkParser,
-        }
+      '.rst': 'restructuredtext',
+      '.md': 'markdown',
+}
 master_doc = 'index'
 project = u'verible'
 copyright = str(datetime.now().year)
@@ -23,6 +20,5 @@ htmlhelp_basename = 'verible'
 html_theme = 'sphinx_rtd_theme'
 file_insertion_enabled = False
 latex_documents = [
-  ('index', 'verible.tex', u'verible Documentation',
-   u'', 'manual'),
+  ('index', 'verible.tex', u'verible Documentation', u'', 'manual'),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function, unicode_literals
+
+from datetime import datetime
+
+from recommonmark.parser import CommonMarkParser
+
+extensions = []
+templates_path = ['templates', '_templates', '.templates']
+source_suffix = ['.rst', '.md']
+source_parsers = {
+            '.md': CommonMarkParser,
+        }
+master_doc = 'index'
+project = u'verible'
+copyright = str(datetime.now().year)
+version = 'latest'
+release = 'latest'
+exclude_patterns = ['_build']
+pygments_style = 'sphinx'
+htmlhelp_basename = 'verible'
+html_theme = 'sphinx_rtd_theme'
+file_insertion_enabled = False
+latex_documents = [
+  ('index', 'verible.tex', u'verible Documentation',
+   u'', 'manual'),
+]

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,9 +4,9 @@ Using Verible
 .. toctree::
    :maxdepth: 2
 
-   style_lint
-   formatter
-   indexing
+   style_lint.md
+   formatter.md
+   indexing.md
 
 Developing Verible
 ==================
@@ -14,5 +14,5 @@ Developing Verible
 .. toctree::
    :maxdepth: 2
 
-   development
-   parser_design
+   development.md
+   parser_design.md

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,18 @@
+Using Verible
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   style_lint
+   formatter
+   indexing
+
+Developing Verible
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   development
+   parser_design

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,6 @@
+sphinx
+sphinx-rtd-theme
+pillow
+mock
+commonmark
+recommonmark

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,5 +2,4 @@ sphinx
 sphinx-rtd-theme
 pillow
 mock
-commonmark
-recommonmark
+myst-parser


### PR DESCRIPTION
Add a bunch of files that are no longer provided by default;
 * `.readthedocs.yml` and `requirements.txt` for configuration of the readthedocs build.
 * `conf.py` file for configuration of sphinx.
 * `index.rst` file to provide a based page.