### PR TITLE
Include "zlib.h" directly instead of "zlib/inlude/zlib.h"

### DIFF
--- a/common/util/simple_zip.cc
+++ b/common/util/simple_zip.cc
@@ -24,7 +24,7 @@
 
 #include "absl/strings/string_view.h"
 #include "third_party/portable_endian/portable_endian.h"
-#include "zlib/include/zlib.h"
+#include "zlib.h"
 
 namespace verible {
 namespace zip {


### PR DESCRIPTION
The hedronvision compilation DB is not providing the include path for that (even though bazel can deal with both).