### PR TITLE
Use single-header json implementation.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -61,10 +61,17 @@ single_version_override(
     patches = ["//bazel:absl.patch"],
 )
 
+# Json module only provide the multi-header target, but that will
+# make misc-inlude-cleaner complain about not direct includes.
+bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name="jsonhpp")
+single_version_override(
+    module_name = "nlohmann_json",
+    patches = ["//bazel:nlohmann_module.patch"],
+)
+
 bazel_dep(name = "re2", version = "2023-09-01", repo_name="com_googlesource_code_re2")
 
 # Newer versions require bazel 7, so this is the last we can use currently.
 bazel_dep(name = "googletest", version = "1.14.0.bcr.1", repo_name="com_google_googletest")
 bazel_dep(name = "protobuf", version = "26.0", repo_name="com_google_protobuf")
-bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name="jsonhpp")
 bazel_dep(name = "zlib", version = "1.3.1")

--- a/bazel/nlohmann_module.patch
+++ b/bazel/nlohmann_module.patch
@@ -1,0 +1,23 @@
+--- BUILD.bazel	2024-09-27 08:43:50.907170239 -0700
++++ BUILD.bazel	2024-09-27 08:46:27.441297623 -0700
+@@ -1,5 +1,5 @@
+ cc_library(
+-    name = "json",
++    name = "json-multiheader",
+     hdrs = [
+         "include/nlohmann/adl_serializer.hpp",
+         "include/nlohmann/byte_container_with_subtype.hpp",
+@@ -51,3 +51,13 @@
+     visibility = ["//visibility:public"],
+     alwayslink = True,
+ )
++cc_library(
++    name = "json",
++    hdrs = [
++        "single_include/nlohmann/json.hpp",
++    ],
++    includes = ["single_include"],
++    visibility = ["//visibility:public"],
++    copts = ["-fexceptions"],
++    features = ["-use_header_modules"],  # precompiled headers incompatible with -fexceptions.
++)


### PR DESCRIPTION
clang-tidy complains if a symbol is not in a header directly included with the [misc-include-cleaner] check. Since the multi-header does one indirection, this results in these warnings.

Using the single-header library helps. Patch upostream bzlmod package to provide that.

TODO: check with bzlmod mintainer for nlohmann_json to maybe provide a target for that.