### PR TITLE
Make formatter line-wrap search ordering deterministic

### DIFF
--- a/verible/common/formatting/line-wrap-searcher.cc
+++ b/verible/common/formatting/line-wrap-searcher.cc
@@ -14,6 +14,7 @@
 
 #include "verible/common/formatting/line-wrap-searcher.h"
 
+#include <cstddef>
 #include <memory>
 #include <ostream>
 #include <queue>
@@ -36,11 +37,21 @@ namespace {
 // use some sort of pool-allocator.
 struct SearchState {
   std::shared_ptr<const StateNode> state;
+  // Monotonically increasing insertion order for deterministic FIFO ties.
+  std::size_t sequence;
 
-  explicit SearchState(const std::shared_ptr<const StateNode> &s) : state(s) {}
+  SearchState(const std::shared_ptr<const StateNode> &s, std::size_t sequence)
+      : state(s), sequence(sequence) {}
 
   // Inverted to min-heap: *lowest* penalty has the highest search priority.
-  bool operator<(const SearchState &r) const { return *r.state < *state; }
+  bool operator<(const SearchState &r) const {
+    if (*r.state < *state) return true;
+    if (*state < *r.state) return false;
+    // std::priority_queue does not otherwise preserve insertion order for
+    // equivalent states, which can make the selected wrapping
+    // platform-specific.
+    return sequence > r.sequence;
+  }
 };
 }  // namespace
 
@@ -57,13 +68,11 @@ std::vector<FormattedExcerpt> SearchLineWraps(const UnwrappedLine &uwline,
   }
 
   // Worklist for decision searching, ordered by cumulative penalty.
-  // Note: a heap-based priority-queue will not guarantee stable ordering
-  // among equal-valued keys.  If first-come-first-serve tie-breaking is
-  // important, consider switching to a std::map.
   std::priority_queue<SearchState> worklist;
 
   // Seed worklist with a NodeState that should have 0 penalty.
-  SearchState seed(std::make_shared<StateNode>(uwline, style));
+  std::size_t next_sequence = 0;
+  SearchState seed(std::make_shared<StateNode>(uwline, style), next_sequence++);
   worklist.push(seed);
 
   bool aborted_search = false;
@@ -116,7 +125,8 @@ std::vector<FormattedExcerpt> SearchLineWraps(const UnwrappedLine &uwline,
     if (token.before.break_decision == SpacingOptions::kPreserve) {
       VLOG(4) << "preserving spaces before \'" << token.token->text() << '\'';
       SearchState preserved(std::make_shared<StateNode>(
-          next.state, style, SpacingDecision::kPreserve));
+                                next.state, style, SpacingDecision::kPreserve),
+                            next_sequence++);
       worklist.push(preserved);
     } else {
       // Remaining options are: Undecided, MustWrap, MustAppend
@@ -125,7 +135,8 @@ std::vector<FormattedExcerpt> SearchLineWraps(const UnwrappedLine &uwline,
         VLOG(4) << "considering appending \'" << token.token->text() << '\'';
         // Consider cost of appending token to current line.
         SearchState appended(std::make_shared<StateNode>(
-            next.state, style, SpacingDecision::kAppend));
+                                 next.state, style, SpacingDecision::kAppend),
+                             next_sequence++);
         worklist.push(appended);
         VLOG(4) << "  cost: " << appended.state->cumulative_cost;
         VLOG(4) << "  column: " << appended.state->current_column;
@@ -133,8 +144,9 @@ std::vector<FormattedExcerpt> SearchLineWraps(const UnwrappedLine &uwline,
       if (token.before.break_decision != SpacingOptions::kMustAppend) {
         VLOG(4) << "considering wrapping \'" << token.token->text() << '\'';
         // Consider cost of line wrapping here.
-        SearchState wrapped(std::make_shared<StateNode>(
-            next.state, style, SpacingDecision::kWrap));
+        SearchState wrapped(std::make_shared<StateNode>(next.state, style,
+                                                        SpacingDecision::kWrap),
+                            next_sequence++);
         worklist.push(wrapped);
         VLOG(4) << "  cost: " << wrapped.state->cumulative_cost;
         VLOG(4) << "  column: " << wrapped.state->current_column;

--- a/verible/verilog/formatting/formatter-tuning_test.cc
+++ b/verible/verilog/formatting/formatter-tuning_test.cc
@@ -144,6 +144,23 @@ module m;
   end
 endmodule
 )sv"},
+    {// Equivalent search states must be visited in deterministic order.
+     R"sv(
+module m;
+  function f();
+    return first_call_with_a_long_name_to_force_platform_dependent_wrapping_xxxxxxxxxxxxxx(a, b, c, d) && second_call_with_a_long_name_to_keep_the_rhs_wrapped_xxxxxxxxxxxxxxxxxxxxxx();
+  endfunction
+endmodule
+)sv",
+     R"sv(
+module m;
+  function f();
+    return first_call_with_a_long_name_to_force_platform_dependent_wrapping_xxxxxxxxxxxxxx(a, b, c,
+                                                                                           d) &&
+        second_call_with_a_long_name_to_keep_the_rhs_wrapped_xxxxxxxxxxxxxxxxxxxxxx();
+  endfunction
+endmodule
+)sv"},
 };
 
 TEST(FormatterEndToEndTest, PenaltySensitiveLineWrapping100Col) {


### PR DESCRIPTION
Make Verible line-wrap search deterministic when multiple queued states have equal cost and terminal column.

`SearchLineWraps()` uses `std::priority_queue<SearchState>`. Previously, equivalent states had no final ordering, so heap behavior could select different wrapping paths across standard-library implementations. Official macOS and Linux release artifacts format the same input differently.

This change adds FIFO insertion order as the final tie-breaker and includes a reduced regression test.

## Reproduction

The issue reproduces with official `v0.0-4051-g9fdb4057` and `v0.0-4053-g89d4d98a` release artifacts.

Save as `repro.sv`:

```systemverilog
module m;
  function f();
    return first_call_with_a_long_name_to_force_platform_dependent_wrapping_xxxxxxxxxxxxxx(a, b, c, d) && second_call_with_a_long_name_to_keep_the_rhs_wrapped_xxxxxxxxxxxxxxxxxxxxxx();
  endfunction
endmodule
```

Run:

```bash
verible-verilog-format repro.sv
```

The official Linux x86-64 artifact produces:

```systemverilog
module m;
  function f();
    return first_call_with_a_long_name_to_force_platform_dependent_wrapping_xxxxxxxxxxxxxx(a, b, c,
                                                                                           d) &&
        second_call_with_a_long_name_to_keep_the_rhs_wrapped_xxxxxxxxxxxxxxxxxxxxxx();
  endfunction
endmodule
```

The official macOS artifact produces:

```systemverilog
module m;
  function f();
    return first_call_with_a_long_name_to_force_platform_dependent_wrapping_xxxxxxxxxxxxxx(a, b,
                                                                                           c, d) &&
        second_call_with_a_long_name_to_keep_the_rhs_wrapped_xxxxxxxxxxxxxxxxxxxxxx();
  endfunction
endmodule
```

Each artifact is idempotent on its own output and rewrites the other artifact's output back to its preferred layout. `--show_equally_optimal_wrappings` prints no diagnostics for this fixture.

## Fix

Assign each queued search state a monotonically increasing sequence number. When the existing comparator cannot distinguish two states, prefer the state inserted first.

This preserves the existing cost and terminal-column priorities while making equivalent-state ordering deterministic.

## Validation

Built the patched formatter from source on macOS arm64 and Linux x86-64. Both now produce identical output for the reduced fixture.

```text
SHA-256:
1a3775db233cc9ef45deb98eeacf9e465d19b6d2fc119552ae0140b15ce4baa5
```

Passed on both platforms:

```bash
bazel test \
  //verible/common/formatting:all \
  //verible/verilog/formatting:all
```

Also ran:

```bash
clang-format --dry-run -Werror \
  verible/common/formatting/line-wrap-searcher.cc \
  verible/verilog/formatting/formatter-tuning_test.cc
```