### PR TITLE
Always use included script for installing.

### DIFF
--- a/.github/bin/simple-install.sh
+++ b/.github/bin/simple-install.sh
@@ -15,11 +15,16 @@ fi
 TARGET_DIR=$1
 mkdir -p "${TARGET_DIR}"
 
-BASE_DIR=bazel-bin/verible/verilog/tools
+# Requires to have built before with
+#  bazel build :install-binaries
 
+# Could we get the list of source from bazel query somehow ?
+
+TOOLS_DIR=bazel-bin/verible/verilog/tools
 for f in diff/verible-verilog-diff \
            formatter/verible-verilog-format \
            kythe/verible-verilog-kythe-extractor \
+           kythe/verible-verilog-kythe-kzip-writer \
            lint/verible-verilog-lint \
            ls/verible-verilog-ls \
            obfuscator/verible-verilog-obfuscate \
@@ -27,5 +32,11 @@ for f in diff/verible-verilog-diff \
            project/verible-verilog-project \
            syntax/verible-verilog-syntax
 do
-  install "${BASE_DIR}/$f" "${TARGET_DIR}"
+  install "${TOOLS_DIR}/$f" "${TARGET_DIR}"
+done
+
+COMMON_TOOLS_DIR=bazel-bin/verible/common/tools
+for f in verible-patch-tool
+do
+  install "${COMMON_TOOLS_DIR}/$f" "${TARGET_DIR}"
 done

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -260,7 +260,10 @@ jobs:
 
     - name: Gather and pack binaries
       if: matrix.mode == 'compile' && matrix.arch == 'x86_64'
-      run: bazel run :install -c fastbuild -- $VERIBLE_BINDIR && tar cfv verible-bin.tar -C $VERIBLE_BINDIR .
+      run: |
+        bazel build -c fastbuild :install-binaries
+        .github/bin/simple-install.sh $VERIBLE_BINDIR
+        tar cfv verible-bin.tar -C $VERIBLE_BINDIR .
 
     - name: Upload bazel-bin
       if: matrix.mode == 'compile' && matrix.arch == 'x86_64'
@@ -385,9 +388,7 @@ jobs:
         .github/bin/run-clang-tidy-cached.cc --checks="-*"
 
   MacOsBuild:
-    # New MacOS has a broken patch utility:
-    # //verible/verilog/tools/lint:lint-tool_test trips over a no-newline-at-end-of-file
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
 
     - name: Install Dependencies
@@ -414,7 +415,9 @@ jobs:
         restore-keys: bazelcache_macos_
 
     - name: Tests
-      run: bazel test -c opt --noshow_progress --test_output=errors --cxxopt=-Wno-range-loop-analysis //...
+      # MacOS has a broken patch utility:
+      # //verible/verilog/tools/lint:lint-tool_test trips over a no-newline-at-end-of-file
+      run: bazel test -c opt --noshow_progress --test_output=errors --cxxopt=-Wno-range-loop-analysis -- //... -//verible/verilog/tools/lint:lint-tool_test
 
     - name: Build
       run: bazel build -c opt --noshow_progress --test_output=errors --cxxopt=-Wno-range-loop-analysis :install-binaries
@@ -486,7 +489,7 @@ jobs:
     - name: Prepare release
       run: |
         $VERSION = git describe --match=v*
-        C:/ProgramData/chocolatey/lib/bazel/bazel.exe run -c opt :install -- "c:/verible-${VERSION}-win64"
+        bash .github/bin/simple-install.sh "c:/verible-${VERSION}-win64"
         7z a "verible-${VERSION}-win64.zip" "c:/verible-${VERSION}-win64"
 
     - name: 📤 Upload artifact

--- a/BUILD
+++ b/BUILD
@@ -41,15 +41,9 @@ filegroup(
     name = "install-scripts",
     srcs = [
         "//verible/common/tools:verible-transform-interactive",
-        "//verible/verilog/tools/formatter:git-verilog-format",
+        "//verible/verilog/tools/formatter:git-verible-verilog-format",
         "//verible/verilog/tools/formatter:verible-verilog-format-changed-lines-interactive",
     ],
-)
-
-# Installing; see README.md
-alias(
-    name = "install",
-    actual = "//bazel:install",
 )
 
 genrule(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ use_repo(m4, "m4")
 register_toolchains("@m4//:toolchain")
 
 # Register bison rules and toolchain.
-bazel_dep(name = "rules_bison", version = "0.2.2")
+bazel_dep(name = "rules_bison", version = "0.3")
 
 bison = use_extension(
     "@rules_bison//bison/extensions:bison_repository_ext.bzl",

--- a/README.md
+++ b/README.md
@@ -238,12 +238,13 @@ For simple installation, we provide regular [binary releases].
 If you prefer to build and install the binaries locally yourself:
 
 ```bash
-# In your home directory
-bazel run -c opt :install -- ~/bin
+bazel build -c opt :install-binaries
 
-# For a system directory that requires root-access, call with -s option.
-# (Do _not_ run bazel with sudo.)
-bazel run -c opt :install -- -s /usr/local/bin
+# install In your home directory
+.github/bin/simple-install.sh ~/bin
+
+# For a system directory that requires root-access, call scfript with sudo.
+sudo .github/bin/simple-install.sh /usr/local/bin
 ```
 
 (this requies a compliant `install` utility, otherwise simply copy

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,27 +73,6 @@ http_archive(
 # External tools needed
 #
 
-# 'make install' equivalent rule 2023-02-21
-http_archive(
-    name = "com_github_google_rules_install",
-    # The installer uses an option -T that is not available on MacOS, but
-    # it is benign to leave out.
-    # Upstream bug https://github.com/google/bazel_rules_install/issues/31
-    patch_args = ["-p1"],
-    patches = ["//bazel:installer.patch"],
-    sha256 = "aba3c1ae179beb92c1fc4502d66d7d7c648f90eb51897aa4b0ae4a76ce225eec",
-    strip_prefix = "bazel_rules_install-6001facc1a96bafed0e414a529b11c1819f0cdbe",
-    urls = ["https://github.com/google/bazel_rules_install/archive/6001facc1a96bafed0e414a529b11c1819f0cdbe.zip"],
-)
-
-load("@com_github_google_rules_install//:deps.bzl", "install_rules_dependencies")
-
-install_rules_dependencies()
-
-load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
-
-install_rules_setup()
-
 http_archive(
     name = "rules_m4",
     sha256 = "10ce41f150ccfbfddc9d2394ee680eb984dc8a3dfea613afd013cfb22ea7445c",

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,32 +1,10 @@
 workspace(name = "com_google_verible")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 #
 # External tools needed
 #
-
-# 'make install' equivalent rule 2023-02-21
-http_archive(
-    name = "com_github_google_rules_install",
-    # The installer uses an option -T that is not available on MacOS, but
-    # it is benign to leave out.
-    # Upstream bug https://github.com/google/bazel_rules_install/issues/31
-    patch_args = ["-p1"],
-    patches = ["//bazel:installer.patch"],
-    sha256 = "aba3c1ae179beb92c1fc4502d66d7d7c648f90eb51897aa4b0ae4a76ce225eec",
-    strip_prefix = "bazel_rules_install-6001facc1a96bafed0e414a529b11c1819f0cdbe",
-    urls = ["https://github.com/google/bazel_rules_install/archive/6001facc1a96bafed0e414a529b11c1819f0cdbe.zip"],
-)
-
-load("@com_github_google_rules_install//:deps.bzl", "install_rules_dependencies")
-
-install_rules_dependencies()
-
-load("@com_github_google_rules_install//:setup.bzl", "install_rules_setup")
-
-install_rules_setup()
 
 # 2024-02-06
 http_archive(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -3,7 +3,6 @@ Rules for adding './configure && make' style dependencies.
 """
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@com_github_google_rules_install//installer:def.bzl", "installer")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -45,14 +44,4 @@ bool_flag(
 config_setting(
     name = "static_linked_executables",
     flag_values = {":create_static_linked_executables": "true"},
-)
-
-# This installer is here, so that the toplevel BUILD file does not have
-# to pull in the full rules_install to keep that light of dependencies.
-installer(
-    name = "install",
-    data = [
-        "//:install-binaries",
-        "//:install-scripts",
-    ],
 )

--- a/verible/verilog/tools/formatter/BUILD
+++ b/verible/verilog/tools/formatter/BUILD
@@ -37,7 +37,7 @@ cc_binary(
 #   //verible/verilog/tools/formatter:verible-verilog-format
 #   //verible/common/tools:verible-patch-tool
 filegroup(
-    name = "git-verilog-format",
+    name = "git-verible-verilog-format",
     srcs = ["git-verible-verilog-format.sh"],
     visibility = ["//:__pkg__"],  # for release
 )


### PR DESCRIPTION
The upstream installer bazel utility is not updated and is not working well on all operating systems. Let's simplify that by just using the script we already have.