### PR TITLE
Make biso/flex work with local and BCR tools work with bazel 8

### DIFF
--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -26,21 +26,56 @@ def genyacc(
         extra_outs = []):
     """Build rule for generating C or C++ sources with Bison.
     """
+    all_outs = [header_out, source_out] + extra_outs
+
+    def replace_outs(options, prefix):
+        res = []
+        for opt in options:
+            for out in all_outs:
+                opt = opt.replace("$(location %s)" % out, "$(location %s%s)" % (prefix, out))
+            res.append(opt)
+        return res
+
+    native.genrule(
+        name = name + "_toolchain",
+        srcs = [src],
+        outs = ["toolchain/" + out for out in all_outs],
+        cmd = select({
+            "@platforms//os:windows": "mkdir -p $(@D)/toolchain && win_bison.exe --defines=$(location toolchain/" + header_out + ") --output-file=$(location toolchain/" + source_out + ") " + " ".join(replace_outs(extra_options, "toolchain/")) + " $<",
+            "//conditions:default": "mkdir -p $(@D)/toolchain && M4=$(M4) $(BISON) --defines=$(location toolchain/" + header_out + ") --output-file=$(location toolchain/" + source_out + ") " + " ".join(replace_outs(extra_options, "toolchain/")) + " $<",
+        }),
+        toolchains = [
+            "@rules_bison//bison:current_bison_toolchain",
+            "@rules_m4//m4:current_m4_toolchain",
+        ],
+        tags = ["manual"],
+    )
+
+    native.genrule(
+        name = name + "_local",
+        srcs = [src],
+        outs = ["local/" + out for out in all_outs],
+        cmd = select({
+            "@platforms//os:windows": "mkdir -p $(@D)/local && win_bison.exe --defines=$(location local/" + header_out + ") --output-file=$(location local/" + source_out + ") " + " ".join(replace_outs(extra_options, "local/")) + " $<",
+            "//conditions:default": "mkdir -p $(@D)/local && bison --defines=$(location local/" + header_out + ") --output-file=$(location local/" + source_out + ") " + " ".join(replace_outs(extra_options, "local/")) + " $<",
+        }),
+        tags = ["manual"],
+    )
+
+    def generate_copy_cmds(prefix):
+        return " && ".join(["cp $(location %s%s) $(location %s)" % (prefix, out, out) for out in all_outs])
+
     native.genrule(
         name = name,
-        srcs = [src],
-        outs = [header_out, source_out] + extra_outs,
-        cmd = select({
-            "//bazel:use_local_flex_bison_enabled": "bison --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-            "@platforms//os:windows": "win_bison.exe --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-            "//conditions:default": "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
+        srcs = select({
+            "//bazel:use_local_flex_bison_enabled": ["local/" + out for out in all_outs],
+            "@platforms//os:windows": ["local/" + out for out in all_outs],
+            "//conditions:default": ["toolchain/" + out for out in all_outs],
         }),
-        toolchains = select({
-            "//bazel:use_local_flex_bison_enabled": [],
-            "@platforms//os:windows": [],
-            "//conditions:default": [
-                "@rules_bison//bison:current_bison_toolchain",
-                "@rules_m4//m4:current_m4_toolchain",
-            ],
+        outs = all_outs,
+        cmd = select({
+            "//bazel:use_local_flex_bison_enabled": generate_copy_cmds("local/"),
+            "@platforms//os:windows": generate_copy_cmds("local/"),
+            "//conditions:default": generate_copy_cmds("toolchain/"),
         }),
     )

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -21,20 +21,38 @@ def genlex(name, src, out):
     """Generate C/C++ language source from lex file using Flex
     """
     native.genrule(
-        name = name,
+        name = name + "_toolchain",
         srcs = [src],
-        outs = [out],
+        outs = ["toolchain/" + out],
         cmd = select({
-            "//bazel:use_local_flex_bison_enabled": "flex --outfile=$@ $<",
-            "@platforms//os:windows": "win_flex.exe --outfile=$@ $<",
-            "//conditions:default": "M4=$(M4) $(FLEX) --outfile=$@ $<",
+            "@platforms//os:windows": "mkdir -p $(@D)/toolchain && win_flex.exe --outfile=$@ $<",
+            "//conditions:default": "mkdir -p $(@D)/toolchain && M4=$(M4) $(FLEX) --outfile=$@ $<",
         }),
-        toolchains = select({
-            "//bazel:use_local_flex_bison_enabled": [],
-            "@platforms//os:windows": [],
-            "//conditions:default": [
-                "@rules_flex//flex:current_flex_toolchain",
-                "@rules_m4//m4:current_m4_toolchain",
-            ],
+        toolchains = [
+            "@rules_flex//flex:current_flex_toolchain",
+            "@rules_m4//m4:current_m4_toolchain",
+        ],
+        tags = ["manual"],
+    )
+
+    native.genrule(
+        name = name + "_local",
+        srcs = [src],
+        outs = ["local/" + out],
+        cmd = select({
+            "@platforms//os:windows": "mkdir -p $(@D)/local && win_flex.exe --outfile=$@ $<",
+            "//conditions:default": "mkdir -p $(@D)/local && flex --outfile=$@ $<",
         }),
+        tags = ["manual"],
+    )
+
+    native.genrule(
+        name = name,
+        srcs = select({
+            "//bazel:use_local_flex_bison_enabled": ["local/" + out],
+            "@platforms//os:windows": ["local/" + out],
+            "//conditions:default": ["toolchain/" + out],
+        }),
+        outs = [out],
+        cmd = "cp $< $@",
     )

--- a/shell.nix
+++ b/shell.nix
@@ -7,12 +7,13 @@ let
   verible_used_stdenv = pkgs.stdenv;
   #verible_used_stdenv = pkgs.gcc15Stdenv;
   #verible_used_stdenv = pkgs.clang19Stdenv;
+  bazel = pkgs.bazel_7;
 in
 verible_used_stdenv.mkDerivation {
   name = "verible-build-environment";
   buildInputs = with pkgs;
     [
-      bazel_7
+      bazel
       git
 
       # For scripts used inside bzl rules and tests
@@ -41,6 +42,8 @@ verible_used_stdenv.mkDerivation {
       llvmPackages_19.clang-tools    # for clang-format
     ];
   shellHook = ''
+      export USE_BAZEL_VERSION=${bazel.version}
+
       # clang tidy: use latest.
       export CLANG_TIDY=${pkgs.llvmPackages_22.clang-tools}/bin/clang-tidy
 


### PR DESCRIPTION
We can't select on a toolchain anymore, so break up the build rules into a local and non-local genrule and choose outputs from these.

Fixes #2435