### PR TITLE
Bump dependencies possible with bazel 7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,23 +3,19 @@ module(
     version = "head",
 )
 
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "nlohmann_json", version = "3.11.3.bcr.1")
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
-bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
-
-# Parsing tools.
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 bazel_dep(name = "rules_m4", version = "0.2.3")
 bazel_dep(name = "rules_flex", version = "0.3")
 bazel_dep(name = "rules_bison", version = "0.3")
-
-# Last versions compatible w/ bazel6 https://github.com/chipsalliance/verible/issues/2336
-bazel_dep(name = "abseil-cpp", version = "20240116.2")
+bazel_dep(name = "abseil-cpp", version = "20250127.0")
 bazel_dep(name = "protobuf", version = "31.0-rc2")
 
-bazel_dep(name = "googletest", version = "1.14.0.bcr.1", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
 
 # To build compilation DB and run build-cleaning
 bazel_dep(name = "bant", version = "0.2.0", dev_dependency = True)


### PR DESCRIPTION
Using bazel 7 allows to bump a few more depenencies to head.