### PR TITLE
Add --alignment_group_boundary flag to control alignment group splitting

### DIFF
--- a/verible/verilog/formatting/BUILD
+++ b/verible/verilog/formatting/BUILD
@@ -268,6 +268,7 @@ cc_library(
         "//verible/common/formatting:align",
         "//verible/common/formatting:basic-format-style",
         "//verible/common/formatting:basic-format-style-init",
+        "//verible/common/util:enum-flags",
         "@abseil-cpp//absl/flags:flag",
     ],
 )

--- a/verible/verilog/formatting/align.cc
+++ b/verible/verilog/formatting/align.cc
@@ -93,6 +93,53 @@ static bool TokensHaveParenthesis(const T &tokens) {
                      });
 }
 
+// Returns true if the partition contains a separator comment line.
+// A separator comment is an EOL comment whose body (after stripping "//"
+// and optional leading whitespace) consists of 4 or more consecutive
+// identical characters. Examples: "// ----", "// ====",
+// "/////////////////////".
+static bool IsSeparatorComment(const TokenPartitionTree &partition) {
+  const auto &uwline = partition.Value();
+  const auto token_range = uwline.TokensRange();
+  if (token_range.empty()) return false;
+
+  for (const auto &ftoken : token_range) {
+    if (ftoken.TokenEnum() !=
+        static_cast<int>(verilog_tokentype::TK_EOL_COMMENT)) {
+      continue;
+    }
+
+    std::string_view text = ftoken.Text();
+    // Strip leading "//"
+    if (text.size() < 2 || text[0] != '/' || text[1] != '/') continue;
+    std::string_view body = text.substr(2);
+
+    // Strip optional leading whitespace
+    const auto start = body.find_first_not_of(" \t");
+    if (start == std::string_view::npos) continue;
+    body = body.substr(start);
+
+    // Check for 4+ consecutive identical characters
+    if (body.size() < 4) continue;
+    const char first = body[0];
+    if (std::all_of(body.begin(), body.end(),
+                    [first](char ch) { return ch == first; })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool BlankLinesBreakGroups(AlignmentGroupBoundary b) {
+  return b == AlignmentGroupBoundary::kBlankLines ||
+         b == AlignmentGroupBoundary::kBlankLinesAndSeparatorComments;
+}
+
+static bool SeparatorCommentsBreakGroups(AlignmentGroupBoundary b) {
+  return b == AlignmentGroupBoundary::kSeparatorComments ||
+         b == AlignmentGroupBoundary::kBlankLinesAndSeparatorComments;
+}
+
 static bool IgnoreCommentsAndPreprocessingDirectives(
     const TokenPartitionTree &partition) {
   const auto &uwline = partition.Value();
@@ -597,14 +644,20 @@ static AlignedPartitionClassification AlignClassify(
 }
 
 static std::vector<TaggedTokenPartitionRange> GetConsecutiveModuleItemGroups(
-    const TokenPartitionRange &partitions) {
+    const TokenPartitionRange &partitions, AlignmentGroupBoundary boundary) {
   VLOG(2) << __FUNCTION__;
   return GetPartitionAlignmentSubranges(
       partitions,  //
-      [](const TokenPartitionTree &partition)
+      [boundary](const TokenPartitionTree &partition)
           -> AlignedPartitionClassification {
         const Symbol *origin = partition.Value().Origin();
-        if (origin == nullptr) return {AlignmentGroupAction::kIgnore};
+        if (origin == nullptr) {
+          if (SeparatorCommentsBreakGroups(boundary) &&
+              IsSeparatorComment(partition)) {
+            return {AlignmentGroupAction::kNoMatch};
+          }
+          return {AlignmentGroupAction::kIgnore};
+        }
         const verible::SymbolTag symbol_tag = origin->Tag();
         if (symbol_tag.kind != verible::SymbolKind::kNode) {
           return AlignClassify(AlignmentGroupAction::kIgnore);
@@ -625,14 +678,20 @@ static std::vector<TaggedTokenPartitionRange> GetConsecutiveModuleItemGroups(
 }
 
 static std::vector<TaggedTokenPartitionRange> GetConsecutiveClassItemGroups(
-    const TokenPartitionRange &partitions) {
+    const TokenPartitionRange &partitions, AlignmentGroupBoundary boundary) {
   VLOG(2) << __FUNCTION__;
   return GetPartitionAlignmentSubranges(
       partitions,  //
-      [](const TokenPartitionTree &partition)
+      [boundary](const TokenPartitionTree &partition)
           -> AlignedPartitionClassification {
         const Symbol *origin = partition.Value().Origin();
-        if (origin == nullptr) return {AlignmentGroupAction::kIgnore};
+        if (origin == nullptr) {
+          if (SeparatorCommentsBreakGroups(boundary) &&
+              IsSeparatorComment(partition)) {
+            return {AlignmentGroupAction::kNoMatch};
+          }
+          return {AlignmentGroupAction::kIgnore};
+        }
         const verible::SymbolTag symbol_tag = origin->Tag();
         if (symbol_tag.kind != verible::SymbolKind::kNode) {
           return {AlignmentGroupAction::kIgnore};
@@ -647,14 +706,20 @@ static std::vector<TaggedTokenPartitionRange> GetConsecutiveClassItemGroups(
 }
 
 static std::vector<TaggedTokenPartitionRange> GetAlignableStatementGroups(
-    const TokenPartitionRange &partitions) {
+    const TokenPartitionRange &partitions, AlignmentGroupBoundary boundary) {
   VLOG(2) << __FUNCTION__;
   return GetPartitionAlignmentSubranges(
       partitions,  //
-      [](const TokenPartitionTree &partition)
+      [boundary](const TokenPartitionTree &partition)
           -> AlignedPartitionClassification {
         const Symbol *origin = partition.Value().Origin();
-        if (origin == nullptr) return {AlignmentGroupAction::kIgnore};
+        if (origin == nullptr) {
+          if (SeparatorCommentsBreakGroups(boundary) &&
+              IsSeparatorComment(partition)) {
+            return {AlignmentGroupAction::kNoMatch};
+          }
+          return {AlignmentGroupAction::kIgnore};
+        }
         const verible::SymbolTag symbol_tag = origin->Tag();
         if (symbol_tag.kind != verible::SymbolKind::kNode) {
           return AlignClassify(AlignmentGroupAction::kIgnore);
@@ -1487,21 +1552,55 @@ static std::vector<AlignablePartitionGroup> AlignActualNamedPorts(
       &IgnoreWithinActualNamedPortPartitionGroup, full_range, vstyle);
 }
 
+// Extracts alignable partition groups, optionally pre-splitting the range at
+// blank lines when the alignment_group_boundary style setting requires it.
+static std::vector<AlignablePartitionGroup>
+ExtractAlignablePartitionGroupsWithBoundary(
+    const std::function<std::vector<TaggedTokenPartitionRange>(
+        const TokenPartitionRange &)> &group_extractor,
+    const verible::IgnoreAlignmentRowPredicate &ignore_group_predicate,
+    const TokenPartitionRange &full_range, const FormatStyle &vstyle) {
+  if (!BlankLinesBreakGroups(vstyle.alignment_group_boundary)) {
+    return ExtractAlignablePartitionGroups(
+        group_extractor, ignore_group_predicate, full_range, vstyle);
+  }
+  // Pre-split at blank lines, then apply grouping to each sub-range.
+  std::vector<AlignablePartitionGroup> all_groups;
+  const auto sub_ranges =
+      verible::GetSubpartitionsBetweenBlankLines(full_range);
+  for (const auto &sub_range : sub_ranges) {
+    auto groups = ExtractAlignablePartitionGroups(
+        group_extractor, ignore_group_predicate, sub_range, vstyle);
+    for (const auto &group : groups) {
+      all_groups.push_back(group);
+    }
+  }
+  return all_groups;
+}
+
 static std::vector<AlignablePartitionGroup> AlignModuleItems(
     const TokenPartitionRange &full_range, const FormatStyle &vstyle) {
   // Currently, this only handles data/net/variable declarations.
   // TODO(b/161814377): align continuous assignments
-  return ExtractAlignablePartitionGroups(
-      &GetConsecutiveModuleItemGroups,
-      &IgnoreCommentsAndPreprocessingDirectives, full_range, vstyle);
+  auto group_extractor = [&vstyle](const TokenPartitionRange &range) {
+    return GetConsecutiveModuleItemGroups(range,
+                                          vstyle.alignment_group_boundary);
+  };
+  return ExtractAlignablePartitionGroupsWithBoundary(
+      group_extractor, &IgnoreCommentsAndPreprocessingDirectives, full_range,
+      vstyle);
 }
 
 static std::vector<AlignablePartitionGroup> AlignClassItems(
     const TokenPartitionRange &full_range, const FormatStyle &vstyle) {
   // TODO(fangism): align other class items besides member variables.
-  return ExtractAlignablePartitionGroups(
-      &GetConsecutiveClassItemGroups, &IgnoreCommentsAndPreprocessingDirectives,
-      full_range, vstyle);
+  auto group_extractor = [&vstyle](const TokenPartitionRange &range) {
+    return GetConsecutiveClassItemGroups(range,
+                                         vstyle.alignment_group_boundary);
+  };
+  return ExtractAlignablePartitionGroupsWithBoundary(
+      group_extractor, &IgnoreCommentsAndPreprocessingDirectives, full_range,
+      vstyle);
 }
 
 static std::vector<AlignablePartitionGroup> AlignCaseItems(
@@ -1527,9 +1626,12 @@ static std::vector<AlignablePartitionGroup> AlignParameterDeclarations(
 
 static std::vector<AlignablePartitionGroup> AlignStatements(
     const TokenPartitionRange &full_range, const FormatStyle &vstyle) {
-  return ExtractAlignablePartitionGroups(
-      &GetAlignableStatementGroups, &IgnoreCommentsAndPreprocessingDirectives,
-      full_range, vstyle);
+  auto group_extractor = [&vstyle](const TokenPartitionRange &range) {
+    return GetAlignableStatementGroups(range, vstyle.alignment_group_boundary);
+  };
+  return ExtractAlignablePartitionGroupsWithBoundary(
+      group_extractor, &IgnoreCommentsAndPreprocessingDirectives, full_range,
+      vstyle);
 }
 
 static std::vector<AlignablePartitionGroup> AlignDistItems(

--- a/verible/verilog/formatting/format-style-init.cc
+++ b/verible/verilog/formatting/format-style-init.cc
@@ -14,14 +14,58 @@
 
 #include "verible/verilog/formatting/format-style-init.h"
 
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
 #include "absl/flags/flag.h"
 #include "verible/common/formatting/align.h"
 #include "verible/common/formatting/basic-format-style-init.h"
 #include "verible/common/formatting/basic-format-style.h"
+#include "verible/common/util/enum-flags.h"
 #include "verible/verilog/formatting/format-style.h"
 
 using verible::AlignmentPolicy;
 using verible::IndentationStyle;
+using verilog::formatter::AlignmentGroupBoundary;
+
+// AlignmentGroupBoundary flag support.
+namespace verilog {
+namespace formatter {
+
+static const verible::EnumNameMap<AlignmentGroupBoundary> &
+AlignmentGroupBoundaryNameMap() {
+  static const verible::EnumNameMap<AlignmentGroupBoundary>
+      kAlignmentGroupBoundaryNameMap({
+          {"none", AlignmentGroupBoundary::kNone},
+          {"blank-lines", AlignmentGroupBoundary::kBlankLines},
+          {"separator-comments", AlignmentGroupBoundary::kSeparatorComments},
+          {"blank-lines-and-separator-comments",
+           AlignmentGroupBoundary::kBlankLinesAndSeparatorComments},
+      });
+  return kAlignmentGroupBoundaryNameMap;
+}
+
+std::ostream &operator<<(std::ostream &stream,
+                         AlignmentGroupBoundary boundary) {
+  return AlignmentGroupBoundaryNameMap().Unparse(boundary, stream);
+}
+
+bool AbslParseFlag(std::string_view text, AlignmentGroupBoundary *boundary,
+                   std::string *error) {
+  return AlignmentGroupBoundaryNameMap().Parse(text, boundary, error,
+                                               "AlignmentGroupBoundary");
+}
+
+std::string AbslUnparseFlag(const AlignmentGroupBoundary &boundary) {
+  std::ostringstream stream;
+  stream << boundary;
+  return stream.str();
+}
+
+}  // namespace formatter
+}  // namespace verilog
 
 ABSL_FLAG(bool, try_wrap_long_lines, false,
           "If true, let the formatter attempt to optimize line wrapping "
@@ -91,6 +135,12 @@ ABSL_FLAG(bool, compact_indexing_and_selections, true,
 ABSL_FLAG(bool, wrap_end_else_clauses, false,
           "Split end and else keywords into separate lines");
 
+ABSL_FLAG(AlignmentGroupBoundary, alignment_group_boundary,
+          AlignmentGroupBoundary::kNone,
+          "Control what breaks alignment groups for module items, statements, "
+          "and class items: {none,blank-lines,separator-comments,"
+          "blank-lines-and-separator-comments}");
+
 ABSL_FLAG(bool, port_declarations_right_align_packed_dimensions, false,
           "If true, packed dimensions in contexts with enabled alignment are "
           "aligned to the right.");
@@ -139,6 +189,7 @@ void InitializeFromFlags(FormatStyle *style) {
   STYLE_FROM_FLAG(expand_coverpoints);
   STYLE_FROM_FLAG(compact_indexing_and_selections);
   STYLE_FROM_FLAG(wrap_end_else_clauses);
+  STYLE_FROM_FLAG(alignment_group_boundary);
 
 #undef STYLE_FROM_FLAG
 }

--- a/verible/verilog/formatting/format-style.h
+++ b/verible/verilog/formatting/format-style.h
@@ -15,11 +15,33 @@
 #ifndef VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_H_
 #define VERIBLE_VERILOG_FORMATTING_FORMAT_STYLE_H_
 
+#include <iosfwd>
+#include <string>
+#include <string_view>
+
 #include "verible/common/formatting/align.h"
 #include "verible/common/formatting/basic-format-style.h"
 
 namespace verilog {
 namespace formatter {
+
+// Controls what breaks alignment groups for module items, statements,
+// and class items.
+enum class AlignmentGroupBoundary {
+  // No additional group splitting (default, current behavior).
+  kNone,
+  // Blank lines break alignment groups.
+  kBlankLines,
+  // Separator comment lines (e.g., // ----) break alignment groups.
+  kSeparatorComments,
+  // Both blank lines and separator comments break alignment groups.
+  kBlankLinesAndSeparatorComments,
+};
+
+std::ostream &operator<<(std::ostream &, AlignmentGroupBoundary);
+bool AbslParseFlag(std::string_view text, AlignmentGroupBoundary *boundary,
+                   std::string *error);
+std::string AbslUnparseFlag(const AlignmentGroupBoundary &boundary);
 
 // Style parameters that are specific to Verilog formatter
 struct FormatStyle : public verible::BasicFormatStyle {
@@ -97,6 +119,11 @@ struct FormatStyle : public verible::BasicFormatStyle {
 
   bool port_declarations_right_align_packed_dimensions = false;
   bool port_declarations_right_align_unpacked_dimensions = false;
+
+  // Controls what breaks alignment groups for module items, statements,
+  // and class items.
+  AlignmentGroupBoundary alignment_group_boundary =
+      AlignmentGroupBoundary::kNone;
 
   // At this time line wrap optimization is problematic and risks ruining
   // otherwise reasonable code.  When set to false, this switch will make the

--- a/verible/verilog/formatting/formatter_test.cc
+++ b/verible/verilog/formatting/formatter_test.cc
@@ -18870,6 +18870,321 @@ TEST(FormatterEndToEndTest, FuzzingRegression_outofmemory) {
   TestForNonCrash(string_view_from_literal("`f(1'O`f())\n"));
 }
 
+TEST(FormatterEndToEndTest, AlignmentGroupBoundaryNone) {
+  // Default behavior: separator comments and blank lines do NOT break groups.
+  static constexpr FormatterTestCase kTestCases[] = {
+      {// Separator comment does not break alignment group
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// ============\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo    = 1'b1;\n"
+       "  assign baar   = 1'b0;\n"
+       "  // ============\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+  };
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.alignment_group_boundary = AlignmentGroupBoundary::kNone;
+  style.assignment_statement_alignment = AlignmentPolicy::kAlign;
+  for (const auto &test_case : kTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+TEST(FormatterEndToEndTest, AlignmentGroupBoundarySeparatorComments) {
+  static constexpr FormatterTestCase kTestCases[] = {
+      {// Separator comment breaks alignment group
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// ============\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "  // ============\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Dashes separator also breaks
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// ------------\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "  // ------------\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// No space after // also works
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "//============\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "  //============\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Slash separator (/////) also works
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "//////////\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "  //////////\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Regular comment does NOT break alignment
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// Title text\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo    = 1'b1;\n"
+       "  assign baar   = 1'b0;\n"
+       "  // Title text\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Multi-line comment block with separators
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// ============\n"
+       "// Title\n"
+       "// ============\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "  // ============\n"
+       "  // Title\n"
+       "  // ============\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Short repeated body (3 chars) does NOT break
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// ---\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo    = 1'b1;\n"
+       "  assign baar   = 1'b0;\n"
+       "  // ---\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Declarations also respect separator comments
+       "module m;\n"
+       "logic       a;\n"
+       "logic [7:0] b;\n"
+       "// ============\n"
+       "logic c_long_name;\n"
+       "logic d;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  logic       a;\n"
+       "  logic [7:0] b;\n"
+       "  // ============\n"
+       "  logic c_long_name;\n"
+       "  logic d;\n"
+       "endmodule\n"},
+      {// Statements in always blocks
+       "module m;\n"
+       "always_comb begin\n"
+       "aaaaa = b;\n"
+       "c     = 1'b0;\n"
+       "// ============\n"
+       "dd = eee;\n"
+       "ffffff = g;\n"
+       "end\n"
+       "endmodule\n",
+       "module m;\n"
+       "  always_comb begin\n"
+       "    aaaaa = b;\n"
+       "    c     = 1'b0;\n"
+       "    // ============\n"
+       "    dd     = eee;\n"
+       "    ffffff = g;\n"
+       "  end\n"
+       "endmodule\n"},
+  };
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.alignment_group_boundary = AlignmentGroupBoundary::kSeparatorComments;
+  style.assignment_statement_alignment = AlignmentPolicy::kAlign;
+  style.module_net_variable_alignment = AlignmentPolicy::kAlign;
+  for (const auto &test_case : kTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+TEST(FormatterEndToEndTest, AlignmentGroupBoundaryBlankLines) {
+  static constexpr FormatterTestCase kTestCases[] = {
+      {// Blank line breaks alignment group
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// No blank line: single alignment group
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo    = 1'b1;\n"
+       "  assign baar   = 1'b0;\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Single item before blank line (not enough for alignment)
+       "module m;\n"
+       "assign foo = 1'b1;\n"
+       "\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo = 1'b1;\n"
+       "\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+      {// Separator comment does NOT break (only blank lines)
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "// ============\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo    = 1'b1;\n"
+       "  assign baar   = 1'b0;\n"
+       "  // ============\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "endmodule\n"},
+  };
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.alignment_group_boundary = AlignmentGroupBoundary::kBlankLines;
+  style.assignment_statement_alignment = AlignmentPolicy::kAlign;
+  for (const auto &test_case : kTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
+TEST(FormatterEndToEndTest,
+     AlignmentGroupBoundaryBlankLinesAndSeparatorComments) {
+  static constexpr FormatterTestCase kTestCases[] = {
+      {// Both blank line and separator break groups
+       "module m;\n"
+       "assign foo  = 1'b1;\n"
+       "assign baar = 1'b0;\n"
+       "\n"
+       "assign baaaaz = 1'b1;\n"
+       "assign c      = 1'b0;\n"
+       "// ============\n"
+       "assign dd  = 1'b1;\n"
+       "assign eee = 1'b0;\n"
+       "endmodule\n",
+       "module m;\n"
+       "  assign foo  = 1'b1;\n"
+       "  assign baar = 1'b0;\n"
+       "\n"
+       "  assign baaaaz = 1'b1;\n"
+       "  assign c      = 1'b0;\n"
+       "  // ============\n"
+       "  assign dd  = 1'b1;\n"
+       "  assign eee = 1'b0;\n"
+       "endmodule\n"},
+  };
+  FormatStyle style;
+  style.column_limit = 40;
+  style.indentation_spaces = 2;
+  style.wrap_spaces = 4;
+  style.alignment_group_boundary =
+      AlignmentGroupBoundary::kBlankLinesAndSeparatorComments;
+  style.assignment_statement_alignment = AlignmentPolicy::kAlign;
+  for (const auto &test_case : kTestCases) {
+    VLOG(1) << "code-to-format:\n" << test_case.input << "<EOF>";
+    std::ostringstream stream;
+    const auto status =
+        FormatVerilog(test_case.input, "<filename>", style, stream);
+    EXPECT_OK(status) << status.message();
+    EXPECT_EQ(stream.str(), test_case.expected) << "code:\n" << test_case.input;
+  }
+}
+
 }  // namespace
 }  // namespace formatter
 }  // namespace verilog

--- a/verible/verilog/tools/formatter/README.md
+++ b/verible/verilog/tools/formatter/README.md
@@ -79,6 +79,9 @@ To pipe from stdin, use '-' as <file>.
       This is a short-term measure to reduce risk-of-harm.); default: false;
     --wrap_end_else_clauses (Split end and else keywords into separate lines);
       default: false;
+    --alignment_group_boundary (Control what breaks alignment groups for module
+      items, statements, and class items: {none,blank-lines,separator-comments,
+      blank-lines-and-separator-comments}); default: none;
 
   Flags from verilog/tools/formatter/verilog_format.cc:
     --failsafe_success (If true, always exit with 0 status, even if there were
@@ -329,6 +332,63 @@ This also implies that previously aligned code will most likely remain aligned.
 
 Finally, if none of the above conditions hold, the formatter will leave the
 original code as-is, preserving all pre-existing spaces.
+
+### Alignment Group Boundaries
+
+By default, an aligned section (e.g. a block of module items, statements, or
+class items) is treated as a single alignment group, even when the code is
+visually divided into logically separate sub-sections. This means the formatter
+aligns across blank lines and separator comments, which is not always desired.
+
+For example, given:
+
+```systemverilog
+logic a;
+logic [31:0] data;
+
+// ----
+logic en;
+logic [7:0] count;
+```
+
+the default behavior treats all four declarations as one group and aligns the
+second sub-section to the width of the first:
+
+```systemverilog
+logic        a;
+logic [31:0] data;
+
+// ----
+logic        en;
+logic [7:0]  count;
+```
+
+The `--alignment_group_boundary` flag lets you break alignment groups at
+section boundaries so each sub-section is aligned independently:
+
+*   `none` (default): no additional splitting; the whole section is one group.
+*   `blank-lines`: a blank line starts a new alignment group.
+*   `separator-comments`: a separator comment starts a new alignment group. A
+    separator comment is a `//` comment on its own line whose text (after the
+    `//`) is four or more consecutive identical characters, e.g. `// ----`,
+    `// ====`, or `/////`. A trailing comment after code on the same line does
+    not count.
+*   `blank-lines-and-separator-comments`: both blank lines and separator
+    comments start a new alignment group.
+
+With `--alignment_group_boundary=separator-comments`, the separator comment
+ends the first group so each sub-section is aligned to its own width:
+
+```systemverilog
+logic        a;
+logic [31:0] data;
+
+// ----
+logic       en;
+logic [7:0] count;
+```
+
+This applies to module items, statements, and class items.
 
 ## Failsafe Behavior
 


### PR DESCRIPTION
Currently, alignment groups for module items, statements, and class items are not broken by blank lines or separator comments. This means statements in logically separate sections (e.g., separated by "// ----" headers) get aligned together.

Add a new flag --alignment_group_boundary with four modes:
  none (default), blank-lines, separator-comments,
  blank-lines-and-separator-comments

A separator comment is an EOL comment whose body consists of 4 or more consecutive identical characters (e.g., "// ----", "// ====", "/////").

Affects AlignModuleItems, AlignStatements, and AlignClassItems.