### PR TITLE
Don't initialize empty string_views. Find places that were not prepared.

### DIFF
--- a/verible/common/analysis/file-analyzer.cc
+++ b/verible/common/analysis/file-analyzer.cc
@@ -143,7 +143,7 @@ void FileAnalyzer::ExtractLinterTokenErrorDetail(
     const RejectedToken &error_token,
     const ReportLinterErrorFunction &error_report) const {
   const LineColumnRange range = Data().GetRangeForToken(error_token.token_info);
-  absl::string_view context_line = "";
+  absl::string_view context_line;
   const auto &lines = Data().Lines();
   if (range.start.line < static_cast<int>(lines.size())) {
     context_line = lines[range.start.line];

--- a/verible/common/analysis/lint-rule-status.cc
+++ b/verible/common/analysis/lint-rule-status.cc
@@ -106,7 +106,7 @@ std::string LintStatusFormatter::FormatWithRelatedTokens(
     return std::string(message);
   }
   size_t beg_pos = 0;
-  size_t end_pos = message.find("@", beg_pos);
+  size_t end_pos = message.find('@', beg_pos);
   std::ostringstream s;
   for (const auto &token : tokens) {
     if (end_pos == absl::string_view::npos) {
@@ -122,7 +122,7 @@ std::string LintStatusFormatter::FormatWithRelatedTokens(
     }
 
     beg_pos = end_pos + 1;
-    end_pos = message.find("@", beg_pos);
+    end_pos = message.find('@', beg_pos);
   }
 
   return absl::StrReplaceAll(s.str(), {{"\\@", "@"}});

--- a/verible/common/formatting/format-token_test.cc
+++ b/verible/common/formatting/format-token_test.cc
@@ -218,9 +218,9 @@ class ConnectPreFormatTokensPreservedSpaceStartsTest
       public UnwrappedLineMemoryHandler {};
 
 TEST_F(ConnectPreFormatTokensPreservedSpaceStartsTest, Empty) {
-  constexpr absl::string_view text("");
+  const char *text = "";
   CreateTokenInfosExternalStringBuffer({});
-  ConnectPreFormatTokensPreservedSpaceStarts(text.begin(), &pre_format_tokens_);
+  ConnectPreFormatTokensPreservedSpaceStarts(text, &pre_format_tokens_);
   EXPECT_TRUE(pre_format_tokens_.empty());
 }
 

--- a/verible/common/strings/position_test.cc
+++ b/verible/common/strings/position_test.cc
@@ -21,7 +21,7 @@ namespace verible {
 namespace {
 
 TEST(AdvancingTextNewColumnPositionTest, EmptyString) {
-  const absl::string_view text("");
+  const absl::string_view text;
   EXPECT_EQ(AdvancingTextNewColumnPosition(0, text), 0);
   EXPECT_EQ(AdvancingTextNewColumnPosition(1, text), 1);
   EXPECT_EQ(AdvancingTextNewColumnPosition(8, text), 8);

--- a/verible/common/strings/range_test.cc
+++ b/verible/common/strings/range_test.cc
@@ -25,7 +25,7 @@ namespace verible {
 namespace {
 
 TEST(MakeStringViewRangeTest, Empty) {
-  absl::string_view text("");
+  absl::string_view text;
   auto copy_view = make_string_view_range(text.begin(), text.end());
   EXPECT_TRUE(BoundsEqual(copy_view, text));
 }
@@ -44,7 +44,13 @@ TEST(MakeStringViewRangeTest, BadRange) {
 using IntPair = std::pair<int, int>;
 
 TEST(ByteOffsetRangeTest, EmptyInEmpty) {
-  const absl::string_view superstring("");
+  const absl::string_view superstring("");  // NOLINT
+  const auto substring = superstring;
+  EXPECT_EQ(SubstringOffsets(substring, superstring), IntPair(0, 0));
+}
+
+TEST(ByteOffsetRangeTest, EmptyInNullptrEmpty) {
+  const absl::string_view superstring;  // default constructor init with nullptr
   const auto substring = superstring;
   EXPECT_EQ(SubstringOffsets(substring, superstring), IntPair(0, 0));
 }

--- a/verible/common/strings/split_test.cc
+++ b/verible/common/strings/split_test.cc
@@ -42,7 +42,7 @@ TEST(StringSpliteratorTest, CompileTimeAsFunction) {
 }
 
 TEST(StringSpliteratorTest, EmptyOriginal) {
-  constexpr absl::string_view empty("");
+  constexpr absl::string_view empty;
   StringSpliterator splitter(empty);
   EXPECT_TRUE(splitter);
   EXPECT_TRUE(BoundsEqual(splitter.Remainder(), empty));
@@ -137,7 +137,7 @@ static std::vector<IntPair> SplitLinesToOffsets(absl::string_view text) {
 }
 
 TEST(SplitLinesTest, Empty) {
-  constexpr absl::string_view text("");
+  constexpr absl::string_view text;
   const auto lines = SplitLines(text);
   EXPECT_TRUE(lines.empty());
 }
@@ -185,7 +185,7 @@ static std::vector<IntPair> SplitLinesKeepLineTerminatorToOffsets(
 }
 
 TEST(SplitLinesKeepLineTerminatorTest, Empty) {
-  constexpr absl::string_view text("");
+  constexpr absl::string_view text;
   const auto lines = SplitLinesKeepLineTerminator(text);
   EXPECT_TRUE(lines.empty());
 }

--- a/verible/common/text/token-info-test-util_test.cc
+++ b/verible/common/text/token-info-test-util_test.cc
@@ -175,7 +175,7 @@ TEST(TokenInfoTestDataTest, FindImportantTokensTest) {
 TEST(TokenInfoTestDataTest, RebaseToCodeCopyEmpty) {
   std::vector<TokenInfo> tokens;
   const TokenInfoTestData test_data{};
-  constexpr absl::string_view other_text("");
+  constexpr absl::string_view other_text;
   EXPECT_EQ(test_data.code, other_text);
   test_data.RebaseToCodeCopy(&tokens, other_text);
   EXPECT_TRUE(tokens.empty());

--- a/verible/common/text/tree-builder-test-util.cc
+++ b/verible/common/text/tree-builder-test-util.cc
@@ -24,7 +24,7 @@
 
 namespace verible {
 
-constexpr absl::string_view kDontCareText("");
+constexpr absl::string_view kDontCareText;
 
 SymbolPtr XLeaf(int token_enum) { return Leaf(token_enum, kDontCareText); }
 

--- a/verible/common/text/tree-compare_test.cc
+++ b/verible/common/text/tree-compare_test.cc
@@ -136,7 +136,7 @@ TEST(TreeEqualityTest, NonEmptyNodesEqualByEnumString) {
 }
 
 TEST(TreeEqualityTest, NonEmptyNodesNotEqualByEnum) {
-  constexpr absl::string_view foo("");
+  constexpr absl::string_view foo;
   SymbolPtr tree1 = Node(Leaf(1, foo), Leaf(2, foo));
   SymbolPtr tree2 = Node(Leaf(1, foo), Leaf(2, foo), Leaf(3, foo));
   SymbolPtr tree3 = Node(Leaf(3, foo), Leaf(1, foo), Leaf(2, foo));

--- a/verible/common/text/tree-utils_test.cc
+++ b/verible/common/text/tree-utils_test.cc
@@ -225,7 +225,7 @@ TEST(StringSpanOfSymbolTest, DeepEmptyTree) {
 }
 
 TEST(StringSpanOfSymbolTest, LeafOnlyEmptyText) {
-  constexpr absl::string_view text("");
+  constexpr absl::string_view text;
   SymbolPtr symbol = Leaf(1, text);
   const auto range = StringSpanOfSymbol(*symbol);
   EXPECT_TRUE(range.empty());
@@ -240,7 +240,7 @@ TEST(StringSpanOfSymbolTest, LeafOnlyNonemptyText) {
 }
 
 TEST(StringSpanOfSymbolTest, DeepLeafOnlyEmptyText) {
-  constexpr absl::string_view text("");
+  constexpr absl::string_view text;
   SymbolPtr symbol = Node(Node(Leaf(1, text)));
   const auto range = StringSpanOfSymbol(*symbol);
   EXPECT_TRUE(BoundsEqual(range, text));
@@ -1007,7 +1007,7 @@ TEST(MutateLeavesTest, NodeAndLeaves) {
 
 // Test that a leafless root node is not pruned.
 TEST(PruneSyntaxTreeAfterOffsetTest, LeaflessRootNode) {
-  constexpr absl::string_view text("");
+  constexpr absl::string_view text;
   SymbolPtr tree = Node();
   SymbolPtr expect = Node();  // distinct copy
   PruneSyntaxTreeAfterOffset(&tree, text.begin());
@@ -1168,7 +1168,7 @@ TEST(PruneSyntaxTreeAfterOffsetTest, DeleteAll) {
 
 // Test that root node without leaves is cleared because no locations match.
 TEST(TrimSyntaxTreeTest, RootNodeOnly) {
-  constexpr absl::string_view range("");
+  constexpr absl::string_view range;
   SymbolPtr tree = Node();
   TrimSyntaxTree(&tree, range);
   EXPECT_EQ(tree, nullptr);
@@ -1176,7 +1176,7 @@ TEST(TrimSyntaxTreeTest, RootNodeOnly) {
 
 // Test that tree without leaves is cleared because no locations match.
 TEST(TrimSyntaxTreeTest, TreeNoLeaves) {
-  constexpr absl::string_view range("");
+  constexpr absl::string_view range;
   SymbolPtr tree = Node(TNode(4), TNode(3, TNode(1), TNode(2)), TNode(0));
   TrimSyntaxTree(&tree, range);
   EXPECT_EQ(tree, nullptr);

--- a/verible/common/util/range_test.cc
+++ b/verible/common/util/range_test.cc
@@ -28,7 +28,7 @@ namespace {
 
 // Test that IsSubRange matches same empty string.
 TEST(IsSubRangeTest, SameEmptyString) {
-  const absl::string_view substring = "";
+  const absl::string_view substring;
   EXPECT_TRUE(IsSubRange(substring, substring));
 }
 
@@ -112,7 +112,7 @@ TEST(IsSubRangeTest, DerivedSubStringView) {
 
 // Test that BoundsEqual matches same empty string.
 TEST(BoundsEqualTest, SameEmptyString) {
-  const absl::string_view substring = "";
+  const absl::string_view substring;
   EXPECT_TRUE(BoundsEqual(substring, substring));
 }
 

--- a/verible/verilog/analysis/checkers/BUILD
+++ b/verible/verilog/analysis/checkers/BUILD
@@ -775,7 +775,6 @@ cc_library(
         "//verible/verilog/CST:verilog-matchers",
         "//verible/verilog/analysis:descriptions",
         "//verible/verilog/analysis:lint-rule-registry",
-        "@abseil-cpp//absl/strings:string_view",
     ],
     alwayslink = 1,
 )

--- a/verible/verilog/analysis/checkers/forbidden-symbol-rule.cc
+++ b/verible/verilog/analysis/checkers/forbidden-symbol-rule.cc
@@ -18,7 +18,6 @@
 #include <set>
 #include <string>
 
-#include "absl/strings/string_view.h"
 #include "verible/common/analysis/lint-rule-status.h"
 #include "verible/common/analysis/matcher/bound-symbol-manager.h"
 #include "verible/common/analysis/matcher/matcher.h"

--- a/verible/verilog/analysis/checkers/package-filename-rule.cc
+++ b/verible/verilog/analysis/checkers/package-filename-rule.cc
@@ -91,9 +91,9 @@ void PackageFilenameRule::Lint(const TextStructureView &text_structure,
       verible::file::Basename(verible::file::Stem(filename));
   std::vector<absl::string_view> basename_components =
       absl::StrSplit(basename, '.');
+  if (basename_components.empty() || basename_components[0].empty()) return;
   std::string unitname(basename_components[0].begin(),
                        basename_components[0].end());
-  if (unitname.empty()) return;
 
   if (allow_dash_for_underscore_) {
     // If we allow for dashes, let's first convert them back to underscore.

--- a/verible/verilog/analysis/checkers/parameter-name-style-rule.cc
+++ b/verible/verilog/analysis/checkers/parameter-name-style-rule.cc
@@ -53,8 +53,8 @@ static constexpr absl::string_view kUpperCamelCaseRegex =
 // ALL_CAPS
 static constexpr absl::string_view kAllCapsRegex = "[A-Z_0-9]+";
 
-static constexpr absl::string_view kLocalparamDefaultRegex = "";
-static constexpr absl::string_view kParameterDefaultRegex = "";
+static constexpr absl::string_view kLocalparamDefaultRegex;
+static constexpr absl::string_view kParameterDefaultRegex;
 
 ParameterNameStyleRule::ParameterNameStyleRule()
     : localparam_style_regex_(std::make_unique<re2::RE2>(

--- a/verible/verilog/analysis/symbol-table.h
+++ b/verible/verilog/analysis/symbol-table.h
@@ -241,7 +241,7 @@ struct DeclarationTypeInfo {
   const verible::Symbol *syntax_origin = nullptr;
 
   // holds optional string_view describing direction of the port
-  absl::string_view direction = "";
+  absl::string_view direction;
 
   // holds additional type specifications, used mostly in multiline definitions
   // of ports

--- a/verible/verilog/analysis/verilog-linter-configuration_test.cc
+++ b/verible/verilog/analysis/verilog-linter-configuration_test.cc
@@ -162,7 +162,7 @@ class FakeTextStructureView : public TextStructureView {
 static const verible::LineColumnMap dummy_map("");
 
 // Don't care about file name for these tests.
-static constexpr absl::string_view filename = "";
+static constexpr absl::string_view filename;
 
 TEST(ProjectPolicyTest, MatchesAnyPath) {
   struct TestCase {
@@ -645,7 +645,7 @@ TEST(RuleBundleTest, UnparseRuleBundleEmpty) {
 }
 
 TEST(RuleBundleTest, ParseRuleBundleEmpty) {
-  constexpr absl::string_view text = "";
+  constexpr absl::string_view text;
   RuleBundle bundle;
   std::string error;
   bool success = bundle.ParseConfiguration(text, ',', &error);

--- a/verible/verilog/analysis/verilog-project.cc
+++ b/verible/verilog/analysis/verilog-project.cc
@@ -213,7 +213,7 @@ std::string VerilogProject::GetRelativePathToSource(
 
 void VerilogProject::UpdateFileContents(
     absl::string_view path, const verilog::VerilogAnalyzer *parsed) {
-  constexpr absl::string_view kCorpus = "";
+  constexpr absl::string_view kCorpus;
   const std::string projectpath = GetRelativePathToSource(path);
 
   // If we get a non-null parsed file, use that, otherwise fall back to

--- a/verible/verilog/analysis/verilog-project_test.cc
+++ b/verible/verilog/analysis/verilog-project_test.cc
@@ -367,7 +367,7 @@ TEST(VerilogProjectTest, UpdateFileContentsEmptyFile) {
   EXPECT_EQ(project.LookupFileOrigin(search_substring), from_file);
 
   // Prepare an empty file
-  constexpr absl::string_view empty_file_content("");
+  constexpr absl::string_view empty_file_content;
   const ScopedTestFile empty_file(project_root_dir, empty_file_content);
   const absl::string_view empty_file_reference =
       Basename(empty_file.filename());

--- a/verible/verilog/formatting/tree-unwrapper_test.cc
+++ b/verible/verilog/formatting/tree-unwrapper_test.cc
@@ -274,7 +274,7 @@ class TreeUnwrapperTest : public ::testing::Test {
 // Test that TreeUnwrapper produces the correct UnwrappedLines from an empty
 // file
 TEST_F(TreeUnwrapperTest, UnwrapEmptyFile) {
-  const absl::string_view source_code = "";
+  const absl::string_view source_code;
 
   auto tree_unwrapper = CreateTreeUnwrapper(source_code);
   tree_unwrapper->Unwrap();

--- a/verible/verilog/tools/kythe/indexing-facts-tree-extractor_test.cc
+++ b/verible/verilog/tools/kythe/indexing-facts-tree-extractor_test.cc
@@ -251,7 +251,7 @@ TEST(FactsTreeExtractor, EqualOperatorTest) {
 }
 
 TEST(FactsTreeExtractor, EmptyCSTTest) {
-  constexpr absl::string_view code_text = "";
+  constexpr absl::string_view code_text;
 
   SimpleTestProject project(code_text);
 

--- a/verible/verilog/tools/kythe/kythe-facts.h
+++ b/verible/verilog/tools/kythe/kythe-facts.h
@@ -26,7 +26,7 @@ namespace verilog {
 namespace kythe {
 
 inline constexpr absl::string_view kDefaultKytheLanguage = "verilog";
-inline constexpr absl::string_view kEmptyKytheLanguage = "";
+inline constexpr absl::string_view kEmptyKytheLanguage;
 
 // Hash-based form of signature for fast and lightweight comparision.
 struct SignatureDigest {

--- a/verible/verilog/tools/ls/symbol-table-handler_test.cc
+++ b/verible/verilog/tools/ls/symbol-table-handler_test.cc
@@ -484,7 +484,7 @@ TEST(SymbolTableHandlerTest, UpdateWithUnparseableEditorContentRegression) {
       verible::file::JoinPath(tempdir, __FUNCTION__);
   ASSERT_TRUE(verible::file::CreateDir(sources_dir).ok());
 
-  absl::string_view filelist_content = "";
+  absl::string_view filelist_content;
   const verible::file::testing::ScopedTestFile filelist(
       sources_dir, filelist_content, "verible.filelist");
   const std::string uri = verible::lsp::PathToLSPUri(sources_dir + "/a.sv");


### PR DESCRIPTION
A string_view initialized with an empty string "" is different from a string_view that is empty initialized (it holds a nullptr). Make sure that all places that deal with string_views (from a testable perspective) also accept empty() with null string views.