### PR TITLE
before-submit.sh: unconditionally update compilation-db

### DIFF
--- a/.github/bin/before-submit.sh
+++ b/.github/bin/before-submit.sh
@@ -27,6 +27,12 @@ else
   NORM=""
 fi
 
+# Compilation DB is needed for clang-tidy, but also
+# makes sure all external dependencies have been fetched so that
+# bant build cleaner can do a good job.
+echo "${BOLD}-- Refresh compilation db --${NORM}"
+.github/bin/make-compilation-db.sh
+
 echo "${BOLD}-- Run build cleaner --${NORM}"
 . <(${BANT} dwyu ...)
 
@@ -34,8 +40,6 @@ echo "${BOLD}-- Run all tests --${NORM}"
 bazel test -c opt ...
 
 if [ "${RUN_CLANG_TIDY}" -eq 1 ]; then
-  # Run clang-tidy; needs a compilation DB first
-  .github/bin/make-compilation-db.sh
   echo "${BOLD}-- Running clang-tidy and cache results --${NORM}"
   echo "This will take a while if run the first time and no cache has"
   echo "been created yet. Can't wait ? Skip with "

--- a/.github/bin/get-bant-path.sh
+++ b/.github/bin/get-bant-path.sh
@@ -22,7 +22,7 @@ BANT=${BANT:-needs-to-be-compiled-locally}
 # Bant not given, compile from bzlmod dep.
 if [ "${BANT}" = "needs-to-be-compiled-locally" ]; then
   "${BAZEL}" build -c opt --cxxopt=-std=c++20 @bant//bant:bant 2>/dev/null
-  BANT=$(realpath bazel-bin/external/bant*/bant/bant | head -1)
+  BANT=$(realpath bazel-bin/external/bant*/bant/bant | tail -1)
 fi
 
 echo $BANT


### PR DESCRIPTION
The compilation-db is not only useful for the clang-tidy run, but also as preparation for `bant dwyu` to see all external dependencies. Also - it is useful for development purposes of course.