### PR TITLE
fix misleading readme #2163

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ any Linux distribution.
 
 There are also some distributions that include Verible
 
-  * [Nix] has binaries for Linux and MacOS for x86 and Arm.
+  * [Nix] has binaries for Linux x86 and Arm.
   * There is a [homebrew] package for MacOS.
 
 If you prefer to build and install the binaries locally yourself, see


### PR DESCRIPTION
fixes #2163
the installation of verible on macOS is a hit and miss process. the release binaries seems to work fine when extracted and placed in bin other than that, homebrew package itself has some issues.
mentioning outright that nix has binaries available for MacOS in the installation of readme is misleading because the nixpkgs doesn't add macOS as a supported platform and it failes to compile even if you override it. this small change might be insignificant but saves countless hours of nixxing for future readers of readme until the nix pkg issue is fixed.