### PR TITLE
Fix define name concatenation

### DIFF
--- a/verible/verilog/formatting/formatter_test.cc
+++ b/verible/verilog/formatting/formatter_test.cc
@@ -162,6 +162,12 @@ static constexpr FormatterTestCase kFormatterTestCases[] = {
      "`define  BAR\n",
      "`define FOO\n"
      "`define BAR\n"},
+    {"`define FOO_``BAR 1\n", "`define FOO_``BAR 1\n"},
+    {"`define FOO_```BAR 1\n", "`define FOO_```BAR 1\n"},
+    {"`define FOO ``BAR\n", "`define FOO ``BAR\n"},
+    {"`define A``B``C 2\n", "`define A``B``C 2\n"},
+    {"`define A(x)``y\n", "`define A(x) ``y\n"},
+    {"`define    FOO_``BAR\n", "`define FOO_``BAR\n"},
     {"`ifndef    FOO\n"
      "`endif // FOO\n",
      "`ifndef FOO\n"

--- a/verible/verilog/formatting/token-annotator.cc
+++ b/verible/verilog/formatting/token-annotator.cc
@@ -258,6 +258,16 @@ static WithReason<int> SpacesRequiredBetween(
     return {0, "No additional space around empty-string tokens."};
   }
 
+  // A macro definition body that begins with the token-concatenation
+  // operator "``" is part of macro name; preserve spacing if present.
+  // If a closing ')', that ends the definition name.
+  if (left.TokenEnum() == verilog_tokentype::PP_Identifier &&
+      right.TokenEnum() == verilog_tokentype::PP_define_body &&
+      right.Text().substr(0, 2) == "``" &&
+      right.OriginalLeadingSpaces().empty()) {
+    return {0, "Preserve spacing in concatenated name"};
+  }
+
   // Remove any extra spaces between numeric literals' width, base and digits.
   // "16'h123, 'h123" instead of "16 'h123", "16'h 123, 'h 123"
   if (IsInsideNumericLiteral(left, right)) {


### PR DESCRIPTION
This fixes a bug where

    `define FOO```BAR

was misformatting to 

    `define FOO ```BAR

which breaks the meaning.

Assisted with Claude, but human rewrote and reviewed.
