### PR TITLE
Skip a test that will fail with ubsan in case that sanitizer is enabled.

### DIFF
--- a/verible/verilog/formatting/verilog-token_test.cc
+++ b/verible/verilog/formatting/verilog-token_test.cc
@@ -25,6 +25,8 @@ namespace {
 
 using FTT = FormatTokenType;
 
+// UBSAN check will notice, that 9999 is out of range; skip test in that case
+#ifndef UNDEFINED_BEHAVIOR_SANITIZER
 // Test that GetFormatTokenType() correctly converts a TokenInfo enum to FTT
 TEST(VerilogTokenTest, GetFormatTokenTypeTestUnknown) {
   const int FAKE_TOKEN = 9999;
@@ -32,6 +34,7 @@ TEST(VerilogTokenTest, GetFormatTokenTypeTestUnknown) {
   verible::PreFormatToken format_token(&token_info);
   EXPECT_EQ(FTT::unknown, GetFormatTokenType(verilog_tokentype(FAKE_TOKEN)));
 }
+#endif
 
 struct GetFormatTokenTypeTestCase {
   verilog_tokentype token_info_type;


### PR DESCRIPTION
UBSAN is good in knowing beforehand that tests some out-of-range mitigation, that the value in question is indeed out of range and will complain.