### PR TITLE
Replaced clang-cl for MSVC Compiler on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,22 +17,31 @@ common:freebsd --config=unix --linkopt=-lm --host_linkopt=-lm
 common:openbsd --config=unix --linkopt=-lm --host_linkopt=-lm
 common:macos   --config=unix
 
-# Use clang-cl by default on Windows. MSVC has some issues with the codebase,
-# so we focus the effort for now is to have a Windows Verible compiled with
-# clang-cl before fixing the issues unique to MSVC.
-common:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:x64_windows-clang-cl
-common:windows --compiler=clang-cl --cxxopt=/std:c++20 --host_cxxopt=/std:c++20 --client_env=BAZEL_CXXOPTS=/std:c++20
+# Applies to both clang-cl and native MSVC builds.
+common:windows --cxxopt=/std:c++20 --host_cxxopt=/std:c++20 --client_env=BAZEL_CXXOPTS=/std:c++20
 # Actions (e.g. the genrules invoking win_flex.exe/win_bison.exe) need the
 # invoking shell's PATH to find tools installed.
 common:windows --action_env=PATH --host_action_env=PATH
+# Protobuf 31 has [MSVC deprecated](https://github.com/protocolbuffers/protobuf/issues/20085) and need this option to compile
+# The deprecation was later reverted thanks to improvements in bazel 8 and will not be necessary with newer protobuf.
+common:msvc --define=protobuf_allow_msvc=true
 
-build --cxxopt="-Wno-unknown-warning-option" --host_cxxopt="-Wno-unknown-warning-option"
+# Opt-in: build with clang-cl instead of the natively autoconfigured MSVC
+# with bazel --config=clang-cl
+common:clang-cl --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:x64_windows-clang-cl
+common:clang-cl --compiler=clang-cl
+
+common:unix --cxxopt="-Wno-unknown-warning-option" --host_cxxopt="-Wno-unknown-warning-option"
+common:clang-cl --cxxopt="-Wno-unknown-warning-option" --host_cxxopt="-Wno-unknown-warning-option"
 # TODO: this looks like benign where it happens but to be explored further.
-build --cxxopt="-Wno-dangling-reference" --host_cxxopt="-Wno-dangling-reference"
+common:unix --cxxopt="-Wno-dangling-reference" --host_cxxopt="-Wno-dangling-reference"
+common:clang-cl --cxxopt="-Wno-dangling-reference" --host_cxxopt="-Wno-dangling-reference"
 # Newer bisons create an unused label.
-build --cxxopt="-Wno-unused-label" --host_cxxopt="-Wno-unused-label"
+common:unix --cxxopt="-Wno-unused-label" --host_cxxopt="-Wno-unused-label"
+common:clang-cl --cxxopt="-Wno-unused-label" --host_cxxopt="-Wno-unused-label"
 # c++20 warning on protobuf 28.1
-build --cxxopt="-Wno-missing-requires" --host_cxxopt="-Wno-missing-requires"
+common:unix --cxxopt="-Wno-missing-requires" --host_cxxopt="-Wno-missing-requires"
+common:clang-cl --cxxopt="-Wno-missing-requires" --host_cxxopt="-Wno-missing-requires"
 
 # For 3rd party code: Disable warnings entirely.
 # They are not actionable and just create noise.

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -393,22 +393,17 @@ jobs:
 
     - name: Install dependencies
       run: |
-        choco install bazel --force --version=7.6.1
         choco install winflexbison3
-        choco install llvm --allow-downgrade --version=20.1.4
 
     - name: Debug bazel directory settings
-      # We need to explicitly call the bazel binary from choco, otherwise
-      # the default Windows runner seems to run bazelisk(?) and downloads the
-      # latest bazel, which is incompatible. Should be in variable.
-      run: C:/ProgramData/chocolatey/lib/bazel/bazel.exe info
+      run: bazel.exe info
 
     - name: Run Tests
-      run: C:/ProgramData/chocolatey/lib/bazel/bazel.exe test --keep_going --noshow_progress --test_output=errors //...
+      run: bazel.exe test --keep_going --noshow_progress --test_output=errors //...
 
     - name: Build Verible Binaries
       run: |
-        C:/ProgramData/chocolatey/lib/bazel/bazel.exe build --keep_going --noshow_progress -c opt :install-binaries
+        bazel.exe build --keep_going --noshow_progress -c opt :install-binaries
         # Litmus test
         bazel-bin/verible/verilog/tools/syntax/verible-verilog-syntax --version
 
@@ -429,7 +424,7 @@ jobs:
     # prevents packaging up the cache.
     - name: Stop Bazel
       run: |
-        C:/ProgramData/chocolatey/lib/bazel/bazel.exe shutdown
+        bazel.exe shutdown
         # The cache pack/restore has issues with these symbolic links
         rm c:/users/runneradmin/_bazel_runneradmin/*/install
         rm c:/users/runneradmin/_bazel_runneradmin/*/java.log

--- a/README.md
+++ b/README.md
@@ -214,17 +214,16 @@ bazel build -c opt  --//bazel:use_local_flex_bison //...
 
 ### Building on Windows
 
-Building on Windows requires LLVM, WinFlexBison 3 and Git-bash to be installed. Using package manager [chocolatey], this can be done with
+In addition to Bazel & Visual Studio, building on Windows requires WinFlexBison 3 and Git-bash to be installed. Using package manager [chocolatey], this can be done with
 
 ```powershell
-choco install git llvm winflexbison3
+choco install git winflexbison3
 ```
 
-Bazel may also require environment variable to use git-bash and LLVM, on powershell
+Bazel may also require environment variable to use git-bash, on powershell
 
 ```powershell
 $env:BAZEL_SH="C:\Program Files\Git\git-bash.exe"
-$env:BAZEL_LLVM="C:\Program Files\LLVM"
 ```
 
 ### Installation


### PR DESCRIPTION
MSVC is the default compiler on Windows and switching verible to use it would alleviate some pain points of using bazel on Windows.

For context, `clang-cl` was originally used because designated identifiers are used in the codebase, which are only supported by C++20 in MSVC, which was not available at the time. Also, MSVC would crash on the codebase, which is no longer the case.

I left the option to use clang-cl, but this is theory as I don't have a Windows system to verify. I removed reference to clang-cl from the doc, so this support is only for devs actively looking for it. It could be removed from .bazelrc if you prefer. As a side note, I don't think adding clang-cl to CI has value since we already build with clang on Linux. 