### PR TITLE
verilog/analysis: allow unique0 qualifier to suppress case-missing-default lint

### DIFF
--- a/verible/verilog/CST/verilog-matchers.h
+++ b/verible/verilog/CST/verilog-matchers.h
@@ -437,6 +437,8 @@ inline constexpr auto HasDefaultCase =
 //     ...
 inline constexpr auto HasUniqueQualifier =
     verible::matcher::MakePathMatcher(L(TK_unique));
+inline constexpr auto HasUnique0Qualifier =
+    verible::matcher::MakePathMatcher(L(TK_unique0));
 // Clean up macros
 #undef N
 #undef L

--- a/verible/verilog/analysis/checkers/case-missing-default-rule.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule.cc
@@ -42,7 +42,7 @@ VERILOG_REGISTER_LINT_RULE(CaseMissingDefaultRule);
 
 static constexpr std::string_view kMessage =
     "Explicitly define a default case for every case statement or add `unique` "
-    "qualifier to the case statement.";
+    "or `unique0` qualifier to the case statement.";
 
 const LintRuleDescriptor &CaseMissingDefaultRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -50,7 +50,7 @@ const LintRuleDescriptor &CaseMissingDefaultRule::GetDescriptor() {
       .topic = "case-statements",
       .desc =
           "Checks that a default case-item is always defined unless the case "
-          "statement has the `unique` qualifier.",
+    "statement has the `unique` or `unique0` qualifier.",
   };
   return d;
 }
@@ -67,13 +67,17 @@ void CaseMissingDefaultRule::HandleSymbol(
   static const Matcher uniqueCaseMatcher(
       NodekCaseStatement(HasUniqueQualifier()));
 
+  static const Matcher unique0CaseMatcher(
+    NodekCaseStatement(HasUnique0Qualifier()));
+
   static const Matcher caseMatcherWithDefaultCase(
       NodekCaseStatement(HasDefaultCase()));
 
-  // If the case statement doesn't have the "unique" qualifier and
-  // it is missing the "default" case, insert the violation
+  // If the case statement doesn't have the "unique" or "unique0" qualifier and
+ // it is missing the "default" case, insert the violation
   if (!uniqueCaseMatcher.Matches(symbol, &manager) &&
-      !caseMatcherWithDefaultCase.Matches(symbol, &manager)) {
+    !unique0CaseMatcher.Matches(symbol, &manager) &&
+    !caseMatcherWithDefaultCase.Matches(symbol, &manager)) {
     violations_.insert(LintViolation(symbol, kMessage, context));
   }
 }


### PR DESCRIPTION
The case-missing-default lint rule currently suppresses violations
when the `unique` qualifier is present, but does not handle `unique0`.

In SystemVerilog, `unique0` is similar to `unique` but explicitly
allows no match — so a missing default case is intentional and valid.

This fix adds `HasUnique0Qualifier` matcher in verilog-matchers.h
and updates the rule logic and messages to treat `unique0` the same
as `unique`.

Fixes #2413