### PR TITLE
Fix binary use of reduction NAND and NOR

### DIFF
--- a/.github/bin/smoke-test.sh
+++ b/.github/bin/smoke-test.sh
@@ -171,9 +171,9 @@ ExpectedFailCount[lint:black-parrot]=155
 ExpectedFailCount[project:black-parrot]=172
 ExpectedFailCount[preprocessor:black-parrot]=173
 
-ExpectedFailCount[syntax:ivtest]=116
-ExpectedFailCount[lint:ivtest]=116
-ExpectedFailCount[project:ivtest]=145
+ExpectedFailCount[syntax:ivtest]=123
+ExpectedFailCount[lint:ivtest]=123
+ExpectedFailCount[project:ivtest]=152
 ExpectedFailCount[preprocessor:ivtest]=26
 
 ExpectedFailCount[syntax:nontrivial-mips]=2

--- a/verible/verilog/parser/verilog-parser_test.cc
+++ b/verible/verilog/parser/verilog-parser_test.cc
@@ -6086,6 +6086,24 @@ static const std::initializer_list<ParserTestData> kInvalidCodeTests = {
      {verible::TK_EOF, ""}},
     {"[int'",  // unexpected EOF
      {verible::TK_EOF, ""}},
+    {"module test(\n",
+     "input logic a,\n",
+     "input logic b,\n",
+     "output logic out\n",
+     ");\n",
+     "assign out = a",  // invalid binary operator
+     {TK_NAND, "~&"},
+     "b;",
+     "endmodule\n"},
+    {"module test(\n",
+     "input logic a,\n",
+     "input logic b,\n",
+     "output logic out\n",
+     ");\n",
+     "assign out = a",  // invalid binary operator
+     {TK_NOR, "~|"},
+     "b;",
+     "endmodule\n"},
 };
 
 using verible::LeafTag;

--- a/verible/verilog/parser/verilog.y
+++ b/verible/verilog/parser/verilog.y
@@ -4437,8 +4437,6 @@ bitand_expr
     { $$ = std::move($1); }
   | bitand_expr '&' caseeq_expr
     { $$ = MakeBinaryExpression($1, $2, $3); }
-  | bitand_expr TK_NAND caseeq_expr
-    { $$ = MakeBinaryExpression($1, $2, $3); }
   ;
 
 xor_expr
@@ -4454,8 +4452,6 @@ bitor_expr
   : xor_expr
     { $$ = std::move($1); }
   | bitor_expr '|' xor_expr
-    { $$ = MakeBinaryExpression($1, $2, $3); }
-  | bitor_expr TK_NOR xor_expr
     { $$ = MakeBinaryExpression($1, $2, $3); }
   ;
 


### PR DESCRIPTION
Addresses #2568 by removing the binary operator grammar rules for `~&` and `~|`, which are valid only as unary reduction operators. Adds regression tests to verify that their invalid binary usage is rejected.