### PR TITLE
(experiment): distinguish singleheader json in toplevel jsonhpp BUILD

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Get Bant
         run: |
           # TODO: provide this as action where we simply say with version=...
-          VERSION="v0.1.7"
+          VERSION="v0.1.8"
           STATIC_VERSION="bant-${VERSION}-linux-static-x86_64"
           wget "https://github.com/hzeller/bant/releases/download/${VERSION}/${STATIC_VERSION}.tar.gz"
           tar xvzf "${STATIC_VERSION}.tar.gz"

--- a/bazel/jsonhpp.BUILD
+++ b/bazel/jsonhpp.BUILD
@@ -5,7 +5,7 @@ licenses(["unencumbered"])  # Public Domain or MIT
 exports_files(["LICENSE"])
 
 cc_library(
-    name = "json",
+    name = "singleheader/json",
     hdrs = [
         "single_include/nlohmann/json.hpp",
     ],

--- a/bazel/nlohmann_module.patch
+++ b/bazel/nlohmann_module.patch
@@ -1,18 +1,11 @@
 --- BUILD.bazel	2024-09-27 08:43:50.907170239 -0700
 +++ BUILD.bazel	2024-09-27 08:46:27.441297623 -0700
-@@ -1,5 +1,5 @@
- cc_library(
--    name = "json",
-+    name = "json-multiheader",
-     hdrs = [
-         "include/nlohmann/adl_serializer.hpp",
-         "include/nlohmann/byte_container_with_subtype.hpp",
 @@ -51,3 +51,13 @@
      visibility = ["//visibility:public"],
      alwayslink = True,
  )
 +cc_library(
-+    name = "json",
++    name = "singleheader/json",
 +    hdrs = [
 +        "single_include/nlohmann/json.hpp",
 +    ],

--- a/common/lsp/BUILD
+++ b/common/lsp/BUILD
@@ -53,7 +53,7 @@ cc_library(
     deps = [
         "//common/util:logging",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -70,7 +70,7 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -85,7 +85,7 @@ genrule(
 cc_library(
     name = "lsp-protocol",
     hdrs = ["lsp-protocol.h"],
-    deps = ["@jsonhpp//:json"],
+    deps = ["@jsonhpp//:singleheader/json"],
 )
 
 cc_library(
@@ -167,7 +167,7 @@ cc_binary(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -181,7 +181,7 @@ cc_binary(
         ":message-stream-splitter",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -224,7 +224,7 @@ genrule(
 cc_library(
     name = "jcxxgen-testfile",
     hdrs = ["jcxxgen-testfile.h"],
-    deps = ["@jsonhpp//:json"],
+    deps = ["@jsonhpp//:singleheader/json"],
 )
 
 cc_test(
@@ -240,6 +240,6 @@ cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )

--- a/common/text/BUILD
+++ b/common/text/BUILD
@@ -36,7 +36,7 @@ cc_library(
     hdrs = ["token_info_json.h"],
     deps = [
         ":token-info",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -414,7 +414,7 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 

--- a/verilog/CST/BUILD
+++ b/verilog/CST/BUILD
@@ -899,7 +899,7 @@ cc_library(
         "//verilog/parser:verilog-token-classifications",
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -952,6 +952,6 @@ cc_test(
         "//verilog/analysis:verilog-analyzer",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )

--- a/verilog/analysis/BUILD
+++ b/verilog/analysis/BUILD
@@ -75,7 +75,7 @@ cc_library(
         "//common/analysis:file-analyzer",
         "//common/strings:line-column-map",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -132,7 +132,7 @@ cc_test(
         "//common/util:logging",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 

--- a/verilog/tools/ls/BUILD
+++ b/verilog/tools/ls/BUILD
@@ -106,7 +106,7 @@ cc_library(
         "//verilog/parser:verilog-token-enum",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -138,7 +138,7 @@ cc_library(
         "//verilog/CST:package",
         "//verilog/CST:seq-block",
         "//verilog/CST:verilog-nonterminals",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -239,7 +239,7 @@ cc_library(
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -260,7 +260,7 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 
@@ -312,6 +312,6 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )

--- a/verilog/tools/syntax/BUILD
+++ b/verilog/tools/syntax/BUILD
@@ -39,7 +39,7 @@ cc_binary(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:string_view",
-        "@jsonhpp//:json",
+        "@jsonhpp//:singleheader/json",
     ],
 )
 


### PR DESCRIPTION
Sketch how this can be done in a way that

  * We can make the same layout for projects supporting both, WORKSPACE and modules. In WORKSPACE, only the toplevel BUILD file can be provided to an external project. Thus we could not make a sub-package without an awkward patch.
  * Still is easy to read as the singleheader-name reflects what it is for, but `json` is also its own separate name.
  * Two simple targets: `:json` and` :singleheader/json`