### PR TITLE
Enhanced Alignment Options for Verilog Formatter

### DIFF
--- a/verible/common/formatting/align.cc
+++ b/verible/common/formatting/align.cc
@@ -64,8 +64,27 @@ static const verible::EnumNameMap<AlignmentPolicy> &AlignmentPolicyNameMap() {
   return kAlignmentPolicyNameMap;
 }
 
+static const verible::EnumNameMap<NamedAlignmentPolicy> &
+NamedAlignmentPolicyNameMap() {
+  static const verible::EnumNameMap<NamedAlignmentPolicy>
+      kNamedAlignmentPolicyNameMap({
+          {"align", NamedAlignmentPolicy::kAlign},
+          {"flush-left", NamedAlignmentPolicy::kFlushLeft},
+          {"preserve", NamedAlignmentPolicy::kPreserve},
+          {"infer", NamedAlignmentPolicy::kInferUserIntent},
+          {"align-both", NamedAlignmentPolicy::kAlignBoth},
+          {"align-both-separated", NamedAlignmentPolicy::kAlignBothSeparated},
+          {"align-both-spaced", NamedAlignmentPolicy::kAlignBothSpaced},
+      });
+  return kNamedAlignmentPolicyNameMap;
+}
+
 std::ostream &operator<<(std::ostream &stream, AlignmentPolicy policy) {
   return AlignmentPolicyNameMap().Unparse(policy, stream);
+}
+
+std::ostream &operator<<(std::ostream &stream, NamedAlignmentPolicy policy) {
+  return NamedAlignmentPolicyNameMap().Unparse(policy, stream);
 }
 
 bool AbslParseFlag(std::string_view text, AlignmentPolicy *policy,
@@ -73,7 +92,19 @@ bool AbslParseFlag(std::string_view text, AlignmentPolicy *policy,
   return AlignmentPolicyNameMap().Parse(text, policy, error, "AlignmentPolicy");
 }
 
+bool AbslParseFlag(std::string_view text, NamedAlignmentPolicy *policy,
+                   std::string *error) {
+  return NamedAlignmentPolicyNameMap().Parse(text, policy, error,
+                                             "NamedAlignmentPolicy");
+}
+
 std::string AbslUnparseFlag(const AlignmentPolicy &policy) {
+  std::ostringstream stream;
+  stream << policy;
+  return stream.str();
+}
+
+std::string AbslUnparseFlag(const NamedAlignmentPolicy &policy) {
   std::ostringstream stream;
   stream << policy;
   return stream.str();

--- a/verible/common/formatting/align.h
+++ b/verible/common/formatting/align.h
@@ -248,12 +248,31 @@ enum class AlignmentPolicy {
   kInferUserIntent,
 };
 
+// Specific enum for named port alignment that combines regular alignment
+// options with parenthesis alignment options
+enum class NamedAlignmentPolicy {
+  // Standard alignment options (from AlignmentPolicy)
+  kPreserve,
+  kFlushLeft,
+  kAlign,
+  kInferUserIntent,
+
+  // Parenthesis alignment options
+  kAlignBoth,
+  kAlignBothSeparated,
+  kAlignBothSpaced
+};
+
 std::ostream &operator<<(std::ostream &, AlignmentPolicy);
+std::ostream &operator<<(std::ostream &, NamedAlignmentPolicy);
 
 bool AbslParseFlag(std::string_view text, AlignmentPolicy *policy,
                    std::string *error);
+bool AbslParseFlag(std::string_view text, NamedAlignmentPolicy *policy,
+                   std::string *error);
 
 std::string AbslUnparseFlag(const AlignmentPolicy &policy);
+std::string AbslUnparseFlag(const NamedAlignmentPolicy &policy);
 
 // This represents one unit of alignable work, which is usually a filtered
 // subset of partitions within a contiguous range of partitions.

--- a/verible/verilog/formatting/align.cc
+++ b/verible/verilog/formatting/align.cc
@@ -261,7 +261,7 @@ class ActualNamedParameterColumnSchemaScanner
   explicit ActualNamedParameterColumnSchemaScanner(const FormatStyle &style)
       : VerilogColumnSchemaScanner(style) {}
 
-  void Visit(const SyntaxTreeNode &node) final {
+  void Visit(const SyntaxTreeNode &node) override {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -285,6 +285,119 @@ class ActualNamedParameterColumnSchemaScanner
   }
 };
 
+// This class marks up token-subranges in named parameter assignments for
+// alignment including both opening and closing parentheses.
+// e.g. ".param_name(param_value)"
+class ActualNamedParameterWithParenthesesColumnSchemaScanner
+    : public ActualNamedParameterColumnSchemaScanner {
+ public:
+  explicit ActualNamedParameterWithParenthesesColumnSchemaScanner(const FormatStyle &style)
+      : ActualNamedParameterColumnSchemaScanner(style),
+        named_param_policy_(style.named_parameter_alignment),
+        add_spaces_inside_parentheses_(
+            style.named_parameter_alignment == 
+            verible::NamedAlignmentPolicy::kAlignBothSeparated),
+        add_space_before_opening_paren_(
+            style.named_parameter_alignment == 
+            verible::NamedAlignmentPolicy::kAlignBothSeparated ||
+            style.named_parameter_alignment == 
+            verible::NamedAlignmentPolicy::kAlignBothSpaced) {}
+
+  void Visit(const SyntaxTreeNode &node) final {
+    auto tag = NodeEnum(node.Tag().tag);
+    VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
+            << TreePathFormatter(Path());
+    
+    // Handle basic column alignment with default implementation
+    if (named_param_policy_ != verible::NamedAlignmentPolicy::kAlignBoth &&
+        named_param_policy_ != verible::NamedAlignmentPolicy::kAlignBothSeparated &&
+        named_param_policy_ != verible::NamedAlignmentPolicy::kAlignBothSpaced) {
+      ActualNamedParameterColumnSchemaScanner::Visit(node);
+      return;
+    }
+    
+    // For alignment with parentheses, we'll handle it ourselves
+    switch (tag) {
+      case NodeEnum::kParamByName: {
+        // Parameter name column
+        ReserveNewColumn(node, FlushLeft);
+        break;
+      }
+      case NodeEnum::kParenGroup:
+        if (Context().DirectParentIs(NodeEnum::kParamByName)) {
+          const SyntaxTreeNode& paren_group = node;
+          if (!paren_group.empty()) {
+            // Handle opening parenthesis
+            const Symbol& opening_paren = *paren_group.front();
+            
+            // Add space before opening paren for align-both-separated
+            // or align-both-spaced mode
+            const verible::AlignmentColumnProperties opening_prop(
+                true, add_space_before_opening_paren_ ? 1 : 0);
+            ReserveNewColumn(opening_paren, opening_prop);
+            
+            // Handle expression inside parentheses
+            if (paren_group.size() >= 2) {
+              const Symbol& expr = *paren_group[1];
+              
+              if (add_spaces_inside_parentheses_) {
+                // For align-both-separated mode:
+                // Add space after opening paren (before expression)
+                SyntaxTreePath expr_path = Path();
+                expr_path.push_back(1);  // Distinct path for expression
+                
+                const verible::AlignmentColumnProperties expr_prop(true, 1);
+                ReserveNewColumn(expr, expr_prop, expr_path);
+              } else {
+                // For align-both and align-both-spaced modes:
+                // No spaces inside parentheses
+                const verible::AlignmentColumnProperties expr_prop(true, 0);
+                ReserveNewColumn(expr, expr_prop);
+              }
+            }
+            
+            // Handle closing parenthesis
+            if (paren_group.size() >= 3) {
+              const Symbol& closing_paren = *paren_group.back();
+              
+              // Need a unique path for the closing paren
+              SyntaxTreePath close_path = Path();
+              close_path.push_back(999);  // High number to ensure it's last
+              
+              if (add_spaces_inside_parentheses_) {
+                // For align-both-separated mode:
+                // Add space before closing paren
+                const verible::AlignmentColumnProperties close_prop(false, 1);
+                ReserveNewColumn(closing_paren, close_prop, close_path);
+              } else {
+                // For align-both and align-both-spaced modes:
+                // No space before closing paren
+                const verible::AlignmentColumnProperties close_prop(false, 0);
+                ReserveNewColumn(closing_paren, close_prop, close_path);
+              }
+            }
+          }
+        }
+        break;
+      default:
+        break;
+    }
+    
+    TreeContextPathVisitor::Visit(node);
+    VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
+  }
+
+ private:
+  // The named parameter alignment policy to use
+  verible::NamedAlignmentPolicy named_param_policy_;
+  
+  // Whether to add spaces inside the parentheses
+  bool add_spaces_inside_parentheses_;
+  
+  // Whether to add space before opening parenthesis
+  bool add_space_before_opening_paren_;
+};
+
 // This class marks up token-subranges in named port connections for alignment.
 // e.g. ".port_name(net_name)"
 class ActualNamedPortColumnSchemaScanner : public VerilogColumnSchemaScanner {
@@ -292,7 +405,7 @@ class ActualNamedPortColumnSchemaScanner : public VerilogColumnSchemaScanner {
   explicit ActualNamedPortColumnSchemaScanner(const FormatStyle &style)
       : VerilogColumnSchemaScanner(style) {}
 
-  void Visit(const SyntaxTreeNode &node) final {
+  void Visit(const SyntaxTreeNode &node) override {
     auto tag = NodeEnum(node.Tag().tag);
     VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
             << TreePathFormatter(Path());
@@ -314,6 +427,122 @@ class ActualNamedPortColumnSchemaScanner : public VerilogColumnSchemaScanner {
     TreeContextPathVisitor::Visit(node);
     VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
   }
+};
+
+// This class marks up token-subranges in named port connections for alignment
+// including both opening and closing parentheses.
+// e.g. ".port_name(net_name)"
+class ActualNamedPortWithParenthesesColumnSchemaScanner
+    : public ActualNamedPortColumnSchemaScanner {
+ public:
+  explicit ActualNamedPortWithParenthesesColumnSchemaScanner(
+      const FormatStyle &style)
+      : ActualNamedPortColumnSchemaScanner(style),
+        named_port_policy_(style.named_port_alignment),
+        add_spaces_inside_parentheses_(
+            style.named_port_alignment ==
+            verible::NamedAlignmentPolicy::kAlignBothSeparated),
+        add_space_before_opening_paren_(
+            style.named_port_alignment ==
+                verible::NamedAlignmentPolicy::kAlignBothSeparated ||
+            style.named_port_alignment ==
+                verible::NamedAlignmentPolicy::kAlignBothSpaced) {}
+
+  void Visit(const SyntaxTreeNode &node) final {
+    auto tag = NodeEnum(node.Tag().tag);
+    VLOG(2) << __FUNCTION__ << ", node: " << tag << " at "
+            << TreePathFormatter(Path());
+
+    // Handle basic column alignment with default implementation
+    if (named_port_policy_ != verible::NamedAlignmentPolicy::kAlignBoth &&
+        named_port_policy_ !=
+            verible::NamedAlignmentPolicy::kAlignBothSeparated &&
+        named_port_policy_ != verible::NamedAlignmentPolicy::kAlignBothSpaced) {
+      ActualNamedPortColumnSchemaScanner::Visit(node);
+      return;
+    }
+
+    // For alignment with parentheses, we'll handle it ourselves
+    switch (tag) {
+      case NodeEnum::kActualNamedPort: {
+        // Port name column
+        ReserveNewColumn(node, FlushLeft);
+        break;
+      }
+      case NodeEnum::kParenGroup:
+        if (Context().DirectParentIs(NodeEnum::kActualNamedPort)) {
+          const SyntaxTreeNode &paren_group = node;
+          if (!paren_group.empty()) {
+            // Handle opening parenthesis
+            const Symbol &opening_paren = *paren_group.front();
+
+            // Only add space before opening paren for align-both-separated or
+            // align-both-spaced mode
+            const verible::AlignmentColumnProperties opening_prop(
+                true, add_space_before_opening_paren_ ? 1 : 0);
+            ReserveNewColumn(opening_paren, opening_prop);
+
+            // Handle expression inside parentheses
+            if (paren_group.size() >= 2) {
+              const Symbol &expr = *paren_group[1];
+
+              if (add_spaces_inside_parentheses_) {
+                // For align-both-separated mode:
+                // Add space after opening paren (before expression)
+                SyntaxTreePath expr_path = Path();
+                expr_path.push_back(1);  // Distinct path for expression
+
+                const verible::AlignmentColumnProperties expr_prop(true, 1);
+                ReserveNewColumn(expr, expr_prop, expr_path);
+              } else {
+                // For align-both mode:
+                // No spaces inside parentheses
+                const verible::AlignmentColumnProperties expr_prop(true, 0);
+                ReserveNewColumn(expr, expr_prop);
+              }
+            }
+
+            // Handle closing parenthesis
+            if (paren_group.size() >= 3) {
+              const Symbol &closing_paren = *paren_group.back();
+
+              // Need a unique path for the closing paren
+              SyntaxTreePath close_path = Path();
+              // FIXME: We need a proper way to implement such behaviour
+              close_path.push_back(999);  // High number to ensure it's last
+
+              if (add_spaces_inside_parentheses_) {
+                // For align-both-separated mode:
+                // Add space before closing paren
+                const verible::AlignmentColumnProperties close_prop(false, 1);
+                ReserveNewColumn(closing_paren, close_prop, close_path);
+              } else {
+                // For align-both mode:
+                // No space before closing paren
+                const verible::AlignmentColumnProperties close_prop(false, 0);
+                ReserveNewColumn(closing_paren, close_prop, close_path);
+              }
+            }
+          }
+        }
+        break;
+      default:
+        break;
+    }
+
+    verilog::formatter::ActualNamedPortColumnSchemaScanner::Visit(node);
+    VLOG(2) << __FUNCTION__ << ", leaving node: " << tag;
+  }
+
+ private:
+  // The named port alignment policy to use
+  verible::NamedAlignmentPolicy named_port_policy_;
+
+  // Whether to add spaces inside the parentheses
+  bool add_spaces_inside_parentheses_;
+
+  // Whether to add space before opening parenthesis
+  bool add_space_before_opening_paren_;
 };
 
 // This class marks up token-subranges in port declarations for alignment.
@@ -1350,72 +1579,169 @@ static void non_tree_column_scanner(
   }
 }
 
+// Function that adapts NamedPortAlignmentPolicy to AlignmentPolicy
+static verible::AlignmentPolicy NamedAlignmentToAlignmentPolicy(
+    const verible::NamedAlignmentPolicy policy) {
+  switch (policy) {
+    case verible::NamedAlignmentPolicy::kPreserve:
+      return verible::AlignmentPolicy::kPreserve;
+    case verible::NamedAlignmentPolicy::kFlushLeft:
+      return verible::AlignmentPolicy::kFlushLeft;
+    case verible::NamedAlignmentPolicy::kAlign:
+    case verible::NamedAlignmentPolicy::kAlignBoth:
+    case verible::NamedAlignmentPolicy::kAlignBothSeparated:
+    case verible::NamedAlignmentPolicy::kAlignBothSpaced:
+      return verible::AlignmentPolicy::kAlign;
+    case verible::NamedAlignmentPolicy::kInferUserIntent:
+      return verible::AlignmentPolicy::kInferUserIntent;
+    default:
+      return verible::AlignmentPolicy::kAlign;
+  }
+}
+
+// Adapter function to get alignment policy from NamedParameterAlignmentPolicy member
+static verible::AlignmentPolicy NamedParameterAlignmentPolicyAdapter(
+    const FormatStyle &style) {
+  return NamedAlignmentToAlignmentPolicy(style.named_parameter_alignment);
+}
+
+// Adapter function to get alignment policy from NamedPortAlignmentPolicy member
+static verible::AlignmentPolicy NamedPortAlignmentPolicyAdapter(
+    const FormatStyle &style) {
+  return NamedAlignmentToAlignmentPolicy(style.named_port_alignment);
+}
+
 // Global registry of all known alignment handlers for Verilog.
 // This organization lets the same handlers be re-used in multiple
 // syntactic contexts, e.g. data declarations can be module items and
 // generate items and block statement items.
 static const AlignmentHandlerMapType &AlignmentHandlerLibrary() {
-  static const auto *handler_map = new AlignmentHandlerMapType{
-      {AlignableSyntaxSubtype::kDataDeclaration,
-       {UnstyledAlignmentCellScannerGenerator<
-            DataDeclarationColumnSchemaScanner>(),
-        function_from_pointer_to_member(
-            &FormatStyle::module_net_variable_alignment)}},
-      {AlignableSyntaxSubtype::kNamedActualParameters,
-       {UnstyledAlignmentCellScannerGenerator<
-            ActualNamedParameterColumnSchemaScanner>(non_tree_column_scanner),
-        function_from_pointer_to_member(
-            &FormatStyle::named_parameter_alignment)}},
-      {AlignableSyntaxSubtype::kNamedActualPorts,
-       {UnstyledAlignmentCellScannerGenerator<
-            ActualNamedPortColumnSchemaScanner>(non_tree_column_scanner),
-        function_from_pointer_to_member(&FormatStyle::named_port_alignment)}},
-      {AlignableSyntaxSubtype::kParameterDeclaration,
-       {UnstyledAlignmentCellScannerGenerator<
-            ParameterDeclarationColumnSchemaScanner>(non_tree_column_scanner),
-        function_from_pointer_to_member(
-            &FormatStyle::formal_parameters_alignment)}},
-      {AlignableSyntaxSubtype::kPortDeclaration,
-       {UnstyledAlignmentCellScannerGenerator<
-            PortDeclarationColumnSchemaScanner>(non_tree_column_scanner),
-        function_from_pointer_to_member(
-            &FormatStyle::port_declarations_alignment)}},
-      {AlignableSyntaxSubtype::kStructUnionMember,
-       {UnstyledAlignmentCellScannerGenerator<
-            StructUnionMemberColumnSchemaScanner>(non_tree_column_scanner),
-        function_from_pointer_to_member(
-            &FormatStyle::struct_union_members_alignment)}},
-      {AlignableSyntaxSubtype::kClassMemberVariables,
-       {UnstyledAlignmentCellScannerGenerator<
-            ClassPropertyColumnSchemaScanner>(),
-        function_from_pointer_to_member(
-            &FormatStyle::class_member_variable_alignment)}},
-      {AlignableSyntaxSubtype::kCaseLikeItems,
-       {UnstyledAlignmentCellScannerGenerator<CaseItemColumnSchemaScanner>(),
-        function_from_pointer_to_member(&FormatStyle::case_items_alignment)}},
-      {AlignableSyntaxSubtype::kContinuousAssignment,
-       {UnstyledAlignmentCellScannerGenerator<AssignmentColumnSchemaScanner>(),
-        function_from_pointer_to_member(
-            &FormatStyle::assignment_statement_alignment)}},
-      {AlignableSyntaxSubtype::kBlockingAssignment,
-       {UnstyledAlignmentCellScannerGenerator<AssignmentColumnSchemaScanner>(),
-        function_from_pointer_to_member(
-            &FormatStyle::assignment_statement_alignment)}},
-      {AlignableSyntaxSubtype::kNonBlockingAssignment,
-       {UnstyledAlignmentCellScannerGenerator<AssignmentColumnSchemaScanner>(),
-        function_from_pointer_to_member(
-            &FormatStyle::assignment_statement_alignment)}},
-      {AlignableSyntaxSubtype::kEnumListAssignment,
-       {UnstyledAlignmentCellScannerGenerator<
-            EnumWithAssignmentsColumnSchemaScanner>(non_tree_column_scanner),
-        function_from_pointer_to_member(
-            &FormatStyle::enum_assignment_statement_alignment)}},
-      {AlignableSyntaxSubtype::kDistItem,
-       {UnstyledAlignmentCellScannerGenerator<DistItemColumnSchemaScanner>(),
-        function_from_pointer_to_member(
-            &FormatStyle::distribution_items_alignment)}},
-  };
-  return *handler_map;
+  static AlignmentHandlerMapType handler_map;
+
+  // Initialize only once
+  if (handler_map.empty()) {
+    // Data Declaration
+    AlignmentGroupHandlers data_decl_handlers;
+    data_decl_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            DataDeclarationColumnSchemaScanner>();
+    data_decl_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::module_net_variable_alignment);
+    handler_map[AlignableSyntaxSubtype::kDataDeclaration] = data_decl_handlers;
+
+    // Named Actual Parameters
+    AlignmentGroupHandlers named_param_handlers;
+    named_param_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            ActualNamedParameterWithParenthesesColumnSchemaScanner>(non_tree_column_scanner);
+    named_param_handlers.policy_func = NamedParameterAlignmentPolicyAdapter;
+    handler_map[AlignableSyntaxSubtype::kNamedActualParameters] =
+        named_param_handlers;
+
+    // Named Actual Ports
+    AlignmentGroupHandlers named_port_handlers;
+    named_port_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            ActualNamedPortWithParenthesesColumnSchemaScanner>(
+            non_tree_column_scanner);
+    named_port_handlers.policy_func = NamedPortAlignmentPolicyAdapter;
+    handler_map[AlignableSyntaxSubtype::kNamedActualPorts] =
+        named_port_handlers;
+
+    // Parameter Declaration
+    AlignmentGroupHandlers param_decl_handlers;
+    param_decl_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            ParameterDeclarationColumnSchemaScanner>(non_tree_column_scanner);
+    param_decl_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::formal_parameters_alignment);
+    handler_map[AlignableSyntaxSubtype::kParameterDeclaration] =
+        param_decl_handlers;
+
+    // Port Declaration
+    AlignmentGroupHandlers port_decl_handlers;
+    port_decl_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            PortDeclarationColumnSchemaScanner>(non_tree_column_scanner);
+    port_decl_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::port_declarations_alignment);
+    handler_map[AlignableSyntaxSubtype::kPortDeclaration] = port_decl_handlers;
+
+    // Struct Union Member
+    AlignmentGroupHandlers struct_member_handlers;
+    struct_member_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            StructUnionMemberColumnSchemaScanner>(non_tree_column_scanner);
+    struct_member_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::struct_union_members_alignment);
+    handler_map[AlignableSyntaxSubtype::kStructUnionMember] =
+        struct_member_handlers;
+
+    // Class Member Variables
+    AlignmentGroupHandlers class_var_handlers;
+    class_var_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            ClassPropertyColumnSchemaScanner>();
+    class_var_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::class_member_variable_alignment);
+    handler_map[AlignableSyntaxSubtype::kClassMemberVariables] =
+        class_var_handlers;
+
+    // Case Items
+    AlignmentGroupHandlers case_item_handlers;
+    case_item_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<CaseItemColumnSchemaScanner>();
+    case_item_handlers.policy_func =
+        function_from_pointer_to_member(&FormatStyle::case_items_alignment);
+    handler_map[AlignableSyntaxSubtype::kCaseLikeItems] = case_item_handlers;
+
+    // Continuous Assignment
+    AlignmentGroupHandlers cont_assign_handlers;
+    cont_assign_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<AssignmentColumnSchemaScanner>();
+    cont_assign_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::assignment_statement_alignment);
+    handler_map[AlignableSyntaxSubtype::kContinuousAssignment] =
+        cont_assign_handlers;
+
+    // Blocking Assignment
+    AlignmentGroupHandlers block_assign_handlers;
+    block_assign_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<AssignmentColumnSchemaScanner>();
+    block_assign_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::assignment_statement_alignment);
+    handler_map[AlignableSyntaxSubtype::kBlockingAssignment] =
+        block_assign_handlers;
+
+    // Non-Blocking Assignment
+    AlignmentGroupHandlers nonblock_assign_handlers;
+    nonblock_assign_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<AssignmentColumnSchemaScanner>();
+    nonblock_assign_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::assignment_statement_alignment);
+    handler_map[AlignableSyntaxSubtype::kNonBlockingAssignment] =
+        nonblock_assign_handlers;
+
+    // Enum List Assignment
+    AlignmentGroupHandlers enum_assign_handlers;
+    enum_assign_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<
+            EnumWithAssignmentsColumnSchemaScanner>(non_tree_column_scanner);
+    enum_assign_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::enum_assignment_statement_alignment);
+    handler_map[AlignableSyntaxSubtype::kEnumListAssignment] =
+        enum_assign_handlers;
+
+    // Distribution Item
+    AlignmentGroupHandlers dist_item_handlers;
+    dist_item_handlers.column_scanner_func =
+        UnstyledAlignmentCellScannerGenerator<DistItemColumnSchemaScanner>();
+    dist_item_handlers.policy_func = function_from_pointer_to_member(
+        &FormatStyle::distribution_items_alignment);
+    handler_map[AlignableSyntaxSubtype::kDistItem] = dist_item_handlers;
+  }
+
+  return handler_map;
 }
 
 static verible::AlignmentCellScannerFunction AlignmentColumnScannerSelector(

--- a/verible/verilog/formatting/format-style-init.cc
+++ b/verible/verilog/formatting/format-style-init.cc
@@ -21,6 +21,7 @@
 #include "verible/verilog/formatting/format-style.h"
 
 using verible::AlignmentPolicy;
+using verible::NamedAlignmentPolicy;
 using verible::IndentationStyle;
 
 ABSL_FLAG(bool, try_wrap_long_lines, false,
@@ -55,12 +56,12 @@ ABSL_FLAG(AlignmentPolicy, port_declarations_alignment,
 ABSL_FLAG(AlignmentPolicy, struct_union_members_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format struct/union members: {align,flush-left,preserve,infer}");
-ABSL_FLAG(AlignmentPolicy, named_parameter_alignment,
-          AlignmentPolicy::kInferUserIntent,
-          "Format named actual parameters: {align,flush-left,preserve,infer}");
-ABSL_FLAG(AlignmentPolicy, named_port_alignment,
-          AlignmentPolicy::kInferUserIntent,
-          "Format named port connections: {align,flush-left,preserve,infer}");
+ABSL_FLAG(NamedAlignmentPolicy, named_parameter_alignment,
+          NamedAlignmentPolicy::kAlignBothSpaced,
+          "Format named port connections: {align,flush-left,preserve,infer,align-both,align-both-separated,align-both-spaced}");
+ABSL_FLAG(NamedAlignmentPolicy, named_port_alignment,
+          NamedAlignmentPolicy::kAlignBothSpaced,
+          "Format named port connections: {align,flush-left,preserve,infer,align-both,align-both-separated,align-both-spaced}");
 ABSL_FLAG(
     AlignmentPolicy, module_net_variable_alignment,  //
     AlignmentPolicy::kInferUserIntent,

--- a/verible/verilog/tools/formatter/README.md
+++ b/verible/verilog/tools/formatter/README.md
@@ -52,11 +52,11 @@ To pipe from stdin, use '-' as <file>.
     --module_net_variable_alignment (Format net/variable declarations:
       {align,flush-left,preserve,infer}); default: infer;
     --named_parameter_alignment (Format named actual parameters:
-      {align,flush-left,preserve,infer}); default: infer;
+      {align,flush-left,preserve,infer,align-both,align-both-separated,align-both-spaced}); default: align-both-spaced;
     --named_parameter_indentation (Indent named parameter assignments:
       {indent,wrap}); default: wrap;
     --named_port_alignment (Format named port connections:
-      {align,flush-left,preserve,infer}); default: infer;
+      {align,flush-left,preserve,infer,align-both,align-both-separated,align-both-spaced}); default: align-both-spaced;
     --named_port_indentation (Indent named port connections: {indent,wrap});
       default: wrap;
     --port_declarations_alignment (Format port declarations:
@@ -345,18 +345,18 @@ tree to work with.
 
 Before outputting the formatted result, several properties are checked:
 
-*   **Equivalence**: The output is lexically equivalent to the input, meaning
-    that only whitespaces may have changed, but all other tokens are equal. For
-    example, if two identifiers accidentally got merged together into one (by
-    removing spaces between them), this check would fail. Lexical equivalence
-    also implies that the output is still parseable.
-*   **Convergence**: Re-formatting the _output_ results in no further changes.
-    This property is particularly important when the formatter is used to
-    _check_ that a file is formatted properly. Without convergence, such a check
-    would fail after formatting, potentially asking the user to run formatting
-    two or more times. Note that this requirement is stricter than _eventual
-    convergence_, which allows multiple iterations before reaching a
-    fixed-point.
+- **Equivalence**: The output is lexically equivalent to the input, meaning
+  that only whitespaces may have changed, but all other tokens are equal. For
+  example, if two identifiers accidentally got merged together into one (by
+  removing spaces between them), this check would fail. Lexical equivalence
+  also implies that the output is still parseable.
+- **Convergence**: Re-formatting the _output_ results in no further changes.
+  This property is particularly important when the formatter is used to
+  _check_ that a file is formatted properly. Without convergence, such a check
+  would fail after formatting, potentially asking the user to run formatting
+  two or more times. Note that this requirement is stricter than _eventual
+  convergence_, which allows multiple iterations before reaching a
+  fixed-point.
 
 ### Internal Limits
 


### PR DESCRIPTION
This PR implements a new values for for the formatter:
```
   --named_parameter_alignment (Format named actual parameters:
      {align,flush-left,preserve,infer,align-both,align-both-separated,align-both-spaced}); default: align-both-spaced;
    --named_port_alignment (Format named port connections:
      {align,flush-left,preserve,infer,align-both,align-both-separated,align-both-spaced}); default: align-both-spaced;
```
It helps aligning closing parentheses. The new default is `align-both-spaced` (old one is `align`).
For more examples look [here](https://github.com/ButterSus/verible/tree/pkgbuild?tab=readme-ov-file).