### PR TITLE
Fix test failures due to vector/string allocation changes.

### DIFF
--- a/verible/common/util/container-proxy_test.cc
+++ b/verible/common/util/container-proxy_test.cc
@@ -874,13 +874,14 @@ TYPED_TEST(MutableRandomAccessContainerProxyTest, Capacity) {
 
   const int new_capacity = initial_capacity + 42;
   this->proxy.reserve(new_capacity);
-  EXPECT_EQ(this->proxy.capacity(), new_capacity);
-  EXPECT_EQ(this->container.capacity(), new_capacity);
+  EXPECT_GE(this->proxy.capacity(), new_capacity);
+  EXPECT_EQ(this->proxy.capacity(), this->container.capacity());
 
+  const int capacity_after_first_reserve = this->proxy.capacity();
   const int lower_capacity = 1;
   this->proxy.reserve(lower_capacity);
-  EXPECT_EQ(this->proxy.capacity(), new_capacity);
-  EXPECT_EQ(this->container.capacity(), new_capacity);
+  EXPECT_EQ(this->proxy.capacity(), capacity_after_first_reserve);
+  EXPECT_EQ(this->container.capacity(), capacity_after_first_reserve);
 }
 
 }  // namespace


### PR DESCRIPTION
Imported from internal Piper CL 976458038.

### Description
	Background: in go/lower-growth-rate, we are (a) lowering the growth rate of std::vector and std::string and (b) using size-returning-new for backing allocations, which results in the capacity using all available space from the allocator size class (these changes are implemented in cl/963662015). Most test failures are due to (a) vector/string capacity changes and (b) pointer stability issues. There were also some linker-related failures.
	Some of these changes were originally generated by gemini, but I reviewed and polished all of those changes.
	BUG=175429069
	DO_NOT_UPDATE_BUG=Do not update a child CL bug

Please review and merge these changes on GitHub.