### PR TITLE
Don't complain about vlog layering check in newer abseil.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,7 @@ bazel_dep(name = "rules_bison", version = "0.3")
 # abseil-cpp and googletest can not be updated beyond the following currently,
 # as newer googletest is not compatible with bazel 6 anymore, and abseil-cpp
 # depends on it :( -- to support all active bazel's, we're stuck till EOL bazel6
+# See https://github.com/chipsalliance/verible/issues/2336
 bazel_dep(name = "googletest", version = "1.14.0.bcr.1", dev_dependency = True)
 
 bazel_dep(name = "abseil-cpp", version = "20240116.2")

--- a/verible/common/formatting/BUILD
+++ b/verible/common/formatting/BUILD
@@ -133,6 +133,9 @@ cc_library(
         "layout-optimizer-internal.h",
     ],
     hdrs = ["layout-optimizer.h"],
+    # Can only add @abseil-cpp//absl/log:vlog_is_on after > absl 20240116
+    # https://github.com/chipsalliance/verible/issues/2336
+    features = ["-layering_check"],
     deps = [
         ":basic-format-style",
         ":format-token",

--- a/verible/verilog/analysis/BUILD
+++ b/verible/verilog/analysis/BUILD
@@ -164,6 +164,9 @@ cc_library(
         "verilog-analyzer.h",
         "verilog-excerpt-parse.h",
     ],
+    # Can only add @abseil-cpp//absl/log:vlog_is_on after > absl 20240116
+    # https://github.com/chipsalliance/verible/issues/2336
+    features = ["-layering_check"],
     deps = [
         "//verible/common/analysis:file-analyzer",
         "//verible/common/lexer:token-stream-adapter",
@@ -241,6 +244,9 @@ cc_library(
     name = "verilog-linter",
     srcs = ["verilog-linter.cc"],
     hdrs = ["verilog-linter.h"],
+    # Can only add @abseil-cpp//absl/log:vlog_is_on after > absl 20240116
+    # https://github.com/chipsalliance/verible/issues/2336
+    features = ["-layering_check"],
     deps = [
         ":default-rules",
         ":lint-rule-registry",

--- a/verible/verilog/tools/ls/BUILD
+++ b/verible/verilog/tools/ls/BUILD
@@ -167,6 +167,9 @@ cc_library(
     name = "symbol-table-handler",
     srcs = ["symbol-table-handler.cc"],
     hdrs = ["symbol-table-handler.h"],
+    # Can only add @abseil-cpp//absl/log:vlog_is_on after > absl 20240116
+    # https://github.com/chipsalliance/verible/issues/2336
+    features = ["-layering_check"],
     deps = [
         ":lsp-conversion",
         ":lsp-parse-buffer",


### PR DESCRIPTION
Essentially, allow to compile with newer abseil-cpp even though we have to stay on an older version to honor older bazel versions.

Issues: https://github.com/chipsalliance/verible/issues/2336