### PR TITLE
Update some modules to latest version.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,18 +5,19 @@ module(
 
 bazel_dep(name = "abseil-cpp", version = "20250814.1")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
-bazel_dep(name = "nlohmann_json", version = "3.11.3.bcr.1")
+bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "31.0-rc2")
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
-bazel_dep(name = "rules_bison", version = "0.3")
-bazel_dep(name = "rules_flex", version = "0.3")
+bazel_dep(name = "rules_bison", version = "0.4.bcr.1")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_flex", version = "0.4.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_m4", version = "0.2.3")
+bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
-bazel_dep(name = "rules_cc", version = "0.2.16")
 
-bazel_dep(name = "googletest", version = "1.17.0", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 
 # To build compilation DB and run build-cleaning
 bazel_dep(name = "bant", version = "0.2.10", dev_dependency = True)

--- a/bazel/sh_test_with_runfiles_lib.bzl
+++ b/bazel/sh_test_with_runfiles_lib.bzl
@@ -16,6 +16,8 @@
 """Bazel rule to wrap sh_test with a wrapper loading runfiles library prior to execution
 """
 
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 def sh_test_with_runfiles_lib(name, srcs, size, args, data, deps = []):
     """sh_test wrapper that loads bazel's runfiles library before calling the test.
 
@@ -47,7 +49,7 @@ def sh_test_with_runfiles_lib(name, srcs, size, args, data, deps = []):
     args = ["$(location " + srcs[0] + ")"] + args
     data += srcs
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = ["//bazel:sh_test_with_runfiles_lib.sh"],
         size = size,

--- a/third_party/proto/kythe/BUILD
+++ b/third_party/proto/kythe/BUILD
@@ -1,4 +1,5 @@
 load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/verible/verilog/tools/formatter/BUILD
+++ b/verible/verilog/tools/formatter/BUILD
@@ -2,6 +2,7 @@
 #
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
 load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 

--- a/verible/verilog/tools/kythe/BUILD
+++ b/verible/verilog/tools/kythe/BUILD
@@ -1,6 +1,7 @@
 # 'verible-verilog-kythe-extractor' is a program for extracting Verilog/SystemVerilog to kythe facts.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
 load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 

--- a/verible/verilog/tools/syntax/BUILD
+++ b/verible/verilog/tools/syntax/BUILD
@@ -1,6 +1,7 @@
 # 'verilog_syntax' is a program for checking Verilog/SystemVerilog syntax.
 
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//bazel:sh_test_with_runfiles_lib.bzl", "sh_test_with_runfiles_lib")
 load("//bazel:variables.bzl", "STATIC_EXECUTABLES_FEATURE")
 


### PR DESCRIPTION
Also, explicitly import shell rules from the externally implemented module; what used to be built-in to bazel is now maintained there.

Prepare to be compatible with bazel 9.