### PR TITLE
docs: fix lint rule development guide link

### DIFF
--- a/verible/verilog/tools/lint/README.md
+++ b/verible/verilog/tools/lint/README.md
@@ -33,7 +33,7 @@ Currrent limitations:
 
 ## Developers
 
-[Style lint rule development guide](../../../doc/style_lint.md).
+[Style lint rule development guide](../../../../doc/style_lint.md).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- fix the relative link to the style lint rule development guide in the lint README

## Verification
- confirmed the previous relative target is missing
- confirmed the corrected target resolves to `doc/style_lint.md`
- `git diff --check`

Fixes #2430