### PR TITLE
Only switch to absl::string_view implementation on Windows.

### DIFF
--- a/bazel/absl.patch
+++ b/bazel/absl.patch
@@ -1,12 +1,18 @@
-diff -uw -r a/absl/base/options.h b/absl/base/options.h
---- a/absl/base/options.h	2021-04-02 23:00:31.996584600 -0400
-+++ b/absl/base/options.h	2021-04-02 23:01:07.506208600 -0400
-@@ -154,7 +154,7 @@
+diff --git a/absl/base/options.h b/absl/base/options.h
+index 4b70446b..6a839d94 100644
+--- a/absl/base/options.h
++++ b/absl/base/options.h
+@@ -148,7 +148,13 @@
  // absl::string_view is a typedef of std::string_view, use the feature macro
  // ABSL_USES_STD_STRING_VIEW.
-
--#define ABSL_OPTION_USE_STD_STRING_VIEW 2
+ 
++#ifdef _WIN32
++// On Windows, the std::string_view iterator is not const char*, which
++// is the expectation in a lot of Verible code. Use absl-impl.
 +#define ABSL_OPTION_USE_STD_STRING_VIEW 0
-
++#else
+ #define ABSL_OPTION_USE_STD_STRING_VIEW 2
++#endif
+ 
  // ABSL_OPTION_USE_STD_VARIANT
  //


### PR DESCRIPTION
On gcc and clang-based systems, std::string_view has the iterator behave as expected by a lot of Verible code, being a const char*.

On windows c++ lib, the iterator is its own object, which does not decay to const char*, so in that case we need to use the absl:: implementation which behaves like that.

We used to always change to the absl type, but in reality, we only need to do that on Windows; adapt the abseil patch.

Longer term, we should remove the expectation of the iterator type, but that requires access to a Windows machine to locally go through a compile/fix loop.