### PR TITLE
Add support for inlay hint objects in LSP generation.

### DIFF
--- a/common/lsp/lsp-protocol-enums.h
+++ b/common/lsp/lsp-protocol-enums.h
@@ -63,6 +63,13 @@ enum SymbolKind {
   kOperator = 25,
   kTypeParameter = 26,
 };
+
+// These are the InlayHintKinds defined by the LSP specification.
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#inlayHintKind
+enum InlayHintKind {
+  kType = 1,
+  kParameter = 2,
+};
 }  // namespace lsp
 }  // namespace verible
 #endif  // COMMON_LSP_LSP_PROTOCOL_ENUMS_H

--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -216,3 +216,16 @@ RenameParams:
 
 # Response: Range[]
 
+# -- textDocument/inlayHint
+InlayHintParams:
+  textDocument: TextDocumentIdentifier
+  range: Range
+
+InlayHint:
+  position: Position
+  label: string
+  kind?: integer  # InlayHintKind enum
+  tooltip?: string
+  paddingLeft?: boolean
+  paddingRight?: boolean
+  


### PR DESCRIPTION
Note: this will be used in a dependent XLS change.