### PR TITLE
Checking the validity of line range before generating code actions

### DIFF
--- a/verible/verilog/tools/ls/autoexpand.cc
+++ b/verible/verilog/tools/ls/autoexpand.cc
@@ -1689,6 +1689,7 @@ std::vector<CodeAction> GenerateAutoExpandCodeActions(
     const BufferTracker *const tracker, const CodeActionParams &p) {
   Interval<size_t> line_range{static_cast<size_t>(p.range.start.line),
                               static_cast<size_t>(p.range.end.line)};
+  if (!line_range.valid()) return {};
   if (!tracker) return {};
   const auto current = tracker->current();
   if (!current) return {};  // Can only expand if we have latest version


### PR DESCRIPTION
Added a validity checking of the line range before proceed in `GenerateAutoExpandCodeActions`.

This can prevent a buffer overflow in `AutoExpander::FindAutoKinds()` at https://github.com/chipsalliance/verible/blob/7aae5c08b5a484dc9b24049c68a9e3c2a2a4a445/verible/verilog/tools/ls/autoexpand.cc#L1697

This is because when constructing an `AutoExpander`, the return value of `std::distance` will be negative when `end` goes before `begin`. Which becomes super large when casted into `size_t`, causing buffer overflow.

https://github.com/chipsalliance/verible/blob/7aae5c08b5a484dc9b24049c68a9e3c2a2a4a445/verible/verilog/tools/ls/autoexpand.cc#L370-L373