### PR TITLE
Migrate from the deprecated ABSL_ATTRIBUTE_UNUSED attribute to C++17 [[maybe_unused]]

### DIFF
--- a/verible/common/util/BUILD
+++ b/verible/common/util/BUILD
@@ -22,7 +22,6 @@ cc_library(
     hdrs = ["auto-pop-stack.h"],
     deps = [
         ":logging",
-        "@abseil-cpp//absl/base:core_headers",
     ],
 )
 

--- a/verible/common/util/auto-pop-stack.h
+++ b/verible/common/util/auto-pop-stack.h
@@ -18,7 +18,6 @@
 #include <cstddef>
 #include <vector>
 
-#include "absl/base/attributes.h"
 #include "verible/common/util/logging.h"
 
 namespace verible {
@@ -29,7 +28,7 @@ namespace verible {
 // implementing algorithms based on stack data structures like building
 // inheritance stack of traversed tree.
 template <typename T>
-class AutoPopStack {
+class [[maybe_unused]] AutoPopStack {
  public:
   using value_type = T;
   using this_type = AutoPopStack<value_type>;
@@ -105,7 +104,7 @@ class AutoPopStack {
 
  private:
   stack_type stack_;
-} ABSL_ATTRIBUTE_UNUSED;
+};
 
 }  // namespace verible
 


### PR DESCRIPTION
Imported automatically from internal Piper robot CL 972730734.

Please review and merge these changes on GitHub.