### PR TITLE
parser: accept primitive data types in net declarations

### DIFF
--- a/verible/verilog/parser/verilog-parser_test.cc
+++ b/verible/verilog/parser/verilog-parser_test.cc
@@ -1339,6 +1339,15 @@ static constexpr ParserTestCaseArray kTaskTests = {
 static constexpr ParserTestCaseArray kModuleTests = {
     "module modular_thing;\n"
     "endmodule",
+    "module m;\n"
+    "wire logic b;\n"
+    "endmodule",
+    "module m;\n"
+    "wire bit b;\n"
+    "endmodule",
+    "module m;\n"
+    "wire logic [3:0] b;\n"
+    "endmodule",
     "module semicolon_madness;;;;;\n"
     "endmodule",
     "module automatic modular_thing;\n"

--- a/verible/verilog/parser/verilog.y
+++ b/verible/verilog/parser/verilog.y
@@ -2111,6 +2111,9 @@ data_type_or_implicit
     { $$ = MakeTaggedNode(N::kDataTypeImplicitIdDimensions,
                           MakeDataType($1, MakePackedDimensionsNode($2)),
                           $3, nullptr, nullptr); }
+  | data_type_primitive delay3_or_drive_opt
+    { $$ = MakeTaggedNode(N::kDataTypeImplicitIdDimensions,
+                          $1, $2, nullptr, nullptr); }
   | GenericIdentifier decl_dimensions_opt delay3_or_drive_opt
     { $$ = MakeTaggedNode(N::kDataTypeImplicitIdDimensions,
                           MakeDataType(MakeTaggedNode(N::kLocalRoot,MakeTaggedNode(N::kUnqualifiedId,$1)), MakePackedDimensionsNode($2)),


### PR DESCRIPTION
## Summary

This PR fixes parsing of valid SystemVerilog net declarations using primitive data types.

Previously, declarations such as:

```systemverilog
wire logic b;
wire bit b;
wire logic [3:0] b;
```

were rejected with:

```
syntax error at token "logic"
```

even though they are valid according to IEEE 1800-2017.

## Root cause

The `data_type_or_implicit` grammar rule did not accept `data_type_primitive`, preventing primitive data types from appearing in net declarations.

## Changes

- Add `data_type_primitive` as an alternative in `data_type_or_implicit`.
- Add parser regression tests covering:
  - `wire logic b;`
  - `wire bit b;`
  - `wire logic [3:0] b;`

## Testing

- Reproduced the original issue using `verible-verilog-syntax`.
- Verified that the reproducer now parses successfully.
- Ran the parser regression tests.

Fixes #2533