### PR TITLE
Be a bit more explicit with internal and external linkage.

### DIFF
--- a/verible/common/analysis/matcher/inner-match-handlers.cc
+++ b/verible/common/analysis/matcher/inner-match-handlers.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "verible/common/analysis/matcher/inner-match-handlers.h"
+
 #include <vector>
 
 #include "verible/common/analysis/matcher/bound-symbol-manager.h"

--- a/verible/common/formatting/align.cc
+++ b/verible/common/formatting/align.cc
@@ -132,7 +132,8 @@ struct AlignmentCell {
 using AlignmentRow = VectorTree<AlignmentCell>;
 using AlignmentMatrix = std::vector<AlignmentRow>;
 
-std::ostream &operator<<(std::ostream &stream, const AlignmentCell &cell) {
+static std::ostream &operator<<(std::ostream &stream,
+                                const AlignmentCell &cell) {
   if (!cell.tokens.empty()) {
     // See UnwrappedLine::AsCode for similar printing.
     stream << absl::StrJoin(cell.tokens, " ",
@@ -480,8 +481,8 @@ static std::pair<std::string, char> GetColumnDataCellLabel(
   return {label.str(), node.Value().properties.flush_left ? '<' : '>'};
 }
 
-std::ostream &operator<<(std::ostream &stream,
-                         const VectorTree<AggregateColumnData> &tree) {
+static std::ostream &operator<<(std::ostream &stream,
+                                const VectorTree<AggregateColumnData> &tree) {
   ColumnsTreeFormatter<AggregateColumnData>(
       stream, tree, GetColumnDataCellLabel<AggregateColumnData>);
   return stream;
@@ -493,8 +494,8 @@ std::ostream &operator<<(std::ostream &stream, const ColumnPositionTree &tree) {
   return stream;
 }
 
-std::ostream &operator<<(std::ostream &stream,
-                         const VectorTree<AlignmentCell> &tree) {
+static std::ostream &operator<<(std::ostream &stream,
+                                const VectorTree<AlignmentCell> &tree) {
   ColumnsTreeFormatter<AlignmentCell>(
       stream, tree,
       [](const VectorTree<AlignmentCell> &node)
@@ -515,8 +516,8 @@ std::ostream &operator<<(std::ostream &stream,
   return stream;
 }
 
-std::ostream &operator<<(std::ostream &stream,
-                         const VectorTree<AlignedColumnConfiguration> &tree) {
+static std::ostream &operator<<(
+    std::ostream &stream, const VectorTree<AlignedColumnConfiguration> &tree) {
   ColumnsTreeFormatter<AlignedColumnConfiguration>(
       stream, tree, [](const VectorTree<AlignedColumnConfiguration> &node) {
         const auto &cell = node.Value();

--- a/verible/common/lsp/dummy-ls.cc
+++ b/verible/common/lsp/dummy-ls.cc
@@ -44,7 +44,7 @@ using verible::lsp::JsonRpcDispatcher;
 using verible::lsp::MessageStreamSplitter;
 
 // The "initialize" method requests server capabilities.
-InitializeResult InitializeServer(const nlohmann::json &params) {
+static InitializeResult InitializeServer(const nlohmann::json &params) {
   // Ignore passed client capabilities from params right now,
   // just announce what we do.
   InitializeResult result;

--- a/verible/common/lsp/jcxxgen.cc
+++ b/verible/common/lsp/jcxxgen.cc
@@ -37,6 +37,7 @@ ABSL_FLAG(std::string, json_header, "\"nlohmann/json.hpp\"",
           "Include path to json.hpp including brackets <> or quotes \"\" "
           "around.");
 
+namespace {
 // Interface. Currently private, but could be moved to a header if needed.
 struct Location {
   const char *filename;
@@ -89,13 +90,11 @@ struct ObjectType {
 
 using ObjectTypeVector = std::vector<ObjectType *>;
 
-static bool contains(const std::string &s, char c) {
-  return absl::StrContains(s, c);
-}
+bool contains(const std::string &s, char c) { return absl::StrContains(s, c); }
 
 // Returns if successful.
-static bool ParseObjectTypesFromFile(const std::string &filename,
-                                     ObjectTypeVector *parsed_out) {
+bool ParseObjectTypesFromFile(const std::string &filename,
+                              ObjectTypeVector *parsed_out) {
   static const RE2 emptyline_or_comment_re("^[ \t]*(#.*)?");
   static const RE2 toplevel_object_re("^([a-zA-Z0-9_]+):");
 
@@ -150,7 +149,7 @@ static bool ParseObjectTypesFromFile(const std::string &filename,
 }
 
 // Validate types and return if successful.
-static bool ValidateTypes(ObjectTypeVector *object_types) {
+bool ValidateTypes(ObjectTypeVector *object_types) {
   absl::flat_hash_map<std::string, ObjectType *> typeByName;
 
   for (auto &obj : *object_types) {
@@ -357,6 +356,7 @@ void GenerateCode(const std::string &filename,
     fprintf(out, "}  // %s\n", gen_namespace.c_str());
   }
 }
+}  // namespace
 
 int main(int argc, char *argv[]) {
   const auto usage =
@@ -386,4 +386,5 @@ int main(int argc, char *argv[]) {
 
   GenerateCode(schema_filename, absl::GetFlag(FLAGS_json_header),
                absl::GetFlag(FLAGS_class_namespace), *objects, out);
+  fclose(out);
 }

--- a/verible/common/lsp/lsp-file-utils_test.cc
+++ b/verible/common/lsp/lsp-file-utils_test.cc
@@ -23,7 +23,7 @@
 namespace verible {
 namespace lsp {
 
-std::string PathPrefix(const std::string &path) {
+static std::string PathPrefix(const std::string &path) {
 #ifdef _WIN32
   return absl::StrCat("y:/", path);
 #else
@@ -31,7 +31,7 @@ std::string PathPrefix(const std::string &path) {
 #endif
 }
 
-std::string URIPrefix(const std::string &path) {
+static std::string URIPrefix(const std::string &path) {
 #ifdef _WIN32
   return absl::StrCat("file:///y%3a/", path);
 #else

--- a/verible/common/strings/diff_test.cc
+++ b/verible/common/strings/diff_test.cc
@@ -18,7 +18,6 @@
 #include <initializer_list>
 #include <ostream>
 #include <sstream>
-#include <string>
 #include <string_view>
 #include <vector>
 
@@ -29,7 +28,7 @@
 
 namespace diff {
 // Print functions copied from external_libs/editscript_test.cc
-std::ostream &operator<<(std::ostream &out, Operation operation) {
+static std::ostream &operator<<(std::ostream &out, Operation operation) {
   switch (operation) {
     case Operation::EQUALS:
       return (out << "EQUALS");
@@ -41,19 +40,8 @@ std::ostream &operator<<(std::ostream &out, Operation operation) {
   return out;
 }
 
-std::ostream &operator<<(std::ostream &out, const diff::Edit &edit) {
+static std::ostream &operator<<(std::ostream &out, const diff::Edit &edit) {
   out << "{" << edit.operation << ",[" << edit.start << "," << edit.end << ")}";
-  return out;
-}
-
-std::ostream &operator<<(std::ostream &out, const Edits &edits) {
-  out << "Edits{";
-  std::string outer_delim;
-  for (auto &edit : edits) {
-    out << outer_delim << edit;
-    outer_delim = ",";
-  }
-  out << "};";
   return out;
 }
 

--- a/verible/common/text/text-structure.cc
+++ b/verible/common/text/text-structure.cc
@@ -78,7 +78,7 @@ static bool TokenLocationLess(const TokenInfo &token,
 
 // Makes an iterator-writable copy of items_view without using const_cast.
 template <class V>
-std::vector<typename V::iterator> CopyWriteableIterators(
+static std::vector<typename V::iterator> CopyWriteableIterators(
     V &items, const std::vector<typename V::const_iterator> &items_view) {
   // precondition: items_view's iterators all point into items array.
   // postcondition: results's iterators point to the same items as items_view.

--- a/verible/common/text/text-structure_test.cc
+++ b/verible/common/text/text-structure_test.cc
@@ -72,7 +72,7 @@ TEST(FilterTokensTest, EmptyTokens) {
 }
 
 // Create a one-token token stream and syntax tree.
-void OneTokenTextStructureView(TextStructureView *view) {
+static void OneTokenTextStructureView(TextStructureView *view) {
   TokenInfo token(1, view->Contents());
   view->MutableTokenStream().push_back(token);
   view->MutableTokenStreamView().push_back(view->TokenStream().begin());
@@ -80,7 +80,7 @@ void OneTokenTextStructureView(TextStructureView *view) {
 }
 
 // Create a two-token token stream, no syntax tree.
-void MultiTokenTextStructureViewNoTree(TextStructureView *view) {
+static void MultiTokenTextStructureViewNoTree(TextStructureView *view) {
   const auto contents = view->Contents();
   CHECK_GE(contents.length(), 5);
   auto &stream = view->MutableTokenStream();
@@ -467,7 +467,7 @@ TEST_F(TextStructureViewPublicTest, ExpandSubtreesEmpty) {
 }
 
 // Splits a single token into a syntax tree node with two leaves.
-void FakeParseToken(TextStructureView *data, int offset, int node_tag) {
+static void FakeParseToken(TextStructureView *data, int offset, int node_tag) {
   TokenSequence &tokens = data->MutableTokenStream();
   tokens.push_back(TokenInfo(11, data->Contents().substr(0, offset)));
   tokens.push_back(TokenInfo(12, data->Contents().substr(offset)));

--- a/verible/verilog/CST/module.cc
+++ b/verible/verilog/CST/module.cc
@@ -51,7 +51,7 @@ std::vector<verible::TreeSearchMatch> FindAllProgramDeclarations(
   return SearchSyntaxTree(root, NodekProgramDeclaration());
 }
 
-bool IsModuleOrInterfaceOrProgramDeclaration(
+static bool IsModuleOrInterfaceOrProgramDeclaration(
     const SyntaxTreeNode &declaration) {
   return declaration.MatchesTagAnyOf({NodeEnum::kModuleDeclaration,
                                       NodeEnum::kInterfaceDeclaration,

--- a/verible/verilog/CST/statement.cc
+++ b/verible/verilog/CST/statement.cc
@@ -129,7 +129,7 @@ const SyntaxTreeNode *GetAssertionStatementAssertClause(
                           NodeEnum::kAssertionClause);
 }
 
-const SyntaxTreeNode *GetAssertionClauseStatementBody(
+static const SyntaxTreeNode *GetAssertionClauseStatementBody(
     const Symbol &assertion_clause) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assertion_clause), NodeEnum::kAssertionClause));
@@ -154,7 +154,7 @@ const SyntaxTreeNode *GetAssumeStatementAssumeClause(
                           NodeEnum::kAssumeClause);
 }
 
-const SyntaxTreeNode *GetAssumeClauseStatementBody(
+static const SyntaxTreeNode *GetAssumeClauseStatementBody(
     const Symbol &assume_clause) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assume_clause), NodeEnum::kAssumeClause));
@@ -197,7 +197,7 @@ const SyntaxTreeNode *GetAssertPropertyStatementAssertClause(
                           NodeEnum::kAssertPropertyClause);
 }
 
-const SyntaxTreeNode *GetAssertPropertyStatementBody(
+static const SyntaxTreeNode *GetAssertPropertyStatementBody(
     const Symbol &assert_clause) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assert_clause), NodeEnum::kAssertPropertyClause));
@@ -225,7 +225,7 @@ const SyntaxTreeNode *GetAssumePropertyStatementAssumeClause(
                           NodeEnum::kAssumePropertyClause);
 }
 
-const SyntaxTreeNode *GetAssumePropertyStatementBody(
+static const SyntaxTreeNode *GetAssumePropertyStatementBody(
     const Symbol &assume_clause) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(assume_clause), NodeEnum::kAssumePropertyClause));
@@ -253,7 +253,7 @@ const SyntaxTreeNode *GetExpectPropertyStatementExpectClause(
                           NodeEnum::kExpectPropertyClause);
 }
 
-const SyntaxTreeNode *GetExpectPropertyStatementBody(
+static const SyntaxTreeNode *GetExpectPropertyStatementBody(
     const Symbol &expect_clause) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(expect_clause), NodeEnum::kExpectPropertyClause));
@@ -274,7 +274,7 @@ const SyntaxTreeNode *GetExpectPropertyStatementElseClause(
                              NodeEnum::kElseClause);
 }
 
-const SyntaxTreeNode *GetCoverPropertyStatementBody(
+static const SyntaxTreeNode *GetCoverPropertyStatementBody(
     const Symbol &cover_property) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(cover_property), NodeEnum::kCoverPropertyStatement));
@@ -283,7 +283,7 @@ const SyntaxTreeNode *GetCoverPropertyStatementBody(
       GetSubtreeAsSymbol(*body_node, NodeEnum::kCoverPropertyBody, 0));
 }
 
-const SyntaxTreeNode *GetCoverSequenceStatementBody(
+static const SyntaxTreeNode *GetCoverSequenceStatementBody(
     const Symbol &cover_sequence) {
   const auto *body_node = GetGenericStatementBody(MatchNodeEnumOrNull(
       SymbolCastToNode(cover_sequence), NodeEnum::kCoverSequenceStatement));

--- a/verible/verilog/CST/type.cc
+++ b/verible/verilog/CST/type.cc
@@ -350,7 +350,7 @@ const verible::SyntaxTreeLeaf *GetSymbolIdentifierFromEnumName(
   return verible::GetSubtreeAsLeaf(enum_name, NodeEnum::kEnumName, 0);
 }
 
-const verible::SyntaxTreeLeaf *GetTypeIdentifierFromInterfaceType(
+static const verible::SyntaxTreeLeaf *GetTypeIdentifierFromInterfaceType(
     const verible::Symbol &interface_type) {
   return verible::GetSubtreeAsLeaf(interface_type, NodeEnum::kInterfaceType, 2);
 }

--- a/verible/verilog/analysis/verilog-linter-configuration.cc
+++ b/verible/verilog/analysis/verilog-linter-configuration.cc
@@ -412,7 +412,7 @@ static const verible::EnumNameMap<RuleSet> &RuleSetEnumStringMap() {
   return kRuleSetEnumStringMap;
 }
 
-std::ostream &operator<<(std::ostream &stream, RuleSet rules) {
+static std::ostream &operator<<(std::ostream &stream, RuleSet rules) {
   return RuleSetEnumStringMap().Unparse(rules, stream);
 }
 

--- a/verible/verilog/formatting/align.cc
+++ b/verible/verilog/formatting/align.cc
@@ -234,7 +234,7 @@ class VerilogColumnSchemaScanner : public ColumnSchemaScanner {
 };
 
 template <class ScannerType>
-std::function<verible::AlignmentCellScannerFunction(const FormatStyle &)>
+static std::function<verible::AlignmentCellScannerFunction(const FormatStyle &)>
 UnstyledAlignmentCellScannerGenerator() {
   return [](const FormatStyle &vstyle) {
     return AlignmentCellScannerGenerator<ScannerType>(
@@ -243,9 +243,10 @@ UnstyledAlignmentCellScannerGenerator() {
 }
 
 template <class ScannerType>
-std::function<verible::AlignmentCellScannerFunction(const FormatStyle &)>
-UnstyledAlignmentCellScannerGenerator(
-    const verible::NonTreeTokensScannerFunction &non_tree_column_scanner) {
+std::function<verible::AlignmentCellScannerFunction(
+    const FormatStyle
+        &)> static UnstyledAlignmentCellScannerGenerator(const verible::NonTreeTokensScannerFunction
+                                                             &non_tree_column_scanner) {
   return [non_tree_column_scanner](const FormatStyle &vstyle) {
     return AlignmentCellScannerGenerator<ScannerType>(
         [vstyle] { return ScannerType(vstyle); }, non_tree_column_scanner);
@@ -1292,8 +1293,8 @@ struct AlignmentGroupHandlers {
 // Returns the referenced member by value.
 // TODO(fangism): move this to an STL-style util/functional library
 template <typename MemberType, typename StructType>
-std::function<MemberType(const StructType &)> function_from_pointer_to_member(
-    MemberType StructType::*member) {
+static std::function<MemberType(const StructType &)>
+function_from_pointer_to_member(MemberType StructType::*member) {
   return [member](const StructType &obj) { return obj.*member; };
 }
 

--- a/verible/verilog/formatting/formatter.cc
+++ b/verible/verilog/formatting/formatter.cc
@@ -115,9 +115,10 @@ class Formatter {
 };
 
 // TODO(b/148482625): make this public/re-usable for general content comparison.
-Status VerifyFormatting(const verible::TextStructureView &text_structure,
-                        std::string_view formatted_output,
-                        std::string_view filename) {
+// Not declared in any header, but also used in formatter_test
+extern Status VerifyFormatting(const verible::TextStructureView &text_structure,
+                               std::string_view formatted_output,
+                               std::string_view filename) {
   // Verify that the formatted output creates the same lexical
   // stream (filtered) as the original.  If any tokens were lost, fall back to
   // printing the original source unformatted.

--- a/verible/verilog/formatting/formatter_test.cc
+++ b/verible/verilog/formatting/formatter_test.cc
@@ -53,9 +53,9 @@ namespace verilog {
 namespace formatter {
 
 // private, extern function in formatter.cc, directly tested here.
-absl::Status VerifyFormatting(const verible::TextStructureView &text_structure,
-                              std::string_view formatted_output,
-                              std::string_view filename);
+extern absl::Status VerifyFormatting(
+    const verible::TextStructureView &text_structure,
+    std::string_view formatted_output, std::string_view filename);
 
 namespace {
 

--- a/verible/verilog/formatting/token-annotator.cc
+++ b/verible/verilog/formatting/token-annotator.cc
@@ -922,11 +922,11 @@ static WithReason<SpacingOptions> BreakDecisionBetween(
 // Extern linkage for sake of direct testing, though not exposed in public
 // headers.
 // TODO(fangism): could move this to a -internal.h header.
-void AnnotateFormatToken(const FormatStyle &style,
-                         const PreFormatToken &prev_token,
-                         PreFormatToken *curr_token,
-                         const SyntaxTreeContext &prev_context,
-                         const SyntaxTreeContext &curr_context) {
+extern void AnnotateFormatToken(const FormatStyle &style,
+                                const PreFormatToken &prev_token,
+                                PreFormatToken *curr_token,
+                                const SyntaxTreeContext &prev_context,
+                                const SyntaxTreeContext &curr_context) {
   const auto p = SpacesRequiredBetween(style, prev_token, *curr_token,
                                        prev_context, curr_context);
   curr_token->before.spaces_required = p.spaces_required;

--- a/verible/verilog/formatting/tree-unwrapper.cc
+++ b/verible/verilog/formatting/tree-unwrapper.cc
@@ -174,7 +174,7 @@ TokenScannerStateStrings() {
 }
 
 // Conventional stream printer (declared in header providing enum).
-std::ostream &operator<<(std::ostream &stream, TokenScannerState p) {
+static std::ostream &operator<<(std::ostream &stream, TokenScannerState p) {
   return TokenScannerStateStrings().Unparse(p, stream);
 }
 
@@ -638,12 +638,12 @@ static const verible::EnumNameMap<ContextHint> &ContextHintStrings() {
   return kContextHintStringMap;
 }
 
-std::ostream &operator<<(std::ostream &stream, ContextHint p) {
+static std::ostream &operator<<(std::ostream &stream, ContextHint p) {
   return ContextHintStrings().Unparse(p, stream);
 }
 
-std::ostream &operator<<(std::ostream &stream,
-                         const std::vector<ContextHint> &f) {
+static std::ostream &operator<<(std::ostream &stream,
+                                const std::vector<ContextHint> &f) {
   return stream << verible::SequenceFormatter(f);
 }
 
@@ -1623,7 +1623,8 @@ static void AttachSeparatorToPreviousOrNextPartition(
   partition->Value().SetOrigin(nullptr);
 }
 
-void AttachSeparatorsToListElementPartitions(TokenPartitionTree *partition) {
+static void AttachSeparatorsToListElementPartitions(
+    TokenPartitionTree *partition) {
   CHECK_NOTNULL(partition);
   // Skip the first partition, it can't contain just a separator.
   for (int i = 1; i < static_cast<int>(partition->Children().size()); ++i) {

--- a/verible/verilog/tools/diff/verilog-diff.cc
+++ b/verible/verilog/tools/diff/verilog-diff.cc
@@ -52,15 +52,16 @@ static const verible::EnumNameMap<DiffMode> &DiffModeStringMap() {
   return kDiffModeStringMap;
 }
 
-std::ostream &operator<<(std::ostream &stream, DiffMode p) {
+static std::ostream &operator<<(std::ostream &stream, DiffMode p) {
   return DiffModeStringMap().Unparse(p, stream);
 }
 
-bool AbslParseFlag(std::string_view text, DiffMode *mode, std::string *error) {
+static bool AbslParseFlag(std::string_view text, DiffMode *mode,
+                          std::string *error) {
   return DiffModeStringMap().Parse(text, mode, error, "--mode value");
 }
 
-std::string AbslUnparseFlag(const DiffMode &mode) {
+static std::string AbslUnparseFlag(const DiffMode &mode) {
   std::ostringstream stream;
   stream << mode;
   return stream.str();

--- a/verible/verilog/tools/formatter/verilog-format.cc
+++ b/verible/verilog/tools/formatter/verilog-format.cc
@@ -60,8 +60,8 @@ struct LineRanges {
 
 LineRanges::storage_type LineRanges::values;  // global initializer
 
-bool AbslParseFlag(std::string_view flag_arg, LineRanges * /* unused */,
-                   std::string *error) {
+static bool AbslParseFlag(std::string_view flag_arg, LineRanges * /* unused */,
+                          std::string *error) {
   auto &values = LineRanges::values;
   // Pre-split strings, so that "--flag v1,v2" and "--flag v1 --flag v2" are
   // equivalent.
@@ -75,7 +75,7 @@ bool AbslParseFlag(std::string_view flag_arg, LineRanges * /* unused */,
   return true;
 }
 
-std::string AbslUnparseFlag(LineRanges /* unused */) {
+static std::string AbslUnparseFlag(LineRanges /* unused */) {
   const auto &values = LineRanges::values;
   return absl::StrJoin(values.begin(), values.end(), ",",
                        absl::StreamFormatter());

--- a/verible/verilog/tools/kythe/indexing-facts-tree-extractor.cc
+++ b/verible/verilog/tools/kythe/indexing-facts-tree-extractor.cc
@@ -1039,8 +1039,8 @@ void IndexingFactsTreeExtractor::ExtractMacroDefinition(
   facts_tree_context_.top().Children().push_back(std::move(macro_node));
 }
 
-Anchor GetMacroAnchorFromTokenInfo(const TokenInfo &macro_token_info,
-                                   std::string_view file_content) {
+static Anchor GetMacroAnchorFromTokenInfo(const TokenInfo &macro_token_info,
+                                          std::string_view file_content) {
   // Strip the prefix "`".
   // e.g.
   // `define TEN 0
@@ -1788,7 +1788,7 @@ void IndexingFactsTreeExtractor::ExtractForInitialization(
 
 // Returns string_view of `text` with outermost double-quotes removed.
 // If `text` is not wrapped in quotes, return it as-is.
-std::string_view StripOuterQuotes(std::string_view text) {
+static std::string_view StripOuterQuotes(std::string_view text) {
   return absl::StripSuffix(absl::StripPrefix(text, "\""), "\"");
 }
 

--- a/verible/verilog/tools/lint/verilog-lint.cc
+++ b/verible/verilog/tools/lint/verilog-lint.cc
@@ -61,18 +61,18 @@ static const verible::EnumNameMap<AutofixMode> &AutofixModeEnumStringMap() {
   return kAutofixModeEnumStringMap;
 }
 
-std::ostream &operator<<(std::ostream &stream, AutofixMode mode) {
+static std::ostream &operator<<(std::ostream &stream, AutofixMode mode) {
   return AutofixModeEnumStringMap().Unparse(mode, stream);
 }
 
-std::string AbslUnparseFlag(const AutofixMode &mode) {
+static std::string AbslUnparseFlag(const AutofixMode &mode) {
   std::ostringstream stream;
   AutofixModeEnumStringMap().Unparse(mode, stream);
   return stream.str();
 }
 
-bool AbslParseFlag(std::string_view text, AutofixMode *mode,
-                   std::string *error) {
+static bool AbslParseFlag(std::string_view text, AutofixMode *mode,
+                          std::string *error) {
   return AutofixModeEnumStringMap().Parse(text, mode, error, "--autofix value");
 }
 

--- a/verible/verilog/tools/ls/symbol-table-handler.cc
+++ b/verible/verilog/tools/ls/symbol-table-handler.cc
@@ -229,7 +229,7 @@ bool SymbolTableHandler::LoadProjectFileList(std::string_view current_dir) {
   return true;
 }
 
-const SymbolTableNode *ScanSymbolTreeForDefinitionReferenceComponents(
+static const SymbolTableNode *ScanSymbolTreeForDefinitionReferenceComponents(
     const ReferenceComponentNode *ref, std::string_view symbol) {
   if (verible::IsSubRange(symbol, ref->Value().identifier)) {
     return ref->Value().resolved_symbol;


### PR DESCRIPTION
There are a bunch of functions only really used locally, so make them explicitly static (or put in anonymous namespace). Functiont that are not in header files but are used externally (typically in their corresponding tests): mark explicitly extern.

(Hat-tip to new clang-tidy check `[misc-use-internal-linkage]`)