### PR TITLE
Get ready for clang-tidy 20

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -38,15 +38,15 @@ verible_used_stdenv.mkDerivation {
       lcov              # coverage html generation.
       bazel-buildtools  # buildifier
 
-      clang-tools_18    # for clang-tidy
-      clang-tools_17    # for clang-format
+      llvmPackages_19.clang-tools    # for clang-tidy
+      llvmPackages_17.clang-tools    # for clang-format
     ];
   shellHook = ''
       # clang tidy: use latest.
-      export CLANG_TIDY=${pkgs.clang-tools_18}/bin/clang-tidy
+      export CLANG_TIDY=${pkgs.llvmPackages_19.clang-tools}/bin/clang-tidy
 
       # There is too much volatility between even micro-versions of
-      # clang-format 18. Let's use 17 for now.
-      export CLANG_FORMAT=${pkgs.clang-tools_17}/bin/clang-format
+      # later clang-format. Let's use stable 17 for now.
+      export CLANG_FORMAT=${pkgs.llvmPackages_17.clang-tools}/bin/clang-format
   '';
 }

--- a/verible/common/util/container-util.h
+++ b/verible/common/util/container-util.h
@@ -71,7 +71,9 @@ template <class M>
 const typename M::mapped_type &FindWithDefault(
     M &map, const typename M::key_type &key, const typename M::mapped_type &d) {
   auto found = map.find(key);
-  return (found == map.end()) ? d : found->second;
+  return (found == map.end())
+             ? d  // NOLINT(bugprone-return-const-ref-from-parameter)
+             : found->second;
 }
 
 template <class M>

--- a/verible/verilog/parser/verilog-lexical-context.cc
+++ b/verible/verilog/parser/verilog-lexical-context.cc
@@ -23,6 +23,7 @@
 
 #include "verible/common/text/token-info.h"
 #include "verible/common/util/logging.h"
+#include "verible/common/util/with-reason.h"
 #include "verible/verilog/parser/verilog-token-enum.h"
 
 namespace verilog {

--- a/verible/verilog/tools/ls/BUILD
+++ b/verible/verilog/tools/ls/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "//verible/common/text:text-structure",
         "//verible/common/text:token-info",
         "//verible/common/text:tree-utils",
+        "//verible/common/util:interval",
         "//verible/common/util:logging",
         "//verible/verilog/CST:declaration",
         "//verible/verilog/CST:dimensions",

--- a/verible/verilog/tools/ls/autoexpand.cc
+++ b/verible/verilog/tools/ls/autoexpand.cc
@@ -45,6 +45,7 @@
 #include "verible/common/text/text-structure.h"
 #include "verible/common/text/token-info.h"
 #include "verible/common/text/tree-utils.h"
+#include "verible/common/util/interval.h"
 #include "verible/common/util/logging.h"
 #include "verible/verilog/CST/declaration.h"
 #include "verible/verilog/CST/dimensions.h"


### PR DESCRIPTION
... but for now, just use clang-tidy 19 in shell.nix. TODO: Update to clang-tidy 19 in CI