### PR TITLE
If non-mmap: use stdio reading of files instead of std::stream

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -462,8 +462,8 @@ jobs:
       uses: actions/cache@v3
       with:
         path: "c:/users/runneradmin/_bazel_runneradmin"
-        key: bazelcache_windows2_${{ steps.cache_timestamp.outputs.time }}
-        restore-keys: bazelcache_windows2_
+        key: bazelcache_windows_${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: bazelcache_windows_
 
     - name: Install dependencies
       run: |

--- a/verilog/analysis/checkers/token_stream_lint_rule.cc
+++ b/verilog/analysis/checkers/token_stream_lint_rule.cc
@@ -75,7 +75,8 @@ void TokenStreamLintRule::HandleSymbol(const verible::Symbol &symbol,
                                        return p->Tag().tag == TK_StringLiteral;
                                      });
   const auto &string_literal = SymbolCastToLeaf(**literal);
-  if (absl::StrContains(string_literal.get().text(), "\\\n")) {
+  if (absl::StrContains(string_literal.get().text(), "\\\n") ||
+      absl::StrContains(string_literal.get().text(), "\\\r")) {
     violations_.insert(LintViolation(string_literal, kMessage, context));
   }
 }

--- a/verilog/analysis/checkers/token_stream_lint_rule_test.cc
+++ b/verilog/analysis/checkers/token_stream_lint_rule_test.cc
@@ -59,6 +59,12 @@ TEST(StringLiteralConcatenationTest, FunctionFailures) {
       {"module m;\n",
        "string tmp=",
        {kToken,
+        "\"Humpty Dumpty discovers CRLF \\\r\nHumpty Dumpty CRinged.\""},
+       ";",
+       "\nendmodule"},
+      {"module m;\n",
+       "string tmp=",
+       {kToken,
         "\"Humpty Dumpty sat on a wall. \\\n\\\nHumpty Dumpty had a great "
         "fall.\""},
        ";",

--- a/verilog/tools/obfuscator/verilog_obfuscate.cc
+++ b/verilog/tools/obfuscator/verilog_obfuscate.cc
@@ -25,6 +25,11 @@
 #include <sstream>  // IWYU pragma: keep  // for ostringstream
 #include <string>   // for string, allocator, etc
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 #include "absl/flags/flag.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -70,6 +75,12 @@ static constexpr absl::string_view kBuiltinFunctions[] = {
 };
 
 int main(int argc, char **argv) {
+#ifdef _WIN32
+  // stdio: Windows messes with newlines by default. Fix this here.
+  _setmode(_fileno(stdin), _O_BINARY);
+  _setmode(_fileno(stdout), _O_BINARY);
+#endif
+
   const auto usage = absl::StrCat("usage: ", argv[0],
                                   " [options] < original > output\n"
                                   R"(


### PR DESCRIPTION
std::fstream is much slower than the good ol' standard implementation. In addition, there are no risks of throwing exceptions.