### PR TITLE
Handle invalid format range in LSP adapter and add test

### DIFF
--- a/verible/verilog/tools/ls/verible-lsp-adapter.cc
+++ b/verible/verilog/tools/ls/verible-lsp-adapter.cc
@@ -295,6 +295,7 @@ std::vector<verible::lsp::TextEdit> FormatRange(
     const verible::Interval<int> format_lines{
         p.range.start.line + 1,  // 1 index based
         p.range.end.line + 1 + last_line_include};
+    if (!format_lines.valid()) return result;
     std::string formatted_range;
     if (!FormatVerilogRange(text, format_style, &formatted_range, format_lines)
              .ok()) {

--- a/verible/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verible/verilog/tools/ls/verilog-language-server_test.cc
@@ -611,6 +611,13 @@ TEST_F(VerilogLanguageServerTest, RangeFormattingTest) {
               params.new_text_end_character)
         << "Invalid range for id:  " << params.id;
   }
+
+  const FormattingRequestParams invalid_formatting_params{
+      34, 2, 0, 1, 1, "  assign a=1;\n", 1, 0, 2, 0};
+  const std::string invalid_request = FormattingRequest("file://fmt.sv", invalid_formatting_params);
+  ASSERT_OK(SendRequest(invalid_request));
+  const json empty_response = json::parse(GetResponse());
+  ASSERT_TRUE(empty_response["result"].empty());
 }
 
 // Runs test of entire document formatting with textDocument/formatting request

--- a/verible/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verible/verilog/tools/ls/verilog-language-server_test.cc
@@ -613,7 +613,7 @@ TEST_F(VerilogLanguageServerTest, RangeFormattingTest) {
   }
 
   const FormattingRequestParams invalid_formatting_params{
-      34, 2, 0, 1, 1, "  assign a=1;\n", 1, 0, 2, 0};
+      34, 6, 0, 1, 1, "  assign a=1;\n", 1, 0, 2, 0};
   const std::string invalid_request =
       FormattingRequest("file://fmt.sv", invalid_formatting_params);
   ASSERT_OK(SendRequest(invalid_request));

--- a/verible/verilog/tools/ls/verilog-language-server_test.cc
+++ b/verible/verilog/tools/ls/verilog-language-server_test.cc
@@ -614,7 +614,8 @@ TEST_F(VerilogLanguageServerTest, RangeFormattingTest) {
 
   const FormattingRequestParams invalid_formatting_params{
       34, 2, 0, 1, 1, "  assign a=1;\n", 1, 0, 2, 0};
-  const std::string invalid_request = FormattingRequest("file://fmt.sv", invalid_formatting_params);
+  const std::string invalid_request =
+      FormattingRequest("file://fmt.sv", invalid_formatting_params);
   ASSERT_OK(SendRequest(invalid_request));
   const json empty_response = json::parse(GetResponse());
   ASSERT_TRUE(empty_response["result"].empty());


### PR DESCRIPTION
Prevent a potential crash when receiving an invalid range formatting parameter.