### PR TITLE
Fix unique0 case missing default

### DIFF
--- a/verible/verilog/CST/verilog-matchers.h
+++ b/verible/verilog/CST/verilog-matchers.h
@@ -437,6 +437,8 @@ inline constexpr auto HasDefaultCase =
 //     ...
 inline constexpr auto HasUniqueQualifier =
     verible::matcher::MakePathMatcher(L(TK_unique));
+inline constexpr auto HasUnique0Qualifier =
+    verible::matcher::MakePathMatcher(L(TK_unique0));
 // Clean up macros
 #undef N
 #undef L

--- a/verible/verilog/CST/verilog-matchers_test.cc
+++ b/verible/verilog/CST/verilog-matchers_test.cc
@@ -827,5 +827,55 @@ TEST(VerilogMatchers, HasUniqueQualifierTests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
   }
 }
+
+// Tests for HasUnique0Qualifier matching.
+TEST(VerilogMatchers, HasUnique0QualifierTests) {
+  const RawMatcherTestCase tests[] = {
+      {HasUnique0Qualifier(), "", 0},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         case (in)
+           default: return 0;
+         endcase
+       endfunction
+       )",
+       0},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )",
+       1},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )",
+       0},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique0 if (in) begin
+           return 0;
+         end
+         else if(!in) begin
+           return 1;
+         end
+       endfunction
+       )",
+       1},
+  };
+  for (const auto &test : tests) {
+    verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
+}
+
 }  // namespace
 }  // namespace verilog

--- a/verible/verilog/CST/verilog-matchers_test.cc
+++ b/verible/verilog/CST/verilog-matchers_test.cc
@@ -822,6 +822,15 @@ TEST(VerilogMatchers, HasUniqueQualifierTests) {
        endfunction
        )",
        1},
+      {HasUniqueQualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )",
+       0},
   };
   for (const auto &test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);

--- a/verible/verilog/analysis/checkers/case-missing-default-rule.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule.cc
@@ -42,7 +42,7 @@ VERILOG_REGISTER_LINT_RULE(CaseMissingDefaultRule);
 
 static constexpr std::string_view kMessage =
     "Explicitly define a default case for every case statement or add `unique` "
-    "qualifier to the case statement.";
+    "or `unique0` qualifier to the case statement.";
 
 const LintRuleDescriptor &CaseMissingDefaultRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -50,7 +50,7 @@ const LintRuleDescriptor &CaseMissingDefaultRule::GetDescriptor() {
       .topic = "case-statements",
       .desc =
           "Checks that a default case-item is always defined unless the case "
-          "statement has the `unique` qualifier.",
+          "statement has the `unique` or `unique0` qualifier.",
   };
   return d;
 }
@@ -67,12 +67,16 @@ void CaseMissingDefaultRule::HandleSymbol(
   static const Matcher uniqueCaseMatcher(
       NodekCaseStatement(HasUniqueQualifier()));
 
+  static const Matcher unique0CaseMatcher(
+      NodekCaseStatement(HasUnique0Qualifier()));
+
   static const Matcher caseMatcherWithDefaultCase(
       NodekCaseStatement(HasDefaultCase()));
 
   // If the case statement doesn't have the "unique" qualifier and
   // it is missing the "default" case, insert the violation
   if (!uniqueCaseMatcher.Matches(symbol, &manager) &&
+      !unique0CaseMatcher.Matches(symbol, &manager) &&
       !caseMatcherWithDefaultCase.Matches(symbol, &manager)) {
     violations_.insert(LintViolation(symbol, kMessage, context));
   }

--- a/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
@@ -53,12 +53,20 @@ TEST(CaseMissingDefaultRuleTest, CaseInsideFunctionTests) {
        )"},
       {R"(
        function automatic int foo (input [2:0] in);
+         unique case (in)
+           3'b001: return 1;
+         endcase
+         return 0;
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input [2:0] in);
          unique0 case (in)
            3'b001: return 1;
          endcase
          return 0;
        endfunction
-      )"},
+       )"},
       {R"(
        function automatic int foo (input in);
          )",

--- a/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
@@ -52,6 +52,14 @@ TEST(CaseMissingDefaultRuleTest, CaseInsideFunctionTests) {
        endfunction
        )"},
       {R"(
+       function automatic int foo (input [2:0] in);
+         unique0 case (in)
+           3'b001: return 1;
+         endcase
+         return 0;
+       endfunction
+      )"},
+      {R"(
        function automatic int foo (input in);
          )",
        {TK_case, "case"},

--- a/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
@@ -86,6 +86,22 @@ TEST(CaseMissingDefaultRuleTest, CaseInsideFunctionTests) {
        endfunction
        )"},
       {R"(
+       function automatic int foo (input [2:0] in);
+         unique casex (in)
+           3'b001: return 1;
+         endcase
+         return 0;
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input [2:0] in);
+         unique0 casex (in)
+           3'b001: return 1;
+         endcase
+         return 0;
+       endfunction
+       )"},
+      {R"(
        function automatic int foo (input in);
          )",
        {TK_casex, "casex"},
@@ -101,6 +117,22 @@ TEST(CaseMissingDefaultRuleTest, CaseInsideFunctionTests) {
          casez (in)
            default: return 0;
          endcase
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input [2:0] in);
+         unique casez (in)
+           3'b001: return 1;
+         endcase
+         return 0;
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input [2:0] in);
+         unique0 casez (in)
+           3'b001: return 1;
+         endcase
+         return 0;
        endfunction
        )"},
       {R"(

--- a/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
@@ -144,6 +144,20 @@ TEST(CaseMissingDefaultRuleTest, CaseInsideFunctionTests) {
          endcase
        endfunction
        )"},
+      // A qualified outer case does not exempt an unqualified inner case.
+      {R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: begin;
+             )",
+       {TK_case, "case"},
+       R"( (in)
+               1: return 1;
+             endcase
+           end
+         endcase
+       endfunction
+       )"},
 
       // randcase should not be flagged
       {R"(


### PR DESCRIPTION
Fixes #2413 .

The `case-missing-default` rule currently allows `unique case` statements without a `default` item, but still reports error under `unique0 case` statements while it should not --`unique0 case` is also allowed to omit a matching branch. This updates the rule to treat `unique0 case` like `unique case` when deciding whether a `default` item is required.

Also I have added regression coverage for both the matcher and the lint rule.

Tests:
- bazel test --cache_test_results=no --test_output=errors //verible/verilog/analysis/checkers:case-missing-default-rule_test
- bazel test --cache_test_results=no --test_output=errors //verible/verilog/CST:verilog-matchers_test

