### PR TITLE
Fix indent of `let`

### DIFF
--- a/verible/verilog/formatting/align.cc
+++ b/verible/verilog/formatting/align.cc
@@ -1040,10 +1040,11 @@ class ParameterDeclarationColumnSchemaScanner
 
     const int tag = leaf.get().token_enum();
     switch (tag) {
-      // Align keywords 'parameter', 'localparam' and 'type' under the same
-      // column.
+      // Align keywords 'parameter', 'localparam', 'let' and 'type'
+      // under the same column.
       case verilog_tokentype::TK_parameter:
-      case verilog_tokentype::TK_localparam: {
+      case verilog_tokentype::TK_localparam:
+      case verilog_tokentype::TK_let: {
         ReserveNewColumn(leaf, FlushLeft);
         break;
       }

--- a/verible/verilog/formatting/formatter_test.cc
+++ b/verible/verilog/formatting/formatter_test.cc
@@ -668,6 +668,14 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "module test;\nendmodule\n"
      "`end_keywords\n"},
 
+    // let test cases
+    {
+        "  let X=1   ; let Y=2;let Z     =3;",
+        "let X = 1;\n"
+        "let Y = 2;\n"
+        "let Z = 3;\n",
+    },
+
     // parameter test cases
     {
         "  parameter  int   foo=0 ;",


### PR DESCRIPTION
Fixes previous mis-indent of let, as there was no code I could find to handle it.

Previous output:

```
-  let OFF = 4;
-  let EXPECT = 16;
-  let UNIQUE = 32;
+  let OFF = 4; let EXPECT = 16; let UNIQUE = 32;
```
