### PR TITLE
Add graphviz and tsort output formats to project file-deps

### DIFF
--- a/verible/verilog/analysis/dependencies.cc
+++ b/verible/verilog/analysis/dependencies.cc
@@ -92,6 +92,32 @@ static std::ostream &operator<<(std::ostream &stream, const DepEdge &dep) {
                 << verible::SequenceFormatter(dep.symbols, ", ", "{ ", " }");
 }
 
+// Struct for printing graphviz dependency edge.
+struct DepEdgeDot {
+  const VerilogSourceFile *const ref;
+  const VerilogSourceFile *const def;
+  const FileDependencies::SymbolNameSet &symbols;
+};
+
+static std::ostream &operator<<(std::ostream &stream, const DepEdgeDot &dep) {
+  return stream << "\"" << dep.ref->ReferencedPath() << "\""
+                << " -> "
+                << "\"" << dep.def->ReferencedPath() << "\" [label=\""
+                << verible::SequenceFormatter(dep.symbols, ", ") << "\"]";
+}
+
+// Struct for printing tsort dependency edge.
+struct DepEdgeTsort {
+  const VerilogSourceFile *const ref;
+  const VerilogSourceFile *const def;
+  const FileDependencies::SymbolNameSet &symbols;
+};
+
+static std::ostream &operator<<(std::ostream &stream, const DepEdgeTsort &dep) {
+  return stream << dep.ref->ReferencedPath() << " "
+                << dep.def->ReferencedPath();
+}
+
 static FileDependencies::file_deps_graph_type
 CreateFileDependenciesFromSymbolMap(
     const FileDependencies::symbol_index_type &symbol_map) {
@@ -145,6 +171,26 @@ std::ostream &FileDependencies::PrintGraph(std::ostream &stream) const {
   TraverseDependencyEdges([&stream](const node_type &ref, const node_type &def,
                                     const SymbolNameSet &symbols) {
     stream << DepEdge{.ref = ref, .def = def, .symbols = symbols} << std::endl;
+  });
+  return stream;
+}
+
+std::ostream &FileDependencies::PrintDotGraph(std::ostream &stream) const {
+  stream << "digraph {\n";
+  TraverseDependencyEdges([&stream](const node_type &ref, const node_type &def,
+                                    const SymbolNameSet &symbols) {
+    stream << "  " << DepEdgeDot{.ref = ref, .def = def, .symbols = symbols}
+           << std::endl;
+  });
+  stream << "}\n";
+  return stream;
+}
+
+std::ostream &FileDependencies::PrintTsortGraph(std::ostream &stream) const {
+  TraverseDependencyEdges([&stream](const node_type &ref, const node_type &def,
+                                    const SymbolNameSet &symbols) {
+    stream << DepEdgeTsort{.ref = ref, .def = def, .symbols = symbols}
+           << std::endl;
   });
   return stream;
 }

--- a/verible/verilog/analysis/dependencies.cc
+++ b/verible/verilog/analysis/dependencies.cc
@@ -86,36 +86,29 @@ struct DepEdge {
   const FileDependencies::SymbolNameSet &symbols;
 };
 
-static std::ostream &operator<<(std::ostream &stream, const DepEdge &dep) {
+static std::ostream &print_depedge_human(std::ostream &stream,
+                                         const DepEdge &dep) {
   return stream << '"' << dep.ref->ReferencedPath() << "\" depends on \""
                 << dep.def->ReferencedPath() << "\" for symbols "
                 << verible::SequenceFormatter(dep.symbols, ", ", "{ ", " }");
 }
 
-// Struct for printing graphviz dependency edge.
-struct DepEdgeDot {
-  const VerilogSourceFile *const ref;
-  const VerilogSourceFile *const def;
-  const FileDependencies::SymbolNameSet &symbols;
-};
-
-static std::ostream &operator<<(std::ostream &stream, const DepEdgeDot &dep) {
+static std::ostream &print_depedge_dot(std::ostream &stream,
+                                       const DepEdge &dep) {
   return stream << "\"" << dep.ref->ReferencedPath() << "\""
                 << " -> "
                 << "\"" << dep.def->ReferencedPath() << "\" [label=\""
                 << verible::SequenceFormatter(dep.symbols, ", ") << "\"]";
 }
 
-// Struct for printing tsort dependency edge.
-struct DepEdgeTsort {
-  const VerilogSourceFile *const ref;
-  const VerilogSourceFile *const def;
-  const FileDependencies::SymbolNameSet &symbols;
-};
-
-static std::ostream &operator<<(std::ostream &stream, const DepEdgeTsort &dep) {
+static std::ostream &print_depedge_tsort(std::ostream &stream,
+                                         const DepEdge &dep) {
   return stream << dep.ref->ReferencedPath() << " "
                 << dep.def->ReferencedPath();
+}
+
+static std::ostream &operator<<(std::ostream &stream, const DepEdge &dep) {
+  return print_depedge_human(stream, dep);
 }
 
 static FileDependencies::file_deps_graph_type
@@ -167,10 +160,12 @@ void FileDependencies::TraverseDependencyEdges(
   }
 }
 
-std::ostream &FileDependencies::PrintGraph(std::ostream &stream) const {
+std::ostream &FileDependencies::PrintHumanGraph(std::ostream &stream) const {
   TraverseDependencyEdges([&stream](const node_type &ref, const node_type &def,
                                     const SymbolNameSet &symbols) {
-    stream << DepEdge{.ref = ref, .def = def, .symbols = symbols} << std::endl;
+    print_depedge_human(stream,
+                        DepEdge{.ref = ref, .def = def, .symbols = symbols})
+        << std::endl;
   });
   return stream;
 }
@@ -179,8 +174,10 @@ std::ostream &FileDependencies::PrintDotGraph(std::ostream &stream) const {
   stream << "digraph {\n";
   TraverseDependencyEdges([&stream](const node_type &ref, const node_type &def,
                                     const SymbolNameSet &symbols) {
-    stream << "  " << DepEdgeDot{.ref = ref, .def = def, .symbols = symbols}
-           << std::endl;
+    stream << "  ";
+    print_depedge_dot(stream,
+                      DepEdge{.ref = ref, .def = def, .symbols = symbols})
+        << std::endl;
   });
   stream << "}\n";
   return stream;
@@ -189,14 +186,15 @@ std::ostream &FileDependencies::PrintDotGraph(std::ostream &stream) const {
 std::ostream &FileDependencies::PrintTsortGraph(std::ostream &stream) const {
   TraverseDependencyEdges([&stream](const node_type &ref, const node_type &def,
                                     const SymbolNameSet &symbols) {
-    stream << DepEdgeTsort{.ref = ref, .def = def, .symbols = symbols}
-           << std::endl;
+    print_depedge_tsort(stream,
+                        DepEdge{.ref = ref, .def = def, .symbols = symbols})
+        << std::endl;
   });
   return stream;
 }
 
 std::ostream &operator<<(std::ostream &stream, const FileDependencies &deps) {
-  return deps.PrintGraph(stream);
+  return deps.PrintHumanGraph(stream);
 }
 
 }  // namespace verilog

--- a/verible/verilog/analysis/dependencies.h
+++ b/verible/verilog/analysis/dependencies.h
@@ -97,7 +97,7 @@ struct FileDependencies {
       const std::function<void(const node_type &, const node_type &,
                                const SymbolNameSet &)> &edge_func) const;
 
-  std::ostream &PrintGraph(std::ostream &) const;
+  std::ostream &PrintHumanGraph(std::ostream &) const;
   std::ostream &PrintDotGraph(std::ostream &) const;
   std::ostream &PrintTsortGraph(std::ostream &) const;
 

--- a/verible/verilog/analysis/dependencies.h
+++ b/verible/verilog/analysis/dependencies.h
@@ -98,6 +98,8 @@ struct FileDependencies {
                                const SymbolNameSet &)> &edge_func) const;
 
   std::ostream &PrintGraph(std::ostream &) const;
+  std::ostream &PrintDotGraph(std::ostream &) const;
+  std::ostream &PrintTsortGraph(std::ostream &) const;
 
   // TODO: print unresolved references (no definition found)
 };

--- a/verible/verilog/tools/project/project-tool.cc
+++ b/verible/verilog/tools/project/project-tool.cc
@@ -255,7 +255,7 @@ static absl::Status ShowFileDependencies(const SubcommandArgsRange &args,
 
   // Print.
   if (config.output_format == "human") {
-    deps.PrintGraph(outs);
+    deps.PrintHumanGraph(outs);
   } else if (config.output_format == "tsort") {
     deps.PrintTsortGraph(outs);
   } else if (config.output_format == "dot") {

--- a/verible/verilog/tools/project/project-tool.cc
+++ b/verible/verilog/tools/project/project-tool.cc
@@ -55,6 +55,14 @@ e.g --include_dir_paths directory1,directory2
 if "A.sv" exists in both "directory1" and "directory2" the one in "directory1" is the one we will use.
 )");
 
+ABSL_FLAG(std::string, output_format, "human",
+          R"(Output format for file-deps.
+Available options:
+'human' - human readable format
+'tsort' - tsort consumable two-column list
+'dot' - graphviz format
+)");
+
 using verible::SubcommandArgsRange;
 using verible::SubcommandEntry;
 
@@ -65,6 +73,7 @@ struct VerilogProjectConfig {
   verilog::FileList file_list;
   // See --file_list_root above.
   std::string file_list_root;
+  std::string output_format;
 
   absl::Status LoadFromCommandline(const SubcommandArgsRange &args) {
     const std::vector<std::string_view> cmdline{args.begin(), args.end()};
@@ -77,6 +86,8 @@ struct VerilogProjectConfig {
     file_list.preprocessing.include_dirs.insert(
         file_list.preprocessing.include_dirs.end(), include_paths.begin(),
         include_paths.end());
+
+    output_format = absl::GetFlag(FLAGS_output_format);
 
     file_list_root = absl::GetFlag(FLAGS_file_list_root);
     if (auto fl_path = absl::GetFlag(FLAGS_file_list_path); !fl_path.empty()) {
@@ -243,10 +254,16 @@ static absl::Status ShowFileDependencies(const SubcommandArgsRange &args,
   const verilog::FileDependencies deps(*project_symbols.symbol_table);
 
   // Print.
-  // TODO(hzeller): support various output options {human-readable,
-  // machine-readable, etc.} using subcommand flags (b/164300992).
-  // One variant should include tsort-consumable 2-column text.
-  deps.PrintGraph(outs);
+  if (config.output_format == "human") {
+    deps.PrintGraph(outs);
+  } else if (config.output_format == "tsort") {
+    deps.PrintTsortGraph(outs);
+  } else if (config.output_format == "dot") {
+    deps.PrintDotGraph(outs);
+  } else {
+    return absl::InvalidArgumentError("Unknown output format given: " +
+                                      config.output_format);
+  }
   return absl::OkStatus();
 }
 

--- a/verible/verilog/tools/project/project_tool_test.sh
+++ b/verible/verilog/tools/project/project_tool_test.sh
@@ -349,4 +349,88 @@ EOF
 diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || { exit 1; }
 
 ################################################################################
+echo "=== Show dependencies between two files (modules), graphviz format"
+
+cat > "$MY_INPUT_FILE".A <<EOF
+module mm;
+endmodule
+
+module mm_test;
+  mm dut();
+endmodule
+EOF
+
+cat > "$MY_INPUT_FILE".B <<EOF
+module qq;
+  mm mm_inst();
+endmodule
+EOF
+
+# Construct a file-list on-the-fly as a file-descriptor
+FILE_LIST_INPUT="${TEST_TMPDIR}/myinputlist.txt"
+echo "myinput.txt.A" > "$FILE_LIST_INPUT"
+echo "myinput.txt.B" >> "$FILE_LIST_INPUT"
+"$project_tool" \
+  file-deps \
+  --file_list_path "$FILE_LIST_INPUT" \
+  --file_list_root "$(dirname "$MY_INPUT_FILE".A)" \
+  --output_format dot \
+  > "$MY_OUTPUT_FILE" 2>&1
+
+status="$?"
+[[ $status == 0 ]] || {
+  echo "$LINENO: Expected exit code 0, but got $status"
+  exit 1
+}
+
+cat > "$MY_EXPECT_FILE" <<EOF
+digraph {
+  "myinput.txt.B" -> "myinput.txt.A" [label="mm"]
+}
+EOF
+
+diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || { exit 1; }
+
+################################################################################
+echo "=== Show dependencies between two files (modules), tsort format"
+
+cat > "$MY_INPUT_FILE".A <<EOF
+module mm;
+endmodule
+
+module mm_test;
+  mm dut();
+endmodule
+EOF
+
+cat > "$MY_INPUT_FILE".B <<EOF
+module qq;
+  mm mm_inst();
+endmodule
+EOF
+
+# Construct a file-list on-the-fly as a file-descriptor
+FILE_LIST_INPUT="${TEST_TMPDIR}/myinputlist.txt"
+echo "myinput.txt.A" > "$FILE_LIST_INPUT"
+echo "myinput.txt.B" >> "$FILE_LIST_INPUT"
+"$project_tool" \
+  file-deps \
+  --file_list_path "$FILE_LIST_INPUT" \
+  --file_list_root "$(dirname "$MY_INPUT_FILE".A)" \
+  --output_format tsort \
+  > "$MY_OUTPUT_FILE" 2>&1
+
+status="$?"
+[[ $status == 0 ]] || {
+  echo "$LINENO: Expected exit code 0, but got $status"
+  exit 1
+}
+
+cat > "$MY_EXPECT_FILE" <<EOF
+myinput.txt.B myinput.txt.A
+EOF
+
+diff --strip-trailing-cr -u "$MY_EXPECT_FILE" "$MY_OUTPUT_FILE" || { exit 1; }
+
+################################################################################
 echo "PASS"


### PR DESCRIPTION
Add a new argument `--output_format` with options `human` (default), `tsort`, and `dot` to verible-verilog-project. It only affects `file-deps`.

The various formats can surely be implemented in a neater way in dependencies.cc.