### PR TITLE
Make sure that -xc++ is always part of the compilation DB.

### DIFF
--- a/.github/bin/make-compilation-db.sh
+++ b/.github/bin/make-compilation-db.sh
@@ -42,3 +42,8 @@ ${BANT} compile-flags 2>/dev/null > compile_flags.txt
 for d in bazel-out/../../../external/*flex*/src/FlexLexer.h ; do
   echo "-I$(dirname $d)" >> compile_flags.txt
 done
+
+# clang-tidy sometimes has issues figuring out if a file is c++,
+# so let's tell it. Bant can't always exctract that yet from --config redirects
+# in .bazelrc
+echo "-xc++" >> compile_flags.txt


### PR DESCRIPTION
With the upcoming more complicated way of defining multiple configs in the .bazelrc, current bant can't look through that and exctract the `-xc++` flag anymore.