### PR TITLE
common: text: config_utils: make ParseNameValues skip empty strings

### DIFF
--- a/common/text/config_utils.cc
+++ b/common/text/config_utils.cc
@@ -45,7 +45,8 @@ absl::Status ParseNameValues(string_view config_string,
                              const std::initializer_list<NVConfigSpec> &spec) {
   if (config_string.empty()) return absl::OkStatus();
 
-  for (const string_view single_config : absl::StrSplit(config_string, ';')) {
+  for (const string_view single_config :
+       absl::StrSplit(config_string, ';', absl::SkipEmpty())) {
     const std::pair<string_view, string_view> nv_pair =
         absl::StrSplit(single_config, ':');
     const auto value_config = std::find_if(  // linear search

--- a/common/text/config_utils_test.cc
+++ b/common/text/config_utils_test.cc
@@ -201,5 +201,29 @@ TEST(ConfigUtilsTest, ParseMultipleParameters) {
   EXPECT_EQ(str1, "some text string");
   EXPECT_EQ(regex->pattern(), "[A-B0-9_]");
 }
+
+TEST(ConfigUtilsTest, AllowTrailingOrLeadingSemicolons) {
+  absl::Status s;
+  int answer;
+  bool panic;
+  s = ParseNameValues("answer:42;panic:off;", {{"answer", SetInt(&answer)},
+                                               {"panic", SetBool(&panic)}});
+  EXPECT_TRUE(s.ok());
+  EXPECT_FALSE(panic);
+  EXPECT_EQ(answer, 42);
+
+  s = ParseNameValues(";answer:43;panic:on", {{"answer", SetInt(&answer)},
+                                              {"panic", SetBool(&panic)}});
+  EXPECT_TRUE(s.ok()) << s.message();
+  EXPECT_TRUE(panic);
+  EXPECT_EQ(answer, 43);
+
+  s = ParseNameValues(";answer:44;panic:on;", {{"answer", SetInt(&answer)},
+                                               {"panic", SetBool(&panic)}});
+  EXPECT_TRUE(s.ok()) << s.message();
+  EXPECT_TRUE(panic);
+  EXPECT_EQ(answer, 44);
+}
+
 }  // namespace config
 }  // namespace verible


### PR DESCRIPTION
```
$ cat .rules.verible_lint
+always-ff-non-blocking=catch_modifying_assignments:on;
$ verible-verilog-lint file.sv --rules_config_search
E0929 18:52:13.789277   24408 verilog_linter.cc:146] Fatal error: always-ff-non-blocking : unknown parameter; supported parameters are 'catch_modifying_assignments', 'waive_for_locals'
```

Current configuration parsing hard-fails upon encountering trailing or leading semicolons in the configuration string. Let's make the process more robust and ignore them.