### PR TITLE
Simplify MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,56 +9,16 @@ bazel_dep(name = "nlohmann_json", version = "3.11.3.bcr.1")
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
 
-# Register m4/flex/bison rules and toolchains
+# Parsing tools.
 bazel_dep(name = "rules_m4", version = "0.2.3")
-
-m4 = use_extension(
-    "@rules_m4//m4/extensions:m4_repository_ext.bzl",
-    "m4_repository_ext",
-)
-m4.repository(
-    name = "m4",
-    extra_copts = ["-O3"],
-    version = "1.4.18",
-)
-use_repo(m4, "m4")
-
-register_toolchains("@m4//:toolchain")
-
 bazel_dep(name = "rules_flex", version = "0.3")
-
-flex = use_extension(
-    "@rules_flex//flex/extensions:flex_repository_ext.bzl",
-    "flex_repository_ext",
-)
-flex.repository(
-    name = "flex",
-    extra_copts = ["-O3"],
-    version = "2.6.4",
-)
-use_repo(flex, "flex")
-
-register_toolchains("@flex//:toolchain")
-
 bazel_dep(name = "rules_bison", version = "0.3")
-
-bison = use_extension(
-    "@rules_bison//bison/extensions:bison_repository_ext.bzl",
-    "bison_repository_ext",
-)
-bison.repository(
-    name = "bison",
-    extra_copts = ["-O3"],
-    version = "3.3.2",
-)
-use_repo(bison, "bison")
-
-register_toolchains("@bison//:toolchain")
 
 # abseil-cpp and googletest can not be updated beyond the following currently,
 # as newer googletest is not compatible with bazel 6 anymore, and abseil-cpp
 # depends on it :( -- to support all active bazel's, we're stuck till EOL bazel6
-bazel_dep(name = "googletest", version = "1.14.0.bcr.1")
+bazel_dep(name = "googletest", version = "1.14.0.bcr.1", dev_dependency = True)
+
 bazel_dep(name = "abseil-cpp", version = "20240116.2")
 single_version_override(
     module_name = "abseil-cpp",


### PR DESCRIPTION
 * The m4/flex/bison rules don't need the toolchain stuff.
 * googletest: can be a dev_dependency