### PR TITLE
Fix module-level alignment breaking after non-alignable constructs

### DIFF
--- a/verible/verilog/formatting/align.cc
+++ b/verible/verilog/formatting/align.cc
@@ -1487,12 +1487,27 @@ static std::vector<AlignablePartitionGroup> AlignActualNamedPorts(
       &IgnoreWithinActualNamedPortPartitionGroup, full_range, vstyle);
 }
 
+// First partition by blank lines, then within each blank-line-separated
+// group, identify consecutive alignable items (declarations and continuous
+// assignments).  This ensures that blank lines break alignment groups
+// while non-alignable constructs (e.g. module instantiations) within a
+// blank-line group do not prevent subsequent items from being aligned.
+static std::vector<TaggedTokenPartitionRange>
+GetModuleItemGroupsBetweenBlankLines(const TokenPartitionRange &partitions) {
+  const std::vector<TokenPartitionRange> blank_line_groups(
+      verible::GetSubpartitionsBetweenBlankLines(partitions));
+  std::vector<TaggedTokenPartitionRange> result;
+  for (const auto &group : blank_line_groups) {
+    auto subgroups = GetConsecutiveModuleItemGroups(group);
+    result.insert(result.end(), subgroups.begin(), subgroups.end());
+  }
+  return result;
+}
+
 static std::vector<AlignablePartitionGroup> AlignModuleItems(
     const TokenPartitionRange &full_range, const FormatStyle &vstyle) {
-  // Currently, this only handles data/net/variable declarations.
-  // TODO(b/161814377): align continuous assignments
   return ExtractAlignablePartitionGroups(
-      &GetConsecutiveModuleItemGroups,
+      &GetModuleItemGroupsBetweenBlankLines,
       &IgnoreCommentsAndPreprocessingDirectives, full_range, vstyle);
 }
 


### PR DESCRIPTION
## Summary

- `AlignModuleItems` was the only alignment function that did not split partitions by blank lines before classifying groups
- When a non-alignable construct (e.g. module instantiation, macro call) appeared in the module body, `GetConsecutiveModuleItemGroups` returned `kNoMatch`, permanently breaking alignment for all subsequent `assign` statements and declarations in that scope
- Added `GetModuleItemGroupsBetweenBlankLines` which first partitions by blank lines, then runs `GetConsecutiveModuleItemGroups` within each sub-range — matching the pattern used by every other alignment function

### Before

```systemverilog
    assign short_a            = 1;  // aligned
    assign really_long_name_b = 2;  // aligned
    inst #() u (.Z(z));             // breaks alignment permanently
    assign c = 3;                   // NOT aligned
    assign longer_d = 4;            // NOT aligned
```

### After

```systemverilog
    assign short_a            = 1;  // aligned (group 1)
    assign really_long_name_b = 2;  // aligned (group 1)
    inst #() u (.Z(z));             // ends group 1, does not affect group 2
    assign c        = 3;            // aligned (group 2)
    assign longer_d = 4;            // aligned (group 2)
```

Blank lines continue to separate alignment groups as expected. Also removes the resolved `TODO(b/161814377)` comment.

## Test plan

- [ ] Verified on a 7400-line production RTL file with module instantiations, `DFF` macros, and hundreds of `assign` statements
- [ ] Small test case confirms: instantiations don't break alignment, blank lines do break alignment
- [ ] Existing verible tests should pass (alignment functions for ports, structs, enums, etc. already use blank-line splitting)

Related issues: #2021, #2481