### PR TITLE
build cleaner, compilation db making: simplify

### DIFF
--- a/.github/bin/make-compilation-db.sh
+++ b/.github/bin/make-compilation-db.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2021 The Verible Authors.
+# Copyright 2021-2025 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ fi
 BAZEL_OPTS="-c opt --noshow_progress"
 # Bazel-build all targets that generate files, so that they can be
 # seen in dependency analysis.
-${BAZEL} build ${BAZEL_OPTS} $(${BANT} list-targets | \
-  egrep "genrule|cc_proto_library|genlex|genyacc" | awk '{print $3}')
+${BAZEL} build ${BAZEL_OPTS} $(${BANT} list-targets \
+  | awk '/genrule|cc_proto_library|genlex|genyacc/ {print $3}')
 
 # Some selected targets to trigger all dependency fetches from MODULE.bazel
 # verilog-y-final to create a header, kzip creator to trigger build of any.pb.h
@@ -42,7 +42,7 @@ ${BAZEL} build ${BAZEL_OPTS} //verible/verilog/parser:verilog-y-final \
   //verible/verilog/tools/kythe:verible-verilog-kythe-kzip-writer \
   //verible/common/lsp:json-rpc-dispatcher_test
 
-# bant does not distinguish the includes per file yet, so instead of
+# bant does not distinguish the compile flags per file yet, so instead of
 # a compile_commands.json, we can just as well create a simpler
 # compile_flags.txt which is easier to digest for all kinds of tools anyway.
 ${BANT} compile-flags 2>/dev/null > compile_flags.txt

--- a/.github/bin/run-build-cleaner.sh
+++ b/.github/bin/run-build-cleaner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2024 The Verible Authors.
+# Copyright 2024-2025 The Verible Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,15 +23,19 @@ BANT=${BANT:-needs-to-be-compiled-locally}
 if [ "${BANT}" = "needs-to-be-compiled-locally" ]; then
   # Bant not given, compile from bzlmod dep.
   ${BAZEL} build -c opt --cxxopt=-std=c++20 @bant//bant:bant >/dev/null 2>&1
-  BANT=$(realpath bazel-bin/external/bant*/bant/bant)
+  BANT=$(realpath bazel-bin/external/bant*/bant/bant | head -1)
 fi
 
 DWYU_OUT="${TMPDIR:-/tmp}/dwyu.out"
 
 if "${BANT}" -q dwyu ... ; then
-  echo "Dependencies ok"
+  echo "Dependencies ok." >&2
 else
-  echo
-  echo "^ Please run buildozer commands to fix the dependencies and amend PR"
+  cat >&2 <<EOF
+
+Build dependency issues found, the following one-liner will fix it. Amend PR.
+
+source <(.github/bin/run-build-cleaner.sh)
+EOF
   exit 1
 fi

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,4 +32,4 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2")
 
 # To build compilation DB and run build-cleaning
-bazel_dep(name = "bant", version = "0.1.11", dev_dependency = True)
+bazel_dep(name = "bant", version = "0.1.13", dev_dependency = True)


### PR DESCRIPTION
Both of these use http://bant.build/ - simplify the scripts around it.
 * make compilation db: reduce need for command line tools; no egrep needed anymore.
 * build cleaner: output info messaging to stderr, so that output can be sourced directly.