### PR TITLE
Fix typo in help message of the formatter tool

### DIFF
--- a/verible/verilog/formatting/format-style-init.cc
+++ b/verible/verilog/formatting/format-style-init.cc
@@ -76,7 +76,7 @@ ABSL_FLAG(AlignmentPolicy, case_items_alignment,
           "Format case items: {align,flush-left,preserve,infer}");
 ABSL_FLAG(AlignmentPolicy, distribution_items_alignment,
           AlignmentPolicy::kInferUserIntent,
-          "Aligh distribution items: {align,flush-left,preserve,infer}");
+          "Align distribution items: {align,flush-left,preserve,infer}");
 ABSL_FLAG(AlignmentPolicy, assignment_statement_alignment,
           AlignmentPolicy::kInferUserIntent,
           "Format various assignments: {align,flush-left,preserve,infer}");

--- a/verible/verilog/tools/formatter/README.md
+++ b/verible/verilog/tools/formatter/README.md
@@ -43,7 +43,7 @@ To pipe from stdin, use '-' as <file>.
       {align,flush-left,preserve,infer}); default: infer;
     --compact_indexing_and_selections (Use compact binary expressions inside
       indexing / bit selection operators); default: true;
-    --distribution_items_alignment (Aligh distribution items:
+    --distribution_items_alignment (Align distribution items:
       {align,flush-left,preserve,infer}); default: infer;
     --enum_assignment_statement_alignment (Format assignments with enums:
       {align,flush-left,preserve,infer}); default: infer;


### PR DESCRIPTION
Fix typo in help message of option --distribution_items_alignment in formatter tool