### PR TITLE
fix(verilog/parser):fix the truncation bug of rejectChar #2372

### DIFF
--- a/verible/verilog/parser/verilog.lex
+++ b/verible/verilog/parser/verilog.lex
@@ -102,7 +102,7 @@
 
 /* identifier */
 Alpha [a-zA-Z]
-RejectChar [\x7F-\xFF]
+RejectChar [\x7F-\xFF]+
 IdentifierStart {Alpha}|"_"
 Letter {IdentifierStart}|"$"
 Digit [0-9]


### PR DESCRIPTION
After debugging, I found that the issue was caused by RejectChar truncating multi-byte illegal characters, which led to the exception when converting JSON to string. I have made the necessary changes, and this resolves issue https://github.com/chipsalliance/verible/issues/2372.