### PR TITLE
Don't send diagnostic notifiacations by default.

### DIFF
--- a/verible/verilog/tools/ls/BUILD
+++ b/verible/verilog/tools/ls/BUILD
@@ -269,6 +269,7 @@ cc_binary(
     deps = [
         ":verilog-language-server",
         "//verible/common/util:init-command-line",
+        "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/status",
     ],
 )

--- a/verible/verilog/tools/ls/verible-verilog-ls_test.sh
+++ b/verible/verilog/tools/ls/verible-verilog-ls_test.sh
@@ -115,7 +115,7 @@ cat > "${JSON_EXPECTED}" <<EOF
 ]
 EOF
 
-"${LSP_SERVER}" < ${TMP_IN} 2> "${MSG_OUT}" \
+"${LSP_SERVER}" --push_diagnostic_notifications < ${TMP_IN} 2> "${MSG_OUT}" \
   | ${JSON_RPC_EXPECT} ${JSON_EXPECTED}
 
 JSON_RPC_EXIT=$?

--- a/verible/verilog/tools/ls/verilog-language-server.cc
+++ b/verible/verilog/tools/ls/verilog-language-server.cc
@@ -42,7 +42,8 @@ ABSL_FLAG(bool, variables_in_outline, true,
 
 namespace verilog {
 
-VerilogLanguageServer::VerilogLanguageServer(const WriteFun &write_fun)
+VerilogLanguageServer::VerilogLanguageServer(bool push_diagnostic_notification,
+                                             const WriteFun &write_fun)
     : dispatcher_(write_fun), text_buffers_(&dispatcher_) {
   // All bodies the stream splitter extracts are pushed to the json dispatcher
   stream_splitter_.SetMessageProcessor(
@@ -55,11 +56,13 @@ VerilogLanguageServer::VerilogLanguageServer(const WriteFun &write_fun)
 
   // Whenever there is a new parse result ready, use that as an opportunity
   // to send diagnostics to the client.
-  parsed_buffers_.AddChangeListener(
-      [this](const std::string &uri,
-             const verilog::BufferTracker *buffer_tracker) {
-        if (buffer_tracker) SendDiagnostics(uri, *buffer_tracker);
-      });
+  if (push_diagnostic_notification) {
+    parsed_buffers_.AddChangeListener(
+        [this](const std::string &uri,
+               const verilog::BufferTracker *buffer_tracker) {
+          if (buffer_tracker) SendDiagnostics(uri, *buffer_tracker);
+        });
+  }
   SetRequestHandlers();
 }
 

--- a/verible/verilog/tools/ls/verilog-language-server.h
+++ b/verible/verilog/tools/ls/verilog-language-server.h
@@ -38,7 +38,8 @@ class VerilogLanguageServer {
   using WriteFun = verible::lsp::JsonRpcDispatcher::WriteFun;
 
   // Constructor preparing the callbacks for Language Server requests
-  explicit VerilogLanguageServer(const WriteFun &write_fun);
+  explicit VerilogLanguageServer(bool push_diagnostic_notification,
+                                 const WriteFun &write_fun);
 
   // Reads single request and responds to it (public to mock in tests).
   absl::Status Step(const ReadFun &read_fun);

--- a/verible/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verible/verilog/tools/ls/verilog-language-server_test.cc
@@ -124,7 +124,9 @@ class VerilogLanguageServerTest : public ::testing::Test {
   // sends textDocument/initialize request.
   // It stores the response in initialize_response field for further processing
   void SetUp() override {  // not yet final
+    const bool push_notifications = true;
     server_ = std::make_unique<VerilogLanguageServer>(
+        push_notifications,
         [this](std::string_view response) { response_stream_ << response; });
 
     absl::Status status = InitializeCommunication();


### PR DESCRIPTION
These days, editors seem to mostly use the feature to actively request diagnostics, so sending them as notification is just creating unnecessary churn and possibly are shown twice.

Default off now, but can be enabled with `--push_diagnostic_notifications`

Issues #2164 #2376