### PR TITLE
Add support for soft packed union syntax

### DIFF
--- a/verible/verilog/formatting/formatter_test.cc
+++ b/verible/verilog/formatting/formatter_test.cc
@@ -8138,6 +8138,22 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  bit [31:0]          second;\n"
      "  generic_type_name_t third;\n"
      "} type_t;\n"},
+    {"typedef union soft packed {\n"
+     "bit [3:0] first; bit [31:0] second; generic_type_name_t third;\n"
+     "} type_t;",
+     "typedef union soft packed {\n"
+     "  bit [3:0]           first;\n"
+     "  bit [31:0]          second;\n"
+     "  generic_type_name_t third;\n"
+     "} type_t;\n"},
+    {"typedef union soft {\n"
+     "bit [3:0] first; bit [31:0] second; generic_type_name_t third;\n"
+     "} type_t;",
+     "typedef union soft {\n"
+     "  bit [3:0]           first;\n"
+     "  bit [31:0]          second;\n"
+     "  generic_type_name_t third;\n"
+     "} type_t;\n"},
     {"typedef struct {\n"
      "// comment\n"
      "bit [3:0] first; bit [31:0] second; generic_type_name_t third;\n"

--- a/verible/verilog/parser/verilog-parser_test.cc
+++ b/verible/verilog/parser/verilog-parser_test.cc
@@ -3805,6 +3805,10 @@ static constexpr ParserTestCaseArray kUnionTests = {
     "union tagged packed { int i; bit b; } foo;",
     "union tagged packed signed { int i; bit b; } foo;",
     "union tagged packed unsigned { int i; bit b; } foo;",
+    "union soft { int i; bit b; } foo;",
+    "union soft packed { int i; bit b; } foo;",
+    "union soft packed signed { int i; bit b; } foo;",
+    "union soft packed unsigned { int i; bit b; } foo;",
 };
 
 // TODO(fangism): implement and test ENUM_CONSTANT

--- a/verible/verilog/parser/verilog.y
+++ b/verible/verilog/parser/verilog.y
@@ -3729,7 +3729,7 @@ enum_name
 struct_data_type
   : TK_struct packed_signing_opt '{' struct_union_member_list '}'
     { $$ = MakeTaggedNode(N::kStructType, $1, $2, MakeBraceGroup($3, $4, $5)); }
-  | TK_union TK_tagged_opt packed_signing_opt '{' struct_union_member_list '}'
+  | TK_union TK_union_qualifier_opt packed_signing_opt '{' struct_union_member_list '}'
     { $$ = MakeTaggedNode(N::kUnionType, $1, $2, $3,
                           MakeBraceGroup($4, $5, $6)); }
   ;
@@ -7380,6 +7380,14 @@ TK_static_opt
   ;
 TK_tagged_opt
   : TK_tagged
+    { $$ = std::move($1); }
+  | /* empty */
+    { $$ = nullptr; }
+  ;
+TK_union_qualifier_opt
+  : TK_soft
+    { $$ = std::move($1); }
+  | TK_tagged
     { $$ = std::move($1); }
   | /* empty */
     { $$ = nullptr; }


### PR DESCRIPTION
`verible-verilog-lint` fails on this snippet

```systemverilog
package example_pkg;
    typedef union soft packed {
        logic a;
        logic b;
    } cmd_payload_t;
endpackage
```

with

```
hw/rtl/example_pkg.sv:3:19-22: syntax error at token "soft"
hw/rtl/example_pkg.sv:6:5: syntax error at token "}"
```

Soft packed union syntax is described in the SV 2023 standard, section 7.3.1.

This patch adds support for it.