### PR TITLE
Exempt unique0 case statements from case-missing-default

### DIFF
--- a/verible/verilog/CST/verilog-matchers.h
+++ b/verible/verilog/CST/verilog-matchers.h
@@ -437,6 +437,17 @@ inline constexpr auto HasDefaultCase =
 //     ...
 inline constexpr auto HasUniqueQualifier =
     verible::matcher::MakePathMatcher(L(TK_unique));
+
+// Matches the `unique0` qualifier, e.g.
+//
+//   unique0 case (in)
+//     1: return 0;
+//   endcase
+//
+// Unlike `unique`, `unique0` permits zero matching case items, so it is
+// tracked separately from HasUniqueQualifier.
+inline constexpr auto HasUnique0Qualifier =
+    verible::matcher::MakePathMatcher(L(TK_unique0));
 // Clean up macros
 #undef N
 #undef L

--- a/verible/verilog/CST/verilog-matchers_test.cc
+++ b/verible/verilog/CST/verilog-matchers_test.cc
@@ -822,6 +822,66 @@ TEST(VerilogMatchers, HasUniqueQualifierTests) {
        endfunction
        )",
        1},
+      // `unique0` is a distinct token and must not be matched here.
+      {HasUniqueQualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )",
+       0},
+  };
+  for (const auto &test : tests) {
+    verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);
+  }
+}
+
+// Tests for HasUnique0Qualifier matching.
+TEST(VerilogMatchers, HasUnique0QualifierTests) {
+  const RawMatcherTestCase tests[] = {
+      {HasUnique0Qualifier(), "", 0},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         case (in)
+           default: return 0;
+         endcase
+       endfunction
+       )",
+       0},
+      // `unique` must not be matched by the `unique0` matcher.
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )",
+       0},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )",
+       1},
+      {HasUnique0Qualifier(),
+       R"(
+       function automatic int foo (input in);
+         unique0 if (in) begin
+           return 0;
+         end
+         else if(!in) begin
+           return 1;
+         end
+       endfunction
+       )",
+       1},
   };
   for (const auto &test : tests) {
     verible::matcher::RunRawMatcherTestCase<VerilogAnalyzer>(test);

--- a/verible/verilog/analysis/checkers/case-missing-default-rule.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule.cc
@@ -42,7 +42,7 @@ VERILOG_REGISTER_LINT_RULE(CaseMissingDefaultRule);
 
 static constexpr std::string_view kMessage =
     "Explicitly define a default case for every case statement or add `unique` "
-    "qualifier to the case statement.";
+    "or `unique0` qualifier to the case statement.";
 
 const LintRuleDescriptor &CaseMissingDefaultRule::GetDescriptor() {
   static const LintRuleDescriptor d{
@@ -50,7 +50,7 @@ const LintRuleDescriptor &CaseMissingDefaultRule::GetDescriptor() {
       .topic = "case-statements",
       .desc =
           "Checks that a default case-item is always defined unless the case "
-          "statement has the `unique` qualifier.",
+          "statement has the `unique` or `unique0` qualifier.",
   };
   return d;
 }
@@ -67,12 +67,16 @@ void CaseMissingDefaultRule::HandleSymbol(
   static const Matcher uniqueCaseMatcher(
       NodekCaseStatement(HasUniqueQualifier()));
 
+  static const Matcher unique0CaseMatcher(
+      NodekCaseStatement(HasUnique0Qualifier()));
+
   static const Matcher caseMatcherWithDefaultCase(
       NodekCaseStatement(HasDefaultCase()));
 
-  // If the case statement doesn't have the "unique" qualifier and
-  // it is missing the "default" case, insert the violation
+  // If the case statement doesn't have the "unique" or "unique0" qualifier
+  // and it is missing the "default" case, insert the violation
   if (!uniqueCaseMatcher.Matches(symbol, &manager) &&
+      !unique0CaseMatcher.Matches(symbol, &manager) &&
       !caseMatcherWithDefaultCase.Matches(symbol, &manager)) {
     violations_.insert(LintViolation(symbol, kMessage, context));
   }

--- a/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
+++ b/verible/verilog/analysis/checkers/case-missing-default-rule_test.cc
@@ -329,6 +329,97 @@ TEST(CaseMissingDefaultRuleTest, NestedCaseInsideTaskTests) {
   RunLintTestCases<VerilogAnalyzer, CaseMissingDefaultRule>(kTestCases);
 }
 
+// Tests that case statements carrying the `unique` or `unique0` qualifier are
+// exempt from requiring a default case-item, while an unqualified case
+// statement still reports a violation.
+TEST(CaseMissingDefaultRuleTest, UniqueQualifierTests) {
+  const std::initializer_list<LintTestCase> kTestCases = {
+      // `unique` exempts case/casex/casez from needing a default.
+      {R"(
+       function automatic int foo (input in);
+         unique case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input in);
+         unique casex (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input in);
+         unique casez (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+
+      // `unique0` likewise exempts case/casex/casez.
+      {R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input in);
+         unique0 casex (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+      {R"(
+       function automatic int foo (input in);
+         unique0 casez (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+
+      // A qualifier combined with an explicit default is still fine.
+      {R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: return 0;
+           default: return 1;
+         endcase
+       endfunction
+       )"},
+
+      // Control: without a qualifier, a missing default still violates.
+      {R"(
+       function automatic int foo (input in);
+         )",
+       {TK_case, "case"},
+       R"( (in)
+           1: return 0;
+         endcase
+       endfunction
+       )"},
+
+      // A qualified outer case does not exempt an unqualified inner case.
+      {R"(
+       function automatic int foo (input in);
+         unique0 case (in)
+           1: begin;
+             )",
+       {TK_case, "case"},
+       R"( (in)
+               1: return 1;
+             endcase
+           end
+         endcase
+       endfunction
+       )"},
+  };
+
+  RunLintTestCases<VerilogAnalyzer, CaseMissingDefaultRule>(kTestCases);
+}
+
 }  // namespace
 }  // namespace analysis
 }  // namespace verilog


### PR DESCRIPTION
The case-missing-default rule suppressed its violation only for the `unique` qualifier, so `unique0 case` was reported as missing a default even though the qualifier explicitly permits zero matching case items.

TK_unique0 was already handled by the lexer and parser; only the HasUniqueQualifier matcher was missing it. Add a separate HasUnique0Qualifier matcher rather than widening HasUniqueQualifier, so the matcher name keeps matching the token it looks for, and check both in the rule. Update the violation message and rule description, which previously mentioned only `unique`.

Adds rule-level tests for `unique` and `unique0` across case/casex/casez, including nesting and unqualified control cases; the rule had no qualifier tests before. Also tests that neither matcher matches the other's token.

Fixes #2413