### PR TITLE
fix issue 2288: add --rules=+generate-label-prefix=prefix:A_ to change the style_regex

### DIFF
--- a/verible/verilog/analysis/checkers/BUILD
+++ b/verible/verilog/analysis/checkers/BUILD
@@ -816,6 +816,7 @@ cc_library(
         "//verible/common/analysis:syntax-tree-lint-rule",
         "//verible/common/analysis/matcher",
         "//verible/common/analysis/matcher:bound-symbol-manager",
+        "//verible/common/text:config-utils",
         "//verible/common/text:symbol",
         "//verible/common/text:syntax-tree-context",
         "//verible/common/text:token-info",
@@ -826,6 +827,7 @@ cc_library(
         "//verible/verilog/analysis:descriptions",
         "//verible/verilog/analysis:lint-rule-registry",
         "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/status",
     ],
     alwayslink = 1,
 )

--- a/verible/verilog/analysis/checkers/generate-label-prefix-rule.cc
+++ b/verible/verilog/analysis/checkers/generate-label-prefix-rule.cc
@@ -14,12 +14,16 @@
 
 #include "verible/verilog/analysis/checkers/generate-label-prefix-rule.h"
 
+#include <string>
 #include <string_view>
 
+#include "absl/status/status.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "verible/common/analysis/lint-rule-status.h"
 #include "verible/common/analysis/matcher/bound-symbol-manager.h"
 #include "verible/common/analysis/matcher/matcher.h"
+#include "verible/common/text/config-utils.h"
 #include "verible/common/text/symbol.h"
 #include "verible/common/text/syntax-tree-context.h"
 #include "verible/common/text/token-info.h"
@@ -38,18 +42,17 @@ using verible::matcher::Matcher;
 // Register the lint rule
 VERILOG_REGISTER_LINT_RULE(GenerateLabelPrefixRule);
 
-static constexpr std::string_view kMessage =
-    "All generate block labels must start with g_ or gen_";
+static constexpr std::string_view kDefaultPrefix = "g_";
 
-// TODO(fangism): and be lower_snake_case?
-// TODO(fangism): generalize to a configurable pattern and
-// rename this class/rule to GenerateLabelNamingStyle?
+GenerateLabelPrefixRule::GenerateLabelPrefixRule() : prefix_(kDefaultPrefix) {}
 
 const LintRuleDescriptor &GenerateLabelPrefixRule::GetDescriptor() {
   static const LintRuleDescriptor d{
       .name = "generate-label-prefix",
       .topic = "generate-constructs",
-      .desc = "Checks that every generate block label starts with g_ or gen_.",
+      .desc = "Checks that every generate block label starts with the specified prefix.",
+      .param = {{"prefix", std::string(kDefaultPrefix),
+                 "The required prefix for generate block labels."}},
   };
   return d;
 }
@@ -84,13 +87,22 @@ void GenerateLabelPrefixRule::HandleSymbol(
       }
 
       if (label != nullptr) {
-        if (!(absl::StartsWith(label->text(), "g_") ||
-              absl::StartsWith(label->text(), "gen_"))) {
-          violations_.insert(verible::LintViolation(*label, kMessage, context));
+        // Check if label starts with the configured prefix (case-insensitive)
+        if (!absl::StartsWithIgnoreCase(label->text(), prefix_)) {
+          std::string message = absl::StrCat(
+              "Generate block label must start with \"", prefix_, "\"");
+          violations_.insert(verible::LintViolation(*label, message, context));
         }
       }
     }
   }
+}
+
+absl::Status GenerateLabelPrefixRule::Configure(std::string_view configuration) {
+  using verible::config::SetString;
+  absl::Status s = verible::ParseNameValues(
+      configuration, {{"prefix", SetString(&prefix_)}});
+  return s;
 }
 
 verible::LintRuleStatus GenerateLabelPrefixRule::Report() const {

--- a/verible/verilog/analysis/checkers/generate-label-prefix-rule.h
+++ b/verible/verilog/analysis/checkers/generate-label-prefix-rule.h
@@ -16,7 +16,10 @@
 #define VERIBLE_VERILOG_ANALYSIS_CHECKERS_GENERATE_LABEL_PREFIX_RULE_H_
 
 #include <set>
+#include <string>
+#include <string_view>
 
+#include "absl/status/status.h"
 #include "verible/common/analysis/lint-rule-status.h"
 #include "verible/common/analysis/syntax-tree-lint-rule.h"
 #include "verible/common/text/symbol.h"
@@ -32,6 +35,8 @@ class GenerateLabelPrefixRule : public verible::SyntaxTreeLintRule {
  public:
   using rule_type = verible::SyntaxTreeLintRule;
 
+  GenerateLabelPrefixRule();
+
   static const LintRuleDescriptor &GetDescriptor();
 
   void HandleSymbol(const verible::Symbol &symbol,
@@ -39,8 +44,13 @@ class GenerateLabelPrefixRule : public verible::SyntaxTreeLintRule {
 
   verible::LintRuleStatus Report() const final;
 
+  absl::Status Configure(std::string_view configuration) final;
+
  private:
   std::set<verible::LintViolation> violations_;
+  
+  // Configurable prefix for generate block labels
+  std::string prefix_;
 };
 
 }  // namespace analysis


### PR DESCRIPTION
in issues https://github.com/chipsalliance/verible/issues/2288, 
I proposed making the generate labels parameterized. Presumably, everyone was too busy to optimize this issue, so I have attempted to fix the problem.

In this issue, you also agreed that this was a good idea.

Currently, **g_** remains the default option, but users can customize it. 
For example:
`verible-verilog-lint --rules=+generate-label-prefix=prefix:A_ ./sv.sv`

Fixes #2288