### PR TITLE
patch: reject non-positive hunk start line to avoid OOB read

### DIFF
--- a/verible/common/strings/patch.cc
+++ b/verible/common/strings/patch.cc
@@ -229,7 +229,8 @@ absl::Status Hunk::VerifyAgainstOriginalLines(
   int line_number = header_.old_range.start;  // 1-indexed
   for (const MarkedLine &line : lines_) {
     if (line.IsAdded()) continue;  // ignore added lines
-    if (line_number > static_cast<int>(original_lines.size())) {
+    if (line_number < 1 ||
+        line_number > static_cast<int>(original_lines.size())) {
       return absl::OutOfRangeError(absl::StrCat(
           "Patch hunk references line ", line_number, " in a file with only ",
           original_lines.size(), " lines"));

--- a/verible/common/strings/patch_test.cc
+++ b/verible/common/strings/patch_test.cc
@@ -755,6 +755,34 @@ TEST(HunkVerifyAgainstOriginalLinesTest, LineNumberOutOfBounds) {
   }
 }
 
+TEST(HunkVerifyAgainstOriginalLinesTest, NonPositiveStartLine) {
+  // A hunk header whose old-file start is 0 (line numbers are 1-indexed) must
+  // be rejected rather than indexing original_lines at a non-positive offset.
+  const std::vector<std::string_view> kHunkText = {
+      {
+          "@@ -0,2 +1,2 @@",  //
+          " line1",           // retained line reached with line_number == 0
+          "-line2",           //
+          "+line pi",         //
+      },
+  };
+  const std::vector<std::string_view> kOriginal = {
+      "line1",
+      "line2",
+  };
+  Hunk hunk;
+  {
+    const LineRange range(kHunkText.begin(), kHunkText.end());
+    const auto status = hunk.Parse(range);
+    ASSERT_TRUE(status.ok()) << status.message();
+  }
+  {
+    const auto status = hunk.VerifyAgainstOriginalLines(kOriginal);
+    EXPECT_EQ(status.code(), absl::StatusCode::kOutOfRange);
+    EXPECT_TRUE(absl::StrContains(status.message(), "references line 0"));
+  }
+}
+
 TEST(HunkVerifyAgainstOriginalLinesTest, InconsistentRetainedLine) {
   const std::vector<std::string_view> kHunkText = {
       {


### PR DESCRIPTION
### Problem
`Hunk::VerifyAgainstOriginalLines` can read a `std::vector` out of bounds on a malformed patch.

### Root cause
`common/strings/patch.cc` guards `original_lines[line_number - 1]` (line 237) only against `line_number` being too large; there is no lower-bound check. `line_number` comes from `header_.old_range.start`, parsed by `HunkIndices::Parse` with `absl::SimpleAtoi` (which accepts `0` and negatives), and `Hunk::IsValid` only checks that the non-added line count equals `old_range.count`. So a hunk header like `@@ -0,1 +1,1 @@` followed by a context line parses successfully with `line_number == 0`, and `original_lines[0 - 1]` indexes at `(size_t)-1` — an out-of-bounds read; the subsequent `.Text()` comparison then dereferences a wild `string_view`. Reachable via `verible-patch-tool apply` on a crafted patch file.

### Fix
Extend the existing bounds error to also reject `line_number < 1`.

### Verification
Static reasoning; the existing `LineNumberOutOfBounds` test exercises only the upper bound. (Verible builds with Bazel, which I don't have set up locally — happy to add a lower-bound test case.)
