### PR TITLE
Fix formatting of `interface class`

### DIFF
--- a/verible/verilog/formatting/formatter_test.cc
+++ b/verible/verilog/formatting/formatter_test.cc
@@ -3885,6 +3885,22 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "  endtask\n"
      "  // class is about to end\n"
      "endclass\n"},
+
+    // interface class test cases
+    {"interface class Foo;\nendclass\n",
+     "interface class Foo;\n"
+     "endclass\n"},
+    {"interface   class   Foo  ;  endclass\n",
+     "interface class Foo;\n"
+     "endclass\n"},
+    {"interface class Foo extends Bar , Baz ;\nendclass\n",
+     "interface class Foo extends Bar, Baz;\n"
+     "endclass\n"},
+    {"interface class Foo;\n  pure   virtual   task   foo (  ) ; \nendclass\n",
+     "interface class Foo;\n"
+     "  pure virtual task foo();\n"
+     "endclass\n"},
+
     // class property alignment test cases
     {"class c;\n"
      "int foo  ;\n"

--- a/verible/verilog/formatting/tree-unwrapper.cc
+++ b/verible/verilog/formatting/tree-unwrapper.cc
@@ -803,6 +803,7 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     case NodeEnum::kTypeDeclaration:
     case NodeEnum::kNetTypeDeclaration:
     case NodeEnum::kForwardDeclaration:
+    case NodeEnum::kInterfaceClassMethod:
     case NodeEnum::kConstraintDeclaration:
     case NodeEnum::kConstraintExpression:
     case NodeEnum::kCovergroupDeclaration:
@@ -881,6 +882,7 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     case NodeEnum::kTaskDeclaration:
     case NodeEnum::kClassDeclaration:
     case NodeEnum::kClassHeader:
+    case NodeEnum::kInterfaceClassDeclaration:
     case NodeEnum::kBegin:
     case NodeEnum::kEnd:
     // case NodeEnum::kFork:  // TODO(fangism): introduce this node enum
@@ -1201,7 +1203,6 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     // For the following constructs, always expand the view to subpartitions.
     // Add a level of indentation.
     case NodeEnum::kPackageImportList:
-    case NodeEnum::kInterfaceClassDeclaration:
     case NodeEnum::kCasePatternItemList:
     case NodeEnum::kConstraintBlockItemList:
     case NodeEnum::kConstraintExpressionList:
@@ -1311,6 +1312,7 @@ void TreeUnwrapper::SetIndentationsAndCreatePartitions(
     case NodeEnum::kCaseInsideItemList:
     case NodeEnum::kGenerateCaseItemList:
     case NodeEnum::kClassItems:
+    case NodeEnum::kInterfaceClassItemList:
     case NodeEnum::kModuleItemList:
     case NodeEnum::kGenerateItemList:
     // Aligns parameter, net/variable, and assignment declarations in packages.


### PR DESCRIPTION
This fixes the formatting of `interface class` to properly be similar to `class`.
