### PR TITLE
Switch to hedronvision/bazel-compile-commands for compilation db.

### DIFF
--- a/.github/bin/make-compilation-db.sh
+++ b/.github/bin/make-compilation-db.sh
@@ -13,16 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -u
-set -e
+# This is pretty noisy.
+bazel run -c opt @hedron_compile_commands//:refresh_all > /dev/null 2>&1
 
-readonly OUTPUT_BASE="$(bazel info output_base)"
-
-readonly COMPDB_SCRIPT="${OUTPUT_BASE}/external/rules_compdb/generate.py"
-[ -r "${COMPDB_SCRIPT}" ] || bazel fetch ...
-
-python3 "${COMPDB_SCRIPT}"
-
-# Remove a flags observed in the wild that clang-tidy doesn't understand.
-sed -i -e 's/-fno-canonical-system-headers//g; s/DEBUG_PREFIX_MAP_PWD=.//g' \
-       compile_commands.json
+sed -i -e 's/bazel-out\/.*\/bin\/external\//bazel-out\/..\/..\/..\/external\//g' compile_commands.json
+sed -i -e 's/bazel-out\/.*\/bin/bazel-bin/g' compile_commands.json

--- a/.github/bin/run-clang-format.sh
+++ b/.github/bin/run-clang-format.sh
@@ -37,7 +37,7 @@ find . -name "*.h" -o -name "*.cc" \
 # If we have buildifier installed, use that on BUILD files
 if command -v ${BUILDIFIER} >/dev/null; then
   echo "Run $(buildifier --version)"
-  ${BUILDIFIER} -lint=fix WORKSPACE $(find . -name BUILD -o -name "*.bzl")
+  ${BUILDIFIER} -lint=fix WORKSPACE* MODULE.bazel $(find . -name BUILD -o -name "*.bzl")
 fi
 
 # Check if we got any diff

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -92,15 +92,28 @@ jobs:
         path: |
           /root/.cache/clang-tidy
           /root/.cache/bazel
-        key: clang-tidy-${{ steps.cache_timestamp.outputs.time }}
-        restore-keys: clang-tidy-
+        key: clang-tidy-2-${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: clang-tidy-2-
+
+    - name: Make compilation DB
+      run: |
+        .github/bin/make-compilation-db.sh
+        wc -l compile_commands.json
+
+    - name: Build generated files
+      run: |
+        bazel build //common/lsp:jcxxgen-testfile-gen \
+          //common/lsp:lsp-protocol-gen \
+          //common/util:version-header \
+          //verilog/CST:verilog-nonterminals-foreach-gen \
+          //verilog/parser:verilog-parse-interface \
+          //verilog/parser:gen-verilog-token-enum \
+          //third_party/proto/kythe:storage_cc_proto \
+          //third_party/proto/kythe:analysis_cc_proto
 
     - name: Run clang tidy
       run: |
-        echo "::group::Make Compilation DB"
-        .github/bin/make-compilation-db.sh
         wc -l compile_commands.json
-        echo "::endgroup::"
         # For runtime references, use clang-tidy 11 that still has it, everything else: latest.
         CLANG_TIDY=clang-tidy-11 ./.github/bin/run-clang-tidy-cached.cc --checks="-*,google-runtime-references" \
            || ( cat verible_clang-tidy.out ; exit 1)
@@ -380,6 +393,7 @@ jobs:
         # Just a smoke test to make sure developer scripts run on Mac
         echo "::group::Make Compilation DB"
         .github/bin/make-compilation-db.sh
+        head -30 compile_commands.json
         echo "::endgroup::"
         # Quick with no checks to be fast (full tidy run in ClangTidy action)
         .github/bin/run-clang-tidy-cached.cc --checks="-*"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,74 +4,87 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-
 bazel_dep(name = "rules_license", version = "0.0.8")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 # Register m4 rules and toolchain.
 bazel_dep(name = "rules_m4", version = "0.2.3")
+
 m4 = use_extension(
     "@rules_m4//m4/extensions:m4_repository_ext.bzl",
     "m4_repository_ext",
 )
 m4.repository(
     name = "m4",
-    version = "1.4.18",
     extra_copts = ["-O3"],
+    version = "1.4.18",
 )
 use_repo(m4, "m4")
+
 register_toolchains("@m4//:toolchain")
 
 # Register bison rules and toolchain.
 bazel_dep(name = "rules_bison", version = "0.2.2")
+
 bison = use_extension(
     "@rules_bison//bison/extensions:bison_repository_ext.bzl",
     "bison_repository_ext",
 )
 bison.repository(
     name = "bison",
-    version = "3.3.2",
     extra_copts = ["-O3"],
+    version = "3.3.2",
 )
 use_repo(bison, "bison")
+
 register_toolchains("@bison//:toolchain")
 
 # Register flex rules and toolchain.
 bazel_dep(name = "rules_flex", version = "0.2.1")
+
 flex = use_extension(
     "@rules_flex//flex/extensions:flex_repository_ext.bzl",
     "flex_repository_ext",
 )
 flex.repository(
     name = "flex",
-    version = "2.6.4",
     extra_copts = ["-O3"],
+    version = "2.6.4",
 )
 use_repo(flex, "flex")
+
 register_toolchains("@flex//:toolchain")
 
 # abseil-cpp can not be updated beyond the following curringly, as newer
 # ones use googletest that is not compatible with bazel 6 anymore.
-bazel_dep(name = "abseil-cpp", version = "20240116.2", repo_name="com_google_absl")
+bazel_dep(name = "abseil-cpp", version = "20240116.2", repo_name = "com_google_absl")
 single_version_override(
     module_name = "abseil-cpp",
     patch_strip = 1,
-    version = "20240116.2",
     patches = ["//bazel:absl.patch"],
+    version = "20240116.2",
 )
 
 # Json module only provide the multi-header target, but that will
 # make misc-inlude-cleaner complain about not direct includes.
-bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name="jsonhpp")
+bazel_dep(name = "nlohmann_json", version = "3.11.3", repo_name = "jsonhpp")
 single_version_override(
     module_name = "nlohmann_json",
     patches = ["//bazel:nlohmann_module.patch"],
 )
 
-bazel_dep(name = "re2", version = "2023-09-01", repo_name="com_googlesource_code_re2")
+bazel_dep(name = "re2", version = "2023-09-01", repo_name = "com_googlesource_code_re2")
 
 # Newer versions require bazel 7, so this is the last we can use currently.
-bazel_dep(name = "googletest", version = "1.14.0.bcr.1", repo_name="com_google_googletest")
-bazel_dep(name = "protobuf", version = "26.0", repo_name="com_google_protobuf")
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1", repo_name = "com_google_googletest")
+bazel_dep(name = "protobuf", version = "26.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "zlib", version = "1.3.1")
+
+# Make compilation DB
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,4 @@
+# Legacy workspace for bazel5. Will go away.
 workspace(name = "com_google_verible")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -177,14 +178,27 @@ http_archive(
     ],
 )
 
-# 2024-02-06
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
 http_archive(
-    name = "rules_compdb",
-    sha256 = "70232adda61e89a4192be43b4719d35316ed7159466d0ab4f3da0ecb1fbf00b2",
-    strip_prefix = "bazel-compilation-database-fa872dd80742b3dccd79a711f52f286cbde33676",
-    urls = ["https://github.com/grailbio/bazel-compilation-database/archive/fa872dd80742b3dccd79a711f52f286cbde33676.tar.gz"],
+    name = "hedron_compile_commands",
+    sha256 = "044b148b111e17cee61d8c3aaeed42069f7325460382340afca4919f8265094c",
+    strip_prefix = "bazel-compile-commands-extractor-1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/1e08f8e0507b6b6b1f4416a9a22cf5c28beaba93.tar.gz",
 )
 
-load("@rules_compdb//:deps.bzl", "rules_compdb_deps")
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
 
-rules_compdb_deps()
+hedron_compile_commands_setup()
+
+load("@hedron_compile_commands//:workspace_setup_transitive.bzl", "hedron_compile_commands_setup_transitive")
+
+hedron_compile_commands_setup_transitive()
+
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive")
+
+hedron_compile_commands_setup_transitive_transitive()
+
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive_transitive")
+
+hedron_compile_commands_setup_transitive_transitive_transitive()

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,7 +1,6 @@
 workspace(name = "com_google_verible")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 #
 # External tools needed
@@ -27,15 +26,3 @@ install_rules_dependencies()
 load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
 
 install_rules_setup()
-
-# 2024-02-06
-http_archive(
-    name = "rules_compdb",
-    sha256 = "70232adda61e89a4192be43b4719d35316ed7159466d0ab4f3da0ecb1fbf00b2",
-    strip_prefix = "bazel-compilation-database-fa872dd80742b3dccd79a711f52f286cbde33676",
-    urls = ["https://github.com/grailbio/bazel-compilation-database/archive/fa872dd80742b3dccd79a711f52f286cbde33676.tar.gz"],
-)
-
-load("@rules_compdb//:deps.bzl", "rules_compdb_deps")
-
-rules_compdb_deps()


### PR DESCRIPTION
The grailbio/bazel-compilation-database only works for non-bzlmod while hedronvision works for old and new bazel.

It is slower and more invasive (creating unwanted links and adds things to .git), so mostly reluctant change for now.