### PR TITLE
Update code for msvc compatibility

### DIFF
--- a/external_libs/editscript.h
+++ b/external_libs/editscript.h
@@ -179,8 +179,10 @@ inline int64_t CommonAffix(TokenIter span1_begin, TokenIter span1_end,
 template <typename TokenIter>
 class Diff {
  private:
-  friend Edits GetTokenDiffs<>(TokenIter tokens1_begin, TokenIter tokens1_end,
-                               TokenIter tokens2_begin, TokenIter tokens2_end);
+  friend Edits diff::GetTokenDiffs<>(TokenIter tokens1_begin,
+                                     TokenIter tokens1_end,
+                                     TokenIter tokens2_begin,
+                                     TokenIter tokens2_end);
 
   /**
    * Finds the differences between two vectors of tokens, returning edits

--- a/verible/common/text/tree-utils_test.cc
+++ b/verible/common/text/tree-utils_test.cc
@@ -810,13 +810,11 @@ TEST(FindLastSubtreeTest, MatchLeaf) {
 // FindSubtreeStartingAtOffset tests
 
 constexpr std::string_view kFindSubtreeTestText("abcdef");
-const std::string_view kFindSubtreeTestSubstring(
-    kFindSubtreeTestText.substr(1, 3));
 
 struct FindSubtreeStartingAtOffsetTest : public testing::Test {
   SymbolPtr tree;
   FindSubtreeStartingAtOffsetTest()
-      : tree(Leaf(0, kFindSubtreeTestSubstring)) {}
+      : tree(Leaf(0, kFindSubtreeTestText.substr(1, 3))) {}
 };
 
 // Test that a single leaf yields itself when it starts < offset.

--- a/verible/common/util/tree-operations.h
+++ b/verible/common/util/tree-operations.h
@@ -174,9 +174,11 @@ void ReserveIfSupported(Container &, ...) {}  // NOLINT
 // `TreeNodeTraits<T>` is defined for every class `T` fulfilling the TreeNode
 // concept. It can be used in SFINAE tests.
 template <class Node,  //
-          typename Children_ =
-              tree_operations_internal::TreeNodeChildrenTraits<Node>>
+          typename Children_ = detected_or_t<
+              UnavailableFeatureTraits,
+              tree_operations_internal::TreeNodeChildrenTraits, Node>>
 struct TreeNodeTraits : FeatureTraits {
+  static constexpr bool available = Children_::available;
   using Parent =
       detected_or_t<UnavailableFeatureTraits,
                     tree_operations_internal::TreeNodeParentTraits, Node>;


### PR DESCRIPTION
This allow forward compatibility with MSVC on Windows, which supports should come once the project is migrated to bazel 8/9.

Disclaimer: The fix to `tree-operations.h` and `tree-utils_test.cc` was done by AI.