### PR TITLE
Prefer clang-format-19 in run-format.sh

### DIFF
--- a/.github/bin/run-format.sh
+++ b/.github/bin/run-format.sh
@@ -31,10 +31,16 @@ done
 
 FORMAT_OUT=${TMPDIR:-/tmp}/clang-format-diff.out
 
-# Use the provided Clang format binary, or try to fallback to clang-format-17
-# or clang-format.
+# Use the provided Clang format binary, or try clang-format-19 (CI version),
+# then older numbered versions, then unversioned clang-format.
 if [[ ! -v CLANG_FORMAT ]]; then
-  if command -v "clang-format-17" 2>&1 >/dev/null
+  if command -v "clang-format-19" 2>&1 >/dev/null
+  then
+    CLANG_FORMAT="clang-format-19"
+  elif command -v "clang-format-18" 2>&1 >/dev/null
+  then
+    CLANG_FORMAT="clang-format-18"
+  elif command -v "clang-format-17" 2>&1 >/dev/null
   then
     CLANG_FORMAT="clang-format-17"
   elif command -v "clang-format" 2>&1 >/dev/null
@@ -44,6 +50,7 @@ if [[ ! -v CLANG_FORMAT ]]; then
     (echo "-- Missing the clang-format binary! --"; exit 1)
   fi
 fi
+echo "Using ${CLANG_FORMAT} ($("${CLANG_FORMAT}" --version))"
 
 BUILDIFIER=${BUILDIFIER:-buildifier}
 


### PR DESCRIPTION
## Summary
- Ran `.github/bin/run-format.sh` on current `master` with **clang-format-19** (the version CI installs). No `*.h`/`*.cc` files changed; the tree is already clean for CI.
- The rewrites reported in #2580 came from the script falling back to **clang-format-17**, which disagrees with 19 on eight files.
- Prefer clang-format-19 (then 18, 17, unversioned) so a local `run-format.sh` matches CI and is a no-op on `master`.

Fixes #2580

## Test plan
- [x] `CLANG_FORMAT=clang-format-19 .github/bin/run-format.sh` leaves the tree unchanged
- [x] Unset `CLANG_FORMAT` now selects clang-format-19 and leaves the tree unchanged
- [x] `CLANG_FORMAT=clang-format-17 .github/bin/run-format.sh` still rewrites the eight files from #2580 (not included in this PR; those diffs would fail CI)
- [ ] CI on this PR is green
