### PR TITLE
Use flex and bison directly instead from toolchain.

### DIFF
--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -394,7 +394,6 @@ jobs:
     - name: Install dependencies
       run: |
         choco install bazel --force --version=7.6.1
-        choco install winflexbison3
         choco install llvm --allow-downgrade --version=20.1.4
 
     - name: Debug bazel directory settings

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,17 +3,18 @@ module(
     version = "head",
 )
 
+# Experimental for m4
+bazel_dep(name = "rules_cc_autoconf", version = "0.15.0")
 bazel_dep(name = "abseil-cpp", version = "20250814.1")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
+bazel_dep(name = "bison", version = "3.8.2.bcr.7")
+bazel_dep(name = "flex", version = "2.6.4.bcr.5")
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "31.0-rc2")
 bazel_dep(name = "re2", version = "2024-07-02.bcr.1")
-bazel_dep(name = "rules_bison", version = "0.4.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.2.16")
-bazel_dep(name = "rules_flex", version = "0.4.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "rules_m4", version = "0.2.3")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 

--- a/README.md
+++ b/README.md
@@ -201,25 +201,12 @@ instead of default `gold` linker).
 bazel build -c opt --config=create_static_linked_executables //...
 ```
 
-### Optionally using local flex/bison for build
-
-Flex and Bison, that are needed for the parser generation, are compiled as part
-of the build process. But if for any reason you want or need local tools (e.g.
-if you encounter a compile problem with them - please file a bug then)
-can choose so by adding `--//bazel:use_local_flex_bison` to your bazel
-command line:
-
-```bash
-# Also append the option '--//bazel:use_local_flex_bison' to test/install commands
-bazel build -c opt  --//bazel:use_local_flex_bison //...
-```
-
 ### Building on Windows
 
-Building on Windows requires LLVM, WinFlexBison 3 and Git-bash to be installed. Using package manager [chocolatey], this can be done with
+Building on Windows requires LLVM and Git-bash to be installed. Using package manager [chocolatey], this can be done with
 
 ```powershell
-choco install git llvm winflexbison3
+choco install git llvm
 ```
 
 Bazel may also require environment variable to use git-bash and LLVM, on powershell

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -13,13 +13,6 @@ package(
     features = ["layering_check"],
 )
 
-cc_library(
-    name = "flex",
-    deps = [
-        "@rules_flex//flex:current_flex_toolchain",  # For FlexLexer.h
-    ],
-)
-
 exports_files([
     "bison.bzl",
     "flex.bzl",
@@ -30,11 +23,7 @@ exports_files([
 bool_flag(
     name = "use_local_flex_bison",
     build_setting_default = False,
-)
-
-config_setting(
-    name = "use_local_flex_bison_enabled",
-    flag_values = {":use_local_flex_bison": "true"},
+    deprecation = "This flag is not doing anything anymore",
 )
 
 bool_flag(

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Bazel rule to run bison toolchain
+"""Bazel rule to run bison
 """
+
+load("@bison//:bison.bzl", "bison")
 
 # Adapter rule around the @rules_bison toolchain.
 def genyacc(
@@ -26,21 +28,13 @@ def genyacc(
         extra_outs = []):
     """Build rule for generating C or C++ sources with Bison.
     """
-    native.genrule(
+
+    bison(
         name = name,
         srcs = [src],
         outs = [header_out, source_out] + extra_outs,
-        cmd = select({
-            "//bazel:use_local_flex_bison_enabled": "bison --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-            "@platforms//os:windows": "win_bison.exe --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-            "//conditions:default": "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
-        }),
-        toolchains = select({
-            "//bazel:use_local_flex_bison_enabled": [],
-            "@platforms//os:windows": [],
-            "//conditions:default": [
-                "@rules_bison//bison:current_bison_toolchain",
-                "@rules_m4//m4:current_m4_toolchain",
-            ],
-        }),
+        args = [
+            "--output-file=$(location " + source_out + ")",
+            "--defines=$(location " + header_out + ")",
+        ] + extra_options + ["$(location " + src + ")"],
     )

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -13,28 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Bazel rule to run flex toolchain
+"""Bazel rule to run flex
 """
+
+load("@flex//:flex.bzl", "flex")
 
 # Adapter rule around the @rules_flex toolchain.
 def genlex(name, src, out):
     """Generate C/C++ language source from lex file using Flex
     """
-    native.genrule(
+    flex(
         name = name,
         srcs = [src],
         outs = [out],
-        cmd = select({
-            "//bazel:use_local_flex_bison_enabled": "flex --outfile=$@ $<",
-            "@platforms//os:windows": "win_flex.exe --outfile=$@ $<",
-            "//conditions:default": "M4=$(M4) $(FLEX) --outfile=$@ $<",
-        }),
-        toolchains = select({
-            "//bazel:use_local_flex_bison_enabled": [],
-            "@platforms//os:windows": [],
-            "//conditions:default": [
-                "@rules_flex//flex:current_flex_toolchain",
-                "@rules_m4//m4:current_m4_toolchain",
-            ],
-        }),
+        args = [
+            "--outfile=$(location " + out + ")",
+            "$(location " + src + ")",
+        ],
     )

--- a/shell.nix
+++ b/shell.nix
@@ -6,13 +6,14 @@
 let
   verible_used_stdenv = pkgs.stdenv;
   #verible_used_stdenv = pkgs.gcc15Stdenv;
-  #verible_used_stdenv = pkgs.clang19Stdenv;
+  #verible_used_stdenv = pkgs.llvmPackages_21.stdenv;
+  bazel = pkgs.bazel_7;
 in
 verible_used_stdenv.mkDerivation {
   name = "verible-build-environment";
   buildInputs = with pkgs;
     [
-      bazel_7
+      bazel
       git
 
       # For scripts used inside bzl rules and tests
@@ -25,10 +26,6 @@ verible_used_stdenv.mkDerivation {
 
       # To manually run export_json_examples
       python3Packages.anytree
-
-      # For using --//bazel:use_local_flex_bison if desired
-      flex
-      bison
 
       # To build vscode vsix package
       nodejs
@@ -46,5 +43,7 @@ verible_used_stdenv.mkDerivation {
 
       # Last version that current github CI supports.
       export CLANG_FORMAT=${pkgs.llvmPackages_19.clang-tools}/bin/clang-format
+
+      export USE_BAZEL_VERSION=${bazel.version}
   '';
 }

--- a/verible/common/analysis/BUILD
+++ b/verible/common/analysis/BUILD
@@ -12,8 +12,7 @@ package(
         "//verible/verilog/tools/lint:__subpackages__",
         "//verible/verilog/tools/ls:__subpackages__",
     ],
-    # Not yet enabled, lexer does not find FlexLexer.h
-    #features = ["layering_check"],
+    features = ["layering_check"],
 )
 
 cc_library(
@@ -70,13 +69,13 @@ cc_library(
         "//conditions:default": ["-Wno-implicit-fallthrough"],
     }),
     deps = [
-        "//bazel:flex",
         "//verible/common/lexer:flex-lexer-adapter",
         "//verible/common/lexer:token-stream-adapter",
         "//verible/common/text:token-info",
         "//verible/common/text:token-stream-view",
         "//verible/common/util:iterator-range",
         "//verible/common/util:logging",
+        "@flex//:headers",
     ],
 )
 

--- a/verible/verilog/parser/BUILD
+++ b/verible/verilog/parser/BUILD
@@ -14,8 +14,7 @@ package(
     default_visibility = [
         "//verible/verilog:__subpackages__",
     ],
-    # Not yet enabled, lexer does not find FlexLexer.h
-    #features = ["layering_check"],
+    features = ["layering_check"],
 )
 
 genlex(
@@ -39,9 +38,9 @@ cc_library(
     }),
     deps = [
         ":verilog-token-enum",
-        "//bazel:flex",
         "//verible/common/lexer:flex-lexer-adapter",
         "//verible/common/text:token-info",
+        "@flex//:headers",
     ],
 )
 


### PR DESCRIPTION
The flex toolchain from rules_{bison,flex} do not have a version that works on Windows.

Using these directly simplifies things as well.

Fixes #2435