### PR TITLE
Add a potential problems check to make sure no .bazelversion is used.

### DIFF
--- a/.github/bin/check-potential-problems.sh
+++ b/.github/bin/check-potential-problems.sh
@@ -99,4 +99,9 @@ if [ $? -eq 0 ]; then
   EXIT_CODE=1
 fi
 
+if [ -e .bazelversion ]; then
+  echo "Don't use .bazelversion. It is a poorly implemented bazel feature that does not support semantic versioning. Instead, make the repo work with all currently active bazel versions."
+  EXIT_CODE=1
+fi
+
 exit "${EXIT_CODE}"


### PR DESCRIPTION
.bazelversion is a very crude bazel feature that does not support semantic versioning, let alone version ranges. In combination with baselisk, it even attempts to download binaries from the 'net instead of using system-available versions.

Instead of pinning a bazel version, the repo should be kept in a state, that it works with all actively maintained bazel versions.