### PR TITLE
[LSP] Add TextDocumentEdit for textDocument/rename support.

### DIFF
--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -228,3 +228,13 @@ InlayHint:
   tooltip?: string
   paddingLeft?: boolean
   paddingRight?: boolean
+
+# -- textDcoument/rename
+
+OptionalVersionedTextDocumentIdentifier:
+  <: TextDocumentIdentifier
+  version?: integer
+
+TextDocumentEdit:
+  textDocument: OptionalVersionedTextDocumentIdentifier
+  edits: object  # TextEdit[]

--- a/common/lsp/lsp-protocol.yaml
+++ b/common/lsp/lsp-protocol.yaml
@@ -237,4 +237,4 @@ OptionalVersionedTextDocumentIdentifier:
 
 TextDocumentEdit:
   textDocument: OptionalVersionedTextDocumentIdentifier
-  edits: object  # TextEdit[]
+  edits+: TextEdit


### PR DESCRIPTION
See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename

Result is `WorkspaceEdit` which prefers `documentChanges` which contain `TextDocumentEdit[]`

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit

(Note: we can do this with support for `changes?` in the LSP but this is the suggested way for new implementations, so figured I'd add.)