### PR TITLE
c++ standard: switch to c++20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,21 +10,18 @@ build --enable_platform_specific_config
 build --workspace_status_command="bash bazel/build-version.sh"
 
 # Systems with gcc or clang
-common:unix    --cxxopt=-xc++ --host_cxxopt=-xc++ --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
+common:unix    --cxxopt=-xc++      --host_cxxopt=-xc++
+common:unix    --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 common:linux   --config=unix
 common:freebsd --config=unix --linkopt=-lm --host_linkopt=-lm
 common:openbsd --config=unix --linkopt=-lm --host_linkopt=-lm
 common:macos   --config=unix
 
-# https://github.com/abseil/abseil-cpp/issues/848
-# https://github.com/bazelbuild/bazel/issues/4341#issuecomment-758361769
-common:macos --features=-supports_dynamic_linker --linkopt=-framework --linkopt=CoreFoundation --host_linkopt=-framework --host_linkopt=CoreFoundation
-
 # Use clang-cl by default on Windows. MSVC has some issues with the codebase,
 # so we focus the effort for now is to have a Windows Verible compiled with
 # clang-cl before fixing the issues unique to MSVC.
 common:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:x64_windows-clang-cl
-common:windows --compiler=clang-cl --cxxopt=/std:c++17 --host_cxxopt=/std:c++17 --client_env=BAZEL_CXXOPTS=/std:c++17
+common:windows --compiler=clang-cl --cxxopt=/std:c++20 --host_cxxopt=/std:c++20 --client_env=BAZEL_CXXOPTS=/std:c++20
 
 build --cxxopt="-Wno-unknown-warning-option" --host_cxxopt="-Wno-unknown-warning-option"
 # TODO: this looks like benign where it happens but to be explored further.

--- a/.github/settings.sh
+++ b/.github/settings.sh
@@ -29,7 +29,7 @@ fi
 
 export GIT_VERSION=${GIT_VERSION:-$(git describe --match='v*')}
 
-export BAZEL_CXXOPTS="-std=c++17"
+export BAZEL_CXXOPTS="-std=c++20"
 
 # Progress output is just noisy in CI outputs.
 export BAZEL_OPTS="-c opt --noshow_progress"

--- a/.github/workflows/verible-ci.yml
+++ b/.github/workflows/verible-ci.yml
@@ -124,7 +124,6 @@ jobs:
         - test
         - test-clang
         - test-nortti
-        - test-c++20
         - test-c++23
         - smoke-test
         #- smoke-test-analyzer  #issue: #2046
@@ -140,8 +139,6 @@ jobs:
         - arm64
         exclude:
           - mode: test-nortti
-            arch: arm64
-          - mode: test-c++20
             arch: arm64
           - mode: test-c++23
             arch: arm64
@@ -182,12 +179,10 @@ jobs:
         set -x
         apt -qqy update
         apt -qq -y install build-essential wget git python3 python-is-python3 default-jdk cmake python3-pip ripgrep
-        apt -qq -y install gcc-10 g++-10
         apt -qq -y install gcc-14 g++-14
         apt -qq -y install clang-19
         source ./.github/settings.sh
-        # Use newer compiler for c++2x compilation. Also slang needs c++20
-        ./.github/bin/set-compiler.sh $([[ "$MODE" == test-c++2* || "$MODE" == "smoke-test-analyzer" ]] && echo 14 || echo 10)
+        ./.github/bin/set-compiler.sh 14
         ARCH="$ARCH" ./.github/bin/install-bazel.sh
 
     - name: Build Slang


### PR DESCRIPTION
Technically, we only can use designated initializers with c++20 anyway, so this is now matching.
Simplify compiler use, and don't check against a super-ancient one anymore, but use a somewhat recent gcc 15