### PR TITLE
Rename forbid-line-continuations rule file to match rule name

### DIFF
--- a/verilog/analysis/checkers/BUILD
+++ b/verilog/analysis/checkers/BUILD
@@ -31,6 +31,7 @@ cc_library(
         ":explicit-task-lifetime-rule",
         ":forbid-consecutive-null-statements-rule",
         ":forbid-defparam-rule",
+        ":forbid-line-continuations-rule",
         ":forbid-negative-array-dim",
         ":forbidden-anonymous-enums-rule",
         ":forbidden-anonymous-structs-unions-rule",
@@ -66,7 +67,6 @@ cc_library(
         ":struct-union-name-style-rule",
         ":suggest-parentheses-rule",
         ":suspicious-semicolon-rule",
-        ":token-stream-lint-rule",
         ":truncated-numeric-literal-rule",
         ":undersized-binary-literal-rule",
         ":unpacked-dimensions-rule",
@@ -1103,9 +1103,9 @@ cc_test(
 )
 
 cc_library(
-    name = "token-stream-lint-rule",
-    srcs = ["token_stream_lint_rule.cc"],
-    hdrs = ["token_stream_lint_rule.h"],
+    name = "forbid-line-continuations-rule",
+    srcs = ["forbid_line_continuations_rule.cc"],
+    hdrs = ["forbid_line_continuations_rule.h"],
     deps = [
         "//common/analysis:lint-rule-status",
         "//common/analysis:syntax-tree-lint-rule",
@@ -1125,10 +1125,10 @@ cc_library(
 )
 
 cc_test(
-    name = "token-stream-lint-rule_test",
-    srcs = ["token_stream_lint_rule_test.cc"],
+    name = "forbid-line-continuations-rule_test",
+    srcs = ["forbid_line_continuations_rule_test.cc"],
     deps = [
-        ":token-stream-lint-rule",
+        ":forbid-line-continuations-rule",
         "//common/analysis:linter-test-utils",
         "//common/analysis:syntax-tree-linter-test-utils",
         "//verilog/analysis:verilog-analyzer",

--- a/verilog/analysis/checkers/forbid_line_continuations_rule.cc
+++ b/verilog/analysis/checkers/forbid_line_continuations_rule.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "verilog/analysis/checkers/token_stream_lint_rule.h"
+#include "verilog/analysis/checkers/forbid_line_continuations_rule.h"
 
 #include <algorithm>
 #include <set>
@@ -38,14 +38,14 @@ using verible::LintViolation;
 using verible::SyntaxTreeContext;
 using verible::matcher::Matcher;
 
-// Register TokenStreamLintRule
-VERILOG_REGISTER_LINT_RULE(TokenStreamLintRule);
+// Register ForbidLineContinuationsRule
+VERILOG_REGISTER_LINT_RULE(ForbidLineContinuationsRule);
 
 static constexpr absl::string_view kMessage =
     "The lines can't be continued with \'\\\', use concatenation operator with "
     "braces";
 
-const LintRuleDescriptor &TokenStreamLintRule::GetDescriptor() {
+const LintRuleDescriptor &ForbidLineContinuationsRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "forbid-line-continuations",
       .topic = "forbid-line-continuations",
@@ -62,8 +62,8 @@ static const Matcher &StringLiteralMatcher() {
   return matcher;
 }
 
-void TokenStreamLintRule::HandleSymbol(const verible::Symbol &symbol,
-                                       const SyntaxTreeContext &context) {
+void ForbidLineContinuationsRule::HandleSymbol(
+    const verible::Symbol &symbol, const SyntaxTreeContext &context) {
   verible::matcher::BoundSymbolManager manager;
   if (!StringLiteralMatcher().Matches(symbol, &manager)) {
     return;
@@ -81,7 +81,7 @@ void TokenStreamLintRule::HandleSymbol(const verible::Symbol &symbol,
   }
 }
 
-LintRuleStatus TokenStreamLintRule::Report() const {
+LintRuleStatus ForbidLineContinuationsRule::Report() const {
   return LintRuleStatus(violations_, GetDescriptor());
 }
 

--- a/verilog/analysis/checkers/forbid_line_continuations_rule.h
+++ b/verilog/analysis/checkers/forbid_line_continuations_rule.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_TOKEN_STREAM_LINT_RULE_H_
-#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_TOKEN_STREAM_LINT_RULE_H_
+#ifndef VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_LINE_CONTINUATIONS_RULE_H_
+#define VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_LINE_CONTINUATIONS_RULE_H_
 
 #include <set>
 
@@ -26,8 +26,7 @@
 namespace verilog {
 namespace analysis {
 
-// TokenStreamLintRule finds occurrences of any string literal.
-class TokenStreamLintRule : public verible::SyntaxTreeLintRule {
+class ForbidLineContinuationsRule final : public verible::SyntaxTreeLintRule {
  public:
   using rule_type = verible::SyntaxTreeLintRule;
 
@@ -45,4 +44,4 @@ class TokenStreamLintRule : public verible::SyntaxTreeLintRule {
 }  // namespace analysis
 }  // namespace verilog
 
-#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_TOKEN_STREAM_LINT_RULE_H_
+#endif  // VERIBLE_VERILOG_ANALYSIS_CHECKERS_FORBID_LINE_CONTINUATIONS_RULE_H_

--- a/verilog/analysis/checkers/forbid_line_continuations_rule_test.cc
+++ b/verilog/analysis/checkers/forbid_line_continuations_rule_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "verilog/analysis/checkers/token_stream_lint_rule.h"
+#include "verilog/analysis/checkers/forbid_line_continuations_rule.h"
 
 #include <initializer_list>
 
@@ -43,7 +43,7 @@ TEST(StringLiteralConcatenationTest, FunctionPass) {
        "end\nendmodule"},
   };
 
-  RunLintTestCases<VerilogAnalyzer, TokenStreamLintRule>(
+  RunLintTestCases<VerilogAnalyzer, ForbidLineContinuationsRule>(
       kStringLiteralTestCases);
 }
 
@@ -83,7 +83,7 @@ TEST(StringLiteralConcatenationTest, FunctionFailures) {
        "end\nendmodule"},
   };
 
-  RunLintTestCases<VerilogAnalyzer, TokenStreamLintRule>(
+  RunLintTestCases<VerilogAnalyzer, ForbidLineContinuationsRule>(
       kStringLiteralTestCases);
 }
 


### PR DESCRIPTION
The old name was token_stream_lint_rule{.h,.cc,_test.cc} which sounds like an accidental use of a generic example name.

Renamed this now to match the actual rule it implements forbid_line_continuations_rule{.h,.cc,_test.cc}