### PR TITLE
Updated flex/bison toolchain for bazel 8+ compat

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,9 @@ common:macos   --config=unix
 # clang-cl before fixing the issues unique to MSVC.
 common:windows --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl --extra_execution_platforms=//:x64_windows-clang-cl
 common:windows --compiler=clang-cl --cxxopt=/std:c++20 --host_cxxopt=/std:c++20 --client_env=BAZEL_CXXOPTS=/std:c++20
+# Actions (e.g. the genrules invoking win_flex.exe/win_bison.exe) need the
+# invoking shell's PATH to find tools installed.
+common:windows --action_env=PATH --host_action_env=PATH
 
 build --cxxopt="-Wno-unknown-warning-option" --host_cxxopt="-Wno-unknown-warning-option"
 # TODO: this looks like benign where it happens but to be explored further.

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -4,6 +4,7 @@ Rules for adding './configure && make' style dependencies.
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load(":no_toolchain.bzl", "no_toolchain")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -23,6 +24,7 @@ cc_library(
 exports_files([
     "bison.bzl",
     "flex.bzl",
+    "no_toolchain.bzl",
     "sh_test_with_runfiles_lib.bzl",
     "sh_test_with_runfiles_lib.sh",
 ])
@@ -35,6 +37,12 @@ bool_flag(
 config_setting(
     name = "use_local_flex_bison_enabled",
     flag_values = {":use_local_flex_bison": "true"},
+)
+
+# Placeholder used where a select() would otherwise need to switch a
+# genrule's non-configurable `toolchains` attribute (see flex.bzl/bison.bzl):
+no_toolchain(
+    name = "no_toolchain",
 )
 
 bool_flag(

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -26,6 +26,23 @@ def genyacc(
         extra_outs = []):
     """Build rule for generating C or C++ sources with Bison.
     """
+
+    native.alias(
+        name = name + "_bison_toolchain",
+        actual = select({
+            "//bazel:use_local_flex_bison_enabled": "//bazel:no_toolchain",
+            "@platforms//os:windows": "//bazel:no_toolchain",
+            "//conditions:default": "@rules_bison//bison:current_bison_toolchain",
+        }),
+    )
+    native.alias(
+        name = name + "_m4_toolchain",
+        actual = select({
+            "//bazel:use_local_flex_bison_enabled": "//bazel:no_toolchain",
+            "@platforms//os:windows": "//bazel:no_toolchain",
+            "//conditions:default": "@rules_m4//m4:current_m4_toolchain",
+        }),
+    )
     native.genrule(
         name = name,
         srcs = [src],
@@ -35,12 +52,8 @@ def genyacc(
             "@platforms//os:windows": "win_bison.exe --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
             "//conditions:default": "M4=$(M4) $(BISON) --defines=$(location " + header_out + ") --output-file=$(location " + source_out + ") " + " ".join(extra_options) + " $<",
         }),
-        toolchains = select({
-            "//bazel:use_local_flex_bison_enabled": [],
-            "@platforms//os:windows": [],
-            "//conditions:default": [
-                "@rules_bison//bison:current_bison_toolchain",
-                "@rules_m4//m4:current_m4_toolchain",
-            ],
-        }),
+        toolchains = [
+            ":" + name + "_bison_toolchain",
+            ":" + name + "_m4_toolchain",
+        ],
     )

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -20,6 +20,23 @@
 def genlex(name, src, out):
     """Generate C/C++ language source from lex file using Flex
     """
+
+    native.alias(
+        name = name + "_flex_toolchain",
+        actual = select({
+            "//bazel:use_local_flex_bison_enabled": "//bazel:no_toolchain",
+            "@platforms//os:windows": "//bazel:no_toolchain",
+            "//conditions:default": "@rules_flex//flex:current_flex_toolchain",
+        }),
+    )
+    native.alias(
+        name = name + "_m4_toolchain",
+        actual = select({
+            "//bazel:use_local_flex_bison_enabled": "//bazel:no_toolchain",
+            "@platforms//os:windows": "//bazel:no_toolchain",
+            "//conditions:default": "@rules_m4//m4:current_m4_toolchain",
+        }),
+    )
     native.genrule(
         name = name,
         srcs = [src],
@@ -29,12 +46,8 @@ def genlex(name, src, out):
             "@platforms//os:windows": "win_flex.exe --outfile=$@ $<",
             "//conditions:default": "M4=$(M4) $(FLEX) --outfile=$@ $<",
         }),
-        toolchains = select({
-            "//bazel:use_local_flex_bison_enabled": [],
-            "@platforms//os:windows": [],
-            "//conditions:default": [
-                "@rules_flex//flex:current_flex_toolchain",
-                "@rules_m4//m4:current_m4_toolchain",
-            ],
-        }),
+        toolchains = [
+            ":" + name + "_flex_toolchain",
+            ":" + name + "_m4_toolchain",
+        ],
     )

--- a/bazel/no_toolchain.bzl
+++ b/bazel/no_toolchain.bzl
@@ -1,0 +1,28 @@
+# -*- Python -*-
+# Copyright 2017-2026 The Verible Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A placeholder target for genrule's `toolchains` attribute.
+
+genrule's `toolchains` attribute requires each entry to provide
+TemplateVariableInfo (or ToolchainTypeInfo). Used where a platform (e.g.
+Windows) needs no real toolchain there, like for using local winflexbison.
+"""
+
+def _no_toolchain_impl(ctx):
+    return [platform_common.TemplateVariableInfo({})]
+
+no_toolchain = rule(
+    implementation = _no_toolchain_impl,
+)


### PR DESCRIPTION
This is an alternative to #2520 to make bison/flex rules works on bazel 8 and beyond.

Bazel 7 allowed to use select on a toolchain, which is not allowed in bazel 8.

The command line option `//bazel:use_local_flex_bison_enabled` works on my machine as is. From test in #2460 it needs the extra_env to work on Windows in CI environment.

Disclaimer: this code is from an AI agent