### PR TITLE
clang-tidy can get confused if gmock is needed.

### DIFF
--- a/common/util/tree_operations_test.cc
+++ b/common/util/tree_operations_test.cc
@@ -30,7 +30,7 @@
 #include "common/util/logging.h"
 #include "common/util/spacer.h"
 #include "common/util/type_traits.h"
-#include "gmock/gmock.h"
+#include "gmock/gmock.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
 
 /*


### PR DESCRIPTION
It might not see all if-def'ed branches.