### PR TITLE
Fix clang-tidy findings on files usually excluded.

### DIFF
--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -579,8 +579,10 @@ cc_test(
             srcs = ["tree_operations_test.cc"],
             defines = ["COMPILATION_SHARD=" + shard],
             deps = [
+                ":logging",
                 ":spacer",
                 ":tree-operations",
+                ":type-traits",
                 "@com_google_absl//absl/strings",
                 "@com_google_absl//absl/strings:str_format",
                 "@com_google_googletest//:gtest",

--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -14,7 +14,7 @@
 
 #include "common/util/tree_operations.h"
 
-#include <charconv>
+#include <cstdlib>
 #include <initializer_list>
 #include <list>
 #include <ostream>
@@ -27,7 +27,9 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
+#include "common/util/logging.h"
 #include "common/util/spacer.h"
+#include "common/util/type_traits.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -487,8 +487,8 @@ cc_test(
     srcs = ["symbol_table_test.cc"],
     deps = [
         ":symbol-table",
+        ":verilog-filelist",
         ":verilog-project",
-        "//common/text:symbol",
         "//common/text:tree-utils",
         "//common/util:file-util",
         "//common/util:logging",

--- a/verilog/analysis/symbol_table_test.cc
+++ b/verilog/analysis/symbol_table_test.cc
@@ -15,7 +15,6 @@
 #include "verilog/analysis/symbol_table.h"
 
 #include <algorithm>
-#include <functional>
 #include <iostream>
 #include <iterator>
 #include <memory>
@@ -26,7 +25,6 @@
 #include "absl/base/attributes.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
-#include "common/text/symbol.h"
 #include "common/text/tree_utils.h"
 #include "common/util/file_util.h"
 #include "common/util/logging.h"
@@ -34,6 +32,7 @@
 #include "common/util/tree_operations.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "verilog/analysis/verilog_filelist.h"
 #include "verilog/analysis/verilog_project.h"
 
 namespace verilog {


### PR DESCRIPTION
The tree_operations_test.cc and symbol_table_test.cc are usually excluded from the clang-tidy checks because clang-tidy is particularly slow on them. So there were some includes missing, which are fixed here.