### PR TITLE
Fixing naming style for constant expressions

### DIFF
--- a/verilog/analysis/checkers/enum_name_style_rule.cc
+++ b/verilog/analysis/checkers/enum_name_style_rule.cc
@@ -44,11 +44,11 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-static constexpr absl::string_view style_default_regex = "[a-z_0-9]+(_t|_e)";
+static constexpr absl::string_view kDefaultStyleRegex = "[a-z_0-9]+(_t|_e)";
 
 EnumNameStyleRule::EnumNameStyleRule()
     : style_regex_(
-          std::make_unique<re2::RE2>(style_default_regex, re2::RE2::Quiet)) {}
+          std::make_unique<re2::RE2>(kDefaultStyleRegex, re2::RE2::Quiet)) {}
 
 const LintRuleDescriptor &EnumNameStyleRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -61,7 +61,7 @@ const LintRuleDescriptor &EnumNameStyleRule::GetDescriptor() {
           "to "
           "https://github.com/chipsalliance/verible/tree/master/verilog/tools/"
           "lint#readme for more detail on verible regex patterns.",
-      .param = {{"style_regex", std::string(style_default_regex),
+      .param = {{"style_regex", std::string(kDefaultStyleRegex),
                  "A regex used to check enum type name style."}},
   };
   return d;

--- a/verilog/analysis/checkers/package_filename_rule.cc
+++ b/verilog/analysis/checkers/package_filename_rule.cc
@@ -43,7 +43,7 @@ using verible::TextStructureView;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(PackageFilenameRule);
 
-static constexpr absl::string_view optional_suffix = "_pkg";
+static constexpr absl::string_view kOptionalSuffix = "_pkg";
 
 static constexpr absl::string_view kMessage =
     "Package declaration name must match the file name "
@@ -106,7 +106,7 @@ void PackageFilenameRule::Lint(const TextStructureView &text_structure,
         GetPackageNameToken(*package_match.match);
     if (!package_name_token) continue;
     absl::string_view package_id = package_name_token->text();
-    auto package_id_plus_suffix = absl::StrCat(package_id, optional_suffix);
+    auto package_id_plus_suffix = absl::StrCat(package_id, kOptionalSuffix);
     if ((package_id != unitname) && (package_id_plus_suffix != unitname)) {
       violations_.insert(verible::LintViolation(
           *package_name_token,

--- a/verilog/analysis/checkers/signal_name_style_rule.cc
+++ b/verilog/analysis/checkers/signal_name_style_rule.cc
@@ -48,11 +48,11 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-static constexpr absl::string_view style_default_regex = "[a-z_0-9]+";
+static constexpr absl::string_view kDefaultStyleRegex = "[a-z_0-9]+";
 
 SignalNameStyleRule::SignalNameStyleRule()
     : style_regex_(
-          std::make_unique<re2::RE2>(style_default_regex, re2::RE2::Quiet)) {}
+          std::make_unique<re2::RE2>(kDefaultStyleRegex, re2::RE2::Quiet)) {}
 
 const LintRuleDescriptor &SignalNameStyleRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -65,7 +65,7 @@ const LintRuleDescriptor &SignalNameStyleRule::GetDescriptor() {
           "expects \"lower_snake_case\". Refer to "
           "https://github.com/chipsalliance/verible/tree/master/verilog/tools/"
           "lint#readme for more detail on verible regex patterns.",
-      .param = {{"style_regex", std::string(style_default_regex),
+      .param = {{"style_regex", std::string(kDefaultStyleRegex),
                  "A regex used to check signal names style."}},
   };
   return d;


### PR DESCRIPTION
As discussed in #2213, fixing the naming style for a few constants.