### PR TITLE
Symbol Table: Model Procedural and Generate Scopes Explicitly

### DIFF
--- a/verible/verilog/CST/BUILD
+++ b/verible/verilog/CST/BUILD
@@ -733,6 +733,8 @@ cc_library(
         "//verible/common/text:symbol",
         "//verible/common/text:tree-utils",
         "//verible/common/text:visitors",
+        "//verible/common/util:casts",
+        "//verible/verilog/parser:verilog-token-enum",
     ],
 )
 

--- a/verible/verilog/CST/statement.cc
+++ b/verible/verilog/CST/statement.cc
@@ -21,11 +21,13 @@
 #include "verible/common/text/concrete-syntax-tree.h"
 #include "verible/common/text/symbol.h"
 #include "verible/common/text/tree-utils.h"
+#include "verible/common/util/casts.h"
 #include "verible/verilog/CST/declaration.h"
 #include "verible/verilog/CST/identifier.h"
 #include "verible/verilog/CST/type.h"
 #include "verible/verilog/CST/verilog-matchers.h"  // IWYU pragma: keep
 #include "verible/verilog/CST/verilog-nonterminals.h"
+#include "verible/verilog/parser/verilog-token-enum.h"
 
 namespace verilog {
 
@@ -447,6 +449,21 @@ const SyntaxTreeNode *GetAnyConditionalElseClause(const Symbol &conditional) {
 }
 
 // Returns the data type node from for loop initialization.
+const verible::SyntaxTreeLeaf *GetGenvarKeywordFromForInitialization(
+    const verible::Symbol &for_initialization) {
+  const verible::Symbol *child0 =
+      GetSubtreeAsSymbol(for_initialization, NodeEnum::kForInitialization, 0);
+  if (child0 == nullptr) return nullptr;
+  if (child0->Kind() == verible::SymbolKind::kLeaf) {
+    const auto *leaf =
+        verible::down_cast<const verible::SyntaxTreeLeaf *>(child0);
+    if (leaf->get().token_enum() == TK_genvar) {
+      return leaf;
+    }
+  }
+  return nullptr;
+}
+
 const verible::SyntaxTreeNode *GetDataTypeFromForInitialization(
     const verible::Symbol &for_initialization) {
   const auto *data_type = verible::GetSubtreeAsSymbol(

--- a/verible/verilog/CST/statement.h
+++ b/verible/verilog/CST/statement.h
@@ -179,8 +179,13 @@ const verible::SyntaxTreeNode *GetAnyConditionalElseClause(
     const verible::Symbol &conditional);
 
 // Returns the data type node from for loop initialization.
+// Returns the genvar keyword leaf from a for initialization, or nullptr if not
+// present.
+const verible::SyntaxTreeLeaf *GetGenvarKeywordFromForInitialization(
+    const verible::Symbol &for_initialization);
+
 const verible::SyntaxTreeNode *GetDataTypeFromForInitialization(
-    const verible::Symbol &);
+    const verible::Symbol &for_initialization);
 
 // Returns the variable name leaf from for loop initialization.
 const verible::SyntaxTreeLeaf *GetVariableNameFromForInitialization(

--- a/verible/verilog/analysis/symbol-table.cc
+++ b/verible/verilog/analysis/symbol-table.cc
@@ -100,6 +100,8 @@ static const verible::EnumNameMap<SymbolMetaType> &SymbolMetaTypeNames() {
       {"enum", SymbolMetaType::kEnumType},
       {"<enum constant>", SymbolMetaType::kEnumConstant},
       {"interface", SymbolMetaType::kInterface},
+      {"genvar", SymbolMetaType::kGenvar},
+      {"generate loop", SymbolMetaType::kGenerateLoop},
       {"<unspecified>", SymbolMetaType::kUnspecified},
       {"<callable>", SymbolMetaType::kCallable},
   });
@@ -212,6 +214,18 @@ class SymbolTable::Builder : public TreeContextVisitor {
       case NodeEnum::kGenerateElseClause:
         DeclareGenerateElse(node);
         break;
+
+      // separate cases for handling different parts of generate construct
+      case NodeEnum::kLoopGenerateConstruct:
+        DeclareGenerateLoop(node);
+        break;
+      case NodeEnum::kGenerateBlock:
+        DeclareGenerateBlock(node);
+        break;
+      case NodeEnum::kGenvarDeclaration:
+        DeclareGenvarDeclaration(node);
+        break;
+
       case NodeEnum::kPackageDeclaration:
         DeclarePackage(node);
         break;
@@ -312,11 +326,11 @@ class SymbolTable::Builder : public TreeContextVisitor {
       case NodeEnum::kSeqBlock:
         DeclareSequentialBlock(node);
         break;
-      // separate case for for loops
+      // separate case for for-loops
       case NodeEnum::kForLoopStatement:
         DeclareForLoop(node);
         break;
-      // separate case for for loop initialization
+      // separate case for for-loop initialization
       case NodeEnum::kForInitialization:
         DeclareForInitVariable(node);
         break;
@@ -1256,28 +1270,17 @@ class SymbolTable::Builder : public TreeContextVisitor {
                                    SymbolMetaType::kModule);
   }
 
-  std::string_view GetScopeNameFromGenerateBody(const SyntaxTreeNode &body) {
-    if (body.MatchesTag(NodeEnum::kGenerateBlock)) {
-      const SyntaxTreeNode *gen_block = GetGenerateBlockBegin(body);
-      const TokenInfo *label =
-          gen_block ? GetBeginLabelTokenInfo(*gen_block) : nullptr;
-      if (label != nullptr) {
-        // TODO: Check for a matching end-label here, and if its name matches
-        // the begin label, then immediately create a resolved reference because
-        // it only makes sense for it resolve to this begin.
-        // Otherwise, do nothing with the end label.
-        return label->text();
-      }
-    }
-    return current_scope_->Value().CreateAnonymousScope("generate");
-  }
-
   void DeclareGenerateIf(const SyntaxTreeNode &generate_if) {
     const SyntaxTreeNode *body(GetIfClauseGenerateBody(generate_if));
     if (body) {
-      DeclareScopedElementAndDescend(generate_if,
-                                     GetScopeNameFromGenerateBody(*body),
-                                     SymbolMetaType::kGenerate);
+      if (body->MatchesTag(NodeEnum::kGenerateBlock)) {
+        Descend(generate_if);
+      } else {
+        DeclareScopedElementAndDescend(
+            generate_if,
+            current_scope_->Value().CreateAnonymousScope("generate"),
+            SymbolMetaType::kGenerate);
+      }
     }
   }
 
@@ -1290,10 +1293,53 @@ class SymbolTable::Builder : public TreeContextVisitor {
       // and let the if-clause inside create a scope directly under the current
       // scope.
       Descend(*body);
+    } else if (body->MatchesTag(NodeEnum::kGenerateBlock)) {
+      Descend(generate_else);
     } else {
-      DeclareScopedElementAndDescend(generate_else,
-                                     GetScopeNameFromGenerateBody(*body),
+      DeclareScopedElementAndDescend(
+          generate_else,
+          current_scope_->Value().CreateAnonymousScope("generate"),
+          SymbolMetaType::kGenerate);
+    }
+  }
+
+  void DeclareGenerateLoop(const SyntaxTreeNode &node) {
+    const std::string_view scope_name =
+        current_scope_->Value().CreateAnonymousScope("generate-for");
+    DeclareScopedElementAndDescend(node, scope_name,
+                                   SymbolMetaType::kGenerateLoop);
+  }
+
+  void DeclareGenerateBlock(const SyntaxTreeNode &node) {
+    const SyntaxTreeNode *gen_block = GetGenerateBlockBegin(node);
+    const TokenInfo *label =
+        gen_block ? GetBeginLabelTokenInfo(*gen_block) : nullptr;
+    if (label != nullptr) {
+      DeclareScopedElementAndDescend(node, label->text(),
                                      SymbolMetaType::kGenerate);
+    } else {
+      const std::string_view scope_name =
+          current_scope_->Value().CreateAnonymousScope("generate");
+      DeclareScopedElementAndDescend(node, scope_name,
+                                     SymbolMetaType::kGenerate);
+    }
+  }
+
+  void DeclareGenvarDeclaration(const SyntaxTreeNode &node) {
+    const auto *identifier_list =
+        GetSubtreeAsSymbol(node, NodeEnum::kGenvarDeclaration, 1);
+    if (!identifier_list) return;
+
+    const auto *list_node =
+        verible::down_cast<const SyntaxTreeNode *>(identifier_list);
+    for (const auto &child : list_node->children()) {
+      if (child && child->Kind() == verible::SymbolKind::kLeaf) {
+        const SyntaxTreeLeaf &leaf = verible::SymbolCastToLeaf(*child);
+        if (leaf.get().token_enum() == verilog_tokentype::SymbolIdentifier) {
+          EmplaceElementInCurrentScope(leaf, leaf.get().text(),
+                                       SymbolMetaType::kGenvar);
+        }
+      }
     }
   }
 
@@ -1307,7 +1353,8 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const std::string_view scope_name =
         label ? label->text()
               : current_scope_->Value().CreateAnonymousScope("block");
-    DeclareScopedElementAndDescend(node, scope_name, SymbolMetaType::kProceduralBlock);
+    DeclareScopedElementAndDescend(node, scope_name,
+                                   SymbolMetaType::kProceduralBlock);
   }
 
   void DeclareForLoop(const SyntaxTreeNode &node) {
@@ -1315,7 +1362,8 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // initialization variables and the loop body.
     const std::string_view scope_name =
         current_scope_->Value().CreateAnonymousScope("for");
-    DeclareScopedElementAndDescend(node, scope_name, SymbolMetaType::kLoopScope);
+    DeclareScopedElementAndDescend(node, scope_name,
+                                   SymbolMetaType::kLoopScope);
   }
 
   void DeclarePackage(const SyntaxTreeNode &package) {
@@ -1468,8 +1516,21 @@ class SymbolTable::Builder : public TreeContextVisitor {
   }
 
   // Declares a variable from a for-loop initialization (e.g. `int i = 0`).
-  // Only handles typed declarations
+  // Handles both explicit `genvar` and standard typed declarations.
   void DeclareForInitVariable(const SyntaxTreeNode &for_init) {
+    const verible::SyntaxTreeLeaf *genvar_keyword =
+        GetGenvarKeywordFromForInitialization(for_init);
+    if (genvar_keyword) {
+      const verible::SyntaxTreeLeaf *var_name =
+          GetVariableNameFromForInitialization(for_init);
+      if (var_name) {
+        EmplaceElementInCurrentScope(*var_name, var_name->get().text(),
+                                     SymbolMetaType::kGenvar);
+      }
+      Descend(for_init);
+      return;
+    }
+
     const verible::SyntaxTreeNode *data_type =
         GetDataTypeFromForInitialization(for_init);
     if (data_type == nullptr) {
@@ -1487,9 +1548,8 @@ class SymbolTable::Builder : public TreeContextVisitor {
     const ValueSaver<DeclarationTypeInfo *> save_type(&declaration_type_info_,
                                                       &decl_type_info);
     Descend(for_init);
-    EmplaceTypedElementInCurrentScope(
-        for_init, var_name->get().text(),
-        SymbolMetaType::kDataNetVariableInstance);
+    EmplaceTypedElementInCurrentScope(for_init, var_name->get().text(),
+                                      SymbolMetaType::kDataNetVariableInstance);
   }
 
   // Declare one (of potentially multiple) instances in a single declaration

--- a/verible/verilog/analysis/symbol-table.cc
+++ b/verible/verilog/analysis/symbol-table.cc
@@ -88,6 +88,9 @@ static const verible::EnumNameMap<SymbolMetaType> &SymbolMetaTypeNames() {
       {"class", SymbolMetaType::kClass},
       {"module", SymbolMetaType::kModule},
       {"package", SymbolMetaType::kPackage},
+      {"generate", SymbolMetaType::kGenerate},
+      {"procedural block", SymbolMetaType::kProceduralBlock},
+      {"loop scope", SymbolMetaType::kLoopScope},
       {"parameter", SymbolMetaType::kParameter},
       {"typedef", SymbolMetaType::kTypeAlias},
       {"data/net/var/instance", SymbolMetaType::kDataNetVariableInstance},
@@ -304,6 +307,18 @@ class SymbolTable::Builder : public TreeContextVisitor {
       case NodeEnum::kBindDirective:
         // TODO(#1241) Not handled right now.
         // TODO(#1255) Not handled right now.
+        break;
+      // separate case for blocks
+      case NodeEnum::kSeqBlock:
+        DeclareSequentialBlock(node);
+        break;
+      // separate case for for loops
+      case NodeEnum::kForLoopStatement:
+        DeclareForLoop(node);
+        break;
+      // separate case for for loop initialization
+      case NodeEnum::kForInitialization:
+        DeclareForInitVariable(node);
         break;
       default:
         Descend(node);
@@ -1282,6 +1297,27 @@ class SymbolTable::Builder : public TreeContextVisitor {
     }
   }
 
+  void DeclareSequentialBlock(const SyntaxTreeNode &node) {
+    // Procedural begin...end blocks introduce a new lexical scope.
+    // Extract optional label from the kBegin child for scope naming.
+    const verible::TokenInfo *label = nullptr;
+    if (!node.empty() && node.front() != nullptr) {
+      label = GetBeginLabelTokenInfo(*node.front());
+    }
+    const std::string_view scope_name =
+        label ? label->text()
+              : current_scope_->Value().CreateAnonymousScope("block");
+    DeclareScopedElementAndDescend(node, scope_name, SymbolMetaType::kProceduralBlock);
+  }
+
+  void DeclareForLoop(const SyntaxTreeNode &node) {
+    // for-loop statements introduce a scope that encompasses both the
+    // initialization variables and the loop body.
+    const std::string_view scope_name =
+        current_scope_->Value().CreateAnonymousScope("for");
+    DeclareScopedElementAndDescend(node, scope_name, SymbolMetaType::kLoopScope);
+  }
+
   void DeclarePackage(const SyntaxTreeNode &package) {
     const auto *token = GetPackageNameToken(package);
     if (!token) return;
@@ -1429,6 +1465,31 @@ class SymbolTable::Builder : public TreeContextVisitor {
     // reset port direction
     Descend(data_decl_node);
     VLOG(2) << "end of " << __FUNCTION__;
+  }
+
+  // Declares a variable from a for-loop initialization (e.g. `int i = 0`).
+  // Only handles typed declarations
+  void DeclareForInitVariable(const SyntaxTreeNode &for_init) {
+    const verible::SyntaxTreeNode *data_type =
+        GetDataTypeFromForInitialization(for_init);
+    if (data_type == nullptr) {
+      // not a variable declaration. Descend normally for references.
+      Descend(for_init);
+      return;
+    }
+    const verible::SyntaxTreeLeaf *var_name =
+        GetVariableNameFromForInitialization(for_init);
+    if (var_name == nullptr) {
+      Descend(for_init);
+      return;
+    }
+    DeclarationTypeInfo decl_type_info;
+    const ValueSaver<DeclarationTypeInfo *> save_type(&declaration_type_info_,
+                                                      &decl_type_info);
+    Descend(for_init);
+    EmplaceTypedElementInCurrentScope(
+        for_init, var_name->get().text(),
+        SymbolMetaType::kDataNetVariableInstance);
   }
 
   // Declare one (of potentially multiple) instances in a single declaration

--- a/verible/verilog/analysis/symbol-table.h
+++ b/verible/verilog/analysis/symbol-table.h
@@ -53,9 +53,9 @@ enum class SymbolMetaType {
   kRoot,
   kClass,
   kModule,
-  kGenerate,  // loop or conditional generate block
-  kProceduralBlock, // begin...end block
-  kLoopScope, // for loop body and init
+  kGenerate,         // loop or conditional generate block
+  kProceduralBlock,  // begin...end block
+  kLoopScope,        // for loop body and init
   kPackage,
   kParameter,
   kTypeAlias,  // typedef
@@ -66,6 +66,8 @@ enum class SymbolMetaType {
   kEnumType,
   kEnumConstant,
   kInterface,
+  kGenvar,
+  kGenerateLoop,
 
   // The following enums represent classes/groups of the above types,
   // and are used for validating metatypes of symbol references.

--- a/verible/verilog/analysis/symbol-table.h
+++ b/verible/verilog/analysis/symbol-table.h
@@ -54,6 +54,8 @@ enum class SymbolMetaType {
   kClass,
   kModule,
   kGenerate,  // loop or conditional generate block
+  kProceduralBlock, // begin...end block
+  kLoopScope, // for loop body and init
   kPackage,
   kParameter,
   kTypeAlias,  // typedef

--- a/verible/verilog/analysis/symbol-table_test.cc
+++ b/verible/verilog/analysis/symbol-table_test.cc
@@ -827,6 +827,102 @@ TEST_F(BuildSymbolTableTest, SeqBlockVariableShadowing) {
   }
 }
 
+TEST_F(BuildSymbolTableTest, GenerateForVariableScope) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  for (genvar i = 0; i < 5; i++) begin : gen_blk\n"
+                            "    int j;\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+
+  // Module has one child: the generate for loop scope (anonymous).
+  ASSERT_EQ(module_node.Children().size(), 1);
+  const SymbolTableNode &for_scope(module_node.Children().begin()->second);
+  EXPECT_EQ(for_scope.Value().metatype, SymbolMetaType::kGenerateLoop);
+
+  // 'i' is declared in the for-loop scope.
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_i, for_scope, "i");
+  EXPECT_EQ(var_i_info.metatype, SymbolMetaType::kGenvar);
+
+  // The generate for-loop body (begin...end) creates another nested scope
+  // containing 'j'.
+  MUST_ASSIGN_LOOKUP_SYMBOL(body_block, for_scope, "gen_blk");
+  EXPECT_EQ(body_block_info.metatype, SymbolMetaType::kGenerate);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_j, body_block, "j");
+  EXPECT_EQ(var_j_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
+TEST_F(BuildSymbolTableTest, GenerateForVariableScopeAnonymous) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  for (genvar i = 0; i < 5; i++) begin\n"
+                            "    int j;\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  ASSERT_EQ(module_node.Children().size(), 1);
+  const SymbolTableNode &for_scope(module_node.Children().begin()->second);
+  EXPECT_EQ(for_scope.Value().metatype, SymbolMetaType::kGenerateLoop);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_i, for_scope, "i");
+  EXPECT_EQ(var_i_info.metatype, SymbolMetaType::kGenvar);
+
+  const SymbolTableNode *body_block = nullptr;
+  for (const auto &child : for_scope.Children()) {
+    if (child.second.Value().metatype == SymbolMetaType::kGenerate) {
+      body_block = &child.second;
+      break;
+    }
+  }
+  ASSERT_NE(body_block, nullptr);
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_j, *body_block, "j");
+  EXPECT_EQ(var_j_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+}
+
+TEST_F(BuildSymbolTableTest, StandaloneGenvarDeclaration) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  genvar i, j;\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_i, module_node, "i");
+  EXPECT_EQ(var_i_info.metatype, SymbolMetaType::kGenvar);
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_j, module_node, "j");
+  EXPECT_EQ(var_j_info.metatype, SymbolMetaType::kGenvar);
+}
+
 TEST_F(BuildSymbolTableTest, ForLoopVariableScope) {
   TestVerilogSourceFile src("foobar.sv",
                             "module m;\n"
@@ -848,22 +944,20 @@ TEST_F(BuildSymbolTableTest, ForLoopVariableScope) {
 
   // Module has one child: the initial block scope.
   ASSERT_EQ(module_node.Children().size(), 1);
-  const SymbolTableNode &init_block(
-      module_node.Children().begin()->second);
+  const SymbolTableNode &init_block(module_node.Children().begin()->second);
   EXPECT_EQ(init_block.Value().metatype, SymbolMetaType::kProceduralBlock);
 
   // The initial block has one child: the for-loop scope.
   ASSERT_EQ(init_block.Children().size(), 1);
-  const SymbolTableNode &for_scope(
-      init_block.Children().begin()->second);
+  const SymbolTableNode &for_scope(init_block.Children().begin()->second);
   EXPECT_EQ(for_scope.Value().metatype, SymbolMetaType::kLoopScope);
 
   // 'i' is declared in the for-loop scope.
   MUST_ASSIGN_LOOKUP_SYMBOL(var_i, for_scope, "i");
   EXPECT_EQ(var_i_info.metatype, SymbolMetaType::kDataNetVariableInstance);
 
-  // The for-loop body (begin...end) creates another nested scope containing 'j'.
-  // Find the block scope child (skip past 'i').
+  // The for-loop body (begin...end) creates another nested scope containing
+  // 'j'. Find the block scope child (skip past 'i').
   const SymbolTableNode *body_block = nullptr;
   for (const auto &child : for_scope.Children()) {
     if (child.second.Value().metatype == SymbolMetaType::kProceduralBlock) {

--- a/verible/verilog/analysis/symbol-table_test.cc
+++ b/verible/verilog/analysis/symbol-table_test.cc
@@ -713,6 +713,226 @@ TEST_F(BuildSymbolTableTest, ModuleDeclarationConditionalGenerateLabeled) {
   }
 }
 
+TEST_F(BuildSymbolTableTest, SeqBlockCreatesAnonymousScope) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  initial begin\n"
+                            "    int x;\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  EXPECT_EQ(module_node_info.metatype, SymbolMetaType::kModule);
+
+  // The begin...end block should create a child scope.
+  ASSERT_EQ(module_node.Children().size(), 1);
+  const SymbolTableNode &block(module_node.Children().begin()->second);
+  const SymbolInfo &block_info(block.Value());
+  EXPECT_EQ(block_info.metatype, SymbolMetaType::kProceduralBlock);
+
+  // 'x' should be declared inside the block scope, not module scope.
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_x, block, "x");
+  EXPECT_EQ(var_x_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
+TEST_F(BuildSymbolTableTest, SeqBlockLabeledScope) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  initial begin : my_block\n"
+                            "    int y;\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  EXPECT_EQ(module_node_info.metatype, SymbolMetaType::kModule);
+
+  // Labeled block should use the label as scope name.
+  MUST_ASSIGN_LOOKUP_SYMBOL(block_node, module_node, "my_block");
+  EXPECT_EQ(block_node_info.metatype, SymbolMetaType::kProceduralBlock);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_y, block_node, "y");
+  EXPECT_EQ(var_y_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
+TEST_F(BuildSymbolTableTest, SeqBlockVariableShadowing) {
+  // Inner begin...end block declares 'x' which shadows the outer module-level
+  // 'x'.  Both declarations should succeed (no "already defined" error).
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  int x;\n"
+                            "  initial begin\n"
+                            "    int x;\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+  EXPECT_EQ(module_node_info.metatype, SymbolMetaType::kModule);
+
+  // Outer 'x' in module scope.
+  MUST_ASSIGN_LOOKUP_SYMBOL(outer_x, module_node, "x");
+  EXPECT_EQ(outer_x_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  // Block scope exists as a second child of module.
+  EXPECT_EQ(module_node.Children().size(), 2);  // x + anonymous block
+  auto iter = module_node.Children().begin();
+  // Find the block child (skip past 'x').
+  while (iter != module_node.Children().end() &&
+         iter->second.Value().metatype != SymbolMetaType::kProceduralBlock) {
+    ++iter;
+  }
+  ASSERT_NE(iter, module_node.Children().end());
+  const SymbolTableNode &block(iter->second);
+
+  // Inner 'x' lives inside the block scope.
+  MUST_ASSIGN_LOOKUP_SYMBOL(inner_x, block, "x");
+  EXPECT_EQ(inner_x_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
+TEST_F(BuildSymbolTableTest, ForLoopVariableScope) {
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  initial begin\n"
+                            "    for (int i = 0; i < 5; i++) begin\n"
+                            "      int j;\n"
+                            "    end\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+
+  // Module has one child: the initial block scope.
+  ASSERT_EQ(module_node.Children().size(), 1);
+  const SymbolTableNode &init_block(
+      module_node.Children().begin()->second);
+  EXPECT_EQ(init_block.Value().metatype, SymbolMetaType::kProceduralBlock);
+
+  // The initial block has one child: the for-loop scope.
+  ASSERT_EQ(init_block.Children().size(), 1);
+  const SymbolTableNode &for_scope(
+      init_block.Children().begin()->second);
+  EXPECT_EQ(for_scope.Value().metatype, SymbolMetaType::kLoopScope);
+
+  // 'i' is declared in the for-loop scope.
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_i, for_scope, "i");
+  EXPECT_EQ(var_i_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  // The for-loop body (begin...end) creates another nested scope containing 'j'.
+  // Find the block scope child (skip past 'i').
+  const SymbolTableNode *body_block = nullptr;
+  for (const auto &child : for_scope.Children()) {
+    if (child.second.Value().metatype == SymbolMetaType::kProceduralBlock) {
+      body_block = &child.second;
+      break;
+    }
+  }
+  ASSERT_NE(body_block, nullptr);
+  MUST_ASSIGN_LOOKUP_SYMBOL(var_j, *body_block, "j");
+  EXPECT_EQ(var_j_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
+TEST_F(BuildSymbolTableTest, ForLoopVariableShadowing) {
+  // Module-level 'i' and for-loop 'i' should not collide.
+  TestVerilogSourceFile src("foobar.sv",
+                            "module m;\n"
+                            "  int i;\n"
+                            "  initial begin\n"
+                            "    for (int i = 0; i < 5; i++) begin\n"
+                            "    end\n"
+                            "  end\n"
+                            "endmodule\n");
+  const auto status = src.Parse();
+  ASSERT_TRUE(status.ok()) << status.message();
+  SymbolTable symbol_table(nullptr);
+  const SymbolTableNode &root_symbol(symbol_table.Root());
+
+  const auto build_diagnostics = BuildSymbolTable(src, &symbol_table);
+  EXPECT_EMPTY_STATUSES(build_diagnostics);
+
+  MUST_ASSIGN_LOOKUP_SYMBOL(module_node, root_symbol, "m");
+
+  // Module-level 'i' exists.
+  MUST_ASSIGN_LOOKUP_SYMBOL(outer_i, module_node, "i");
+  EXPECT_EQ(outer_i_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  // Find the for-loop scope (nested inside the initial block scope).
+  const SymbolTableNode *for_scope = nullptr;
+  for (const auto &child : module_node.Children()) {
+    if (child.second.Value().metatype == SymbolMetaType::kProceduralBlock) {
+      // This is the initial block. Search inside for the for-loop scope.
+      for (const auto &grandchild : child.second.Children()) {
+        if (grandchild.second.Value().metatype == SymbolMetaType::kLoopScope) {
+          for_scope = &grandchild.second;
+          break;
+        }
+      }
+      break;
+    }
+  }
+  ASSERT_NE(for_scope, nullptr);
+
+  // For-loop 'i' lives in the for-loop scope.
+  MUST_ASSIGN_LOOKUP_SYMBOL(loop_i, *for_scope, "i");
+  EXPECT_EQ(loop_i_info.metatype, SymbolMetaType::kDataNetVariableInstance);
+
+  {
+    std::vector<absl::Status> resolve_diagnostics;
+    symbol_table.Resolve(&resolve_diagnostics);
+    EXPECT_EMPTY_STATUSES(resolve_diagnostics);
+  }
+}
+
 TEST_F(BuildSymbolTableTest, ModuleDeclarationWithPorts) {
   TestVerilogSourceFile src("foobar.sv",
                             "module m (\n"


### PR DESCRIPTION
**Symbol Table: Model Procedural and Generate Scopes Explicitly**

Related to #1368 

**Summary**

This PR extends Verible’s symbol-table construction to explicitly model SystemVerilog procedural and generate scopes.

The work was motivated by incorrect Go-to-Definition behavior caused by missing scope information in the symbol table. Although procedural blocks, procedural for-loops, generate-for loops, and genvar declarations are represented in the CST, the symbol-table builder did not consistently create corresponding scopes and symbols. As a result, declarations inside these constructs could be attached to enclosing scopes rather than the scope introduced by the construct itself.

This change adds symbol-table support for procedural blocks, procedural loop scopes, generate-for loop scopes, and genvar declarations, resulting in a hierarchy that more accurately reflects SystemVerilog lexical and elaboration scoping rules and enables correct symbol resolution within these constructs.

**Changes**

*Procedural Scopes*

* Added symbol-table handling for kSeqBlock that creates a dedicated procedural-block scope.
* Added symbol-table handling for kForLoopStatement that creates a dedicated loop scope.
* Added symbol-table handling for typed loop initialization variables (kForInitialization).
* Added dedicated symbol metatypes for procedural block and loop scopes.

*Generate Scopes*

* Added symbol-table handling for kLoopGenerateConstruct that creates a dedicated generate-loop scope.
* Added symbol-table handling for kGenerateBlock.
* Added symbol-table support for standalone genvar declarations.
* Added symbol-table support for inline generate-loop declarations (e.g. for (genvar i = 0; ...)).
* Added dedicated symbol metatypes for generate-loop scopes and genvars.
* Refactored generate-if / generate-else handling so that generate-block scope creation is centralized in kGenerateBlock, avoiding duplicate scope creation.

**Motivation**

Verible already models scopes for constructs such as modules, packages, classes, functions, and generate blocks. However, procedural blocks, procedural loops, generate-for loops, and genvar declarations were not consistently represented in the symbol table.

This resulted in a symbol-table hierarchy that did not fully reflect SystemVerilog lexical and elaboration scoping rules. In particular:

* Variables declared inside procedural blocks were not represented according to lexical shadowing rules.
* Typed procedural loop variables were not represented in a dedicated loop scope.
* Generate-for loop scopes were not represented explicitly.
* Genvar declarations had no symbol-table representation.

These deficiencies also affected symbol resolution. Variables declared within procedural and generate scopes could not always be resolved to the correct declaration, leading to incorrect Go-to-Definition behavior in the language server.

This change extends symbol-table construction so that declarations are inserted into the correct scope and the resulting hierarchy more closely mirrors the structure of the source code.

**Example Symbol Table Hierarchies**

* Procedural Block Scope
```
module m;
  int x;
  initial begin
    int y;
  end
endmodule
```
Symbol table:
```
m [module]
├── %anon-block-0 [procedural block]
│   └── y [data/net/var/instance]
└── x [data/net/var/instance]
```
* Procedural For-Loop Scope
```
module m;
  int i;
  initial begin
    for (int i = 0; i < 4; ++i) begin
      int j;
    end
  end
endmodule
```
Symbol table:
```
m [module]
├── %anon-block-0 [procedural block]
│   └── %anon-for-0 [loop scope]
│       ├── %anon-block-0 [procedural block]
│       │   └── j [data/net/var/instance]
│       └── i [data/net/var/instance]
└── i [data/net/var/instance]
```
This demonstrates correct loop-local scope creation and shadowing between the loop variable and the enclosing declaration.

* Generate-For Scope
```
module m;
  for (genvar i = 0; i < 4; ++i) begin : gen_blk
    int j;
  end
endmodule
```
Symbol table:
```
m [module]
└── %anon-generate-for-0 [generate loop]
    ├── gen_blk [generate]
    │   └── j [data/net/var/instance]
    └── i [genvar]
```
This demonstrates explicit generate-loop scope creation, genvar declaration tracking, and preservation of generate-block hierarchy.

**Go-to-Definition Impact**

A primary motivation for this work was improving symbol resolution in the language server.

Before these changes, declarations introduced inside procedural blocks, procedural loops, and generate constructs were not consistently represented in the symbol table. As a result, Go-to-Definition could fail to resolve references to the correct declaration or could bypass the intended scope hierarchy.

With these scopes now modeled explicitly:

* Variables declared inside procedural blocks resolve to the correct local declaration.
* Typed loop variables resolve within their loop scope.
* Genvar declarations participate in symbol resolution.
* References within generate-loop hierarchies resolve against the correct scope structure.

Manual verification in VS Code confirmed that Go-to-Definition now correctly navigates to declarations within these scopes.

**Testing**

Added tests covering:

*Procedural Scopes*

* anonymous procedural block scopes
* labeled procedural block scopes
* procedural block shadowing
* for-loop variable scopes
* for-loop variable shadowing

*Generate Scopes*

* generate-for loops with labeled blocks
* generate-for loops with anonymous blocks
* standalone genvar declarations
* inline genvar declarations in generate-loop initializations
* nested generate-loop hierarchies

Verified that:

* symbol-table_test passes
* symbol-table-handler_test passes

Additionally, Go-to-Definition was manually verified in VS Code and correctly resolves declarations within:

* procedural block scopes
* procedural loop scopes
* generate-loop scopes
* genvar declarations