### PR TITLE
Instead of absl::optional, use std::optional directly.

### DIFF
--- a/verible/common/analysis/matcher/BUILD
+++ b/verible/common/analysis/matcher/BUILD
@@ -32,7 +32,6 @@ cc_library(
     deps = [
         ":bound-symbol-manager",
         "//verible/common/text:symbol",
-        "@abseil-cpp//absl/types:optional",
     ],
 )
 

--- a/verible/common/analysis/matcher/matcher.h
+++ b/verible/common/analysis/matcher/matcher.h
@@ -16,11 +16,11 @@
 #define VERIBLE_COMMON_ANALYSIS_MATCHER_MATCHER_H_
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "absl/types/optional.h"
 #include "verible/common/analysis/matcher/bound-symbol-manager.h"
 #include "verible/common/text/symbol.h"
 
@@ -99,7 +99,7 @@ class Matcher {
 
   // If present when Matches is called, symbol will be bound to its value
   // If null_opt, then symbol will not be
-  absl::optional<std::string> bind_id_ = absl::nullopt;
+  std::optional<std::string> bind_id_ = std::nullopt;
 };
 
 // BindableMatcher is a subclass of matcher that enables setting

--- a/verible/verilog/analysis/BUILD
+++ b/verible/verilog/analysis/BUILD
@@ -402,7 +402,6 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/time",
-        "@abseil-cpp//absl/types:optional",
     ],
 )
 

--- a/verible/verilog/analysis/verilog-project.cc
+++ b/verible/verilog/analysis/verilog-project.cc
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -27,7 +28,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include "verible/common/strings/mem-block.h"
 #include "verible/common/text/text-structure.h"
 #include "verible/common/util/file-util.h"
@@ -266,7 +266,7 @@ VerilogSourceFile *VerilogProject::LookupRegisteredFileInternal(
   return nullptr;
 }
 
-absl::optional<absl::StatusOr<VerilogSourceFile *>>
+std::optional<absl::StatusOr<VerilogSourceFile *>>
 VerilogProject::FindOpenedFile(std::string_view filename) const {
   const auto found = files_.find(filename);
   if (found != files_.end()) {
@@ -275,7 +275,7 @@ VerilogProject::FindOpenedFile(std::string_view filename) const {
     }
     return found->second.get();
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 absl::StatusOr<VerilogSourceFile *> VerilogProject::OpenTranslationUnit(

--- a/verible/verilog/analysis/verilog-project.h
+++ b/verible/verilog/analysis/verilog-project.h
@@ -27,7 +27,6 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/types/optional.h"
 #include "verible/common/strings/mem-block.h"
 #include "verible/common/strings/string-memory-map.h"
 #include "verible/common/text/text-structure.h"
@@ -355,7 +354,7 @@ class VerilogProject {
 
   // Returns the opened file or parse/not found error. If the file is not
   // opened, returns nullopt.
-  absl::optional<absl::StatusOr<VerilogSourceFile *>> FindOpenedFile(
+  std::optional<absl::StatusOr<VerilogSourceFile *>> FindOpenedFile(
       std::string_view filename) const;
 
   // Attempt to remove file and metadata if it exists. Return 'true' on success.

--- a/verible/verilog/tools/ls/BUILD
+++ b/verible/verilog/tools/ls/BUILD
@@ -195,7 +195,6 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings:str_format",
         "@abseil-cpp//absl/time",
-        "@abseil-cpp//absl/types:optional",
     ],
 )
 

--- a/verible/verilog/tools/ls/symbol-table-handler.h
+++ b/verible/verilog/tools/ls/symbol-table-handler.h
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "absl/status/status.h"
-#include "absl/types/optional.h"
 #include "verible/common/lsp/lsp-protocol.h"
 #include "verible/common/strings/line-column-map.h"
 #include "verible/common/text/symbol.h"
@@ -158,7 +157,7 @@ class SymbolTableHandler {
 
   // Last timestamp of filelist file - used to check whether SymbolTable
   // should be updated
-  absl::optional<std::filesystem::file_time_type> last_filelist_update_;
+  std::optional<std::filesystem::file_time_type> last_filelist_update_;
 
   // tells that symbol table should be rebuilt due to changes in files
   bool files_dirty_ = true;


### PR DESCRIPTION
The absl::optional was only needed in times before c++17, but we're past compatibility with this old standard.