### PR TITLE
port-name-suffix: handle `ref` direction and all-underscore names

### DIFF
--- a/verible/verilog/analysis/checkers/BUILD
+++ b/verible/verilog/analysis/checkers/BUILD
@@ -1821,6 +1821,7 @@ cc_library(
         "//verible/common/text:symbol",
         "//verible/common/text:syntax-tree-context",
         "//verible/common/text:token-info",
+        "//verible/common/util:container-util",
         "//verible/verilog/CST:port",
         "//verible/verilog/CST:verilog-matchers",
         "//verible/verilog/analysis:descriptions",

--- a/verible/verilog/analysis/checkers/port-name-suffix-rule.cc
+++ b/verible/verilog/analysis/checkers/port-name-suffix-rule.cc
@@ -90,10 +90,14 @@ bool PortNameSuffixRule::IsSuffixCorrect(std::string_view suffix,
        {"output", {"o", "no", "po"}},
        {"inout", {"io", "nio", "pio"}}};
 
-  // At this point it is guaranteed that the direction will be set to
-  // one of the expected values (used as keys in the map above).
-  // Therefore checking the suffix like this is safe
-  return suffixes.at(direction).count(suffix) == 1;
+  // `direction` is usually one of the map keys, but the grammar also permits a
+  // `ref` port direction, which has no suffix convention. Look the direction up
+  // safely and treat an unknown direction as "correct" (no violation),
+  // consistent with Violation() which also ignores non-input/output/inout
+  // directions. Using std::map::at() here would throw on e.g. "ref".
+  const auto it = suffixes.find(direction);
+  if (it == suffixes.end()) return true;
+  return it->second.count(suffix) == 1;
 }
 
 void PortNameSuffixRule::HandleSymbol(const Symbol &symbol,
@@ -113,8 +117,11 @@ void PortNameSuffixRule::HandleSymbol(const Symbol &symbol,
         absl::StrSplit(name, '_', absl::SkipEmpty());
 
     if (name_parts.size() < 2) {
-      // No suffix at all
+      // No suffix at all. This also covers an all-underscore name (e.g. "_"),
+      // for which SkipEmpty leaves name_parts empty; return here so the
+      // name_parts.back() access below is not reached on an empty vector.
       Violation(direction, token, context);
+      return;
     }
 
     if (!IsSuffixCorrect(name_parts.back(), direction)) {

--- a/verible/verilog/analysis/checkers/port-name-suffix-rule.cc
+++ b/verible/verilog/analysis/checkers/port-name-suffix-rule.cc
@@ -28,6 +28,7 @@
 #include "verible/common/text/symbol.h"
 #include "verible/common/text/syntax-tree-context.h"
 #include "verible/common/text/token-info.h"
+#include "verible/common/util/container-util.h"
 #include "verible/verilog/CST/port.h"
 #include "verible/verilog/CST/verilog-matchers.h"
 #include "verible/verilog/analysis/descriptions.h"
@@ -91,13 +92,15 @@ bool PortNameSuffixRule::IsSuffixCorrect(std::string_view suffix,
        {"inout", {"io", "nio", "pio"}}};
 
   // `direction` is usually one of the map keys, but the grammar also permits a
-  // `ref` port direction, which has no suffix convention. Look the direction up
-  // safely and treat an unknown direction as "correct" (no violation),
+  // `ref` port direction, which has no suffix convention. FindWithDefault looks
+  // the direction up with an empty-set fallback, so an unknown direction (e.g.
+  // `ref`) has no required suffixes and is treated as "correct" (no violation),
   // consistent with Violation() which also ignores non-input/output/inout
-  // directions. Using std::map::at() here would throw on e.g. "ref".
-  const auto it = suffixes.find(direction);
-  if (it == suffixes.end()) return true;
-  return it->second.count(suffix) == 1;
+  // directions.
+  static const std::set<std::string_view> kNoConvention;
+  const std::set<std::string_view> &valid =
+      verible::container::FindWithDefault(suffixes, direction, kNoConvention);
+  return valid.empty() || valid.count(suffix) == 1;
 }
 
 void PortNameSuffixRule::HandleSymbol(const Symbol &symbol,

--- a/verible/verilog/analysis/checkers/port-name-suffix-rule_test.cc
+++ b/verible/verilog/analysis/checkers/port-name-suffix-rule_test.cc
@@ -57,6 +57,9 @@ TEST(PortNameSuffixRuleTest, AcceptTests) {
       {"module t (input bit name_i); endmodule;"},
       {"module t (output bit abc_o); endmodule;"},
       {"module t (inout bit xyz_io); endmodule;"},
+      // A `ref` port has no suffix convention and must not be flagged (and must
+      // not crash the rule via std::map::at).
+      {"module t (ref logic data_x); endmodule;"},
       {"module t (input logic name_i,\n"
        "output logic abc_o,\n"
        "inout logic xyz_io,\n"
@@ -89,6 +92,10 @@ TEST(PortNameSuffixRuleTest, RejectTests) {
       {"module t (input logic ", {kToken, "_i"}, "); endmodule;"},
       {"module t (output logic ", {kToken, "_o"}, "); endmodule;"},
       {"module t (inout logic ", {kToken, "_io"}, "); endmodule;"},
+
+      // An all-underscore name splits (SkipEmpty) to an empty parts list; it
+      // must report a suffix violation, not dereference an empty vector.
+      {"module t (input logic ", {kToken, "_"}, "); endmodule;"},
 
       {"module t (input logic ", {kToken, "namei"}, "); endmodule;"},
       {"module t (input logic ", {kToken, "nam_ei"}, "); endmodule;"},


### PR DESCRIPTION
### Problem
`PortNameSuffixRule` crashes the linter on two kinds of valid SystemVerilog:

1. A `ref` port direction throws `std::out_of_range` (uncaught → linter abort).
2. An all-underscore port name (e.g. `_`) dereferences an empty vector (UB).

### Details
**1. `ref` direction** — `IsSuffixCorrect` does `suffixes.at(direction)`, where `suffixes` only has keys `{input, output, inout}`. The grammar's `port_direction : dir | TK_ref` allows `ref`, so a port like `module m(ref logic data_x); endmodule` reaches `suffixes.at("ref")`, which throws. `HandleSymbol` runs without a surrounding try/catch, so the linter terminates. (The comment claiming the direction "is guaranteed" to be a known key is incorrect.)

**2. all-underscore name** — `name_parts = absl::StrSplit(name, '_', absl::SkipEmpty())`. For a name that is only underscores (`_`, `__`), every token is empty and `SkipEmpty` drops them all, leaving `name_parts` empty. The `if (name_parts.size() < 2)` block reports a violation but does **not** return, so `name_parts.back()` on the next line dereferences an empty vector (UB).

### Fix
1. Look the direction up with `find()` and treat an unknown direction (e.g. `ref`) as "correct" — no violation — matching `Violation()`, which already ignores non-input/output/inout directions.
2. `return` after the `size() < 2` violation (a name with fewer than two underscore-delimited parts has no suffix to check). This also removes a redundant duplicate `Violation` insert for no-underscore names.

### Tests
`port-name-suffix-rule_test.cc`: a `ref` port is accepted (no violation, no crash); an all-underscore `_` port reports a single suffix violation instead of crashing.
